### PR TITLE
bin: Add ck8s internal helm

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -14,6 +14,7 @@
 - `any` can be used as configuration version to disabled version check
 - Configuration options regarding pod placement and resources for cert-manager
 - Possibility to configure pod placement and resourcess for velero
+- Add `./bin/ck8s ops helm` to allow investigating issues between `helmfile` and `kubectl`.
 
 ### Changed
 

--- a/bin/ck8s
+++ b/bin/ck8s
@@ -21,6 +21,7 @@ usage() {
     # TODO: We might want to make this command less visible once we have proper
     #       support for OIDC logins.
     echo "  ops kubectl <wc|sc>                         run kubectl as cluster admin" 1>&2
+    echo "  ops helm <wc|sc>                            run helm as cluster admin" 1>&2
     # TODO: We might want to make this command less visible once we feel
     #       confident that the apply command and migrations are good enough
     #       that direct Helmfile access is not necessary.
@@ -72,6 +73,11 @@ case "${1}" in
                 [[ "${3}" =~ ^(wc|sc)$ ]] || usage
                 shift 2
                 "${here}/ops.bash" kubectl "${@}"
+            ;;
+            helm)
+                [[ "${3}" =~ ^(wc|sc)$ ]] || usage
+                shift 2
+                "${here}/ops.bash" helm "${@}"
             ;;
             helmfile)
                 [[ "${3}" =~ ^(wc|sc)$ ]] || usage

--- a/bin/ops.bash
+++ b/bin/ops.bash
@@ -14,6 +14,7 @@ source "${here}/common.bash"
 
 usage() {
     echo "Usage: kubectl <wc|sc> ..." >&2
+    echo "       helm <wc|sc> ..." >&2
     echo "       helmfile <wc|sc> ..." >&2
     exit 1
 }
@@ -27,6 +28,17 @@ ops_kubectl() {
     esac
     shift
     with_kubeconfig "${kubeconfig}" kubectl "${@}"
+}
+
+# Run arbitrary helm commands as cluster admin.
+ops_helm() {
+    case "${1}" in
+        sc) kubeconfig="${secrets[kube_config_sc]}" ;;
+        wc) kubeconfig="${secrets[kube_config_wc]}" ;;
+        *) usage ;;
+    esac
+    shift
+    with_kubeconfig "${kubeconfig}" helm "${@}"
 }
 
 # Run arbitrary Helmfile commands as cluster admin.
@@ -62,6 +74,10 @@ case "${1}" in
     kubectl)
         shift
         ops_kubectl "${@}"
+    ;;
+    helm)
+        shift
+        ops_helm "${@}"
     ;;
     helmfile)
         shift


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR add `./bin/ck8s ops helm` to allow investigating issues with Helm releases, i.e., between `ops helmfile` and `ops kubectl`.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

NA

**Special notes for reviewer**:

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [NA] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
