### PR TITLE
config: fixes typo in opsgenie hartbeat config

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,6 +1,8 @@
 ### Release notes
 
-- Configuration for the certificate issuers has been changed and requires running the [migration script](migration/v0.6.x-v0.7.x/migrate-issuer-config.sh).
+- Configuration for the certificate issuers has been changed and requires running the [migration script](migration/v0.6.x-v0.7.x/migrate-issuer-config.sh).'
+- Remove `alerts.opsGenieHeartbeat.enable` and `alerts.opsGenieHeartbeat.enabled` from your config file `sc-config.yaml`.
+- Run `ck8s init` again to update your config files with new options (after checking out v0.7.0).
 
 ### Added
 
@@ -23,3 +25,4 @@
 - Getting stuck at selecting tenant when logging in to Kibana.
 - Typo in elasticsearch slm config for the schedule.
 - Pushing images to Harbor on Safespring
+- Typo in Alertmanager config regarding connection to Opsgenie heartbeat

--- a/config/config/flavors/dev-sc.yaml
+++ b/config/config/flavors/dev-sc.yaml
@@ -5,12 +5,6 @@ global:
 dex:
   enableStaticLogin: true
 
-alerts:
-  alertTo: "null"
-  opsGenieHeartbeat:
-    enable: false
-    name: "set-me"
-
 prometheus:
   storage:
     size: 2Gi

--- a/config/config/flavors/prod-sc.yaml
+++ b/config/config/flavors/prod-sc.yaml
@@ -8,7 +8,7 @@ dex:
 alerts:
   alertTo: "opsgenie"
   opsGenieHeartbeat:
-    enable: true
+    enabled: true
     name: #Fill this out
 
 prometheus:


### PR DESCRIPTION
**What this PR does / why we need it**: Part of qa testing for v0.7.0. This PR fixes a typo in the prod flavor regarding opsgenie heartbeat. Also removes some redundant config in dev flavor.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: #8 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
