### PR TITLE
Target main branch instead of master

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 
 **Checklist:**
 
-- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/master/WIP-CHANGELOG.md)
+- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
 - [ ] Proper commit message prefix on all commits
 - [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
 - Is this changeset backwards compatible for existing clusters? Applying:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -3,7 +3,7 @@ name: UnitTests-pipeline
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - '**.md'
   push:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: Pre-commit
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   pre-commit:

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -4,7 +4,7 @@ The pipeline is now using a ubuntu based docker image now located at dockerhub o
 pipeline will generate its own image using the commit hash. Once a release is made
 it will also tag a image with the same tag.
 
-The pipeline will run on pull requests to master and on push to branches named
+The pipeline will run on pull requests to main and on push to branches named
 `Release-x`. The pipeline workflow is in `.github/workflows` and the scripts used are located in the `pipeline` directory.
 
 ## Ops image
@@ -27,7 +27,7 @@ on an old version of ck8s.
 #### Example scenario
 
 You have a user running on version 0.1.0 of ck8s. In 0.1.0 helm 2.14 is used in
-the cluster. In master helm has been upgraded to helm 3. You need to run maintenance
+the cluster. In main helm has been upgraded to helm 3. You need to run maintenance
 on the users cluster. Instead of downgrading your binary to helm 2.14 you do these steps.
 
 ```

--- a/release/README.md
+++ b/release/README.md
@@ -16,7 +16,7 @@ git push -u origin release-X.Y
 2. Checkout the branch to cut the release from.
 
 ```bash
-git checkout master
+git checkout main
 git pull
 git checkout -b branch_name
 ```
@@ -59,7 +59,7 @@ git push
 git checkout release-X.Y
 git pull
 git checkout -b branch_name
-git cherry-pick [some fix in master]
+git cherry-pick [some fix in main]
 git add -p file-with-some-new-fixes
 git commit
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes references from a master branch to the main branch.

**Which issue this PR fixes**: -

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/master/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
