### PR TITLE
apps: Fix and improve velero config

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Configuration for the certificate issuers has been changed and requires running the [migration script](migration/v0.6.x-v0.7.x/migrate-issuer-config.sh).
 - Configuration for harbor and cert-manager has been changed and requires running init and apply again.
+- Configuration for velero has been changed and requires running init again.
 
 ### Added
 
@@ -12,6 +13,7 @@
 - Falco dashboard added to Grafana
 - `any` can be used as configuration version to disabled version check
 - Configuration options regarding pod placement and resources for cert-manager
+- Possibility to configure pod placement and resourcess for velero
 
 ### Changed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -351,6 +351,8 @@ nginxIngress:
     nodeSelector: {}
 
 velero:
+  tolerations: []
+  nodeSelector: {}
   resources:
     limits:
       cpu: 200m
@@ -358,9 +360,15 @@ velero:
     requests:
       cpu: 100m
       memory: 100Mi
-  tolerations: []
-  affinity: {}
-  nodeSelector: {}
+  restic:
+    tolerations: []
+    resources:
+      limits:
+        cpu: 200m
+        memory: 200Mi
+      requests:
+        cpu: 100m
+        memory: 100Mi
 
 restore:
   cluster: false

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -205,6 +205,8 @@ nginxIngress:
     nodeSelector: {}
 
 velero:
+  tolerations: []
+  nodeSelector: {}
   resources:
     limits:
       cpu: 200m
@@ -212,9 +214,15 @@ velero:
     requests:
       cpu: 100m
       memory: 100Mi
-  tolerations: []
-  affinity: {}
-  nodeSelector: {}
+  restic:
+    tolerations: []
+    resources:
+      limits:
+        cpu: 200m
+        memory: 200Mi
+      requests:
+        cpu: 100m
+        memory: 100Mi
 
 issuers:
   letsencrypt:

--- a/helmfile/values/velero.yaml.gotmpl
+++ b/helmfile/values/velero.yaml.gotmpl
@@ -1,7 +1,6 @@
-installCRDs: false
-
-resources:
-{{- toYaml .Values.velero.resources | nindent 4  }}
+resources:    {{- toYaml .Values.velero.resources | nindent 2  }}
+tolerations:  {{- toYaml .Values.velero.tolerations | nindent 2  }}
+nodeSelector: {{- toYaml .Values.velero.nodeSelector | nindent 2  }}
 
 initContainers:
   - name: velero-plugin-for-aws
@@ -15,82 +14,33 @@ configuration:
   # Cloud provider being used (e.g. aws, azure, gcp).
   provider: aws
 
-  # Parameters for the `default` BackupStorageLocation. See
   # https://velero.io/docs/v1.0.0/api-types/backupstoragelocation/
   backupStorageLocation:
-    # Cloud provider where backups should be stored. Usually should
-    # match `configuration.provider`. Required.
     name: aws
-    # Bucket to store backups in. Required.
     bucket: {{ .Values.s3.buckets.velero }}
-    # Prefix within bucket under which to store backups. Optional.
-    #prefix: will be set outside of values file.
-    # Additional provider-specific configuration. See link above
-    # for details of required/optional fields for your provider.
     config:
       region: {{ .Values.s3.region }}
       s3ForcePathStyle: "true"
       s3Url: {{ .Values.s3.regionEndpoint }}
-  # Parameters for the `default` VolumeSnapshotLocation. See
   # https://velero.io/docs/v1.0.0/api-types/volumesnapshotlocation/
   volumeSnapshotLocation:
     config:
       region: {{ .Values.s3.region }}
 
-# Info about the secret to be used by the Velero deployment, which
-# should contain credentials for the cloud provider IAM account you've
-# set up for Velero.
 credentials:
-  # Whether a secret should be used as the source of IAM account
-  # credentials. Set to false if, for example, using kube2iam or
-  # kiam to provide IAM credentials for the Velero pod.
-  useSecret: true
-  # Name of a pre-existing secret (if any) in the Velero namespace
-  # that should be used to get IAM account credentials. Optional.
-  existingSecret:
-  # Data to be stored in the Velero secret, if `useSecret` is
-  # true and `existingSecret` is empty. This should be the contents
-  # of your IAM credentials file.
+  # Create secret with credentials
   secretContents:
     cloud: |
       [default]
       aws_access_key_id: {{ .Values.s3.accessKey }}
       aws_secret_access_key: {{ .Values.s3.secretKey }}
 
-# Whether to deploy the restic daemonset.
 deployRestic: true
 
 restic:
-  podVolumePath: /var/lib/kubelet/pods
-  resources:
-    limits:
-      cpu: 200m
-      memory: 200Mi
-    requests:
-      cpu: 100m
-      memory: 100Mi
+  resources:   {{- toYaml .Values.velero.restic.resources | nindent 4  }}
+  tolerations: {{- toYaml .Values.velero.restic.tolerations | nindent 4  }}
 
-# Backup schedules to create.
-# Eg:
-# schedules:
-#   mybackup:
-#     schedule: "0 0 * * *"
-#     template:
-#       excludedNamespaces: null
-#       excludedResources: null
-#       hooks:
-#         resources: null
-#       includeClusterResources: null
-#       includedNamespaces:
-#       - default
-#       includedResources: null
-#       labelSelector:
-#         matchLabels:
-#           app: test
-#           velero: backup
-#       storageLocation: ""
-#       ttl: 720h0m0s
-#       volumeSnapshotLocations: null
 schedules:
   daily-backup:
     schedule: "0 0 * * *" #once per day


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit fixes the slightly broken config
that had no effect. This also add some new configration options
with regards to pod placement. Also removes some default comments
and values from the values file for velero.

**Which issue this PR fixes**:
fixes #45  
fixes #46 

**Special notes for reviewer**:
Tested backwards compatability by checking that there is no diff
```
git checkout main
helmfile -l app=velero apply
git checkout ol/fix-velero-conf;
Update my config
helmfile -l app=velero diff
```

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
