### PR TITLE
Init script will not override config, plus missing migration script

### DIFF
--- a/bin/init.bash
+++ b/bin/init.bash
@@ -73,24 +73,16 @@ generate_base_sc_config() {
     file=$1
     tmpfile=$(mktemp)
 
+    envsubst > "$tmpfile" < "${config_defaults_path}/config/sc-config.yaml"
     if [[ ${CK8S_CLOUD_PROVIDER} == "citycloud" ]]; then
-        if [[ -f $file ]]; then
-            yq merge -i "$file" "${config_defaults_path}/config/citycloud.yaml"
-        else
-            cat "${config_defaults_path}/config/citycloud.yaml" > "$file"
-        fi
-        echo "" >> "$file"
-        yq merge "$file" "${config_defaults_path}/config/sc-config.yaml" > "$tmpfile"
-        envsubst > "$file" < "$tmpfile"
-    else
-        if [[ -f $file ]]; then
-            yq merge "$file" "${config_defaults_path}/config/sc-config.yaml" > "$tmpfile"
-            envsubst > "$file" < "$tmpfile"
-        else
-            envsubst > "$file" < "${config_defaults_path}/config/sc-config.yaml"
-        fi
+        yq merge -i "$tmpfile" "${config_defaults_path}/config/citycloud.yaml"
     fi
-    yq merge -i --overwrite "$file" "${config_defaults_path}/config/flavors/${CK8S_FLAVOR}-sc.yaml"
+    yq merge -i --overwrite "$tmpfile" "${config_defaults_path}/config/flavors/${CK8S_FLAVOR}-sc.yaml"
+    if [[ -f $file ]]; then
+        yq merge -i "$file" "$tmpfile"
+    else
+        cat "$tmpfile" > "$file"
+    fi
 }
 
 generate_base_wc_config() {
@@ -100,13 +92,14 @@ generate_base_wc_config() {
     fi
     file=$1
     tmpfile=$(mktemp)
+
+    envsubst > "$tmpfile" < "${config_defaults_path}/config/wc-config.yaml"
+    yq merge -i --overwrite "$tmpfile" "${config_defaults_path}/config/flavors/${CK8S_FLAVOR}-wc.yaml"
     if [[ -f $file ]]; then
-        yq merge "$file" "${config_defaults_path}/config/wc-config.yaml" > "$tmpfile"
-        envsubst > "$file" < "$tmpfile"
+        yq merge -i "$file" "$tmpfile"
     else
-        envsubst > "$file" < "${config_defaults_path}/config/wc-config.yaml"
+        cat "$tmpfile" > "$file"
     fi
-    yq merge -i --overwrite "$file" "${config_defaults_path}/config/flavors/${CK8S_FLAVOR}-wc.yaml"
 }
 
 # Usage: set_storage_class <config-file>

--- a/migration/v0.6.x-v0.7.x/migrate-issuer-config.sh
+++ b/migration/v0.6.x-v0.7.x/migrate-issuer-config.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
+for cluster in sc wc; do
+  config="${CK8S_CONFIG_PATH}/${cluster}-config.yaml"
+  cert_type=$(yq r "$config" 'global.certType')
+
+  issuer="letsencrypt-$cert_type"
+  if [ "$cert_type" = prod ]; then
+    verify_tls=true
+  else
+    verify_tls=false
+  fi
+  prod_email=$(yq r "$config" 'letsencrypt.prod.email')
+  staging_email=$(yq r "$config" 'letsencrypt.staging.email')
+
+  if [ -z "$cert_type" ]; then
+    echo "Error: 'global.certType' is missing in $config."
+    echo "Cannot migrate to 'global.issuer' and 'global.verifyTls'."
+    exit 1
+  elif [ -z "$prod_email" ]; then
+    echo "Error: 'letsencrypt.prod.email' is missing in $config."
+    echo "Cannot migrate to 'issuers.letsencrypt' configuration."
+    exit 1
+  elif [ -z "$staging_email" ]; then
+    echo "Error: 'letsencrypt.staging.email' is missing in $config."
+    echo "Cannot migrate to 'issuers.letsencrypt' configuration."
+    exit 1
+  fi
+
+  echo "Migrating configuration in file $config"
+
+  yq w -i "$config" 'global.issuer' "$issuer"
+  yq w -i "$config" 'global.verifyTls' "$verify_tls"
+
+  cat <<EOF >> "$config"
+issuers:
+  letsencrypt:
+    enabled: true
+    prod:
+      email: "$prod_email"
+    staging:
+      email: "$staging_email"
+  extraIssuers: []
+EOF
+
+  echo "You can now remove 'global.certType' and 'letsencrypt.*' from $config."
+  echo "Just be careful to NOT remove 'issuers.letsencrypt.*'."
+done


### PR DESCRIPTION
**What this PR does / why we need it**: This is part of the qa testing for the next release (0.7.0).
This changes the init script to never override any existing config values in a users config path. But it will still add any missing config values (that might have been added with a new feature).
This PR also adds back a migration script that is used in the migration to v0.7.0

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #16 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
