### PR TITLE
apps: add support for baremetal provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ See [Quickstart](#Quickstart) for instructions on how to initialize the repo
 
 ### Cloud providers
 
-Currently we support four cloud providers: Exoscale, Safespring, Citycloud and AWS (beta).
-This is controlled by the value `global.cloudProvider` in the config files.
+Currently we support four cloud providers: Exoscale, Safespring, Citycloud and AWS (beta). In addition to this we support running Compliant Kubernetes on bare metal (beta).
+Which provider to use is controlled by the value `global.cloudProvider` in the config files.
 
 ## Setup
 
@@ -117,7 +117,7 @@ Assuming you already have everything needed to install the apps, this is what yo
 
    ```bash
    export CK8S_ENVIRONMENT_NAME=my-ck8s-cluster
-   export CK8S_CLOUD_PROVIDER=[exoscale|safespring|citycloud|aws]
+   export CK8S_CLOUD_PROVIDER=[exoscale|safespring|citycloud|aws|baremetal]
    export CK8S_FLAVOR=[dev|prod] # defaults to dev
    ```
 

--- a/bin/common.bash
+++ b/bin/common.bash
@@ -106,6 +106,7 @@ validate_cloud() {
     if [ "${1}" != "exoscale" ] &&
        [ "${1}" != "safespring" ] &&
        [ "${1}" != "citycloud" ] &&
+       [ "${1}" != "baremetal" ] &&
        [ "${1}" != "aws" ]; then
         log_error "ERROR: Unsupported cloud provider: ${1}"
         exit 1

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -103,6 +103,7 @@ generate_base_wc_config() {
 }
 
 # Usage: set_storage_class <config-file>
+# baremetal support is experimental, keep as separate case until stable
 set_storage_class() {
     file=$1
     if [[ ! -f "${file}" ]]; then
@@ -125,6 +126,11 @@ set_storage_class() {
           es_storage_class=ebs-gp2
           ;;
 
+        baremetal)
+	  storage_class=node-local
+	  es_storage_class=node-local
+	  ;;
+
     esac
     replace_set_me "$1" 'global.storageClass' "$storage_class"
     # Only write if field exists already
@@ -134,6 +140,7 @@ set_storage_class() {
 }
 
 # Usage: set_nginx_config <config-file>
+# baremetal support is experimental, keep as separate case until stable
 set_nginx_config() {
     file=$1
     if [[ ! -f "${file}" ]]; then
@@ -163,13 +170,20 @@ set_nginx_config() {
           replace_set_me "$1" 'ingressNginx.controller.service.annotations' "$service_annotations"
           ;;
 
+        baremetal)
+	  use_proxy_protocol=false
+	  use_host_port=true
+	  service_enabled=false
+	  ;;
+
     esac
     replace_set_me "$1" 'ingressNginx.controller.config.useProxyProtocol' "$use_proxy_protocol"
     replace_set_me "$1" 'ingressNginx.controller.useHostPort' "$use_host_port"
     replace_set_me "$1" 'ingressNginx.controller.service.enabled' "$service_enabled"
 }
 
-# Usage: set_nginx_config <config-file>
+# Usage: set_elasticsearch_config <config-file>
+# baremetal support is experimental, keep as separate case until stable
 set_elasticsearch_config() {
     file=$1
     if [[ ! -f "${file}" ]]; then
@@ -186,12 +200,17 @@ set_elasticsearch_config() {
           use_regionendpoint=false
           ;;
 
+        baremetal)
+	  use_regionendpoint=true
+	  ;;
+
     esac
 
     replace_set_me "$1" 'fluentd.useRegionEndpoint' "$use_regionendpoint"
 }
 
 # Usage: set_harbor_config <config-file>
+# baremetal support is experimental, keep as separate case until stable
 set_harbor_config() {
     file=$1
     if [[ ! -f "${file}" ]]; then
@@ -213,6 +232,11 @@ set_harbor_config() {
           persistence_type=swift
           disable_redirect=true
           ;;
+
+        baremetal)
+          persistence_type=s3
+	  disable_redirect=false
+	  ;;
 
     esac
     replace_set_me "$1" 'harbor.persistence.type' "$persistence_type"


### PR DESCRIPTION
**What this PR does / why we need it**:
Bare metal support is under development. This means that the apps repo must support it. This PR adds "baremetal" as a cloud provider setting in init so that when you run ck8s init for bare metal you  get settings based on that.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
