### PR TITLE
apps sc: fixes mismatched s3 config in elastic backup

### DIFF
--- a/bin/init.bash
+++ b/bin/init.bash
@@ -196,6 +196,7 @@ set_elasticsearch_config() {
     esac
 
     replace_set_me "$1" 'elasticsearch.useRegionEndpoint' "$use_regionendpoint"
+    replace_set_me "$1" 'elasticsearch.snapshotRepository' "s3_${CK8S_CLOUD_PROVIDER}_7.x"
 }
 
 # Usage: set_harbor_config <config-file>

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -186,7 +186,7 @@ elasticsearch:
   tolerations: []
   affinity: {}
   nodeSelector: {}
-  snapshotRepository: elastic-snapshots
+  snapshotRepository: "set-me"
   useRegionEndpoint: "set-me"
 
 fluentd:

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -382,7 +382,7 @@ releases:
   labels:
     app: opendistro
   chart: elastisys/opendistro-es
-  version: 1.10.1
+  version: 1.10.2
   missingFileHandler: Error
   needs:
   - cert-manager/cert-manager

--- a/helmfile/values/opendistro-es.yaml.gotmpl
+++ b/helmfile/values/opendistro-es.yaml.gotmpl
@@ -462,6 +462,8 @@ curator:
 configurer:
   enabled: true
 
+  snapshotRepository: {{ .Values.elasticsearch.snapshotRepository }}
+
   helm:
     deletePolicy: before-hook-creation
 


### PR DESCRIPTION
**What this PR does / why we need it**: Part of qa testing for v0.7.0. Fixes elasticsearch backups failing due to mismatching config in backup job and elasticsearch

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: #15 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
