### PR TITLE
apps: moved misplaced fluentd conf

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -11,6 +11,7 @@
 See [migrations docs for nginx](migration/v0.7.x-v0.8.x/nginx.md) for instruction on how to perform the upgrade.
 - The config option `nginxIngress.controller.daemonset.useHostPort` has been replaced by `ingressNginx.controller.useHostPort`.
 Make sure to remove the old option from your config when upgrading.
+- Move useRegionEndpoint from elasticsearch to fluentd in sc-config.yaml before upgrading.
 
 ### Added
 
@@ -29,6 +30,7 @@ Make sure to remove the old option from your config when upgrading.
 - Helm has been upgraded to v3.4.1
 - Grafana has been updated to a new chart repo and bumped to version 5.8.16
 - Bump `kubectl` to 1.17.11
+- useRegionEndpoint moved to fluentd conf.
 
 ### Fixed
 

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -188,8 +188,7 @@ set_elasticsearch_config() {
 
     esac
 
-    replace_set_me "$1" 'elasticsearch.useRegionEndpoint' "$use_regionendpoint"
-    replace_set_me "$1" 'elasticsearch.snapshotRepository' "s3_${CK8S_CLOUD_PROVIDER}_7.x"
+    replace_set_me "$1" 'fluentd.useRegionEndpoint' "$use_regionendpoint"
 }
 
 # Usage: set_harbor_config <config-file>

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -199,8 +199,7 @@ elasticsearch:
   tolerations: []
   affinity: {}
   nodeSelector: {}
-  snapshotRepository: "set-me"
-  useRegionEndpoint: "set-me"
+  snapshotRepository: elastic-snapshots
 
 fluentd:
   resources:
@@ -213,6 +212,7 @@ fluentd:
   tolerations: []
   affinity: {}
   nodeSelector: {}
+  useRegionEndpoint: "set-me"
   aggregator:
     resources:
       limits:

--- a/helmfile/values/fluentd-aggregator.yaml.gotmpl
+++ b/helmfile/values/fluentd-aggregator.yaml.gotmpl
@@ -52,7 +52,7 @@ configMaps:
 
       aws_key_id "#{ENV['AWS_ACCESS_KEY_ID']}"
       aws_sec_key "#{ENV['AWS_ACCESS_SECRET_KEY']}"
-      {{ if eq .Values.elasticsearch.useRegionEndpoint true -}}
+      {{ if eq .Values.fluentd.useRegionEndpoint true -}}
       s3_endpoint {{ .Values.s3.regionEndpoint }}
       force_path_style true
       {{ else -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
The configuration key useRegionEndpoint was mistakenly placed under elasticsearch config when it should have been under fluentd. This PR corrects that.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*:

fixes #265


**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/master/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [X] requires running a migration script. 
        - re-run init
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
