### PR TITLE
pipeline: RBAC tests failed when usernames/namespaces had quotes

### DIFF
--- a/pipeline/test/services/workload-cluster/testUserRbac.sh
+++ b/pipeline/test/services/workload-cluster/testUserRbac.sh
@@ -59,8 +59,8 @@ echo
 echo "Testing user RBAC"
 echo "====================="
 
-user_namespaces=$(yq r "$CONFIG_FILE" 'user.namespaces' | sed 's/-//' - )
-user_admin_users=$(yq r "$CONFIG_FILE" 'user.adminUsers' | sed 's/-//' - )
+user_namespaces=$(yq r "$CONFIG_FILE" 'user.namespaces[*]')
+user_admin_users=$(yq r "$CONFIG_FILE" 'user.adminUsers[*]')
 
 for user in ${user_admin_users}; do
     testCanUserDo "get" "node" "$user"


### PR DESCRIPTION
**What this PR does / why we need it**: Part of qa tests for v0.7.0. Simple fix for some rbac tests.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #17 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
