### PR TITLE
apps: Updating nginx ingress helm chart

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -15,6 +15,7 @@
 - Certificate issuer configuration has been changed from `letsencrypt` to `issuers.letsencrypt` and extended to support more issuers.
 - Explicitly disabled multitenancy in Kibana.
 - Cloud provider dependencies are removed from the templates, instead, keys are added to the sc|wc-config.yaml by the init script so no more "hidden" config. This requires a re-run of ck8s init or manully adding the missing keys.
+- Ingress nginx has been updated to a new chart repo and bumped to version 2.10
 
 ### Fixed
 

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -10,6 +10,8 @@ repositories:
   url: https://vmware-tanzu.github.io/helm-charts
 - name: falcosecurity
   url: https://falcosecurity.github.io/charts
+- name: ingress-nginx
+  url: https://kubernetes.github.io/ingress-nginx
 
 # workload_cluster specfic repositories
 {{ if eq .Environment.Name "workload_cluster" }}
@@ -50,8 +52,8 @@ releases:
   namespace: nginx-ingress
   labels:
     app: nginx-ingress
-  chart: stable/nginx-ingress
-  version: 1.26.2
+  chart: ingress-nginx/ingress-nginx
+  version: 2.10.0
   missingFileHandler: Error
   wait: true
   values:


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the ingress helm chart to the new repo. It also bumps the version to 2.10 since the old version (1.26.2) does not exist in the new repo. Later versions (2.11 and onwards) are breaking the configuration. Deployment names and namespaces are NOT changed.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/master/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [] is completely transparent, will not impact the workload in any way.
    - [X] requires running a migration script.
        - Rerun apply
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.