### PR TITLE
apps: Add config options for cert-manager

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Release notes
 
 - Configuration for the certificate issuers has been changed and requires running the [migration script](migration/v0.6.x-v0.7.x/migrate-issuer-config.sh).
-- Configuration for harbor has been changed and requires running init and apply again.
+- Configuration for harbor and cert-manager has been changed and requires running init and apply again.
 
 ### Added
 
@@ -11,6 +11,7 @@
 - Added falco exporter to workload cluster
 - Falco dashboard added to Grafana
 - `any` can be used as configuration version to disabled version check
+- Configuration options regarding pod placement and resources for cert-manager
 
 ### Changed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -375,3 +375,21 @@ issuers:
     staging:
       email: "set-me"
   extraIssuers: []
+
+certmanager:
+  resources: {}
+  nodeSelector: {}
+  tolerations: {}
+  affinity: {}
+
+  webhook:
+    resources: {}
+    nodeSelector: {}
+    tolerations: {}
+    affinity: {}
+
+  cainjector:
+    resources: {}
+    nodeSelector: {}
+    tolerations: {}
+    affinity: {}

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -224,3 +224,21 @@ issuers:
     staging:
       email: "set-me"
   extraIssuers: []
+
+certmanager:
+  resources: {}
+  nodeSelector: {}
+  tolerations: {}
+  affinity: {}
+
+  webhook:
+    resources: {}
+    nodeSelector: {}
+    tolerations: {}
+    affinity: {}
+
+  cainjector:
+    resources: {}
+    nodeSelector: {}
+    tolerations: {}
+    affinity: {}

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -66,6 +66,8 @@ releases:
   version: v0.14.1
   missingFileHandler: Error
   wait: true
+  values:
+  - values/cert-manager.yaml.gotmpl
 
 # Prometheus-operator
 - name: prometheus-operator

--- a/helmfile/values/cert-manager.yaml.gotmpl
+++ b/helmfile/values/cert-manager.yaml.gotmpl
@@ -1,0 +1,16 @@
+resources:    {{- toYaml .Values.certmanager.resources | nindent 2 }}
+nodeSelector: {{- toYaml .Values.certmanager.nodeSelector | nindent 2 }}
+affinity:     {{- toYaml .Values.certmanager.affinity | nindent 2 }}
+tolerations:  {{- toYaml .Values.certmanager.tolerations | nindent 2 }}
+
+webhook:
+  resources:    {{- toYaml .Values.certmanager.webhook.resources | nindent 4 }}
+  nodeSelector: {{- toYaml .Values.certmanager.webhook.nodeSelector | nindent 4 }}
+  affinity:     {{- toYaml .Values.certmanager.webhook.affinity | nindent 4 }}
+  tolerations:  {{- toYaml .Values.certmanager.webhook.tolerations | nindent 4 }}
+
+cainjector:
+  resources:    {{- toYaml .Values.certmanager.cainjector.resources | nindent 4 }}
+  nodeSelector: {{- toYaml .Values.certmanager.cainjector.nodeSelector | nindent 4 }}
+  affinity:     {{- toYaml .Values.certmanager.cainjector.affinity | nindent 4 }}
+  tolerations:  {{- toYaml .Values.certmanager.cainjector.tolerations | nindent 4 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit gives one the option to configure pod assignment and
resources for cert-manager and it's "sub-components".

**Which issue this PR fixes**:
fixes: #43 
fixes #42 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
