### PR TITLE
Added support for GCS

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -16,6 +16,7 @@ Make sure to remove the old option from your config when upgrading.
 Make sure to remove the option from your config when upgrading.
 - With the replacement of the helm chart `stable/prometheus-operator` to `prometheus-community/kube-prometheus-stack`, it is required to manually execute some steps to upgrade.
 See [migrations docs for prometheus-operator](migration/v0.7.x-v0.8.x/migrate-prometheus-operator.md) for instructions on how to perform the upgrade.
+- Migrate existing config to the new object storage config by running the script `migration/v0.7.x-v0.8.x/migrate-object-storage.sh`
 
 ### Added
 
@@ -26,6 +27,7 @@ See [migrations docs for prometheus-operator](migration/v0.7.x-v0.8.x/migrate-pr
 - Add `./bin/ck8s ops helm` to allow investigating issues between `helmfile` and `kubectl`.
 - Allow nginx config options to be set in the ingress controller.
 - Allow user-alertmanager to be deployed in custom namespace and not only in `monitoring`.
+- Support for GCS
 
 ### Changed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -10,10 +10,14 @@ global:
   storageClass: "set-me"
   clusterDns: "10.43.0.10"
 
-s3:
-  region: "set-me"
-  regionAddress: "set-me"
-  regionEndpoint: "set-me"
+objectStorage:
+  type: "s3"
+  # gcs:
+  #   project: "set-me"
+  # s3:
+  #   region: "set-me"
+  #   regionAddress: "set-me"
+  #   regionEndpoint: "set-me"
   buckets:
     harbor: "${CK8S_ENVIRONMENT_NAME}-harbor"
     velero: "${CK8S_ENVIRONMENT_NAME}-velero"

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -10,10 +10,14 @@ global:
   storageClass: "set-me"
   clusterDns: "10.43.0.10"
 
-s3:
-  region: "set-me"
-  regionAddress: "set-me"
-  regionEndpoint: "set-me"
+objectStorage:
+  type: "s3"
+  # gcs:
+  #   project: "set-me"
+  # s3:
+  #   region: "set-me"
+  #   regionAddress: "set-me"
+  #   regionEndpoint: "set-me"
   buckets:
     harbor: "${CK8S_ENVIRONMENT_NAME}-harbor"
     velero: "${CK8S_ENVIRONMENT_NAME}-velero"

--- a/config/secrets/sc-secrets.yaml
+++ b/config/secrets/sc-secrets.yaml
@@ -1,6 +1,10 @@
-s3:
-  accessKey:
-  secretKey:
+objectStorage: {}
+  # gcs:
+  #   keyfileData: |
+  #     {}
+  # s3:
+  #   accessKey: "set-me"
+  #   secretKey: "set-me"
 grafana:
   password: somelongsecret
   clientSecret: somelongsecret

--- a/config/secrets/wc-secrets.yaml
+++ b/config/secrets/wc-secrets.yaml
@@ -1,6 +1,10 @@
-s3:
-  accessKey:
-  secretKey:
+objectStorage: {}
+  # gcs:
+  #   keyfileData: |
+  #     {}
+  # s3:
+  #   accessKey: "set-me"
+  #   secretKey: "set-me"
 user:
   grafanaPassword: somelongsecret
   prometheusPassword: somelongsecret

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -388,7 +388,7 @@ releases:
   labels:
     app: opendistro
   chart: elastisys/opendistro-es
-  version: 1.10.2
+  version: 1.10.3
   missingFileHandler: Error
   needs:
   - cert-manager/cert-manager

--- a/helmfile/charts/harbor-backup/templates/harbor-backup-job.yaml
+++ b/helmfile/charts/harbor-backup/templates/harbor-backup-job.yaml
@@ -15,9 +15,12 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: run
-              image: elastisys/backup-postgres:1.0.0
+              image: elastisys/backup-postgres:1.1.0
               command: ['/bin/bash', '/scripts/harbor-backup.sh']
               env:
+              {{- if .Values.s3.enabled }}
+                - name: S3_BACKUP
+                  value: "true"
                 - name: AWS_ACCESS_KEY_ID
                   valueFrom:
                     secretKeyRef:
@@ -28,6 +31,18 @@ spec:
                     secretKeyRef:
                       name: harbor-backup-secret
                       key: aws-secret-access-key
+                - name: BUCKET_NAME
+                  value: {{ .Values.s3.bucket }}
+                - name: S3_REGION_ENDPOINT
+                  value: {{ .Values.s3.endpoint }}
+              {{- else if .Values.gcs.enabled }}
+                - name: GCS_BACKUP
+                  value: "true"
+                - name: GCS_KEYFILE
+                  value: /etc/gcs/gcs-credentials.json
+                - name: BUCKET_NAME
+                  value: {{ .Values.gcs.bucket }}
+              {{- end }}
                 - name: PGPASSWORD
                   valueFrom:
                     secretKeyRef:
@@ -35,10 +50,6 @@ spec:
                       key: db-password
                 - name: PG_HOSTNAME
                   value: {{ .Values.pgHostname }}
-                - name: S3_BUCKET
-                  value: {{ .Values.s3.bucket }}
-                - name: S3_REGION_ENDPOINT
-                  value: {{ .Values.s3.endpoint }}
                 - name: DAYS_TO_RETAIN
                   value: "{{ .Values.retentionDays }}"
               volumeMounts:
@@ -46,9 +57,18 @@ spec:
                   mountPath: /scripts
                 - name: backup
                   mountPath: /backup
+                {{ if .Values.gcs.enabled -}}
+                - name: gcs-credentials
+                  mountPath: /etc/gcs
+                {{- end }}
           volumes:
           - name: scripts
             configMap:
               name: {{ .Release.Name }}-cm
           - name: backup
             emptyDir: {}
+          {{- if .Values.gcs.enabled }}
+          - name: gcs-credentials
+            secret:
+              secretName: harbor-backup-secret
+          {{- end }}

--- a/helmfile/charts/harbor-backup/templates/harbor-backup-secret.yaml
+++ b/helmfile/charts/harbor-backup/templates/harbor-backup-secret.yaml
@@ -4,6 +4,11 @@ metadata:
   name: harbor-backup-secret
 type: Opaque
 stringData:
+{{- if .Values.s3.enabled }}
   aws-access-key-id: "{{ .Values.s3.accessKey }}"
   aws-secret-access-key: "{{ .Values.s3.secretKey }}"
+{{- else if .Values.gcs.enabled }}
+  gcs-credentials.json: |
+    {{- .Values.gcs.keyfileData | nindent 4 }}
+{{- end }}
   db-password: "{{ .Values.dbPassword }}"

--- a/helmfile/charts/harbor-backup/values.yaml
+++ b/helmfile/charts/harbor-backup/values.yaml
@@ -3,8 +3,13 @@ dbPassword: ""
 retentionDays: 7
 schedule: "0 0 * * *"
 s3:
+  enabled: false
   accessKey: ""
   secretKey: ""
   bucket: ""
   endpoint: ""
+gcs:
+  enabled: false
+  keyfileData: ""
+  bucket: ""
 startingDeadlineSeconds: 200

--- a/helmfile/charts/sc-logs-retention/scripts/logs-retention.sh
+++ b/helmfile/charts/sc-logs-retention/scripts/logs-retention.sh
@@ -1,24 +1,60 @@
 #!/bin/bash
 
+S3_BACKUP=${S3_BACKUP:-""}
+GCS_BACKUP=${GCS_BACKUP:-""}
+
 set -euo pipefail
 
 : "${RETENTION_DAYS:?Missing RETENTION_DAYS}"
+: "${BUCKET_NAME:?Missing BUCKET_NAME}"
+
+if [[ ${S3_BACKUP} == "true" ]]; then
+  : "${S3_REGION_ENDPOINT:?Missing S3_REGION_ENDPOINT}"
+elif [[ ${GCS_BACKUP} == "true" ]]; then
+  : "${GCS_KEYFILE:?Missing GCS_KEYFILE}"
+fi
 
 echo "Deleting old SC log backups (retain ${RETENTION_DAYS} days)"
-SC_LOG_BACKUPS=$(aws s3 ls "s3://${S3_BUCKET}/logs/" --endpoint-url="${S3_REGION_ENDPOINT}" | awk '{print $2}')
-SC_LOG_BACKUPS_LATEST=$(echo "${SC_LOG_BACKUPS}" | tail -n "${RETENTION_DAYS}")
-SC_LOG_BACKUPS_REST=$(echo "${SC_LOG_BACKUPS}" | head -n "-${RETENTION_DAYS}")
+
+if [[ ${S3_BACKUP} == "true" ]]; then
+  SC_LOG_BACKUPS=$(aws s3 ls "s3://${BUCKET_NAME}/logs/" --endpoint-url="${S3_REGION_ENDPOINT}" | awk '{print $2}')
+
+elif [[ ${GCS_BACKUP} == "true" ]]; then
+  BACKUP_PREFIX="gs://${BUCKET_NAME}/logs/"
+
+  SC_LOG_BACKUPS=$(gsutil -o "Credentials:gs_service_key_file=${GCS_KEYFILE}" ls "${BACKUP_PREFIX}" | \
+    sed 's!'"${BACKUP_PREFIX}"'!!')
+
+else
+  echo "ERROR: No backup backend is enabled" >&2
+  exit 1
+fi
+
+declare -a SC_LOG_BACKUPS_LATEST
+declare -a SC_LOG_BACKUPS_REST
+mapfile -t SC_LOG_BACKUPS_LATEST < <(echo "${SC_LOG_BACKUPS}" | tail -n "${RETENTION_DAYS}")
+mapfile -t SC_LOG_BACKUPS_REST <   <(echo "${SC_LOG_BACKUPS}" | head -n "-${RETENTION_DAYS}")
+
 echo "Listing ${RETENTION_DAYS} latest backups"
-echo "${SC_LOG_BACKUPS_LATEST}"
+echo "${SC_LOG_BACKUPS_LATEST[@]}"
 echo
 echo "Listing the rest"
-echo "${SC_LOG_BACKUPS_REST}"
+echo "${SC_LOG_BACKUPS_REST[@]}"
 echo
-if [ -z "${SC_LOG_BACKUPS_REST}" ]; then
-    echo "No backups were found for automatic removal"
+if [ ${#SC_LOG_BACKUPS_REST[@]} -eq 0 ]; then
+  echo "No backups were found for automatic removal"
 else
-    for BACKUP in "${SC_LOG_BACKUPS_REST[@]}"; do
-        echo "Deleting backup s3://${S3_BUCKET}/logs/${BACKUP}"
-        aws s3 rm --recursive "s3://${S3_BUCKET}/logs/${BACKUP}" --endpoint-url="${S3_REGION_ENDPOINT}"
-    done
+  for BACKUP in "${SC_LOG_BACKUPS_REST[@]}"; do
+      if [[ ${S3_BACKUP} == "true" ]]; then
+          BACKUP_URI="s3://${BUCKET_NAME}/logs/${BACKUP}"
+
+          echo "Deleting backup ${BACKUP_URI}"
+          aws s3 rm --recursive "${BACKUP_URI}" --endpoint-url="${S3_REGION_ENDPOINT}"
+      elif [[ ${GCS_BACKUP} == "true" ]]; then
+          BACKUP_URI="gs://${BUCKET_NAME}/logs/${BACKUP}"
+
+          echo "Deleting backup ${BACKUP_URI}"
+          gsutil -o "Credentials:gs_service_key_file=${GCS_KEYFILE}" rm "$BACKUP_URI"
+      fi
+  done
 fi

--- a/helmfile/charts/sc-logs-retention/templates/configmap-env.yaml
+++ b/helmfile/charts/sc-logs-retention/templates/configmap-env.yaml
@@ -5,7 +5,12 @@ metadata:
   labels:
     {{- include "sc-logs-retention.labels" . | nindent 4 }}
 data:
+{{- if .Values.s3.enabled }}
   AWS_DEFAULT_REGION: {{ .Values.s3.region }}
   S3_REGION_ENDPOINT: {{ .Values.s3.regionEndpoint }}
-  S3_BUCKET: {{ .Values.s3.bucket }}
   RETENTION_DAYS: {{ .Values.s3.retentionDays | quote }}
+  BUCKET_NAME: {{ .Values.s3.bucket }}
+{{- else if .Values.gcs.enabled }}
+  BUCKET_NAME: {{ .Values.gcs.bucket }}
+  RETENTION_DAYS: {{ .Values.gcs.retentionDays | quote }}
+{{- end }}

--- a/helmfile/charts/sc-logs-retention/templates/cronjob.yaml
+++ b/helmfile/charts/sc-logs-retention/templates/cronjob.yaml
@@ -31,6 +31,9 @@ spec:
                 {{- toYaml .Values.securityContext | nindent 16 }}
               command: ['/bin/bash', '/scripts/logs-retention.sh']
               env:
+              {{- if .Values.s3.enabled }}
+                - name: S3_BACKUP
+                  value: "true"
                 - name: AWS_ACCESS_KEY_ID
                   valueFrom:
                     secretKeyRef:
@@ -41,6 +44,12 @@ spec:
                     secretKeyRef:
                       key: s3_secret_key
                       name:  {{ include "sc-logs-retention.fullname" . }}
+              {{- else if .Values.gcs.enabled }}
+                - name: GCS_BACKUP
+                  value: "true"
+                - name: GCS_KEYFILE
+                  value: /etc/gcs/gcs-credentials.json
+              {{- end }}
               envFrom:
                 - configMapRef:
                     name: {{ include "sc-logs-retention.fullname" . }}-env
@@ -49,10 +58,19 @@ spec:
               volumeMounts:
                 - name: scripts
                   mountPath: /scripts
+                {{- if .Values.gcs.enabled }}
+                - name: gcs-credentials
+                  mountPath: /etc/gcs
+                {{- end }}
           volumes:
             - name: scripts
               configMap:
                 name: {{ include "sc-logs-retention.fullname" . }}-script
+            {{- if .Values.gcs.enabled }}
+            - name: gcs-credentials
+              secret:
+                secretName: {{ include "sc-logs-retention.fullname" . }}
+            {{- end }}
           {{- with .Values.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/helmfile/charts/sc-logs-retention/templates/secret.yaml
+++ b/helmfile/charts/sc-logs-retention/templates/secret.yaml
@@ -5,5 +5,10 @@ metadata:
   labels:
     {{- include "sc-logs-retention.labels" . | nindent 4 }}
 stringData:
+{{- if .Values.s3.enabled }}
   s3_access_key: "{{ .Values.s3.accessKey }}"
   s3_secret_key: "{{ .Values.s3.secretKey }}"
+{{- else if .Values.gcs.enabled }}
+  gcs-credentials.json: |
+    {{- .Values.gcs.keyfileData | nindent 4 }}
+{{- end }}

--- a/helmfile/charts/sc-logs-retention/values.yaml
+++ b/helmfile/charts/sc-logs-retention/values.yaml
@@ -13,12 +13,19 @@ startingDeadlineSeconds: 1200
 serviceAccountName: "fluentd-aggregator"
 
 s3:
+  enabled: false
   region: ""
   regionEndpoint: ""
   bucket: ""
   retentionDays: 7
   accessKey: ""
   secretKey: ""
+
+gcs:
+  enabled: false
+  retentionDays: 7
+  bucket: ""
+  keyfileData: ""
 
 podAnnotations: {}
 

--- a/helmfile/values/fluentd-aggregator.yaml.gotmpl
+++ b/helmfile/values/fluentd-aggregator.yaml.gotmpl
@@ -10,8 +10,13 @@ tolerations: {{- toYaml .Values.fluentd.aggregator.tolerations | nindent 2 }}
 plugins:
   enabled: true
   pluginsList:
+    {{ if eq .Values.objectStorage.type "s3" -}}
     # TODO: pin version
     - fluent-plugin-s3
+    {{ else if eq .Values.objectStorage.type "gcs" -}}
+    - digest-crc -v "0.5.1"
+    - fluent-plugin-gcs
+    {{- end }}
 
 service:
   type: ClusterIP
@@ -29,6 +34,7 @@ persistence:
   enabled: true
   size: 10Gi
 
+{{ if eq .Values.objectStorage.type "s3" -}}
 extraEnvVars:
  - name: AWS_ACCESS_KEY_ID
    valueFrom:
@@ -40,6 +46,7 @@ extraEnvVars:
      secretKeyRef:
        name: s3-credentials
        key: s3_secret_key
+{{- end }}
 
 configMaps:
   output.conf: |
@@ -48,17 +55,26 @@ configMaps:
     </match>
     <match **>
       @id output-s3
+      {{ if eq .Values.objectStorage.type "gcs" -}}
+      @type gcs
+
+      project {{ .Values.objectStorage.gcs.project }}
+      keyfile /etc/fluent/config.d/gcp_credentials.json
+      bucket {{ .Values.objectStorage.buckets.scFluentd }}
+      object_key_format %{path}%{time_slice}_%{index}.%{file_extension}
+      {{ else if eq .Values.objectStorage.type "s3" -}}
       @type s3
 
       aws_key_id "#{ENV['AWS_ACCESS_KEY_ID']}"
       aws_sec_key "#{ENV['AWS_ACCESS_SECRET_KEY']}"
       {{ if eq .Values.fluentd.useRegionEndpoint true -}}
-      s3_endpoint {{ .Values.s3.regionEndpoint }}
+      s3_endpoint {{ .Values.objectStorage.s3.regionEndpoint }}
       force_path_style true
       {{ else -}}
-      s3_region {{ .Values.s3.region }}
+      s3_region {{ .Values.objectStorage.s3.region }}
       {{ end -}}
-      s3_bucket {{ .Values.s3.buckets.scFluentd }}
+      s3_bucket {{ .Values.objectStorage.buckets.scFluentd }}
+      {{- end }}
 
       path logs/%Y%m%d/${tag}/
 
@@ -75,3 +91,8 @@ configMaps:
         chunk_limit_size 50m
       </buffer>
     </match>
+
+  {{ if eq .Values.objectStorage.type "gcs" -}}
+  gcp_credentials.json: |
+    {{ .Values.objectStorage.gcs.keyfileData | nindent 4 }}
+  {{- end }}

--- a/helmfile/values/harbor-backup.yaml.gotmpl
+++ b/helmfile/values/harbor-backup.yaml.gotmpl
@@ -1,6 +1,17 @@
 dbPassword: {{ .Values.harbor.databasePassword }}
+{{ if eq .Values.objectStorage.type "s3" -}}
 s3:
-  accessKey: {{ .Values.s3.accessKey }}
-  secretKey: {{ .Values.s3.secretKey }}
-  bucket: {{ .Values.s3.buckets.harbor }}
-  endpoint: {{ .Values.s3.regionEndpoint }}
+  enabled: true
+  accessKey: {{ .Values.objectStorage.s3.accessKey }}
+  secretKey: {{ .Values.objectStorage.s3.secretKey }}
+  bucket: {{ .Values.objectStorage.buckets.harbor }}
+  endpoint: {{ .Values.objectStorage.s3.regionEndpoint }}
+{{ else if eq .Values.objectStorage.type "gcs" -}}
+# TODO
+# Fix harbor backup chart to support gcs
+gcs:
+  enabled: true
+  bucket: {{ .Values.objectStorage.buckets.harbor }}
+  keyfileData: |
+    {{ .Values.objectStorage.gcs.keyfileData | nindent 4 }}
+{{- end }}

--- a/helmfile/values/harbor.yaml.gotmpl
+++ b/helmfile/values/harbor.yaml.gotmpl
@@ -38,19 +38,26 @@ persistence:
       authurl: {{ .Values.citycloud.authURL }}/v3
       username: {{ .Values.citycloud.username }}
       password: {{ .Values.citycloud.password }}
-      container: {{ .Values.s3.buckets.harbor }}
+      container: {{ .Values.objectStorage.buckets.harbor }}
       region: {{ .Values.citycloud.regionName }}
       authversion: {{ .Values.citycloud.authVersion }}
       tenant: {{ .Values.citycloud.tenantName }}
       domain: {{ .Values.citycloud.projectDomainName }}
     {{ else }}
+    {{ if eq .Values.objectStorage.type "s3" }}
     type: s3
     s3:
-      region: {{ .Values.s3.region }}
-      regionendpoint: {{ .Values.s3.regionEndpoint }}
-      bucket: {{ .Values.s3.buckets.harbor }}
-      secretkey: {{ .Values.s3.secretKey }}
-      accesskey: {{ .Values.s3.accessKey }}
+      region: {{ .Values.objectStorage.s3.region }}
+      regionendpoint: {{ .Values.objectStorage.s3.regionEndpoint }}
+      bucket: {{ .Values.objectStorage.buckets.harbor }}
+      secretkey: {{ .Values.objectStorage.s3.secretKey }}
+      accesskey: {{ .Values.objectStorage.s3.accessKey }}
+    {{ else if eq .Values.objectStorage.type "gcs" }}
+    type: gcs
+    gcs:
+      bucket: {{ .Values.objectStorage.buckets.harbor }}
+      encodedkey: {{ .Values.objectStorage.gcs.keyfileData | b64enc }}
+    {{- end }}
     {{ end }}
 
 externalURL: https://harbor.{{ .Values.global.baseDomain }}

--- a/helmfile/values/influxdb.yaml.gotmpl
+++ b/helmfile/values/influxdb.yaml.gotmpl
@@ -1,18 +1,17 @@
 elastisys_custom:
   # The following values must be set in order to use the chart.
   influx_addr: {{ .Values.influxDB.address }}
-  s3_region: {{ .Values.s3.region }}
-  s3_region_endpoint: {{ .Values.s3.regionEndpoint }}
-  s3_influx_bucket_name: {{ .Values.s3.buckets.influxDB }}
-  s3_access_key: {{ .Values.s3.accessKey }}
-  s3_secret_key: {{ .Values.s3.secretKey }}
   influxdb_user: {{ .Values.influxDB.user }}
   influxdb_password: {{ .Values.influxDB.password }}
   s3_credentials: |+
+  {{- if eq .Values.objectStorage.type "s3" }}
     [default]
-    aws_access_key_id={{ .Values.s3.accessKey }}
-    aws_secret_access_key={{ .Values.s3.secretKey }}
-    region={{ .Values.s3.region }}
+    aws_access_key_id={{ .Values.objectStorage.s3.accessKey }}
+    aws_secret_access_key={{ .Values.objectStorage.s3.secretKey }}
+    region={{ .Values.objectStorage.s3.region }}
+  {{- else if eq .Values.objectStorage.type "gcs" }}
+    {{ .Values.objectStorage.gcs.keyfileData | nindent 4 }}
+  {{- end }}
 
   metrics:
     jobs:
@@ -138,7 +137,14 @@ backup:
     size: {{ add .Values.influxDB.metrics.sizeWc .Values.influxDB.metrics.sizeSc -}}Ki # the sum of influxDB.metrics.sizeWc and influxDB.metrics.sizeWc (all values in KB)
   schedule: "0 0 * * *"
   startingDeadlineSeconds: 200
+  {{- if eq .Values.objectStorage.type "s3" }}
   s3:
     credentialsSecret: influxdb-backup-secret #TODO: use influxdb.fullname from _helpers.tpl instead hardcoded "influxdb"
-    destination: s3://{{ .Values.s3.buckets.influxDB }}
-    endpointUrl: {{ .Values.s3.regionEndpoint }}
+    destination: s3://{{ .Values.objectStorage.buckets.influxDB }}
+    endpointUrl: {{ .Values.objectStorage.s3.regionEndpoint }}
+  {{- else if eq .Values.objectStorage.type "gcs" }}
+  gcs:
+    destination: gs://{{ .Values.objectStorage.buckets.influxDB }}
+    serviceAccountSecretKey: credentials
+    serviceAccountSecret: influxdb-backup-secret
+  {{- end }}

--- a/helmfile/values/opendistro-es.yaml.gotmpl
+++ b/helmfile/values/opendistro-es.yaml.gotmpl
@@ -14,23 +14,41 @@ elasticsearch:
       existingCertSecretKeySubPath: tls.key
       existingCertSecretRootCASubPath: ca.crt
 
+  {{ if eq .Values.objectStorage.type "s3" -}}
   s3:
     enabled: true
     useExistingSecret: false
     secretName: opendistro-es-s3-credentials
-    accessKey: {{ .Values.s3.accessKey }}
-    secretKey: {{ .Values.s3.secretKey }}
-    bucketName: {{ .Values.s3.buckets.elasticsearch }}
+    accessKey: {{ .Values.objectStorage.s3.accessKey }}
+    secretKey: {{ .Values.objectStorage.s3.secretKey }}
     provider: {{ .Values.global.cloudProvider }}
+    bucketName: {{ .Values.objectStorage.buckets.elasticsearch }}
+  {{ else if eq .Values.objectStorage.type "gcs" -}}
+  s3:
+    enabled: false
+  gcs:
+    enabled: true
+    useExistingSecret: false
+    secretName: opendistro-es-gcs-credentials
+    bucketName: {{ .Values.objectStorage.buckets.elasticsearch }}
+    keyfileData: |
+      {{ .Values.objectStorage.gcs.keyfileData | nindent 6 }}
+  {{- end }}
 
   extraVolumes:
   - emptyDir: {}
     name: internal-elasticsearch-config-local
   - emptyDir: {}
     name: internal-elasticsearch-plugins-local
+  {{ if eq .Values.objectStorage.type "s3" -}}
   - name: s3-credentials
     secret:
       secretName: opendistro-es-s3-credentials
+  {{ else if eq .Values.objectStorage.type "gcs" -}}
+  - name: gcs-credentials
+    secret:
+      secretName: opendistro-es-gcs-credentials
+  {{- end }}
 
   extraVolumeMounts:
   - mountPath: /usr/share/elasticsearch/config
@@ -39,17 +57,23 @@ elasticsearch:
     name: internal-elasticsearch-plugins-local
 
   extraInitContainers:
-  - name: install-s3
+  - name: install-object-storage-plugin
     image: amazon/opendistro-for-elasticsearch:1.10.1
     command:
     - sh
     - -c
     - |
-      /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch repository-s3
+      {{ if eq .Values.objectStorage.type "s3" -}}
+      /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch repository-s3 || exit 1
 
       /usr/share/elasticsearch/bin/elasticsearch-keystore create
       /usr/share/elasticsearch/bin/elasticsearch-keystore add-file s3.client.default.access_key /mnt/elastic-internal/s3-credentials/s3.client.default.access_key
       /usr/share/elasticsearch/bin/elasticsearch-keystore add-file s3.client.default.secret_key /mnt/elastic-internal/s3-credentials/s3.client.default.secret_key
+      {{ else if eq .Values.objectStorage.type "gcs" -}}
+      /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch repository-gcs || exit 1
+
+      /usr/share/elasticsearch/bin/elasticsearch-keystore add-file --force gcs.client.default.credentials_file /mnt/elastic-internal/gcs-credentials.json
+      {{- end }}
 
       # Disable performance_analyzer due to issue where disk is being filled up
       /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_performance_analyzer
@@ -73,8 +97,13 @@ elasticsearch:
       name: internal-elasticsearch-config-local
     - mountPath: /mnt/elastic-internal/elasticsearch-plugins-local
       name: internal-elasticsearch-plugins-local
+    {{ if eq .Values.objectStorage.type "s3" -}}
     - mountPath: /mnt/elastic-internal/s3-credentials
       name: s3-credentials
+    {{ else if eq .Values.objectStorage.type "gcs" -}}
+    - mountPath: /mnt/elastic-internal/
+      name: gcs-credentials
+    {{- end }}
 
   securityConfig:
     config:
@@ -259,8 +288,13 @@ elasticsearch:
     node:
       attr.box_type: hot
 
-    s3.client.default.endpoint: {{ .Values.s3.regionEndpoint }}
+    {{ if eq .Values.objectStorage.type "s3" -}}
+    s3.client.default.endpoint: {{ .Values.objectStorage.s3.regionEndpoint }}
     s3.client.default.path_style_access: true
+    {{ else if eq .Values.objectStorage.type "gcs" -}}
+    # TODO
+    # Add config related to gcs (if any)
+    {{- end }}
 
 
 

--- a/helmfile/values/sc-logs-retention.yaml.gotmpl
+++ b/helmfile/values/sc-logs-retention.yaml.gotmpl
@@ -1,12 +1,3 @@
-
-s3:
-  region: {{ .Values.s3.region | quote }}
-  regionEndpoint: {{ .Values.s3.regionEndpoint | quote }}
-  bucket: {{ .Values.s3.buckets.scFluentd | quote }}
-  retentionDays: {{ .Values.logRetention.days }}
-  accessKey: {{ .Values.s3.accessKey | quote }}
-  secretKey: {{ .Values.s3.secretKey | quote }}
-
 resources:
   requests:
     cpu: 100m
@@ -14,3 +5,29 @@ resources:
   limits:
     memory: 100Mi
     cpu: 200m
+
+{{ if eq .Values.objectStorage.type "s3" -}}
+s3:
+  enabled: true
+  region: {{ .Values.objectStorage.s3.region | quote }}
+  regionEndpoint: {{ .Values.objectStorage.s3.regionEndpoint | quote }}
+  bucket: {{ .Values.objectStorage.buckets.scFluentd | quote }}
+  retentionDays: {{ .Values.logRetention.days }}
+  accessKey: {{ .Values.objectStorage.s3.accessKey | quote }}
+  secretKey: {{ .Values.objectStorage.s3.secretKey | quote }}
+
+image:
+  repository: amazon/aws-cli
+  tag: "2.0.45"
+
+{{ else if eq .Values.objectStorage.type "gcs" -}}
+gcs:
+  enabled: true
+  bucket: {{ .Values.objectStorage.buckets.scFluentd | quote }}
+  keyfileData: |
+    {{ .Values.objectStorage.gcs.keyfileData | nindent 4 }}
+
+image:
+  repository: google/cloud-sdk
+  tag: "318.0.0-slim"
+{{- end }}

--- a/helmfile/values/velero.yaml.gotmpl
+++ b/helmfile/values/velero.yaml.gotmpl
@@ -3,37 +3,79 @@ tolerations:  {{- toYaml .Values.velero.tolerations | nindent 2  }}
 nodeSelector: {{- toYaml .Values.velero.nodeSelector | nindent 2  }}
 
 initContainers:
+  {{- if eq .Values.objectStorage.type "s3" }}
   - name: velero-plugin-for-aws
     image: velero/velero-plugin-for-aws:v1.0.0
     imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /target
         name: plugins
+  {{- else if eq .Values.objectStorage.type "gcs" }}
+  - name: velero-plugin-for-gcs
+    image: velero/velero-plugin-for-gcp:v1.1.0
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+      - mountPath: /target
+        name: plugins
+  {{- end }}
 
 configuration:
   # Cloud provider being used (e.g. aws, azure, gcp).
+  {{- if eq .Values.objectStorage.type "s3" }}
   provider: aws
+  {{- else if eq .Values.objectStorage.type "gcs" }}
+  provider: gcp
+  {{- end }}
 
   # https://velero.io/docs/v1.0.0/api-types/backupstoragelocation/
   backupStorageLocation:
+    {{- if eq .Values.objectStorage.type "s3" }}
+    # Cloud provider where backups should be stored. Usually should
+    # match `configuration.provider`. Required.
     name: aws
-    bucket: {{ .Values.s3.buckets.velero }}
+    # Bucket to store backups in. Required.
+    bucket: {{ .Values.objectStorage.buckets.velero }}
+    # Prefix within bucket under which to store backups. Optional.
+    #prefix: will be set outside of values file.
+    # Additional provider-specific configuration. See link above
+    # for details of required/optional fields for your provider.
     config:
-      region: {{ .Values.s3.region }}
+      region: {{ .Values.objectStorage.s3.region }}
       s3ForcePathStyle: "true"
-      s3Url: {{ .Values.s3.regionEndpoint }}
+      s3Url: {{ .Values.objectStorage.s3.regionEndpoint }}
+    {{- else if eq .Values.objectStorage.type "gcs" }}
+    # Cloud provider where backups should be stored. Usually should
+    # match `configuration.provider`. Required.
+    name: gcs
+    # Bucket to store backups in. Required.
+    bucket: {{ .Values.objectStorage.buckets.velero }}
+    # Prefix within bucket under which to store backups. Optional.
+    #prefix: will be set outside of values file.
+    # Additional provider-specific configuration. See link above
+    # for details of required/optional fields for your provider.
+    {{- end }}
+
+  # Parameters for the `default` VolumeSnapshotLocation. See
   # https://velero.io/docs/v1.0.0/api-types/volumesnapshotlocation/
   volumeSnapshotLocation:
     config:
-      region: {{ .Values.s3.region }}
+      {{- if eq .Values.objectStorage.type "s3" }}
+      region: {{ .Values.objectStorage.s3.region }}
+      {{- else if eq .Values.objectStorage.type "gcs" }}
+      project: {{ .Values.objectStorage.gcs.project }}
+      {{- end }}
 
 credentials:
   # Create secret with credentials
   secretContents:
     cloud: |
+    {{- if eq .Values.objectStorage.type "s3" }}
       [default]
-      aws_access_key_id: {{ .Values.s3.accessKey }}
-      aws_secret_access_key: {{ .Values.s3.secretKey }}
+      aws_access_key_id: {{ .Values.objectStorage.s3.accessKey }}
+      aws_secret_access_key: {{ .Values.objectStorage.s3.secretKey }}
+    {{- else if eq .Values.objectStorage.type "gcs" }}
+      {{ .Values.objectStorage.gcs.keyfileData | nindent 6 }}
+    {{- end }}
 
 deployRestic: true
 

--- a/migration/v0.7.x-v0.8.x/migrate-object-storage.sh
+++ b/migration/v0.7.x-v0.8.x/migrate-object-storage.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
+for cluster in sc wc; do
+  config="${CK8S_CONFIG_PATH}/${cluster}-config.yaml"
+
+  s3_region=$(yq r "$config" 's3.region')
+  s3_region_address=$(yq r "$config" 's3.regionAddress')
+  s3_region_endpoint=$(yq r "$config" 's3.regionEndpoint')
+
+  buckets_harbor=$(yq r "$config" 's3.buckets.harbor')
+  buckets_velero=$(yq r "$config" 's3.buckets.velero')
+  buckets_elasticsearch=$(yq r "$config" 's3.buckets.elasticsearch')
+  buckets_influxDB=$(yq r "$config" 's3.buckets.influxDB')
+  buckets_scFluentd=$(yq r "$config" 's3.buckets.scFluentd')
+
+  yq w -i "$config" 'objectStorage.type' "s3"
+
+  yq w -i "$config" 'objectStorage.s3.region' "${s3_region}"
+  yq w -i "$config" 'objectStorage.s3.regionAddress' "${s3_region_address}"
+  yq w -i "$config" 'objectStorage.s3.regionEndpoint' "${s3_region_endpoint}"
+
+  yq w -i "$config" 'objectStorage.buckets.harbor' "${buckets_harbor}"
+  yq w -i "$config" 'objectStorage.buckets.velero' "${buckets_velero}"
+  yq w -i "$config" 'objectStorage.buckets.elasticsearch' "${buckets_elasticsearch}"
+  yq w -i "$config" 'objectStorage.buckets.influxDB' "${buckets_influxDB}"
+  yq w -i "$config" 'objectStorage.buckets.scFluentd' "${buckets_scFluentd}"
+
+  yq d -i "$config" 's3'
+done
+
+secret="${CK8S_CONFIG_PATH}/secrets.yaml"
+secret_tmp="${CK8S_CONFIG_PATH}/secrets_tmp.yaml"
+sops_conf="${CK8S_CONFIG_PATH}/.sops.yaml"
+
+s3_access_key=$(sops -d --extract '["s3"]["accessKey"]' "${secret}")
+s3_secret_key=$(sops -d --extract '["s3"]["secretKey"]' "${secret}")
+
+sops -d "${secret}" | \
+  yq w - 'objectStorage.s3.accessKey' "${s3_access_key}" | \
+  yq w - 'objectStorage.s3.secretKey' "${s3_secret_key}" | \
+  yq d - 's3' | \
+  sops --config "${sops_conf}" --input-type=yaml -e /dev/stdin > "${secret_tmp}"
+mv "${secret_tmp}" "${secret}"

--- a/pipeline/init.bash
+++ b/pipeline/init.bash
@@ -5,6 +5,7 @@ set -eu -o pipefail
 here="$(dirname "$(readlink -f "$0")")"
 ck8s="${here}/../bin/ck8s"
 source "${here}/common.bash"
+: "${secrets[secrets_file]:?Missing secrets}"
 
 export CK8S_FLAVOR="${CI_CK8S_FLAVOR:-dev}"
 export CK8S_ENVIRONMENT_NAME="${CK8S_ENVIRONMENT_NAME:-apps-${CK8S_CLOUD_PROVIDER}-${CK8S_FLAVOR}-${GITHUB_RUN_ID}}"
@@ -15,14 +16,17 @@ export CK8S_ENVIRONMENT_NAME="${CK8S_ENVIRONMENT_NAME:-apps-${CK8S_CLOUD_PROVIDE
 
 # Update ck8s configuration
 
+objectStoreProvider=$(sops_exec_file "${secrets[secrets_file]}" 'yq r -e {} objectStorage.type')
 case "${CK8S_CLOUD_PROVIDER}" in
     "exoscale")
     for cluster in sc wc; do
         config_update "${cluster}" "global.baseDomain" "${CK8S_ENVIRONMENT_NAME}.a1ck.io"
         config_update "${cluster}" "global.opsDomain" "ops.${CK8S_ENVIRONMENT_NAME}.a1ck.io"
     done
-    secrets_update "s3.accessKey" "${CI_EXOSCALE_KEY}"
-    secrets_update "s3.secretKey" "${CI_EXOSCALE_SECRET}"
+    if [[ ${objectStoreProvider} == "s3" ]]; then
+      secrets_update "objectStorage.s3.accessKey" "${CI_EXOSCALE_KEY}"
+      secrets_update "objectStorage.s3.secretKey" "${CI_EXOSCALE_SECRET}"
+    fi
     ;;
     "safespring")
     for cluster in sc wc; do
@@ -31,8 +35,10 @@ case "${CK8S_CLOUD_PROVIDER}" in
     done
     secrets_update "citycloud.username" "${SAFESPRING_OS_USERNAME}"
     secrets_update "citycloud.password" "${SAFESPRING_OS_PASSWORD}"
-    secrets_update "s3.accessKey" "${SAFESPRING_S3_ACCESS_KEY}"
-    secrets_update "s3.secretKey" "${SAFESPRING_S3_SECRET_KEY}"
+    if [[ ${objectStoreProvider} == "s3" ]]; then
+      secrets_update "objectStorage.s3.accessKey" "${SAFESPRING_S3_ACCESS_KEY}"
+      secrets_update "objectStorage.s3.secretKey" "${SAFESPRING_S3_SECRET_KEY}"
+    fi
     ;;
     "citycloud")
     for cluster in sc wc; do
@@ -41,8 +47,10 @@ case "${CK8S_CLOUD_PROVIDER}" in
     done
     secrets_update "citycloud.username" "${CITYCLOUD_OS_USERNAME}"
     secrets_update "citycloud.password" "${CITYCLOUD_OS_PASSWORD}"
-    secrets_update "s3.accessKey" "${CITYCLOUD_S3_ACCESS_KEY}"
-    secrets_update "s3.secretKey" "${CITYCLOUD_S3_SECRET_KEY}"
+    if [[ ${objectStoreProvider} == "s3" ]]; then
+      secrets_update "objectStorage.s3.accessKey" "${CITYCLOUD_S3_ACCESS_KEY}"
+      secrets_update "objectStorage.s3.secretKey" "${CITYCLOUD_S3_SECRET_KEY}"
+    fi
     ;;
 esac
 

--- a/pipeline/test/infrastructure/s3-buckets.sh
+++ b/pipeline/test/infrastructure/s3-buckets.sh
@@ -17,7 +17,7 @@ config_file="$CK8S_CONFIG_PATH/$1-config.yaml"
 cloud_provider=$(yq r "$config_file" 'global.cloudProvider')
 
 # In config:
-# s3.buckets.<bucket>
+# objectStorage.buckets.<bucket>
 buckets=(
   harbor
   velero
@@ -45,6 +45,6 @@ S3_BUCKET_LIST=$(with_s3cfg "${secrets[s3cfg_file]}" "s3cmd --config {} ls")
 
 for bucket in "${buckets[@]}"
 do
-  bucket_name=$(yq r "$config_file" "s3.buckets.$bucket")
+  bucket_name=$(yq r "$config_file" "objectStorage.buckets.$bucket")
   check_if_bucket_exists "$bucket_name"
 done


### PR DESCRIPTION
**What this PR does / why we need it**:

For the GCP support, we need to support GCS as object storage provider.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

fixes #70 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
