### PR TITLE
Pipeline: allow setting env name outside script

### DIFF
--- a/pipeline/init-unit-tests.bash
+++ b/pipeline/init-unit-tests.bash
@@ -9,7 +9,7 @@ ck8s="${here}/../bin/ck8s"
 source "${here}/common.bash"
 
 export CK8S_FLAVOR="${CI_CK8S_FLAVOR:-dev}"
-export CK8S_ENVIRONMENT_NAME="apps-${CK8S_CLOUD_PROVIDER}-${CK8S_FLAVOR}-${GITHUB_RUN_ID}"
+export CK8S_ENVIRONMENT_NAME="${CK8S_ENVIRONMENT_NAME:-apps-${CK8S_CLOUD_PROVIDER}-${CK8S_FLAVOR}-${GITHUB_RUN_ID}}"
 
 # Initialize ck8s repository
 

--- a/pipeline/init-unit-tests.bash
+++ b/pipeline/init-unit-tests.bash
@@ -2,10 +2,8 @@
 
 set -eu -o pipefail
 
-# shellcheck disable=SC1090
 here="$(dirname "$(readlink -f "$0")")"
 ck8s="${here}/../bin/ck8s"
-# shellcheck disable=SC1090
 source "${here}/common.bash"
 
 export CK8S_FLAVOR="${CI_CK8S_FLAVOR:-dev}"

--- a/pipeline/init-unit-tests.bash
+++ b/pipeline/init-unit-tests.bash
@@ -9,7 +9,7 @@ ck8s="${here}/../bin/ck8s"
 source "${here}/common.bash"
 
 export CK8S_FLAVOR="${CI_CK8S_FLAVOR:-dev}"
-export CK8S_ENVIRONMENT_NAME="compliantkubernetes-apps-${CK8S_CLOUD_PROVIDER}-${CK8S_FLAVOR}-${GITHUB_RUN_ID}"
+export CK8S_ENVIRONMENT_NAME="apps-${CK8S_CLOUD_PROVIDER}-${CK8S_FLAVOR}-${GITHUB_RUN_ID}"
 
 # Initialize ck8s repository
 

--- a/pipeline/init.bash
+++ b/pipeline/init.bash
@@ -9,7 +9,7 @@ ck8s="${here}/../bin/ck8s"
 source "${here}/common.bash"
 
 export CK8S_FLAVOR="${CI_CK8S_FLAVOR:-dev}"
-export CK8S_ENVIRONMENT_NAME="apps-${CK8S_CLOUD_PROVIDER}-${CK8S_FLAVOR}-${GITHUB_RUN_ID}"
+export CK8S_ENVIRONMENT_NAME="${CK8S_ENVIRONMENT_NAME:-apps-${CK8S_CLOUD_PROVIDER}-${CK8S_FLAVOR}-${GITHUB_RUN_ID}}"
 
 # Initialize ck8s repository
 

--- a/pipeline/init.bash
+++ b/pipeline/init.bash
@@ -2,10 +2,8 @@
 
 set -eu -o pipefail
 
-# shellcheck disable=SC1090
 here="$(dirname "$(readlink -f "$0")")"
 ck8s="${here}/../bin/ck8s"
-# shellcheck disable=SC1090
 source "${here}/common.bash"
 
 export CK8S_FLAVOR="${CI_CK8S_FLAVOR:-dev}"

--- a/pipeline/init.bash
+++ b/pipeline/init.bash
@@ -9,7 +9,7 @@ ck8s="${here}/../bin/ck8s"
 source "${here}/common.bash"
 
 export CK8S_FLAVOR="${CI_CK8S_FLAVOR:-dev}"
-export CK8S_ENVIRONMENT_NAME="compliantkubernetes-apps-${CK8S_CLOUD_PROVIDER}-${CK8S_FLAVOR}-${GITHUB_RUN_ID}"
+export CK8S_ENVIRONMENT_NAME="apps-${CK8S_CLOUD_PROVIDER}-${CK8S_FLAVOR}-${GITHUB_RUN_ID}"
 
 # Initialize ck8s repository
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the pipeline is run from a different repository, it is required to be able to set the environment name outside the pipeline script.

**Which issue this PR fixes**: -

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
