### PR TITLE
apps sc: adds datasource option on dashboards

### DIFF
--- a/helmfile/charts/grafana-ops/dashboards/es-dashboard.json
+++ b/helmfile/charts/grafana-ops/dashboards/es-dashboard.json
@@ -1,1528 +1,1702 @@
 {
-    "__inputs": [
-        {
-        "name": "prometheus-sc",
-        "label": "Prometheus",
-        "description": "",
-        "type": "datasource",
-        "pluginId": "prometheus",
-        "pluginName": "Prometheus"
-        }
-    ],
-    "__requires": [
-        {
-        "type": "grafana",
-        "id": "grafana",
-        "name": "Grafana",
-        "version": "4.6.2"
-        },
-        {
-        "type": "panel",
-        "id": "graph",
-        "name": "Graph",
-        "version": ""
-        },
-        {
-        "type": "datasource",
-        "id": "prometheus",
-        "name": "Prometheus",
-        "version": "1.0.0"
-        },
-        {
-        "type": "panel",
-        "id": "singlestat",
-        "name": "Singlestat",
-        "version": ""
-        }
-    ],
     "annotations": {
-        "list": [
+      "list": [
         {
-            "builtIn": 1,
-            "datasource": "-- Grafana --",
-            "enable": true,
-            "hide": true,
-            "iconColor": "rgba(0, 211, 255, 1)",
-            "name": "Annotations & Alerts",
-            "type": "dashboard"
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
         }
-        ]
+      ]
     },
+    "description": "ElasticSearch cluster stats.\r\n\r\nRevision 1 of this dashboard is the same as the Infinity Dashboard Revision 4 (https://grafana.com/dashboards/2322)\r\n\r\nThis is a cleaned up copy with all control characters removed from the dashboard file.  When downloading version 4 of the original Infinity elasticsearch dashboard via curl, the resulting file is corrupted with a missing final curly brace.\r\n",
     "editable": true,
     "gnetId": 6483,
     "graphTooltip": 1,
-    "hideControls": false,
-    "id": null,
+    "id": 24,
+    "iteration": 1604504107746,
     "links": [
-        {
+      {
         "asDropdown": true,
         "icon": "external link",
         "includeVars": false,
         "keepTime": true,
         "tags": [
-            "OS"
+          "OS"
         ],
         "targetBlank": true,
         "title": "OS",
         "type": "dashboards"
-        },
-        {
+      },
+      {
         "asDropdown": true,
         "icon": "external link",
         "keepTime": true,
         "tags": [
-            "MySQL"
+          "MySQL"
         ],
         "targetBlank": true,
         "title": "MySQL",
         "type": "dashboards"
-        },
-        {
+      },
+      {
         "asDropdown": true,
         "icon": "external link",
         "keepTime": true,
         "tags": [
-            "MongoDB"
+          "MongoDB"
         ],
         "targetBlank": true,
         "title": "MongoDB",
         "type": "dashboards"
-        },
-        {
+      },
+      {
         "asDropdown": true,
         "icon": "external link",
         "keepTime": true,
         "tags": [
-            "App"
+          "App"
         ],
         "targetBlank": true,
         "title": "App",
         "type": "dashboards"
-        }
+      }
     ],
-    "refresh": false,
-    "rows": [
-        {
-        "collapse": false,
-        "height": null,
-        "panels": [
-            {
-            "cacheTimeout": null,
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "#d44a3a",
-                "rgba(237, 129, 40, 0.89)",
-                "#299c46"
-            ],
-            "datasource": "prometheus-sc",
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "height": "50",
-            "id": 53,
-            "interval": null,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                "name": "value to text",
-                "value": 1
-                },
-                {
-                "name": "range to text",
-                "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                "from": "null",
-                "text": "N/A",
-                "to": "null"
-                }
-            ],
-            "span": 2,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": true,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": true
-            },
-            "tableColumn": "__name__",
-            "targets": [
-                {
-                "expr": "elasticsearch_cluster_health_status{instance=\"$instance\",cluster=\"$cluster\",color=\"red\"}==1 or (elasticsearch_cluster_health_status{instance=\"$instance\",cluster=\"$cluster\",color=\"green\"}==1)+4 or (elasticsearch_cluster_health_status{instance=\"$instance\",cluster=\"$cluster\",color=\"yellow\"}==1)+22",
-                "format": "time_series",
-                "instant": true,
-                "intervalFactor": 2,
-                "legendFormat": "",
-                "refId": "A"
-                }
-            ],
-            "thresholds": "2,4",
-            "title": "Cluster health",
-            "type": "singlestat",
-            "valueFontSize": "80%",
-            "valueMaps": [
-                {
-                "op": "=",
-                "text": "N/A",
-                "value": "null"
-                },
-                {
-                "op": "=",
-                "text": "Green",
-                "value": "5"
-                },
-                {
-                "op": "=",
-                "text": "Yellow",
-                "value": "3"
-                },
-                {
-                "op": "=",
-                "text": "Red",
-                "value": "1"
-                }
-            ],
-            "valueName": "avg"
-            },
-            {
-            "cacheTimeout": null,
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "#299c46",
-                "rgba(237, 129, 40, 0.89)",
-                "#d44a3a"
-            ],
-            "datasource": "prometheus-sc",
-            "decimals": null,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "height": "50",
-            "id": 81,
-            "interval": null,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                "name": "value to text",
-                "value": 1
-                },
-                {
-                "name": "range to text",
-                "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                "from": "null",
-                "text": "N/A",
-                "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": true,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": true
-            },
-            "tableColumn": "__name__",
-            "targets": [
-                {
-                "expr": "count(elasticsearch_breakers_tripped{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}>0)",
-                "format": "time_series",
-                "instant": true,
-                "intervalFactor": 2,
-                "legendFormat": "",
-                "refId": "A"
-                }
-            ],
-            "thresholds": "1,2",
-            "title": "Tripped for breakers",
-            "type": "singlestat",
-            "valueFontSize": "80%",
-            "valueMaps": [
-                {
-                "op": "=",
-                "text": "0",
-                "value": "N/A"
-                },
-                {
-                "op": "=",
-                "text": "0",
-                "value": "no value"
-                },
-                {
-                "op": "=",
-                "text": "0",
-                "value": "null"
-                }
-            ],
-            "valueName": "avg"
-            },
-            {
-            "cacheTimeout": null,
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(245, 54, 54, 0.9)"
-            ],
-            "datasource": "prometheus-sc",
-            "editable": true,
-            "error": false,
-            "format": "percent",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "height": "50",
-            "id": 51,
-            "interval": null,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                "name": "value to text",
-                "value": 1
-                },
-                {
-                "name": "range to text",
-                "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                "from": "null",
-                "text": "N/A",
-                "to": "null"
-                }
-            ],
-            "span": 2,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "tableColumn": "",
-            "targets": [
-                {
-                "expr": "sum (elasticsearch_process_cpu_percent{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"} ) / count (elasticsearch_process_cpu_percent{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"} )",
-                "format": "time_series",
-                "instant": true,
-                "interval": "",
-                "intervalFactor": 2,
-                "legendFormat": "",
-                "metric": "",
-                "refId": "A",
-                "step": 60
-                }
-            ],
-            "thresholds": "70,80",
-            "title": "CPU usage Avg.",
-            "transparent": false,
-            "type": "singlestat",
-            "valueFontSize": "80%",
-            "valueMaps": [
-                {
-                "op": "=",
-                "text": "N/A",
-                "value": "null"
-                }
-            ],
-            "valueName": "current"
-            },
-            {
-            "cacheTimeout": null,
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(245, 54, 54, 0.9)"
-            ],
-            "datasource": "prometheus-sc",
-            "editable": true,
-            "error": false,
-            "format": "percent",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "height": "50",
-            "id": 50,
-            "interval": null,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                "name": "value to text",
-                "value": 1
-                },
-                {
-                "name": "range to text",
-                "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                "from": "null",
-                "text": "N/A",
-                "to": "null"
-                }
-            ],
-            "span": 2,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "tableColumn": "",
-            "targets": [
-                {
-                "expr": "sum (elasticsearch_jvm_memory_used_bytes{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}) / sum (elasticsearch_jvm_memory_max_bytes{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}) * 100",
-                "format": "time_series",
-                "instant": true,
-                "interval": "",
-                "intervalFactor": 2,
-                "legendFormat": "",
-                "metric": "",
-                "refId": "A",
-                "step": 60
-                }
-            ],
-            "thresholds": "70,80",
-            "title": "JVM memory used Avg.",
-            "transparent": false,
-            "type": "singlestat",
-            "valueFontSize": "80%",
-            "valueMaps": [
-                {
-                "op": "=",
-                "text": "N/A",
-                "value": "null"
-                }
-            ],
-            "valueName": "current"
-            },
-            {
-            "cacheTimeout": null,
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus-sc",
-            "description": "Number of nodes in the cluster",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "height": "50",
-            "id": 10,
-            "interval": null,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                "name": "value to text",
-                "value": 1
-                },
-                {
-                "name": "range to text",
-                "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                "from": "null",
-                "text": "N/A",
-                "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "tableColumn": "",
-            "targets": [
-                {
-                "expr": "elasticsearch_cluster_health_number_of_nodes{instance=\"$instance\",cluster=\"$cluster\"}",
-                "format": "time_series",
-                "instant": true,
-                "interval": "",
-                "intervalFactor": 2,
-                "legendFormat": "",
-                "metric": "",
-                "refId": "A",
-                "step": 60
-                }
-            ],
-            "thresholds": "",
-            "title": "Nodes",
-            "transparent": false,
-            "type": "singlestat",
-            "valueFontSize": "80%",
-            "valueMaps": [
-                {
-                "op": "=",
-                "text": "N/A",
-                "value": "null"
-                }
-            ],
-            "valueName": "current"
-            },
-            {
-            "cacheTimeout": null,
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus-sc",
-            "description": "Number of data nodes in the cluster",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "height": "50",
-            "id": 9,
-            "interval": null,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                "name": "value to text",
-                "value": 1
-                },
-                {
-                "name": "range to text",
-                "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                "from": "null",
-                "text": "N/A",
-                "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "tableColumn": "",
-            "targets": [
-                {
-                "expr": "elasticsearch_cluster_health_number_of_data_nodes{instance=\"$instance\",cluster=\"$cluster\"}",
-                "format": "time_series",
-                "instant": true,
-                "interval": "",
-                "intervalFactor": 2,
-                "legendFormat": "",
-                "metric": "",
-                "refId": "A",
-                "step": 60
-                }
-            ],
-            "thresholds": "",
-            "title": "Data nodes",
-            "transparent": false,
-            "type": "singlestat",
-            "valueFontSize": "80%",
-            "valueMaps": [
-                {
-                "op": "=",
-                "text": "N/A",
-                "value": "null"
-                }
-            ],
-            "valueName": "current"
-            },
-            {
-            "cacheTimeout": null,
-            "colorBackground": false,
-            "colorValue": true,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(245, 54, 54, 0.9)"
-            ],
-            "datasource": "prometheus-sc",
-            "description": "Cluster level changes which have not yet been executed",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "height": "50",
-            "hideTimeOverride": true,
-            "id": 16,
-            "interval": null,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                "name": "value to text",
-                "value": 1
-                },
-                {
-                "name": "range to text",
-                "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                "from": "null",
-                "text": "N/A",
-                "to": "null"
-                }
-            ],
-            "span": 1,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": true
-            },
-            "tableColumn": "",
-            "targets": [
-                {
-                "expr": "elasticsearch_cluster_health_number_of_pending_tasks{instance=\"$instance\",cluster=\"$cluster\"}",
-                "format": "time_series",
-                "instant": true,
-                "interval": "",
-                "intervalFactor": 2,
-                "legendFormat": "",
-                "metric": "",
-                "refId": "A",
-                "step": 60
-                }
-            ],
-            "thresholds": "1,5",
-            "title": "Pending tasks",
-            "transparent": false,
-            "type": "singlestat",
-            "valueFontSize": "80%",
-            "valueMaps": [
-                {
-                "op": "=",
-                "text": "N/A",
-                "value": "null"
-                }
-            ],
-            "valueName": "current"
-            },
-            {
-            "cacheTimeout": null,
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(245, 54, 54, 0.9)"
-            ],
-            "datasource": "prometheus-sc",
-            "editable": true,
-            "error": false,
-            "format": "short",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "height": "50",
-            "id": 89,
-            "interval": null,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                "name": "value to text",
-                "value": 1
-                },
-                {
-                "name": "range to text",
-                "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                "from": "null",
-                "text": "N/A",
-                "to": "null"
-                }
-            ],
-            "span": 2,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": true,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-            },
-            "tableColumn": "",
-            "targets": [
-                {
-                "expr": "sum (elasticsearch_process_open_files_count{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"})",
-                "format": "time_series",
-                "instant": true,
-                "interval": "",
-                "intervalFactor": 2,
-                "legendFormat": "",
-                "metric": "",
-                "refId": "A",
-                "step": 60
-                }
-            ],
-            "thresholds": "",
-            "title": "Open file descriptors per cluster",
-            "transparent": false,
-            "type": "singlestat",
-            "valueFontSize": "80%",
-            "valueMaps": [],
-            "valueName": "current"
-            }
-        ],
+    "panels": [
+      {
+        "collapsed": false,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 90,
+        "panels": [],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "KPI",
-        "titleSize": "h6"
-        },
-        {
-        "collapse": false,
-        "height": null,
-        "panels": [
-            {
-            "cacheTimeout": null,
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus-sc",
-            "description": "The number of primary shards in your cluster. This is an aggregate total across all indices.",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "height": "50",
-            "id": 11,
-            "interval": null,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                "name": "value to text",
-                "value": 1
-                },
-                {
-                "name": "range to text",
-                "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "minSpan": 2,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                "from": "null",
-                "text": "N/A",
-                "to": "null"
-                }
-            ],
-            "repeat": "shard_type",
-            "span": 2,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": true,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": true
-            },
-            "tableColumn": "",
-            "targets": [
-                {
-                "expr": "elasticsearch_cluster_health_active_primary_shards{instance=\"$instance\",cluster=\"$cluster\"}",
-                "format": "time_series",
-                "instant": true,
-                "intervalFactor": 2,
-                "legendFormat": "",
-                "refId": "A",
-                "step": 60
-                }
-            ],
-            "thresholds": "",
-            "title": "Active primary shards",
-            "type": "singlestat",
-            "valueFontSize": "80%",
-            "valueMaps": [
-                {
-                "op": "=",
-                "text": "N/A",
-                "value": "null"
-                }
-            ],
-            "valueName": "current"
-            },
-            {
-            "cacheTimeout": null,
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus-sc",
-            "description": "Aggregate total of all shards across all indices, which includes replica shards",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "height": "50",
-            "id": 39,
-            "interval": null,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                "name": "value to text",
-                "value": 1
-                },
-                {
-                "name": "range to text",
-                "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "minSpan": 2,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                "from": "null",
-                "text": "N/A",
-                "to": "null"
-                }
-            ],
-            "span": 2,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": true,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": true
-            },
-            "tableColumn": "",
-            "targets": [
-                {
-                "expr": "elasticsearch_cluster_health_active_shards{instance=\"$instance\",cluster=\"$cluster\"}",
-                "format": "time_series",
-                "instant": true,
-                "intervalFactor": 2,
-                "legendFormat": "",
-                "refId": "A",
-                "step": 60
-                }
-            ],
-            "thresholds": "",
-            "title": "Active shards",
-            "type": "singlestat",
-            "valueFontSize": "80%",
-            "valueMaps": [
-                {
-                "op": "=",
-                "text": "N/A",
-                "value": "null"
-                }
-            ],
-            "valueName": "current"
-            },
-            {
-            "cacheTimeout": null,
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus-sc",
-            "description": "Count of shards that are being freshly created",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "height": "50",
-            "id": 40,
-            "interval": null,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                "name": "value to text",
-                "value": 1
-                },
-                {
-                "name": "range to text",
-                "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "minSpan": 2,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                "from": "null",
-                "text": "N/A",
-                "to": "null"
-                }
-            ],
-            "span": 2,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": true,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": true
-            },
-            "tableColumn": "",
-            "targets": [
-                {
-                "expr": "elasticsearch_cluster_health_initializing_shards{instance=\"$instance\",cluster=\"$cluster\"}",
-                "format": "time_series",
-                "instant": true,
-                "intervalFactor": 2,
-                "legendFormat": "",
-                "refId": "A",
-                "step": 60
-                }
-            ],
-            "thresholds": "",
-            "title": "Initializing shards",
-            "type": "singlestat",
-            "valueFontSize": "80%",
-            "valueMaps": [
-                {
-                "op": "=",
-                "text": "N/A",
-                "value": "null"
-                }
-            ],
-            "valueName": "current"
-            },
-            {
-            "cacheTimeout": null,
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus-sc",
-            "description": "The number of shards that are currently moving from one node to another node.",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "height": "50",
-            "id": 41,
-            "interval": null,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                "name": "value to text",
-                "value": 1
-                },
-                {
-                "name": "range to text",
-                "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "minSpan": 2,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                "from": "null",
-                "text": "N/A",
-                "to": "null"
-                }
-            ],
-            "span": 2,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": true,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": true
-            },
-            "tableColumn": "",
-            "targets": [
-                {
-                "expr": "elasticsearch_cluster_health_relocating_shards{instance=\"$instance\",cluster=\"$cluster\"}",
-                "format": "time_series",
-                "instant": true,
-                "intervalFactor": 2,
-                "legendFormat": "",
-                "refId": "A",
-                "step": 60
-                }
-            ],
-            "thresholds": "",
-            "title": "Relocating shards",
-            "type": "singlestat",
-            "valueFontSize": "80%",
-            "valueMaps": [
-                {
-                "op": "=",
-                "text": "N/A",
-                "value": "null"
-                }
-            ],
-            "valueName": "current"
-            },
-            {
-            "cacheTimeout": null,
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus-sc",
-            "description": "Shards delayed to reduce reallocation overhead",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "height": "50",
-            "id": 42,
-            "interval": null,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                "name": "value to text",
-                "value": 1
-                },
-                {
-                "name": "range to text",
-                "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "minSpan": 2,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                "from": "null",
-                "text": "N/A",
-                "to": "null"
-                }
-            ],
-            "span": 2,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": true,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": true
-            },
-            "tableColumn": "",
-            "targets": [
-                {
-                "expr": "elasticsearch_cluster_health_delayed_unassigned_shards{instance=\"$instance\",cluster=\"$cluster\"} ",
-                "format": "time_series",
-                "instant": true,
-                "intervalFactor": 2,
-                "legendFormat": "",
-                "refId": "A",
-                "step": 60
-                }
-            ],
-            "thresholds": "",
-            "title": "Delayed shards",
-            "type": "singlestat",
-            "valueFontSize": "80%",
-            "valueMaps": [
-                {
-                "op": "=",
-                "text": "N/A",
-                "value": "null"
-                }
-            ],
-            "valueName": "current"
-            },
-            {
-            "cacheTimeout": null,
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-            ],
-            "datasource": "prometheus-sc",
-            "description": "The number of shards that exist in the cluster state, but cannot be found in the cluster itself",
-            "editable": true,
-            "error": false,
-            "format": "none",
-            "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-            },
-            "height": "50",
-            "id": 82,
-            "interval": null,
-            "links": [],
-            "mappingType": 1,
-            "mappingTypes": [
-                {
-                "name": "value to text",
-                "value": 1
-                },
-                {
-                "name": "range to text",
-                "value": 2
-                }
-            ],
-            "maxDataPoints": 100,
-            "minSpan": 2,
-            "nullPointMode": "connected",
-            "nullText": null,
-            "postfix": "",
-            "postfixFontSize": "50%",
-            "prefix": "",
-            "prefixFontSize": "50%",
-            "rangeMaps": [
-                {
-                "from": "null",
-                "text": "N/A",
-                "to": "null"
-                }
-            ],
-            "span": 2,
-            "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": true,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": true
-            },
-            "tableColumn": "",
-            "targets": [
-                {
-                "expr": "elasticsearch_cluster_health_unassigned_shards{instance=\"$instance\",cluster=\"$cluster\"} ",
-                "format": "time_series",
-                "instant": true,
-                "intervalFactor": 2,
-                "legendFormat": "",
-                "refId": "A",
-                "step": 60
-                }
-            ],
-            "thresholds": "",
-            "title": "Unassigned shards",
-            "type": "singlestat",
-            "valueFontSize": "80%",
-            "valueMaps": [
-                {
-                "op": "=",
-                "text": "N/A",
-                "value": "null"
-                }
-            ],
-            "valueName": "current"
-            }
+        "type": "row"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": true,
+        "colors": [
+          "#d44a3a",
+          "rgba(237, 129, 40, 0.89)",
+          "#299c46"
         ],
+        "datasource": "$datasource",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 4,
+          "x": 0,
+          "y": 1
+        },
+        "height": "50",
+        "id": 53,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": true,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": true
+        },
+        "tableColumn": "{cluster=\"elasticsearch\", color=\"green\", endpoint=\"http\", instance=\"192.168.30.167:9108\", job=\"elasticsearch-exporter\", namespace=\"elastic-system\", pod=\"elasticsearch-exporter-7d8648b6-h8r4x\", service=\"elasticsearch-exporter\"}",
+        "targets": [
+          {
+            "expr": "elasticsearch_cluster_health_status{instance=\"$instance\",cluster=\"$cluster\",color=\"red\"}==1 or (elasticsearch_cluster_health_status{instance=\"$instance\",cluster=\"$cluster\",color=\"green\"}==1)+4 or (elasticsearch_cluster_health_status{instance=\"$instance\",cluster=\"$cluster\",color=\"yellow\"}==1)+22",
+            "format": "time_series",
+            "instant": true,
+            "intervalFactor": 2,
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "thresholds": "2,4",
+        "title": "Cluster health",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          },
+          {
+            "op": "=",
+            "text": "Green",
+            "value": "5"
+          },
+          {
+            "op": "=",
+            "text": "Yellow",
+            "value": "3"
+          },
+          {
+            "op": "=",
+            "text": "Red",
+            "value": "1"
+          }
+        ],
+        "valueName": "avg"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": true,
+        "colors": [
+          "#299c46",
+          "rgba(237, 129, 40, 0.89)",
+          "#d44a3a"
+        ],
+        "datasource": "$datasource",
+        "decimals": null,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 2,
+          "x": 4,
+          "y": 1
+        },
+        "height": "50",
+        "id": 81,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": true,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": true
+        },
+        "tableColumn": "__name__",
+        "targets": [
+          {
+            "expr": "count(elasticsearch_breakers_tripped{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}>0)",
+            "format": "time_series",
+            "instant": true,
+            "intervalFactor": 2,
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "thresholds": "1,2",
+        "title": "Tripped for breakers",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "0",
+            "value": "N/A"
+          },
+          {
+            "op": "=",
+            "text": "0",
+            "value": "no value"
+          },
+          {
+            "op": "=",
+            "text": "0",
+            "value": "null"
+          }
+        ],
+        "valueName": "avg"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": true,
+        "colors": [
+          "rgba(50, 172, 45, 0.97)",
+          "rgba(237, 129, 40, 0.89)",
+          "rgba(245, 54, 54, 0.9)"
+        ],
+        "datasource": "$datasource",
+        "editable": true,
+        "error": false,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "format": "percent",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 4,
+          "x": 6,
+          "y": 1
+        },
+        "height": "50",
+        "id": 51,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "",
+        "targets": [
+          {
+            "expr": "sum (elasticsearch_process_cpu_percent{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"} ) / count (elasticsearch_process_cpu_percent{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"} )",
+            "format": "time_series",
+            "instant": true,
+            "interval": "",
+            "intervalFactor": 2,
+            "legendFormat": "",
+            "metric": "",
+            "refId": "A",
+            "step": 60
+          }
+        ],
+        "thresholds": "70,80",
+        "title": "CPU usage Avg.",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": true,
+        "colors": [
+          "rgba(50, 172, 45, 0.97)",
+          "rgba(237, 129, 40, 0.89)",
+          "rgba(245, 54, 54, 0.9)"
+        ],
+        "datasource": "$datasource",
+        "editable": true,
+        "error": false,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "format": "percent",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 4,
+          "x": 10,
+          "y": 1
+        },
+        "height": "50",
+        "id": 50,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "",
+        "targets": [
+          {
+            "expr": "sum (elasticsearch_jvm_memory_used_bytes{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}) / sum (elasticsearch_jvm_memory_max_bytes{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}) * 100",
+            "format": "time_series",
+            "instant": true,
+            "interval": "",
+            "intervalFactor": 2,
+            "legendFormat": "",
+            "metric": "",
+            "refId": "A",
+            "step": 60
+          }
+        ],
+        "thresholds": "70,80",
+        "title": "JVM memory used Avg.",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "rgba(245, 54, 54, 0.9)",
+          "rgba(237, 129, 40, 0.89)",
+          "rgba(50, 172, 45, 0.97)"
+        ],
+        "datasource": "$datasource",
+        "description": "Number of nodes in the cluster",
+        "editable": true,
+        "error": false,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 2,
+          "x": 14,
+          "y": 1
+        },
+        "height": "50",
+        "id": 10,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "elasticsearch_cluster_health_number_of_nodes{cluster=\"elasticsearch\", endpoint=\"http\", instance=\"192.168.30.167:9108\", job=\"elasticsearch-exporter\", namespace=\"elastic-system\", pod=\"elasticsearch-exporter-7d8648b6-h8r4x\", service=\"elasticsearch-exporter\"}",
+        "targets": [
+          {
+            "expr": "elasticsearch_cluster_health_number_of_nodes{instance=\"$instance\",cluster=\"$cluster\"}",
+            "format": "time_series",
+            "instant": true,
+            "interval": "",
+            "intervalFactor": 2,
+            "legendFormat": "",
+            "metric": "",
+            "refId": "A",
+            "step": 60
+          }
+        ],
+        "thresholds": "",
+        "title": "Nodes",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "rgba(245, 54, 54, 0.9)",
+          "rgba(237, 129, 40, 0.89)",
+          "rgba(50, 172, 45, 0.97)"
+        ],
+        "datasource": "$datasource",
+        "description": "Number of data nodes in the cluster",
+        "editable": true,
+        "error": false,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 2,
+          "x": 16,
+          "y": 1
+        },
+        "height": "50",
+        "id": 9,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "elasticsearch_cluster_health_number_of_data_nodes{cluster=\"elasticsearch\", endpoint=\"http\", instance=\"192.168.30.167:9108\", job=\"elasticsearch-exporter\", namespace=\"elastic-system\", pod=\"elasticsearch-exporter-7d8648b6-h8r4x\", service=\"elasticsearch-exporter\"}",
+        "targets": [
+          {
+            "expr": "elasticsearch_cluster_health_number_of_data_nodes{instance=\"$instance\",cluster=\"$cluster\"}",
+            "format": "time_series",
+            "instant": true,
+            "interval": "",
+            "intervalFactor": 2,
+            "legendFormat": "",
+            "metric": "",
+            "refId": "A",
+            "step": 60
+          }
+        ],
+        "thresholds": "",
+        "title": "Data nodes",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": true,
+        "colors": [
+          "rgba(50, 172, 45, 0.97)",
+          "rgba(237, 129, 40, 0.89)",
+          "rgba(245, 54, 54, 0.9)"
+        ],
+        "datasource": "$datasource",
+        "description": "Cluster level changes which have not yet been executed",
+        "editable": true,
+        "error": false,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 2,
+          "x": 18,
+          "y": 1
+        },
+        "height": "50",
+        "hideTimeOverride": true,
+        "id": 16,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": true
+        },
+        "tableColumn": "elasticsearch_cluster_health_number_of_pending_tasks{cluster=\"elasticsearch\", endpoint=\"http\", instance=\"192.168.30.167:9108\", job=\"elasticsearch-exporter\", namespace=\"elastic-system\", pod=\"elasticsearch-exporter-7d8648b6-h8r4x\", service=\"elasticsearch-exporter\"}",
+        "targets": [
+          {
+            "expr": "elasticsearch_cluster_health_number_of_pending_tasks{instance=\"$instance\",cluster=\"$cluster\"}",
+            "format": "time_series",
+            "instant": true,
+            "interval": "",
+            "intervalFactor": 2,
+            "legendFormat": "",
+            "metric": "",
+            "refId": "A",
+            "step": 60
+          }
+        ],
+        "thresholds": "1,5",
+        "title": "Pending tasks",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "rgba(50, 172, 45, 0.97)",
+          "rgba(237, 129, 40, 0.89)",
+          "rgba(245, 54, 54, 0.9)"
+        ],
+        "datasource": "$datasource",
+        "editable": true,
+        "error": false,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "format": "short",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 4,
+          "x": 20,
+          "y": 1
+        },
+        "height": "50",
+        "id": 89,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": true,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "",
+        "targets": [
+          {
+            "expr": "sum (elasticsearch_process_open_files_count{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"})",
+            "format": "time_series",
+            "instant": true,
+            "interval": "",
+            "intervalFactor": 2,
+            "legendFormat": "",
+            "metric": "",
+            "refId": "A",
+            "step": 60
+          }
+        ],
+        "thresholds": "",
+        "title": "Open file descriptors per cluster",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [],
+        "valueName": "current"
+      },
+      {
+        "collapsed": false,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 4
+        },
+        "id": 91,
+        "panels": [],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Shards",
-        "titleSize": "h6"
-        },
-        {
-        "collapse": false,
-        "height": null,
-        "panels": [
-            {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus-sc",
-            "editable": true,
-            "error": false,
-            "fill": 1,
-            "grid": {},
-            "height": "400",
-            "id": 7,
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                "expr": "irate(elasticsearch_jvm_gc_collection_seconds_count{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 2,
-                "legendFormat": "{{name}} - {{gc}}",
-                "metric": "",
-                "refId": "A",
-                "step": 10
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "GC count",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                "format": "short",
-                "label": "GCs",
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-                },
-                {
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": false
-                }
-            ]
-            },
-            {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "prometheus-sc",
-            "editable": true,
-            "error": false,
-            "fill": 1,
-            "grid": {},
-            "height": "400",
-            "id": 27,
-            "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-                {
-                "expr": "irate(elasticsearch_jvm_gc_collection_seconds_sum{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
-                "format": "time_series",
-                "interval": "",
-                "intervalFactor": 2,
-                "legendFormat": "{{name}} - {{gc}}",
-                "metric": "",
-                "refId": "A",
-                "step": 10
-                }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "GC time",
-            "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
-            },
-            "transparent": false,
-            "type": "graph",
-            "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-            },
-            "yaxes": [
-                {
-                "format": "s",
-                "label": "Time",
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-                },
-                {
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": false
-                }
-            ]
-            }
+        "type": "row"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "rgba(245, 54, 54, 0.9)",
+          "rgba(237, 129, 40, 0.89)",
+          "rgba(50, 172, 45, 0.97)"
         ],
-        "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
-        "title": "JVM Garbage Collection",
-        "titleSize": "h6"
+        "datasource": "$datasource",
+        "description": "The number of primary shards in your cluster. This is an aggregate total across all indices.",
+        "editable": true,
+        "error": false,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
         },
-        {
-        "collapse": true,
-        "height": 250,
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 4,
+          "x": 0,
+          "y": 5
+        },
+        "height": "50",
+        "id": 11,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "maxPerRow": 6,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "repeat": "shard_type",
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": true,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": true
+        },
+        "tableColumn": "elasticsearch_cluster_health_active_primary_shards{cluster=\"elasticsearch\", endpoint=\"http\", instance=\"192.168.30.167:9108\", job=\"elasticsearch-exporter\", namespace=\"elastic-system\", pod=\"elasticsearch-exporter-7d8648b6-h8r4x\", service=\"elasticsearch-exporter\"}",
+        "targets": [
+          {
+            "expr": "elasticsearch_cluster_health_active_primary_shards{instance=\"$instance\",cluster=\"$cluster\"}",
+            "format": "time_series",
+            "instant": true,
+            "intervalFactor": 2,
+            "legendFormat": "",
+            "refId": "A",
+            "step": 60
+          }
+        ],
+        "thresholds": "",
+        "title": "Active primary shards",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "rgba(245, 54, 54, 0.9)",
+          "rgba(237, 129, 40, 0.89)",
+          "rgba(50, 172, 45, 0.97)"
+        ],
+        "datasource": "$datasource",
+        "description": "Aggregate total of all shards across all indices, which includes replica shards",
+        "editable": true,
+        "error": false,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 4,
+          "x": 4,
+          "y": 5
+        },
+        "height": "50",
+        "id": 39,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "maxPerRow": 6,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": true,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": true
+        },
+        "tableColumn": "elasticsearch_cluster_health_active_shards{cluster=\"elasticsearch\", endpoint=\"http\", instance=\"192.168.30.167:9108\", job=\"elasticsearch-exporter\", namespace=\"elastic-system\", pod=\"elasticsearch-exporter-7d8648b6-h8r4x\", service=\"elasticsearch-exporter\"}",
+        "targets": [
+          {
+            "expr": "elasticsearch_cluster_health_active_shards{instance=\"$instance\",cluster=\"$cluster\"}",
+            "format": "time_series",
+            "instant": true,
+            "intervalFactor": 2,
+            "legendFormat": "",
+            "refId": "A",
+            "step": 60
+          }
+        ],
+        "thresholds": "",
+        "title": "Active shards",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "rgba(245, 54, 54, 0.9)",
+          "rgba(237, 129, 40, 0.89)",
+          "rgba(50, 172, 45, 0.97)"
+        ],
+        "datasource": "$datasource",
+        "description": "Count of shards that are being freshly created",
+        "editable": true,
+        "error": false,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 4,
+          "x": 8,
+          "y": 5
+        },
+        "height": "50",
+        "id": 40,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "maxPerRow": 6,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": true,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": true
+        },
+        "tableColumn": "elasticsearch_cluster_health_initializing_shards{cluster=\"elasticsearch\", endpoint=\"http\", instance=\"192.168.30.167:9108\", job=\"elasticsearch-exporter\", namespace=\"elastic-system\", pod=\"elasticsearch-exporter-7d8648b6-h8r4x\", service=\"elasticsearch-exporter\"}",
+        "targets": [
+          {
+            "expr": "elasticsearch_cluster_health_initializing_shards{instance=\"$instance\",cluster=\"$cluster\"}",
+            "format": "time_series",
+            "instant": true,
+            "intervalFactor": 2,
+            "legendFormat": "",
+            "refId": "A",
+            "step": 60
+          }
+        ],
+        "thresholds": "",
+        "title": "Initializing shards",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "rgba(245, 54, 54, 0.9)",
+          "rgba(237, 129, 40, 0.89)",
+          "rgba(50, 172, 45, 0.97)"
+        ],
+        "datasource": "$datasource",
+        "description": "The number of shards that are currently moving from one node to another node.",
+        "editable": true,
+        "error": false,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 4,
+          "x": 12,
+          "y": 5
+        },
+        "height": "50",
+        "id": 41,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "maxPerRow": 6,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": true,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": true
+        },
+        "tableColumn": "elasticsearch_cluster_health_relocating_shards{cluster=\"elasticsearch\", endpoint=\"http\", instance=\"192.168.30.167:9108\", job=\"elasticsearch-exporter\", namespace=\"elastic-system\", pod=\"elasticsearch-exporter-7d8648b6-h8r4x\", service=\"elasticsearch-exporter\"}",
+        "targets": [
+          {
+            "expr": "elasticsearch_cluster_health_relocating_shards{instance=\"$instance\",cluster=\"$cluster\"}",
+            "format": "time_series",
+            "instant": true,
+            "intervalFactor": 2,
+            "legendFormat": "",
+            "refId": "A",
+            "step": 60
+          }
+        ],
+        "thresholds": "",
+        "title": "Relocating shards",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "rgba(245, 54, 54, 0.9)",
+          "rgba(237, 129, 40, 0.89)",
+          "rgba(50, 172, 45, 0.97)"
+        ],
+        "datasource": "$datasource",
+        "description": "Shards delayed to reduce reallocation overhead",
+        "editable": true,
+        "error": false,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 4,
+          "x": 16,
+          "y": 5
+        },
+        "height": "50",
+        "id": 42,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "maxPerRow": 6,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": true,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": true
+        },
+        "tableColumn": "elasticsearch_cluster_health_delayed_unassigned_shards{cluster=\"elasticsearch\", endpoint=\"http\", instance=\"192.168.30.167:9108\", job=\"elasticsearch-exporter\", namespace=\"elastic-system\", pod=\"elasticsearch-exporter-7d8648b6-h8r4x\", service=\"elasticsearch-exporter\"}",
+        "targets": [
+          {
+            "expr": "elasticsearch_cluster_health_delayed_unassigned_shards{instance=\"$instance\",cluster=\"$cluster\"} ",
+            "format": "time_series",
+            "instant": true,
+            "intervalFactor": 2,
+            "legendFormat": "",
+            "refId": "A",
+            "step": 60
+          }
+        ],
+        "thresholds": "",
+        "title": "Delayed shards",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "rgba(245, 54, 54, 0.9)",
+          "rgba(237, 129, 40, 0.89)",
+          "rgba(50, 172, 45, 0.97)"
+        ],
+        "datasource": "$datasource",
+        "description": "The number of shards that exist in the cluster state, but cannot be found in the cluster itself",
+        "editable": true,
+        "error": false,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 4,
+          "x": 20,
+          "y": 5
+        },
+        "height": "50",
+        "id": 82,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "maxPerRow": 6,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": true,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": true
+        },
+        "tableColumn": "elasticsearch_cluster_health_unassigned_shards{cluster=\"elasticsearch\", endpoint=\"http\", instance=\"192.168.30.167:9108\", job=\"elasticsearch-exporter\", namespace=\"elastic-system\", pod=\"elasticsearch-exporter-7d8648b6-h8r4x\", service=\"elasticsearch-exporter\"}",
+        "targets": [
+          {
+            "expr": "elasticsearch_cluster_health_unassigned_shards{instance=\"$instance\",cluster=\"$cluster\"} ",
+            "format": "time_series",
+            "instant": true,
+            "intervalFactor": 2,
+            "legendFormat": "",
+            "refId": "A",
+            "step": 60
+          }
+        ],
+        "thresholds": "",
+        "title": "Unassigned shards",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "collapsed": false,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 8
+        },
+        "id": 92,
+        "panels": [],
+        "repeat": null,
+        "title": "JVM Garbage Collection",
+        "type": "row"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "$datasource",
+        "editable": true,
+        "error": false,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 0,
+          "y": 9
+        },
+        "height": "400",
+        "hiddenSeries": false,
+        "id": 7,
+        "legend": {
+          "alignAsTable": true,
+          "avg": true,
+          "current": true,
+          "hideEmpty": false,
+          "hideZero": false,
+          "max": true,
+          "min": true,
+          "rightSide": false,
+          "show": true,
+          "sort": "avg",
+          "sortDesc": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "irate(elasticsearch_jvm_gc_collection_seconds_count{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
+            "format": "time_series",
+            "interval": "",
+            "intervalFactor": 2,
+            "legendFormat": "{{name}} - {{gc}}",
+            "metric": "",
+            "refId": "A",
+            "step": 10
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "GC count",
+        "tooltip": {
+          "msResolution": false,
+          "shared": true,
+          "sort": 2,
+          "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": "GCs",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "$datasource",
+        "editable": true,
+        "error": false,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 11,
+          "w": 12,
+          "x": 12,
+          "y": 9
+        },
+        "height": "400",
+        "hiddenSeries": false,
+        "id": 27,
+        "legend": {
+          "alignAsTable": true,
+          "avg": true,
+          "current": true,
+          "hideEmpty": false,
+          "hideZero": false,
+          "max": true,
+          "min": true,
+          "rightSide": false,
+          "show": true,
+          "sort": "avg",
+          "sortDesc": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "irate(elasticsearch_jvm_gc_collection_seconds_sum{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
+            "format": "time_series",
+            "interval": "",
+            "intervalFactor": 2,
+            "legendFormat": "{{name}} - {{gc}}",
+            "metric": "",
+            "refId": "A",
+            "step": 10
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "GC time",
+        "tooltip": {
+          "msResolution": false,
+          "shared": true,
+          "sort": 2,
+          "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "s",
+            "label": "Time",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 20
+        },
+        "id": 93,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 12,
+              "x": 0,
+              "y": 25
+            },
             "id": 77,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "total": true,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "total": true,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -1534,72 +1708,77 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 6,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "irate(elasticsearch_indices_translog_operations{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Total translog operations",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 12,
+              "x": 12,
+              "y": 25
+            },
             "id": 78,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -1611,86 +1790,95 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 6,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "irate(elasticsearch_indices_translog_size_in_bytes{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Total translog size in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Translog",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 21
         },
-        {
-        "collapse": true,
-        "height": 250,
+        "id": 94,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 26
+            },
             "id": 79,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": null,
-                "sortDesc": null,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": null,
+              "sortDesc": null,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -1702,74 +1890,79 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_breakers_tripped{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: {{breaker}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Tripped for breakers",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 33
+            },
             "id": 80,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": null,
-                "sortDesc": null,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": null,
+              "sortDesc": null,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -1781,99 +1974,108 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_breakers_estimated_size_bytes{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: {{breaker}}",
                 "refId": "A"
-                },
-                {
+              },
+              {
                 "expr": "elasticsearch_breakers_limit_size_bytes{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: limit for {{breaker}}",
                 "refId": "B"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Estimated size in bytes of breaker",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Breakers",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 22
         },
-        {
-        "collapse": true,
-        "height": 250,
+        "id": 95,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 12,
+              "x": 0,
+              "y": 34
+            },
             "height": "400",
             "id": 30,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -1885,11 +2087,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 6,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_os_load1{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "instant": false,
@@ -1899,8 +2100,8 @@
                 "metric": "",
                 "refId": "A",
                 "step": 20
-                },
-                {
+              },
+              {
                 "expr": "elasticsearch_os_load5{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "instant": false,
@@ -1910,8 +2111,8 @@
                 "metric": "",
                 "refId": "B",
                 "step": 20
-                },
-                {
+              },
+              {
                 "expr": "elasticsearch_os_load15{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "instant": false,
@@ -1921,72 +2122,78 @@
                 "metric": "",
                 "refId": "C",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Load average",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 2,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "short",
                 "label": "CPU usage",
                 "logBase": 1,
                 "max": 100,
                 "min": 0,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 12,
+              "x": 12,
+              "y": 34
+            },
             "height": "400",
             "id": 88,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -1998,11 +2205,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 6,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_process_cpu_percent{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "instant": false,
@@ -2012,72 +2218,78 @@
                 "metric": "",
                 "refId": "A",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "CPU usage",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 2,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "percent",
                 "label": "CPU usage",
                 "logBase": 1,
                 "max": 100,
                 "min": 0,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 0,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 12,
+              "x": 0,
+              "y": 41
+            },
             "height": "400",
             "id": 31,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -2089,11 +2301,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 6,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_jvm_memory_used_bytes{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "interval": "",
@@ -2102,88 +2313,94 @@
                 "metric": "",
                 "refId": "A",
                 "step": 20
-                },
-                {
+              },
+              {
                 "expr": "elasticsearch_jvm_memory_max_bytes{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}} max: {{area}}",
                 "refId": "C",
                 "step": 20
-                },
-                {
+              },
+              {
                 "expr": "elasticsearch_jvm_memory_pool_peak_used_bytes{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}} peak used pool: {{pool}}",
                 "refId": "D",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "JVM memory usage",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 2,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": "Memory",
                 "logBase": 1,
                 "max": null,
                 "min": 0,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 0,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 12,
+              "x": 12,
+              "y": 41
+            },
             "height": "400",
             "id": 54,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -2195,103 +2412,112 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 6,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_jvm_memory_committed_bytes{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}} committed: {{area}}",
                 "refId": "B",
                 "step": 20
-                },
-                {
+              },
+              {
                 "expr": "elasticsearch_jvm_memory_max_bytes{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}} max: {{area}}",
                 "refId": "C",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "JVM memory committed",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 2,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": "Memory",
                 "logBase": 1,
                 "max": null,
                 "min": 0,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "CPU and Memory",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 23
         },
-        {
-        "collapse": true,
-        "height": null,
+        "id": 96,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 12,
+              "x": 0,
+              "y": 42
+            },
             "height": "400",
             "id": 32,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -2303,11 +2529,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 6,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "1-(elasticsearch_filesystem_data_available_bytes{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}/elasticsearch_filesystem_data_size_bytes{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"})",
                 "format": "time_series",
                 "interval": "",
@@ -2316,87 +2541,93 @@
                 "metric": "",
                 "refId": "A",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [
-                {
+              {
                 "colorMode": "custom",
                 "fill": true,
                 "fillColor": "rgba(216, 200, 27, 0.27)",
                 "op": "gt",
                 "value": 0.8
-                },
-                {
+              },
+              {
                 "colorMode": "custom",
                 "fill": true,
                 "fillColor": "rgba(234, 112, 112, 0.22)",
                 "op": "gt",
                 "value": 0.9
-                }
+              }
             ],
             "timeFrom": null,
             "timeShift": null,
             "title": "Disk usage",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 2,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "percentunit",
                 "label": "Disk Usage %",
                 "logBase": 1,
                 "max": 1,
                 "min": 0,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 12,
+              "x": 12,
+              "y": 42
+            },
             "height": "400",
             "id": 47,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -2407,110 +2638,119 @@
             "points": false,
             "renderer": "flot",
             "seriesOverrides": [
-                {
+              {
                 "alias": "sent",
                 "transform": "negative-Y"
-                }
+              }
             ],
             "spaceLength": 10,
-            "span": 6,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "irate(elasticsearch_transport_tx_size_bytes_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: sent ",
                 "refId": "D",
                 "step": 20
-                },
-                {
+              },
+              {
                 "expr": "-irate(elasticsearch_transport_rx_size_bytes_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: received",
                 "refId": "C",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Network usage",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 2,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "Bps",
                 "label": "Bytes/sec",
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "pps",
                 "label": "",
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Disk and Network",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 24
         },
-        {
-        "collapse": true,
-        "height": "",
+        "id": 97,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "decimals": 2,
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 12,
+              "x": 0,
+              "y": 43
+            },
             "height": "400",
             "id": 1,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -2522,11 +2762,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 6,
             "stack": true,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_docs{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "interval": "",
@@ -2535,29 +2774,29 @@
                 "metric": "",
                 "refId": "A",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Documents count on node",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "decimals": 2,
                 "format": "short",
                 "label": "",
@@ -2565,41 +2804,47 @@
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 12,
+              "x": 12,
+              "y": 43
+            },
             "height": "400",
             "id": 24,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -2611,11 +2856,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 6,
             "stack": true,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "irate(elasticsearch_indices_indexing_index_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "interval": "",
@@ -2624,73 +2868,79 @@
                 "metric": "",
                 "refId": "A",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Documents indexed rate",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "short",
                 "label": "index calls/s",
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "description": "Count of deleted documents on this node",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 8,
+              "x": 0,
+              "y": 50
+            },
             "height": "400",
             "id": 25,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -2702,11 +2952,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 4,
             "stack": true,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "irate(elasticsearch_indices_docs_deleted{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "interval": "",
@@ -2715,71 +2964,77 @@
                 "metric": "",
                 "refId": "A",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Documents deleted rate",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "short",
                 "label": "Documents/s",
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "decimals": 2,
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 8,
+              "x": 8,
+              "y": 50
+            },
             "height": "400",
             "id": 26,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -2791,11 +3046,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 4,
             "stack": true,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "rate(elasticsearch_indices_merges_docs_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "interval": "",
@@ -2804,29 +3058,29 @@
                 "metric": "",
                 "refId": "A",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Documents merged rate",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "decimals": 2,
                 "format": "short",
                 "label": "Documents/s",
@@ -2834,41 +3088,47 @@
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 8,
+              "x": 16,
+              "y": 50
+            },
             "height": "400",
             "id": 52,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -2880,11 +3140,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 4,
             "stack": true,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "irate(elasticsearch_indices_merges_total_size_bytes_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "interval": "",
@@ -2893,29 +3152,29 @@
                 "metric": "",
                 "refId": "A",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Documents merged bytes",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "decimals": null,
                 "format": "decbytes",
                 "label": "Bytes/s",
@@ -2923,53 +3182,63 @@
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Documents",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 25
         },
-        {
-        "collapse": true,
-        "height": "",
+        "id": 98,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 12,
+              "x": 0,
+              "y": 51
+            },
             "height": "400",
             "id": 33,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -2981,11 +3250,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 6,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "irate(elasticsearch_indices_search_query_time_seconds{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval]) ",
                 "format": "time_series",
                 "interval": "",
@@ -2994,70 +3262,76 @@
                 "metric": "",
                 "refId": "A",
                 "step": 10
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Query time",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "s",
                 "label": "Time",
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 12,
+              "x": 12,
+              "y": 51
+            },
             "height": "400",
             "id": 5,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -3069,11 +3343,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 6,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "irate(elasticsearch_indices_indexing_index_time_seconds_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "interval": "",
@@ -3082,72 +3355,78 @@
                 "metric": "",
                 "refId": "A",
                 "step": 10
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Indexing time",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "s",
                 "label": "Time",
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 12,
+              "x": 0,
+              "y": 58
+            },
             "height": "400",
             "id": 3,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -3159,11 +3438,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 6,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "irate(elasticsearch_indices_merges_total_time_seconds_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "interval": "",
@@ -3172,72 +3450,78 @@
                 "metric": "",
                 "refId": "A",
                 "step": 10
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Merging time",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 2,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "s",
                 "label": "Time",
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 12,
+              "x": 12,
+              "y": 58
+            },
             "height": "400",
             "id": 87,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -3249,11 +3533,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 6,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "irate(elasticsearch_indices_store_throttle_time_seconds_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "interval": "",
@@ -3262,84 +3545,94 @@
                 "metric": "",
                 "refId": "A",
                 "step": 10
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Throttle time for index store",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 2,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "s",
                 "label": "Time",
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Times",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 26
         },
-        {
-        "collapse": true,
-        "height": 250,
+        "id": 99,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 24,
+              "x": 0,
+              "y": 59
+            },
             "height": "400",
             "id": 48,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": true,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": true,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -3351,11 +3644,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": true,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "rate(elasticsearch_indices_indexing_index_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "interval": "",
@@ -3364,144 +3656,150 @@
                 "metric": "",
                 "refId": "A",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "rate(elasticsearch_indices_search_query_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: query",
                 "refId": "B",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "rate(elasticsearch_indices_search_fetch_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: fetch",
                 "refId": "C",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "rate(elasticsearch_indices_merges_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: merges",
                 "refId": "D",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "rate(elasticsearch_indices_refresh_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: refresh",
                 "refId": "E",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "rate(elasticsearch_indices_flush_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: flush",
                 "refId": "F",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "rate(elasticsearch_indices_get_exists_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: get_exists",
                 "refId": "G",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "rate(elasticsearch_indices_get_missing_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: get_missing",
                 "refId": "H",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "rate(elasticsearch_indices_get_tota{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: get",
                 "refId": "I",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "rate(elasticsearch_indices_indexing_delete_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: indexing_delete",
                 "refId": "J",
                 "step": 10
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Total Operations  rate",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 2,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "short",
                 "label": "Operations/s",
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 24,
+              "x": 0,
+              "y": 66
+            },
             "height": "400",
             "id": 49,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": true,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": true,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -3513,11 +3811,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "irate(elasticsearch_indices_indexing_index_time_seconds_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "interval": "",
@@ -3526,160 +3823,170 @@
                 "metric": "",
                 "refId": "A",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "irate(elasticsearch_indices_search_query_time_seconds{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: query",
                 "refId": "B",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "irate(elasticsearch_indices_search_fetch_time_seconds{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: fetch",
                 "refId": "C",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "irate(elasticsearch_indices_merges_total_time_seconds_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: merges",
                 "refId": "D",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "irate(elasticsearch_indices_refresh_time_seconds_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: refresh",
                 "refId": "E",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "irate(elasticsearch_indices_flush_time_seconds{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: flush",
                 "refId": "F",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "irate(elasticsearch_indices_get_exists_time_seconds{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: get_exists",
                 "refId": "G",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "irate(elasticsearch_indices_get_time_seconds{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: get_time",
                 "refId": "H",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "irate(elasticsearch_indices_get_missing_time_seconds{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: get_missing",
                 "refId": "I",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "irate(elasticsearch_indices_indexing_delete_time_seconds_total{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: indexing_delete",
                 "refId": "J",
                 "step": 10
-                },
-                {
+              },
+              {
                 "expr": "irate(elasticsearch_indices_get_time_seconds{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: get",
                 "refId": "K",
                 "step": 10
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Total Operations time",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 2,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "s",
                 "label": "Time",
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Total Operations stats",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 27
         },
-        {
-        "collapse": true,
-        "height": 728,
+        "id": 100,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
+            "gridPos": {
+              "h": 20,
+              "w": 6,
+              "x": 0,
+              "y": 67
+            },
             "id": 45,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "hideZero": true,
-                "max": true,
-                "min": true,
-                "show": true,
-                "sort": null,
-                "sortDesc": null,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "hideZero": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sort": null,
+              "sortDesc": null,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -3691,78 +3998,83 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "irate(elasticsearch_thread_pool_rejected_count{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: {{ type }}",
                 "refId": "A",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Thread Pool operations rejected",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "msResolution": false,
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
+            "gridPos": {
+              "h": 20,
+              "w": 6,
+              "x": 6,
+              "y": 67
+            },
             "id": 46,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "hideZero": true,
-                "max": true,
-                "min": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "hideZero": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -3774,79 +4086,84 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_thread_pool_active_count{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: {{ type }}",
                 "refId": "A",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Thread Pool operations queued",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "msResolution": false,
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
+            "gridPos": {
+              "h": 20,
+              "w": 6,
+              "x": 12,
+              "y": 67
+            },
             "height": "",
             "id": 43,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "hideZero": true,
-                "max": true,
-                "min": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "hideZero": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -3858,78 +4175,83 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_thread_pool_active_count{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: {{ type }}",
                 "refId": "A",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Thread Pool threads active",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "msResolution": false,
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
+            "gridPos": {
+              "h": 20,
+              "w": 6,
+              "x": 18,
+              "y": 67
+            },
             "id": 44,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "hideZero": true,
-                "max": true,
-                "min": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "hideZero": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -3941,94 +4263,103 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 3,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "irate(elasticsearch_thread_pool_completed_count{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}: {{ type }}",
                 "refId": "A",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Thread Pool operations completed",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "msResolution": false,
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Thread Pool",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 28
         },
-        {
-        "collapse": true,
-        "height": null,
+        "id": 101,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 12,
+              "x": 0,
+              "y": 68
+            },
             "height": "400",
             "id": 4,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -4040,11 +4371,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 6,
             "stack": true,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_fielddata_memory_size_bytes{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "interval": "",
@@ -4053,72 +4383,78 @@
                 "metric": "",
                 "refId": "A",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Field data memory size",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": "Memory",
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 12,
+              "x": 12,
+              "y": 68
+            },
             "height": "400",
             "id": 34,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -4130,11 +4466,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 6,
             "stack": true,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "rate(elasticsearch_indices_fielddata_evictions{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "interval": "",
@@ -4143,72 +4478,78 @@
                 "metric": "",
                 "refId": "A",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Field data evictions",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "short",
                 "label": "Evictions/s",
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 8,
+              "x": 0,
+              "y": 75
+            },
             "height": "400",
             "id": 35,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -4220,11 +4561,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 4,
             "stack": true,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_query_cache_memory_size_bytes{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "interval": "",
@@ -4233,72 +4573,78 @@
                 "metric": "",
                 "refId": "A",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Query cache size",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": "Size",
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 8,
+              "x": 8,
+              "y": 75
+            },
             "height": "400",
             "id": 36,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -4310,11 +4656,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 4,
             "stack": true,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "rate(elasticsearch_indices_query_cache_evictions{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "interval": "",
@@ -4323,72 +4668,78 @@
                 "metric": "",
                 "refId": "A",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Query cache evictions",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "short",
                 "label": "Evictions/s",
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "editable": true,
             "error": false,
             "fill": 1,
             "grid": {},
+            "gridPos": {
+              "h": 11,
+              "w": 8,
+              "x": 16,
+              "y": 75
+            },
             "height": "400",
             "id": 84,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": false,
-                "hideZero": false,
-                "max": true,
-                "min": true,
-                "rightSide": false,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -4400,11 +4751,10 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 4,
             "stack": true,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "rate(elasticsearch_indices_filter_cache_evictions{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}[$interval])",
                 "format": "time_series",
                 "interval": "",
@@ -4413,78 +4763,88 @@
                 "metric": "",
                 "refId": "A",
                 "step": 20
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Evictions from filter cache",
             "tooltip": {
-                "msResolution": false,
-                "shared": true,
-                "sort": 0,
-                "value_type": "cumulative"
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
             },
             "transparent": false,
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "short",
                 "label": "Evictions/s",
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Caches",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 29
         },
-        {
-        "collapse": true,
-        "height": 250,
+        "id": 102,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 76
+            },
             "id": 85,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -4496,74 +4856,79 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": true,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segments_count{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Count of index segments",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 83
+            },
             "id": 86,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -4575,86 +4940,95 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": true,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segments_memory_bytes{instance=\"$instance\",cluster=\"$cluster\",name=~\"$name\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{name}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Current memory size of segments in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Segments",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 30
         },
-        {
-        "collapse": true,
-        "height": 250,
+        "id": 103,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 84
+            },
             "id": 75,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -4666,74 +5040,79 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_docs_primary{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Count of documents with only primary shards",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 91
+            },
             "id": 83,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -4745,74 +5124,79 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_store_size_bytes_primary{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Total size of stored index data in bytes with only primary shards on all nodes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 98
+            },
             "id": 76,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -4824,87 +5208,96 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_store_size_bytes_total{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Total size of stored index data in bytes with all shards on all nodes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Indices: Count of documents and Total size",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 31
         },
-        {
-        "collapse": true,
-        "height": 250,
+        "id": 104,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 99
+            },
             "id": 61,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "hideZero": true,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "hideZero": true,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -4916,75 +5309,80 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_index_writer_memory_bytes_primary{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Index writer with only primary shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 106
+            },
             "id": 62,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "hideZero": true,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "hideZero": true,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -4996,86 +5394,95 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_index_writer_memory_bytes_total{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Index writer with all shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Indices: Index writer",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 32
         },
-        {
-        "collapse": true,
-        "height": 250,
+        "id": 105,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 107
+            },
             "id": 55,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": null,
-                "sortDesc": null,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": null,
+              "sortDesc": null,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -5087,74 +5494,79 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_count_primary{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Segments with only primary shards on all nodes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 114
+            },
             "id": 56,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -5166,74 +5578,79 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_count_total{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Segments with all shards on all nodes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 121
+            },
             "id": 65,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -5245,74 +5662,79 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_memory_bytes_primary{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Size of segments with only primary shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 128
+            },
             "id": 66,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -5324,86 +5746,95 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_memory_bytes_total{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Size of segments with all shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Indices: Segments",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 33
         },
-        {
-        "collapse": true,
-        "height": 250,
+        "id": 106,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 129
+            },
             "id": 57,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -5415,74 +5846,79 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_doc_values_memory_bytes_primary{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Doc values with only primary shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 136
+            },
             "id": 58,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -5494,86 +5930,95 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_doc_values_memory_bytes_total{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Doc values with all shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Indices: Doc values",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 34
         },
-        {
-        "collapse": true,
-        "height": 250,
+        "id": 107,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 137
+            },
             "id": 59,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -5585,74 +6030,79 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_fields_memory_bytes_primary{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Size of fields with only primary shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 144
+            },
             "id": 60,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -5664,86 +6114,95 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_fields_memory_bytes_total{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Size of fields with all shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Indices: Fields",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 35
         },
-        {
-        "collapse": true,
-        "height": 250,
+        "id": 108,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 145
+            },
             "id": 63,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -5755,74 +6214,79 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_fixed_bit_set_memory_bytes_primary{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Size of fixed bit with only primary shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 152
+            },
             "id": 64,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -5834,86 +6298,95 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_fixed_bit_set_memory_bytes_total{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Size of fixed bit with all shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Indices: Fixed bit",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 36
         },
-        {
-        "collapse": true,
-        "height": 250,
+        "id": 109,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 153
+            },
             "id": 67,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -5925,74 +6398,79 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_norms_memory_bytes_primary{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Size of norms with only primary shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 160
+            },
             "id": 68,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -6004,86 +6482,95 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_norms_memory_bytes_total{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Size of norms with all shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Indices: Norms",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 37
         },
-        {
-        "collapse": true,
-        "height": 250,
+        "id": 110,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 161
+            },
             "id": 69,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -6095,74 +6582,79 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_points_memory_bytes_primary{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Size of points with only primary shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 168
+            },
             "id": 70,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -6174,86 +6666,95 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_points_memory_bytes_total{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Size of points with all shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Indices: Points",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 38
         },
-        {
-        "collapse": true,
-        "height": 250,
+        "id": 111,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 169
+            },
             "id": 71,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -6265,74 +6766,79 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_terms_memory_primary{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Size of terms with only primary shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 176
+            },
             "id": 72,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -6344,87 +6850,96 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_terms_memory_total{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Number of terms with all shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Indices: Terms",
-        "titleSize": "h6"
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 39
         },
-        {
-        "collapse": true,
-        "height": 250,
+        "id": 112,
         "panels": [
-            {
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 177
+            },
             "id": 73,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "hideZero": true,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "hideZero": true,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -6436,75 +6951,80 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_version_map_memory_bytes_primary{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Size of version map with only primary shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            },
-            {
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "prometheus-sc",
+            "datasource": "$datasource",
             "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 184
+            },
             "id": 74,
             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": false,
-                "hideZero": true,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sort": "avg",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+              "alignAsTable": true,
+              "avg": true,
+              "current": false,
+              "hideZero": true,
+              "max": true,
+              "min": true,
+              "rightSide": true,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
             },
             "lines": true,
             "linewidth": 1,
@@ -6516,212 +7036,242 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 12,
             "stack": false,
             "steppedLine": false,
             "targets": [
-                {
+              {
                 "expr": "elasticsearch_indices_segment_version_map_memory_bytes_total{instance=~\"$instance\"}",
                 "format": "time_series",
                 "intervalFactor": 2,
                 "legendFormat": "{{index}}",
                 "refId": "A"
-                }
+              }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
             "title": "Size of version map with all shards on all nodes in bytes",
             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
             },
             "type": "graph",
             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
             },
             "yaxes": [
-                {
+              {
                 "format": "bytes",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": true
-                },
-                {
+              },
+              {
                 "format": "short",
                 "label": null,
                 "logBase": 1,
                 "max": null,
                 "min": null,
                 "show": false
-                }
+              }
             ]
-            }
+          }
         ],
         "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
         "title": "Indices: Version map",
-        "titleSize": "h6"
-        }
+        "type": "row"
+      }
     ],
-    "schemaVersion": 14,
+    "refresh": false,
+    "schemaVersion": 25,
     "style": "dark",
     "tags": [
-        "elasticsearch",
-        "App"
+      "elasticsearch",
+      "App"
     ],
     "templating": {
-        "list": [
+      "list": [
         {
-            "auto": true,
-            "auto_count": 30,
-            "auto_min": "10s",
-            "current": {
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "datasource",
+          "options": [],
+          "query": "prometheus",
+          "queryValue": "",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        },
+        {
+          "auto": true,
+          "auto_count": 30,
+          "auto_min": "10s",
+          "current": {
+            "selected": false,
             "text": "auto",
-            "value": "$__auto_interval"
-            },
-            "hide": 0,
-            "label": "Interval",
-            "name": "interval",
-            "options": [
+            "value": "$__auto_interval_interval"
+          },
+          "hide": 0,
+          "label": "Interval",
+          "name": "interval",
+          "options": [
             {
-                "selected": true,
-                "text": "auto",
-                "value": "$__auto_interval"
-            },
-            {
-                "selected": false,
-                "text": "5m",
-                "value": "5m"
+              "selected": true,
+              "text": "auto",
+              "value": "$__auto_interval_interval"
             },
             {
-                "selected": false,
-                "text": "10m",
-                "value": "10m"
+              "selected": false,
+              "text": "5m",
+              "value": "5m"
             },
             {
-                "selected": false,
-                "text": "30m",
-                "value": "30m"
+              "selected": false,
+              "text": "10m",
+              "value": "10m"
             },
             {
-                "selected": false,
-                "text": "1h",
-                "value": "1h"
+              "selected": false,
+              "text": "30m",
+              "value": "30m"
             },
             {
-                "selected": false,
-                "text": "6h",
-                "value": "6h"
+              "selected": false,
+              "text": "1h",
+              "value": "1h"
             },
             {
-                "selected": false,
-                "text": "12h",
-                "value": "12h"
+              "selected": false,
+              "text": "6h",
+              "value": "6h"
             },
             {
-                "selected": false,
-                "text": "1d",
-                "value": "1d"
+              "selected": false,
+              "text": "12h",
+              "value": "12h"
             },
             {
-                "selected": false,
-                "text": "7d",
-                "value": "7d"
+              "selected": false,
+              "text": "1d",
+              "value": "1d"
             },
             {
-                "selected": false,
-                "text": "14d",
-                "value": "14d"
+              "selected": false,
+              "text": "7d",
+              "value": "7d"
             },
             {
-                "selected": false,
-                "text": "30d",
-                "value": "30d"
+              "selected": false,
+              "text": "14d",
+              "value": "14d"
+            },
+            {
+              "selected": false,
+              "text": "30d",
+              "value": "30d"
             }
-            ],
-            "query": "5m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
-            "refresh": 2,
-            "type": "interval"
+          ],
+          "query": "5m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+          "refresh": 2,
+          "skipUrlSync": false,
+          "type": "interval"
         },
         {
-            "allValue": null,
-            "current": {},
-            "datasource": "prometheus-sc",
-            "hide": 0,
-            "includeAll": false,
-            "label": "Cluster",
-            "multi": false,
-            "name": "cluster",
-            "options": [],
-            "query": "label_values(elasticsearch_indices_docs,cluster)",
-            "refresh": 1,
-            "regex": "",
-            "sort": 1,
-            "tagValuesQuery": null,
-            "tags": [],
-            "tagsQuery": null,
-            "type": "query",
-            "useTags": false
+          "allValue": null,
+          "current": {
+            "selected": false,
+            "text": "elasticsearch",
+            "value": "elasticsearch"
+          },
+          "datasource": "$datasource",
+          "definition": "",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Cluster",
+          "multi": false,
+          "name": "cluster",
+          "options": [],
+          "query": "label_values(elasticsearch_indices_docs,cluster)",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": null,
+          "tags": [],
+          "tagsQuery": null,
+          "type": "query",
+          "useTags": false
         },
         {
-            "allValue": null,
-            "current": {},
-            "datasource": "prometheus-sc",
-            "hide": 0,
-            "includeAll": true,
-            "label": "Node name",
-            "multi": true,
-            "name": "name",
-            "options": [],
-            "query": "label_values(elasticsearch_indices_docs{instance=\"$instance\",cluster=\"$cluster\", name!=\"\"},name)",
-            "refresh": 1,
-            "regex": "",
-            "sort": 1,
-            "tagValuesQuery": null,
-            "tags": [],
-            "tagsQuery": null,
-            "type": "query",
-            "useTags": false
+          "allValue": null,
+          "current": {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "$datasource",
+          "definition": "",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Node name",
+          "multi": true,
+          "name": "name",
+          "options": [],
+          "query": "label_values(elasticsearch_indices_docs{instance=\"$instance\",cluster=\"$cluster\", name!=\"\"},name)",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": null,
+          "tags": [],
+          "tagsQuery": null,
+          "type": "query",
+          "useTags": false
         },
         {
-            "allValue": null,
-            "current": {},
-            "datasource": "prometheus-sc",
-            "hide": 0,
-            "includeAll": false,
-            "label": "Source of metrics",
-            "multi": false,
-            "name": "instance",
-            "options": [],
-            "query": "label_values(elasticsearch_indices_docs{cluster=\"$cluster\", name!=\"\"},instance)",
-            "refresh": 1,
-            "regex": "",
-            "sort": 1,
-            "tagValuesQuery": null,
-            "tags": [],
-            "tagsQuery": null,
-            "type": "query",
-            "useTags": false
+          "allValue": null,
+          "current": {
+            "selected": false,
+            "text": "192.168.30.167:9108",
+            "value": "192.168.30.167:9108"
+          },
+          "datasource": "$datasource",
+          "definition": "",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Source of metrics",
+          "multi": false,
+          "name": "instance",
+          "options": [],
+          "query": "label_values(elasticsearch_indices_docs{cluster=\"$cluster\", name!=\"\"},instance)",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": null,
+          "tags": [],
+          "tagsQuery": null,
+          "type": "query",
+          "useTags": false
         }
-        ]
+      ]
     },
     "time": {
-        "from": "now-1h",
-        "to": "now"
+      "from": "now-1h",
+      "to": "now"
     },
     "timepicker": {
-        "refresh_intervals": [
-        "5s",
+      "refresh_intervals": [
         "10s",
         "30s",
         "1m",
@@ -6731,8 +7281,8 @@
         "1h",
         "2h",
         "1d"
-        ],
-        "time_options": [
+      ],
+      "time_options": [
         "5m",
         "15m",
         "1h",
@@ -6742,10 +7292,10 @@
         "2d",
         "7d",
         "30d"
-        ]
+      ]
     },
     "timezone": "browser",
     "title": "ElasticSearch",
-    "version": 106,
-    "description": "ElasticSearch cluster stats.\r\n\r\nRevision 1 of this dashboard is the same as the Infinity Dashboard Revision 4 (https://grafana.com/dashboards/2322)\r\n\r\nThis is a cleaned up copy with all control characters removed from the dashboard file.  When downloading version 4 of the original Infinity elasticsearch dashboard via curl, the resulting file is corrupted with a missing final curly brace.\r\n"
-    }
+    "uid": "3qVYBDhMz",
+    "version": 1
+  }

--- a/helmfile/charts/grafana-ops/dashboards/falco-dashboard.json
+++ b/helmfile/charts/grafana-ops/dashboards/falco-dashboard.json
@@ -1,283 +1,285 @@
 {
-    "__inputs": [
+  "annotations": {
+    "list": [
       {
-        "name": "ck8s-metrics",
-        "label": "Prometheus",
-        "description": "",
-        "type": "datasource",
-        "pluginId": "prometheus",
-        "pluginName": "Prometheus"
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
       }
-    ],
-    "__requires": [
-      {
-        "type": "grafana",
-        "id": "grafana",
-        "name": "Grafana",
-        "version": "6.6.2"
+    ]
+  },
+  "description": "Grafana dashboard for Falco output events",
+  "editable": true,
+  "gnetId": 11914,
+  "graphTooltip": 0,
+  "iteration": 1604504705316,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
       },
-      {
-        "type": "panel",
-        "id": "graph",
-        "name": "Graph",
-        "version": ""
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 0
       },
-      {
-        "type": "datasource",
-        "id": "prometheus",
-        "name": "Prometheus",
-        "version": "1.0.0"
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
       },
-      {
-        "type": "panel",
-        "id": "table",
-        "name": "Table",
-        "version": ""
-      }
-    ],
-    "annotations": {
-      "list": [
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
         {
-          "builtIn": 1,
-          "datasource": "-- Grafana --",
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "type": "dashboard"
+          "expr": "rate(falco_events[5m])",
+          "intervalFactor": 1,
+          "legendFormat": "{{rule}} ({{hostname}})",
+          "refId": "A"
         }
-      ]
-    },
-    "editable": true,
-    "gnetId": 11914,
-    "graphTooltip": 0,
-    "id": null,
-    "links": [],
-    "panels": [
-      {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "ck8s-metrics",
-        "description": "",
-        "fill": 1,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 11,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        },
-        "hiddenSeries": false,
-        "id": 2,
-        "legend": {
-          "alignAsTable": true,
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "rightSide": true,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 1,
-        "nullPointMode": "null",
-        "options": {
-          "dataLinks": []
-        },
-        "percentage": false,
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": true,
-        "steppedLine": false,
-        "targets": [
-          {
-            "expr": "rate(falco_events[5m])",
-            "intervalFactor": 1,
-            "legendFormat": "{{rule}} ({{hostname}})",
-            "refId": "A"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Events rate",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          },
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Events rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
       },
-      {
-        "columns": [],
-        "datasource": "ck8s-metrics",
-        "fontSize": "100%",
-        "gridPos": {
-          "h": 10,
-          "w": 24,
-          "x": 0,
-          "y": 11
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
         },
-        "id": 4,
-        "links": [],
-        "options": {},
-        "pageSize": null,
-        "showHeader": true,
-        "sort": {
-          "col": null,
-          "desc": false
-        },
-        "styles": [
-          {
-            "alias": "Time",
-            "align": "auto",
-            "dateFormat": "YYYY-MM-DD HH:mm:ss",
-            "pattern": "Time",
-            "type": "date"
-          },
-          {
-            "alias": "",
-            "align": "auto",
-            "colorMode": null,
-            "colors": [
-              "rgba(245, 54, 54, 0.9)",
-              "rgba(237, 129, 40, 0.89)",
-              "rgba(50, 172, 45, 0.97)"
-            ],
-            "dateFormat": "YYYY-MM-DD HH:mm:ss",
-            "decimals": 2,
-            "link": false,
-            "mappingType": 1,
-            "pattern": "/__name__|job|kubernetes_name|(__name|helm_|app_|pod_).*/",
-            "thresholds": [],
-            "type": "hidden",
-            "unit": "short"
-          },
-          {
-            "alias": "Count",
-            "align": "auto",
-            "colorMode": null,
-            "colors": [
-              "rgba(245, 54, 54, 0.9)",
-              "rgba(237, 129, 40, 0.89)",
-              "rgba(50, 172, 45, 0.97)"
-            ],
-            "dateFormat": "YYYY-MM-DD HH:mm:ss",
-            "decimals": 0,
-            "mappingType": 1,
-            "pattern": "Value",
-            "thresholds": [],
-            "type": "number",
-            "unit": "short"
-          },
-          {
-            "alias": "",
-            "align": "left",
-            "colorMode": null,
-            "colors": [
-              "rgba(245, 54, 54, 0.9)",
-              "rgba(237, 129, 40, 0.89)",
-              "rgba(50, 172, 45, 0.97)"
-            ],
-            "dateFormat": "YYYY-MM-DD HH:mm:ss",
-            "decimals": 0,
-            "mappingType": 1,
-            "pattern": "priority",
-            "thresholds": [
-              ""
-            ],
-            "type": "number",
-            "unit": "none",
-            "valueMaps": [
-              {
-                "text": "5",
-                "value": "5"
-              }
-            ]
-          },
-          {
-            "alias": "",
-            "align": "left",
-            "colorMode": null,
-            "colors": [
-              "rgba(245, 54, 54, 0.9)",
-              "rgba(237, 129, 40, 0.89)",
-              "rgba(50, 172, 45, 0.97)"
-            ],
-            "decimals": 2,
-            "pattern": "/.*/",
-            "thresholds": [],
-            "type": "string",
-            "unit": "short"
-          }
-        ],
-        "targets": [
-          {
-            "expr": "falco_events",
-            "format": "table",
-            "instant": true,
-            "refId": "A"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Totals",
-        "transform": "table",
-        "transparent": true,
-        "type": "table"
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
       }
-    ],
-    "schemaVersion": 22,
-    "style": "dark",
-    "tags": [],
-    "templating": {
-      "list": []
     },
-    "time": {
-      "from": "now-6h",
-      "to": "now"
-    },
-    "timepicker": {},
-    "timezone": "",
-    "title": "Falco Dashboard",
-    "uid": "FvUFlfuZz",
-    "version": 4,
-    "description": "Grafana dashboard for Falco output events"
-  }
+    {
+      "columns": [],
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 4,
+      "links": [],
+      "pageSize": null,
+      "showHeader": true,
+      "sort": {
+        "col": null,
+        "desc": false
+      },
+      "styles": [
+        {
+          "alias": "Time",
+          "align": "auto",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "date"
+        },
+        {
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": false,
+          "mappingType": 1,
+          "pattern": "/__name__|job|kubernetes_name|(__name|helm_|app_|pod_).*/",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "alias": "Count",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "Value",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "align": "left",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "mappingType": 1,
+          "pattern": "priority",
+          "thresholds": [
+            ""
+          ],
+          "type": "number",
+          "unit": "none",
+          "valueMaps": [
+            {
+              "text": "5",
+              "value": "5"
+            }
+          ]
+        },
+        {
+          "alias": "",
+          "align": "left",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "pattern": "/.*/",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "falco_events",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Totals",
+      "transform": "table",
+      "transparent": true,
+      "type": "table-old"
+    }
+  ],
+  "schemaVersion": 25,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Falco Dashboard",
+  "uid": "FvUFlfuZz",
+  "version": 1
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Part of qa testing for v0.7.0. Adds datasources as an option in the elasticsearch and falco dashboards instead of having them hard-coded.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
