### PR TITLE
apps sc: dex configured to accept OIDC groups from Okta

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -38,6 +38,7 @@ The following options has been removed or replaced
 - Support for GCS
 - Backup retention for InfluxDB.
 - Add Okta as option for OIDC provider
+- Dex configuration to accept groups from Okta as an OIDC provider
 
 ### Changed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -144,6 +144,11 @@ dex:
   tolerations: []
   affinity: {}
   nodeSelector: {}
+  # These two settings are curently only used by okta. If you don't need the groups claims, both options can be set to 'false'.
+  # 'insecureSkipEmailVerified' should only be set to 'true' if the user's okta
+  # configuration does not require a user to verify their identity to okta when their okta account is being created. This is not recommended.
+  insecureSkipEmailVerified: false
+  insecureEnableGroups: true
 
 elasticsearch:
   sso:

--- a/helmfile/values/dex.yaml.gotmpl
+++ b/helmfile/values/dex.yaml.gotmpl
@@ -44,7 +44,14 @@ config:
       redirectURI: https://dex.{{ .Values.global.baseDomain }}/callback
       clientID: {{ .Values.dex.oktaClientID }}
       clientSecret: {{ .Values.dex.oktaClientSecret }}
-      insecureSkipEmailVerified: true
+      insecureSkipEmailVerified: {{ .Values.dex.insecureSkipEmailVerified }}
+      insecureEnableGroups: {{ .Values.dex.insecureEnableGroups }}
+      scopes:
+        - openid
+        - profile
+        - email
+        - groups
+      getUserInfo: true
   {{ end }}
   {{ if eq .Values.dex.oidcProvider "aaa" }}
   - name: AAA


### PR DESCRIPTION
**What this PR does / why we need it**:using Okta as an OIDC provider to dex, dex is configured to accept groups

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #444

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
