### PR TITLE
Vf/init overwrite fix2

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The apps are installed using a combination of helm charts and manifests with the
 * [jq](https://github.com/stedolan/jq) (tested with jq-1.6)
 * [sops](https://github.com/mozilla/sops) (tested with 3.6.1)
 * [s3cmd](https://s3tools.org/s3cmd) available directly in ubuntus repositories (tested with 2.0.1)
-* [yq](https://github.com/mikefarah/yq) (tested with 3.3.2)
+* [yq](https://github.com/mikefarah/yq) (tested with 3.4.1)
 
 Installs requirements using the ansible playbook get-requirements.yaml
 

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -72,6 +72,7 @@ generate_base_sc_config() {
     fi
     file=$1
     tmpfile=$(mktemp)
+    append_trap "rm $tmpfile" EXIT
 
     envsubst > "$tmpfile" < "${config_defaults_path}/config/sc-config.yaml"
     if [[ ${CK8S_CLOUD_PROVIDER} == "citycloud" ]]; then
@@ -91,6 +92,7 @@ generate_base_wc_config() {
     fi
     file=$1
     tmpfile=$(mktemp)
+    append_trap "rm $tmpfile" EXIT
 
     envsubst > "$tmpfile" < "${config_defaults_path}/config/wc-config.yaml"
     yq merge --inplace --overwrite "$tmpfile" "${config_defaults_path}/config/flavors/${CK8S_FLAVOR}-wc.yaml"

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -236,7 +236,7 @@ generate_secrets() {
     yq merge --inplace "$file" "${config_defaults_path}/secrets/wc-secrets.yaml"
     case ${CK8S_CLOUD_PROVIDER} in
 
-        safespring | citycloud)
+        citycloud)
           cloud_file="${config_defaults_path}/secrets/citycloud.yaml"
           yq merge --inplace "$file" "$cloud_file"
           ;;

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -75,14 +75,13 @@ generate_base_sc_config() {
 
     envsubst > "$tmpfile" < "${config_defaults_path}/config/sc-config.yaml"
     if [[ ${CK8S_CLOUD_PROVIDER} == "citycloud" ]]; then
-        yq merge -i "$tmpfile" "${config_defaults_path}/config/citycloud.yaml"
+        yq merge --inplace "$tmpfile" "${config_defaults_path}/config/citycloud.yaml"
     fi
-    yq merge -i --overwrite "$tmpfile" "${config_defaults_path}/config/flavors/${CK8S_FLAVOR}-sc.yaml"
+    yq merge --inplace --overwrite "$tmpfile" "${config_defaults_path}/config/flavors/${CK8S_FLAVOR}-sc.yaml"
     if [[ -f $file ]]; then
-        yq merge -i "$file" "$tmpfile"
-    else
-        cat "$tmpfile" > "$file"
+        yq merge "$tmpfile" "$file" --inplace -a=overwrite --overwrite --prettyPrint
     fi
+    cat "$tmpfile" > "$file"
 }
 
 generate_base_wc_config() {
@@ -94,12 +93,11 @@ generate_base_wc_config() {
     tmpfile=$(mktemp)
 
     envsubst > "$tmpfile" < "${config_defaults_path}/config/wc-config.yaml"
-    yq merge -i --overwrite "$tmpfile" "${config_defaults_path}/config/flavors/${CK8S_FLAVOR}-wc.yaml"
+    yq merge --inplace --overwrite "$tmpfile" "${config_defaults_path}/config/flavors/${CK8S_FLAVOR}-wc.yaml"
     if [[ -f $file ]]; then
-        yq merge -i "$file" "$tmpfile"
-    else
-        cat "$tmpfile" > "$file"
+        yq merge "$tmpfile" "$file" --inplace -a=overwrite --overwrite --prettyPrint
     fi
+    cat "$tmpfile" > "$file"
 }
 
 # Usage: set_storage_class <config-file>

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -59,8 +59,8 @@ replace_set_me(){
         log_error "ERROR: number of args in replace_set_me must be 3. #=[$#]"
         exit 1
     fi
-    if [[ $(yq r "$1" "$2") == "set-me" ]]; then
-       yq w -i "$1" "$2" "$3"
+    if [[ $(yq read "$1" "$2") == "set-me" ]]; then
+       yq write --inplace "$1" "$2" "$3"
     fi
 
 }
@@ -126,8 +126,8 @@ set_storage_class() {
     esac
     replace_set_me "$1" 'global.storageClass' "$storage_class"
     # Only write if field exists already
-    if yq r -e "$file" 'elasticsearch.storageClass' > /dev/null 2> /dev/null; then
-       yq w -i "$file" 'elasticsearch.storageClass' "$es_storage_class"
+    if yq read --exitStatus "$file" 'elasticsearch.storageClass' > /dev/null 2> /dev/null; then
+       yq write --inplace "$file" 'elasticsearch.storageClass' "$es_storage_class"
     fi
 }
 
@@ -227,16 +227,16 @@ generate_secrets() {
     file=$1
     if [[ -f $file ]]; then
         sops_decrypt "$file"
-        yq m -i "$file" "${config_defaults_path}/secrets/sc-secrets.yaml"
+        yq merge --inplace "$file" "${config_defaults_path}/secrets/sc-secrets.yaml"
     else
         cat "${config_defaults_path}/secrets/sc-secrets.yaml" > "$file"
     fi
-    yq m -i "$file" "${config_defaults_path}/secrets/wc-secrets.yaml"
+    yq merge --inplace "$file" "${config_defaults_path}/secrets/wc-secrets.yaml"
     case ${CK8S_CLOUD_PROVIDER} in
 
         safespring | citycloud)
           cloud_file="${config_defaults_path}/secrets/citycloud.yaml"
-          yq m -i "$file" "$cloud_file"
+          yq merge --inplace "$file" "$cloud_file"
           ;;
 
     esac

--- a/get-requirements.yaml
+++ b/get-requirements.yaml
@@ -11,7 +11,7 @@
       jq_version: 1.6
       s3cmd_version: 2.0.1-2
       sops_version: 3.6.1
-      yq_version: 3.3.2
+      yq_version: 3.4.1
     connection: local
     become: yes
     become_user: root

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -54,7 +54,7 @@ RUN wget "https://github.com/s3tools/s3cmd/releases/download/v${S3CMD_VERSION}/s
     rm "s3cmd-${S3CMD_VERSION}.tar.gz"
 
 # yq
-ENV YQ_VERSION "3.3.2"
+ENV YQ_VERSION "3.4.1"
 RUN wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" && \
     chmod +x yq_linux_amd64 && \
     mv yq_linux_amd64 /usr/local/bin/yq


### PR DESCRIPTION
**What this PR does / why we need it**: Part of qa testing for v0.7.0. Yq merges lists in a wierd way, so this was needed to not overwrite things. `--prettyPrint` might not be necessary, but otherwise some lists will be very compact and not so easy to read.
Also made some yq commands easier to read.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: Second fix for #16 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
