### PR TITLE
Remove broken ops grafana oidc config

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -19,3 +19,7 @@
 
 - The user fluentd configuration uses its dedicated values for tolerations, affinity and nodeselector.
 - The wc fluentd tolerations and nodeSelector configuration options are now only specified in the configuration file.
+
+### Removed
+
+- Broken OIDC configuration for the ops Grafana instance has been removed.

--- a/helmfile/values/prometheus-operator-sc.yaml.gotmpl
+++ b/helmfile/values/prometheus-operator-sc.yaml.gotmpl
@@ -213,18 +213,6 @@ grafana:
   grafana.ini:
     server:
       root_url: https://grafana.{{ .Values.global.opsDomain }}
-    auth.generic_oauth:
-      name: dex
-      enabled: true
-      client_id: grafana
-      client_secret: {{ .Values.grafana.clientSecret }}
-      scopes: profile email openid
-      auth_url: https://dex.{{ .Values.global.baseDomain }}/auth
-      token_url: https://dex.{{ .Values.global.baseDomain }}/token
-      api_url: https://dex.{{ .Values.global.baseDomain }}/api
-      allowed_domains: {{ join " " .Values.dex.allowedDomains }}
-      allow_sign_up: true
-      tls_skip_verify_insecure: {{ not .Values.global.verifyTls }}
 
   serviceMonitor:
     relabelings:


### PR DESCRIPTION
**What this PR does / why we need it**:
The ops grafana url is not registered as a valid redirect url, and therefore login with oidc will not work.

There are decisions to be made regarding if/how to limit access to the ops grafana instance.
Therefore there is no clear fix to the broken configuration at the moment.

This PR removes the broken configuration.

**Which issue this PR fixes**:
fixes #52 

**Public facing documentation PR** *(if applicable)*
I do not believe that we have documented the ops grafana instance publicly yet.

**Special notes for reviewer**:
I have tested deploying this, and validated that the dex login option is removed.
It is still possible use static login.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
