### PR TITLE
bin: Upgrade Helm to v3.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The apps are installed using a combination of helm charts and manifests with the
 
 * A running cluster based on [ck8s-cluster](https://github.com/elastisys/ck8s-cluster)
 * [kubectl](https://github.com/kubernetes/kubernetes/releases) (tested with 1.15.2)
-* [helm](https://github.com/helm/helm/releases) (tested with 3.3.4)
+* [helm](https://github.com/helm/helm/releases) (tested with 3.4.1)
 * [helmfile](https://github.com/roboll/helmfile) (tested with v0.129.3)
 * [helm-diff](https://github.com/databus23/helm-diff) (tested with 3.1.1)
 * [helm-secrets](https://github.com/futuresimple/helm-secrets) (tested with 2.0.2)

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Configuration for harbor and cert-manager has been changed and requires running init and apply again.
 - Configuration for velero has been changed and requires running init again.
+- Helm has been upgraded to v3.4.1. Please upgrade the local binary.
 
 ### Added
 
@@ -14,6 +15,7 @@
 
 - Ingress nginx has been updated to a new chart repo and bumped to version 2.10
 - Harbor chart has been upgraded to version 1.5.1
+- Helm has been upgraded to v3.4.1
 
 ### Fixed
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -3,6 +3,10 @@
 - Configuration for harbor and cert-manager has been changed and requires running init and apply again.
 - Configuration for velero has been changed and requires running init again.
 - Helm has been upgraded to v3.4.1. Please upgrade the local binary.
+- The Helm repository `stable` has changed URL and has to be changed manually:
+  `helm repo add "stable" "https://charts.helm.sh/stable" --force-update`
+- The blackbox chart has a changed dependency URL and has to be updated manually:
+  `cd helmfile/charts/blackbox && helm dependency update`
 
 ### Added
 

--- a/bootstrap/storageclass/helmfile/helmfile.yaml
+++ b/bootstrap/storageclass/helmfile/helmfile.yaml
@@ -1,6 +1,6 @@
 repositories:
 - name: stable
-  url: https://kubernetes-charts.storage.googleapis.com
+  url: https://charts.helm.sh/stable
 
 helmDefaults:
   timeout: 600

--- a/get-requirements.yaml
+++ b/get-requirements.yaml
@@ -4,7 +4,7 @@
       install_path: /usr/local/bin
       install_user: "{{ lookup('env','USER') }}"
       kubectl_version: 1.15.2
-      helm_version: 3.3.4
+      helm_version: 3.4.1
       helmfile_version: 0.129.3
       helmdiff_version: 3.1.1
       helmsecrets_version: 2.0.2

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -1,7 +1,7 @@
 # Chart repositories used from within this state file.
 repositories:
 - name: stable
-  url: https://kubernetes-charts.storage.googleapis.com
+  url: https://charts.helm.sh/stable
 - name: jetstack
   url: https://charts.jetstack.io
 - name: kiwigrid

--- a/helmfile/charts/blackbox/requirements.yaml
+++ b/helmfile/charts/blackbox/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: prometheus-blackbox-exporter
     version: 2.0.0
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -25,7 +25,7 @@ RUN wget https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops
     chmod +x /usr/local/bin/sops
 
 # Helm
-ENV HELM_VERSION "v3.3.4"
+ENV HELM_VERSION "v3.4.1"
 RUN wget "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" && \
     tar -zxvf "helm-${HELM_VERSION}-linux-amd64.tar.gz" && \
     mv linux-amd64/helm /usr/local/bin/helm && \


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrades Helm to v3.4.1

**Which issue this PR fixes**: fixes #64 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
