### PR TITLE
fluentd: Added environment name as a record for all logs

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -39,6 +39,7 @@ The following options has been removed or replaced
 - `elasticsearch.retention.kubernetesAge` replaced by `elasticsearch.retention.kubernetesAgeDays`
 - `elasticsearch.retention.otherSize` replaced by `elasticsearch.retention.otherSizeGB`
 - `elasticsearch.retention.otherAge` replaced by `elasticsearch.retention.otherAgeDays`
+- Removed unused config `global.environmentName` and added `global.clusterName` to migrate there's [this script](migration/v0.7.x-v0.8.x/migrate-config.sh)
 
 ### Added
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -54,6 +54,7 @@ The following options has been removed or replaced
 - Backup retention for InfluxDB.
 - Add Okta as option for OIDC provider
 - Dex configuration to accept groups from Okta as an OIDC provider
+- Added record `cluster.name` in all logs to elasticsearch that matches the cluster setting `global.clusterName`
 
 ### Changed
 

--- a/bin/user-kubeconfig.bash
+++ b/bin/user-kubeconfig.bash
@@ -20,12 +20,10 @@ get_user_server() {
 
 log_info "Creating kubeconfig for the user"
 
-environment_name=$(yq r "${config[config_file_wc]}" 'global.environmentName')
-cloud_provider=$(yq r "${config[config_file_wc]}" 'global.cloudProvider')
+cluster_name=$(yq r "${config[config_file_wc]}" 'global.clusterName')
 base_domain=$(yq r "${config[config_file_wc]}" 'global.baseDomain')
 
 # Get server and certificate from the admin kubeconfig
-cluster_name="${environment_name}_${cloud_provider}"
 user_server=$(get_user_server)
 user_certificate_authority=/tmp/user-authority.pem
 append_trap "rm ${user_certificate_authority}" EXIT

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -1,7 +1,7 @@
 global:
   ck8sVersion: ${CK8S_VERSION}
   cloudProvider: ${CK8S_CLOUD_PROVIDER}
-  environmentName: ${CK8S_ENVIRONMENT_NAME}
+  clusterName: ${CK8S_ENVIRONMENT_NAME}-sc
   dnsPrefix: ${CK8S_ENVIRONMENT_NAME}
   baseDomain: "set-me"
   opsDomain: "set-me"

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -1,7 +1,7 @@
 global:
   ck8sVersion: ${CK8S_VERSION}
   cloudProvider: ${CK8S_CLOUD_PROVIDER}
-  environmentName: ${CK8S_ENVIRONMENT_NAME}
+  clusterName: ${CK8S_ENVIRONMENT_NAME}-wc
   dnsPrefix: ${CK8S_ENVIRONMENT_NAME}
   baseDomain: "set-me"
   opsDomain: "set-me"

--- a/helmfile/values/fluentd-sc.yaml.gotmpl
+++ b/helmfile/values/fluentd-sc.yaml.gotmpl
@@ -146,6 +146,13 @@ extraConfigMaps:
       </metric>
     </filter>
 
+    <filter **>
+      @type record_transformer
+      <record>
+        cluster.name "{{ .Values.global.clusterName }}"
+      </record>
+    </filter>
+
   output.conf: |-
     <match **>
       @id output-forwarding

--- a/helmfile/values/fluentd-user.yaml.gotmpl
+++ b/helmfile/values/fluentd-user.yaml.gotmpl
@@ -159,6 +159,13 @@ extraConfigMaps:
       </metric>
     </filter>
 
+    <filter **>
+      @type record_transformer
+      <record>
+        cluster.name "{{ .Values.global.clusterName }}"
+      </record>
+    </filter>
+
     # Include extra configuration files
     @include /etc/fluent/extra-config.d/*.conf
 

--- a/helmfile/values/fluentd-wc.yaml.gotmpl
+++ b/helmfile/values/fluentd-wc.yaml.gotmpl
@@ -161,6 +161,13 @@ extraConfigMaps:
       </metric>
     </filter>
 
+    <filter **>
+      @type record_transformer
+      <record>
+        cluster.name "{{ .Values.global.clusterName }}"
+      </record>
+    </filter>
+
   output.conf: |-
     <match kubeaudit.**>
         @id elasticsearch_kubeaudit

--- a/migration/v0.7.x-v0.8.x/migrate-config.sh
+++ b/migration/v0.7.x-v0.8.x/migrate-config.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
+for cluster in sc wc; do
+  config="${CK8S_CONFIG_PATH}/${cluster}-config.yaml"
+
+  environment_name=$(yq r "$config" 'global.environmentName')
+
+  yq w -i "$config" 'global.clusterName' "${environment_name}-${cluster}"
+
+  yq d -i "$config" 'global.environmentName'
+done

--- a/scripts/deploy-wc.sh
+++ b/scripts/deploy-wc.sh
@@ -9,10 +9,6 @@ source "${SCRIPTS_PATH}/../bin/common.bash"
 : "${config[config_file_wc]:?Missing config}"
 : "${secrets[secrets_file]:?Missing secrets}"
 
-environment=$(yq r -e "${config[config_file_wc]}" 'global.environmentName')
-cloud_provider=$(yq r -e "${config[config_file_wc]}" 'global.cloudProvider')
-export CLUSTER_NAME="${environment}_${cloud_provider}"
-
 # Arg for Helmfile to be interactive so that one can decide on which releases
 # to update if changes are found.
 # USE: --interactive, default is not interactive.


### PR DESCRIPTION
**What this PR does / why we need it**:

To support multi cluster we need to be able to differentiate between all logs in elasticsearch

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*:

fixes #93 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
