### PR TITLE
apps sc: Updating Grafana helm chart

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -21,6 +21,7 @@
 - Ingress nginx has been updated to a new chart repo and bumped to version 2.10
 - Harbor chart has been upgraded to version 1.5.1
 - Helm has been upgraded to v3.4.1
+- Grafana has been updated to a new chart repo and bumped to version 5.8.16
 
 ### Fixed
 

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -23,6 +23,8 @@ repositories:
   url: https://helm.goharbor.io
 - name: elastisys
   url: https://elastisys.github.io/chart-repo
+- name: grafana
+  url: https://grafana.github.io/helm-charts
 {{ end }}
 
 # Defult settings to use with helm.
@@ -221,8 +223,8 @@ releases:
     app: user-grafana
     app.kubernetes.io/instance: user-grafana
     app.kubernetes.io/name: grafana
-  chart: stable/grafana
-  version: 5.3.4
+  chart: grafana/grafana
+  version: 5.8.16
   missingFileHandler: Error
   needs:
   - cert-manager/cert-manager


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the grafana helm chart to the new repo. It also bumps the version to the latest version (6.1.0).

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/master/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [X] requires running a migration script.
        - Rerun apply
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

