### PR TITLE
Petter okta

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -37,6 +37,7 @@ The following options has been removed or replaced
 - Allow user-alertmanager to be deployed in custom namespace and not only in `monitoring`.
 - Support for GCS
 - Backup retention for InfluxDB.
+- Add Okta as option for OIDC provider
 
 ### Changed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -129,7 +129,7 @@ prometheus:
     nodeSelector: {}
 
 dex:
-  # supported: google|aaa
+  # supported: google|okta|aaa
   oidcProvider: google
   allowedDomains:
     - example.com

--- a/config/secrets/sc-secrets.yaml
+++ b/config/secrets/sc-secrets.yaml
@@ -42,4 +42,7 @@ dex:
   staticPassword: $2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W
   googleClientID:
   googleClientSecret:
+  oktaClientID:
+  oktaClientSecret:
   kubeloginClientSecret:
+  issuer:

--- a/helmfile/values/dex.yaml.gotmpl
+++ b/helmfile/values/dex.yaml.gotmpl
@@ -29,15 +29,22 @@ config:
     id: google
     name: Google
     config:
-      # Canonical URL of the provider, also used for configuration discovery.
-      # This value MUST match the value returned in the provider config discovery.
-      #
-      # See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
       issuer: https://accounts.google.com
       redirectURI: https://dex.{{ .Values.global.baseDomain }}/callback
       clientID: {{ .Values.dex.googleClientID }}
       clientSecret: {{ .Values.dex.googleClientSecret }}
       hostedDomains: {{ toYaml .Values.dex.allowedDomains | nindent 6 }}
+  {{ end }}
+  {{ if eq .Values.dex.oidcProvider "okta" }}
+  - type: oidc
+    id: okta
+    name: Okta
+    config:
+      issuer: https://{{ .Values.dex.issuer }}
+      redirectURI: https://dex.{{ .Values.global.baseDomain }}/callback
+      clientID: {{ .Values.dex.oktaClientID }}
+      clientSecret: {{ .Values.dex.oktaClientSecret }}
+      insecureSkipEmailVerified: true
   {{ end }}
   {{ if eq .Values.dex.oidcProvider "aaa" }}
   - name: AAA


### PR DESCRIPTION
**What this PR does / why we need it**: allows okta to be used as an oidc provider to dex

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #201

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:oktaClientID and oktaClientSecret need to be added under dex in secrets.yaml.  We have an okta account - ask myself or Petter for access

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
