### PR TITLE
Upgrade Harbor chart to version 1.5.1

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -19,6 +19,7 @@
 - Explicitly disabled multitenancy in Kibana.
 - Cloud provider dependencies are removed from the templates, instead, keys are added to the sc|wc-config.yaml by the init script so no more "hidden" config. This requires a re-run of ck8s init or manully adding the missing keys.
 - Ingress nginx has been updated to a new chart repo and bumped to version 2.10
+- Harbor chart has been upgraded to version 1.5.1
 
 ### Fixed
 

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -287,7 +287,7 @@ releases:
   labels:
     app: harbor
   chart: harbor/harbor
-  version: 1.4.0
+  version: 1.5.1
   missingFileHandler: Error
   wait: true
   timeout: 600

--- a/helmfile/values/harbor.yaml.gotmpl
+++ b/helmfile/values/harbor.yaml.gotmpl
@@ -2,8 +2,10 @@ expose:
   type: ingress
   tls:
     enabled: true
-    secretName: harbor-core-ingress-cert
-    notarySecretName: harbor-notary-ingress-cert
+    certSource: secret
+    secret:
+      secretName: harbor-core-ingress-cert
+      notarySecretName: harbor-notary-ingress-cert
   ingress:
     annotations:
       cert-manager.io/issuer: {{ .Values.global.issuer }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrades Harbor to version 1.5.1.
This is required to access the `caBundleSecretName` Helm value, which is required to configure trust for a private CA.

**Which issue this PR fixes**:
Fixes #36 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
Tested an upgrade which succeeded. `ck8s test sc` passes as well.
Have not done any more extensive validation of Harbor functionality.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
