### PR TITLE
Relax s3cmd requirement

### DIFF
--- a/get-requirements.yaml
+++ b/get-requirements.yaml
@@ -9,7 +9,7 @@
       helmdiff_version: 3.1.1
       helmsecrets_version: 2.0.2
       jq_version: 1.6
-      s3cmd_version: 2.0.1-2
+      s3cmd_version: 2.0.*
       sops_version: 3.6.1
       yq_version: 3.3.2
     connection: local


### PR DESCRIPTION
Ubuntu 20.04.1 LTS comes with s3cmd 2.0.2-1. Relax the requirement in
`get-requirements.yaml`.

**What this PR does / why we need it**:

This PR update `get-requirements.yaml` so it can be used on Ubuntu 20.04.1 LTS. In particular, it relaxes `s3cmd`s version.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

Documentation on how to setup a Compliant Kubernetes cluster is missing (would be cool to add it, but this is a different issue).

**Special notes for reviewer**:

**Checklist:**

- [NA] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [NA] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
