### PR TITLE
apps wc: Confiugrable namespace and ingress issuer for user-alertmgr

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -12,6 +12,8 @@ See [migrations docs for nginx](migration/v0.7.x-v0.8.x/nginx.md) for instructio
 - The config option `nginxIngress.controller.daemonset.useHostPort` has been replaced by `ingressNginx.controller.useHostPort`.
 Make sure to remove the old option from your config when upgrading.
 - Move useRegionEndpoint from elasticsearch to fluentd in sc-config.yaml before upgrading.
+- The workload cluster config option `prometheus.retention.alertManager` has been removed.
+Make sure to remove the option from your config when upgrading.
 
 ### Added
 
@@ -21,6 +23,7 @@ Make sure to remove the old option from your config when upgrading.
 - Possibility to configure pod placement and resourcess for velero
 - Add `./bin/ck8s ops helm` to allow investigating issues between `helmfile` and `kubectl`.
 - Allow nginx config options to be set in the ingress controller.
+- Allow user-alertmanager to be deployed in custom namespace and not only in `monitoring`.
 
 ### Changed
 
@@ -39,7 +42,9 @@ Make sure to remove the old option from your config when upgrading.
 - The user fluentd configuration uses its dedicated values for tolerations, affinity and nodeselector.
 - The wc fluentd tolerations and nodeSelector configuration options are now only specified in the configuration file.
 - Helmfile install error on `user-alertmanager` when `user.alertmanager.enabled: true`.
+- The wrong job name being used for the alertmanager rules in wc when `user.alertmanager.enabled: true`.
 
 ### Removed
 
 - Broken OIDC configuration for the ops Grafana instance has been removed.
+- Unused alertmanager retention configuration from workload cluster

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -36,6 +36,7 @@ Make sure to remove the option from your config when upgrading.
 - useRegionEndpoint moved to fluentd conf.
 - Dex application upgraded to v2.26.0
 - Dex chart updated to v2.15.2
+- The issuer for the user-alertmanager ingress is now taken from `global.issuer`.
 
 ### Fixed
 

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -28,6 +28,7 @@ user:
     - admin@example.com
   alertmanager:
     enabled: false
+    namespace: monitoring
     ingress:
       enabled: false
 
@@ -59,7 +60,6 @@ prometheus:
   retention:
     size: 4GiB
     age:  3d
-    alertManager: 72h
   resources:
     requests:
       memory: 1Gi

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -435,7 +435,7 @@ releases:
 
 {{ if .Values.user.alertmanager.enabled }}
 - name: user-alertmanager
-  namespace: monitoring
+  namespace: {{ .Values.user.alertmanager.namespace | default "monitoring" }}
   labels:
     app: user-alertmanager
   chart: ./charts/examples/user-alertmanager

--- a/helmfile/charts/examples/user-alertmanager/templates/ingress.yaml
+++ b/helmfile/charts/examples/user-alertmanager/templates/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    cert-manager.io/issuer: self-signed
+    cert-manager.io/issuer: {{ .Values.ingress.issuer }}
     # type of authentication
     nginx.ingress.kubernetes.io/auth-type: basic
     # name of the secret that contains the user/password definitions

--- a/helmfile/charts/examples/user-alertmanager/values.yaml
+++ b/helmfile/charts/examples/user-alertmanager/values.yaml
@@ -1,3 +1,4 @@
 baseDomain: ""
 ingress:
   enabled: false
+  issuer: "self-signed"

--- a/helmfile/charts/user-rbac/templates/rolebindings/alertmanager-configurer.yaml
+++ b/helmfile/charts/user-rbac/templates/rolebindings/alertmanager-configurer.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: alertmanager-configurer
-  namespace: monitoring
+  namespace: {{ .Values.alertmanagerNamespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/helmfile/charts/user-rbac/templates/roles/alertmanager-configurer.yaml
+++ b/helmfile/charts/user-rbac/templates/roles/alertmanager-configurer.yaml
@@ -8,7 +8,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: alertmanager-configurer
-  namespace: monitoring
+  namespace: {{ .Values.alertmanagerNamespace }}
 rules:
 # Allow editing the alertmanager-alertmanager secret
 - apiGroups:

--- a/helmfile/charts/user-rbac/values.yaml
+++ b/helmfile/charts/user-rbac/values.yaml
@@ -2,3 +2,4 @@ namespaces: []
 users: []
 create_namespaces: true
 enableFalcoViewer: false
+alertmanagerNamespace: monitoring

--- a/helmfile/values/prometheus-alerts-wc.yaml.gotmpl
+++ b/helmfile/values/prometheus-alerts-wc.yaml.gotmpl
@@ -1,6 +1,6 @@
 esNodeCount: {{ add .Values.elasticsearch.dataNode.count .Values.elasticsearch.clientNode.count .Values.elasticsearch.masterNode.count }}
-alertmanagerJob: prometheus-operator-alertmanager
-alertmanagerNamespace: monitoring
+alertmanagerJob: alertmanager-operated
+alertmanagerNamespace: {{ .Values.user.alertmanager.namespace }}
 prometheusJob: prometheus-operator-prometheus
 operatorJob: prometheus-operator-operator
 

--- a/helmfile/values/prometheus-operator-wc.yaml.gotmpl
+++ b/helmfile/values/prometheus-operator-wc.yaml.gotmpl
@@ -88,14 +88,15 @@ prometheus:
     # Connect to separately managed alertmanager
     alertingEndpoints:
       - name: alertmanager-operated
-        namespace: monitoring
+        namespace: {{ .Values.user.alertmanager.namespace }}
         port: web
         pathPrefix: /
     {{ end }}
-    resources: {{- toYaml .Values.prometheus.resources | nindent 8  }}
-    nodeSelector: {{- toYaml .Values.prometheus.nodeSelector | nindent 8 }}
-    affinity: {{- toYaml .Values.prometheus.affinity | nindent 8 }}
-    tolerations: {{- toYaml .Values.prometheus.tolerations | nindent 8 }}
+
+    resources:    {{- toYaml .Values.prometheus.resources | nindent 6 }}
+    nodeSelector: {{- toYaml .Values.prometheus.nodeSelector | nindent 6 }}
+    affinity:     {{- toYaml .Values.prometheus.affinity | nindent 6 }}
+    tolerations:  {{- toYaml .Values.prometheus.tolerations | nindent 6 }}
 
     ## How long to retain metrics
     ##
@@ -129,7 +130,7 @@ prometheus:
     {{ end }}
 
     {{ if .Values.user.alertmanager.enabled }}
-    - job_name: 'monitoring/alertmanager-operated'
+    - job_name: '{{ .Values.user.alertmanager.namespace }}/alertmanager-operated'
       scrape_interval: 30s
       metrics_path: /metrics
       scheme: http
@@ -137,7 +138,7 @@ prometheus:
       - role: endpoints
         namespaces:
           names:
-          - monitoring
+          - {{ .Values.user.alertmanager.namespace }}
         selectors:
           - role: endpoints
             label: 'operated-alertmanager=true'

--- a/helmfile/values/user-alertmanager.yaml.gotmpl
+++ b/helmfile/values/user-alertmanager.yaml.gotmpl
@@ -1,6 +1,7 @@
 baseDomain: {{ .Values.global.baseDomain }}
 ingress:
   enabled: {{ .Values.user.alertmanager.ingress.enabled }}
+  issuer: {{ .Values.global.issuer }}
 basic_auth:
   username: alertmanager
   password: {{ .Values.user.prometheusPassword }}

--- a/helmfile/values/user-rbac.yaml.gotmpl
+++ b/helmfile/values/user-rbac.yaml.gotmpl
@@ -1,3 +1,4 @@
 namespaces: {{ toYaml .Values.user.namespaces | nindent 2 }}
 users: {{ toYaml .Values.user.adminUsers | nindent 2 }}
 enableFalcoViewer: {{ toYaml .Values.falco.enabled | nindent 2 }}
+alertmanagerNamespace: {{ .Values.user.alertmanager.namespace }}


### PR DESCRIPTION
**What this PR does / why we need it**:
To deploy user-alertmanager in custom namespace.
The issuer for the ingress is now also configurable.

**Which issue this PR fixes**:
fixes #78 
fixes #80 

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
