### PR TITLE
bin: Assume 'latest' if version is unavailable

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -10,6 +10,7 @@
 - Configurable extra role mappings in Elasticsearch
 - Added falco exporter to workload cluster
 - Falco dashboard added to Grafana
+- `any` can be used as configuration version to disabled version check
 
 ### Changed
 

--- a/bin/common.bash
+++ b/bin/common.bash
@@ -90,7 +90,8 @@ validate_version() {
         log_error "ERROR: global.ck8sVersion is not set in ${file}"
         will_exit="true"
     fi
-    if [ "${version}" != "${ck8s_version}" ]; then
+    if [ "${ck8s_version}" != "any" ] \
+        && [ "${version}" != "${ck8s_version}" ]; then
         log_error "ERROR: Version mismatch!"
         log_error "Config version: ${ck8s_version}"
         log_error "CK8S version: ${version}"


### PR DESCRIPTION
**What this PR does / why we need it**:

To deploy Compliant Kubernetes, one would generally include this repo as
a submodule, in which case tags might be unavailable. This commit allows
for the config to have the version 'latest', essentially meaning "I, the
operator, take responsibility to ensure the version of the config and
the version of ck8s match".

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

Does not really fix, but is related to #32 and #10.

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [NA] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
