### PR TITLE
Allows the specification of nginx configruation options.

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -19,6 +19,7 @@ Make sure to remove the old option from your config when upgrading.
 - Configuration options regarding pod placement and resources for cert-manager
 - Possibility to configure pod placement and resourcess for velero
 - Add `./bin/ck8s ops helm` to allow investigating issues between `helmfile` and `kubectl`.
+- Allow nginx config options to be set in the ingress controller.
 
 ### Changed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -331,6 +331,8 @@ ingressNginx:
       enabled: "set-me"
       type: "set-me"
       annotations: "set-me"
+    # Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
+    additionalConfig: {}
 
   defaultBackend:
   # Chart deploys correctly but does not work with resourceRequests

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -190,6 +190,8 @@ ingressNginx:
       enabled: "set-me"
       type: "set-me"
       annotations: "set-me"
+    # Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
+    additionalConfig: {}
 
   defaultBackend:
   # Chart deploys correctly but does not work with resourceRequests

--- a/helmfile/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile/values/ingress-nginx.yaml.gotmpl
@@ -14,6 +14,9 @@ controller:
     whitelist-source-range: {{ .Values.externalTrafficPolicy.whitelistRange.global }}
     {{ end }}
     use-proxy-protocol: {{ .Values.ingressNginx.controller.config.useProxyProtocol | quote }}
+    {{- with .Values.ingressNginx.controller.additionalConfig }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows the specification of nginx configruation options, like logging format etc.

**Which issue this PR fixes**:
fixes #72 

**Special notes for reviewer**:
Based from #69 where the migration to ingress-nginx has been made.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
