### PR TITLE
apps wc: Fix configuration error for user fluentd

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -22,3 +22,4 @@
 
 - Kibana OIDC logout not redirecting correctly.
 - Getting stuck at selecting tenant when logging in to Kibana.
+- The user fluentd configuration uses its dedicated values for tolerations, affinity and nodeselector.

--- a/helmfile/values/fluentd-user.yaml.gotmpl
+++ b/helmfile/values/fluentd-user.yaml.gotmpl
@@ -1,8 +1,8 @@
 resources: {{- toYaml .Values.fluentd.user.resources | nindent 2  }}
 
-nodeSelector: {{- toYaml .Values.fluentd.nodeSelector | nindent 2  }}
-affinity: {{- toYaml .Values.fluentd.affinity | nindent 2  }}
-tolerations: {{- toYaml .Values.fluentd.tolerations | nindent 2  }}
+nodeSelector: {{- toYaml .Values.fluentd.user.nodeSelector | nindent 2  }}
+affinity: {{- toYaml .Values.fluentd.user.affinity | nindent 2  }}
+tolerations: {{- toYaml .Values.fluentd.user.tolerations | nindent 2  }}
 
 elasticsearch:
   scheme: https


### PR DESCRIPTION
**What this PR does / why we need it**:
The user fluentd config used the wc fluentd values for tolerations, affinity and nodeselector.
This fix makes the user fluentd config use the already existing user fluentd values instead.

I do not have an environment up and have not tested this properly yet.

**Which issue this PR fixes**: -

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
