### PR TITLE
apps sc: Makes harbor storage size configurable

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,9 +1,11 @@
 ### Release notes
 
 - Configuration for the certificate issuers has been changed and requires running the [migration script](migration/v0.6.x-v0.7.x/migrate-issuer-config.sh).
+- Configuration for harbor has been changed and requires running init and apply again.
 
 ### Added
 
+- Configurable persistence size in Harbor
 - Support for providing certificate issuer manifests to override default issuers.
 - Configurable extra role mappings in Elasticsearch
 - Added falco exporter to workload cluster

--- a/config/config/flavors/prod-sc.yaml
+++ b/config/config/flavors/prod-sc.yaml
@@ -58,6 +58,11 @@ elasticsearch:
     rolloverSize: 5
     rolloverAge: 1
 
+harbor:
+  database:
+    persistentVolumeClaim:
+      size: 5Gi
+
 influxDB:
   retention:
     ageWc: 30d

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -45,6 +45,9 @@ harbor:
   tolerations: []
   affinity: {}
   nodeSelector: {}
+  chartmuseum:
+    persistentVolumeClaim:
+      size: 5Gi
   core:
     resources:
       requests:
@@ -53,7 +56,12 @@ harbor:
       limits:
         memory: 512Mi
         cpu: 200m
+  database:
+    persistentVolumeClaim:
+      size: 1Gi
   jobservice:
+    persistentVolumeClaim:
+      size: 1Gi
     resources:
       requests:
         memory: 256Mi
@@ -62,6 +70,8 @@ harbor:
         memory: 512Mi
         cpu: 200m
   registry:
+    persistentVolumeClaim:
+      size: 5Gi
     resources:
       requests:
         memory: 256Mi
@@ -69,6 +79,9 @@ harbor:
       limits:
         memory: 512Mi
         cpu: 200m
+  redis:
+    persistentVolumeClaim:
+      size: 1Gi
   notary:
     resources:
       requests:

--- a/helmfile/values/harbor.yaml.gotmpl
+++ b/helmfile/values/harbor.yaml.gotmpl
@@ -19,15 +19,15 @@ persistence:
   resourcePolicy: "keep"
   persistentVolumeClaim:
     chartmuseum:
-      size: 5Gi
+      size: {{ .Values.harbor.chartmuseum.persistentVolumeClaim.size }}
     registry:
-      size: 5Gi
+      size: {{ .Values.harbor.registry.persistentVolumeClaim.size }}
     jobservice:
-      size: 1Gi
+      size: {{ .Values.harbor.jobservice.persistentVolumeClaim.size }}
     database:
-      size: 1Gi
+      size: {{ .Values.harbor.database.persistentVolumeClaim.size }}
     redis:
-      size: 1Gi
+      size: {{ .Values.harbor.redis.persistentVolumeClaim.size }}
   imageChartStorage:
     {{ if eq .Values.harbor.persistence.type "swift" }}
     type: swift


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes harbor persistence size configurable

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*

**Special notes for reviewer**:

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/master/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [X] requires running a migration script.
        - re-run init and apply
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
