### PR TITLE
config: can now push images to Harbor on safespring

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -8,6 +8,7 @@
 - Configurable extra role mappings in Elasticsearch
 - Added falco exporter to workload cluster
 - Falco dashboard added to Grafana
+- Config option to disable redirection when pushing to Harbor image storage.
 
 ### Changed
 
@@ -21,3 +22,4 @@
 - Kibana OIDC logout not redirecting correctly.
 - Getting stuck at selecting tenant when logging in to Kibana.
 - Typo in elasticsearch slm config for the schedule.
+- Pushing images to Harbor on Safespring

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -200,16 +200,24 @@ set_harbor_config() {
         exit 1
     fi
     case ${CK8S_CLOUD_PROVIDER} in
-        aws | exoscale | safespring)
+        aws | exoscale)
           persistence_type=s3
+          disable_redirect=false
+          ;;
+
+        safespring)
+          persistence_type=s3
+          disable_redirect=true
           ;;
 
         citycloud)
           persistence_type=swift
+          disable_redirect=true
           ;;
 
     esac
     replace_set_me "$1" 'harbor.persistence.type' "$persistence_type"
+    replace_set_me "$1" 'harbor.persistence.disableRedirect' "$disable_redirect"
 }
 
 # Usage: generate_secrets <config-file>

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -79,6 +79,7 @@ harbor:
         cpu: 200m
   persistence:
     type: "set-me"
+    disableRedirect: set-me
 
 prometheus:
   storage:

--- a/helmfile/values/harbor.yaml.gotmpl
+++ b/helmfile/values/harbor.yaml.gotmpl
@@ -29,6 +29,7 @@ persistence:
     redis:
       size: 1Gi
   imageChartStorage:
+    disableredirect: {{ .Values.harbor.persistence.disableRedirect }}
     {{ if eq .Values.harbor.persistence.type "swift" }}
     type: swift
     swift:
@@ -40,7 +41,6 @@ persistence:
       authversion: {{ .Values.citycloud.authVersion }}
       tenant: {{ .Values.citycloud.tenantName }}
       domain: {{ .Values.citycloud.projectDomainName }}
-    disableredirect: true
     {{ else }}
     type: s3
     s3:


### PR DESCRIPTION
**What this PR does / why we need it**: Part of qa testing for v0.7.0. Fixes the problem that images could not be pushed to Harbor on Safespring by adding config option (and correct defaults based on cloud provider). 

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #14 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
