### PR TITLE
Making object storage optional

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -44,6 +44,7 @@ The following options has been removed or replaced
   `./bin/ck8s ops helmfile wc -l app=user-alertmanager destroy && ./bin/ck8s ops helmfile wc -l app=user-alertmanager apply`
 - With the replacement of the helm chart `stable/elasticsearch-exporter` to `prometheus-community/prometheus-elasticsearch-exporter`, it is required to manually execute some steps to upgrade.
 See [migrations docs for elasticsearch-exporter](migration/v0.7.x-v0.8.x/migrate-elasticsearch-exporter.md) for instructions on how to perform the upgrade.
+- Configuration regarding backups (in general) and harbor storage have been changed and requires running init again. If `harbor.persistence.type` equals `s3` or `gcs` in your config you must update it to `objectStorage`.
 
 ### Added
 
@@ -61,6 +62,9 @@ See [migrations docs for elasticsearch-exporter](migration/v0.7.x-v0.8.x/migrate
 - Added record `cluster.name` in all logs to elasticsearch that matches the cluster setting `global.clusterName`
 - Role mapping from OIDC groups to roles in user grafana
 - Configuration options regarding resources/tolerations for prometheus-elasticsearch-exporter
+- Options to disable different types of backups.
+- Harbor image storage can now be set to `filesystem` in order to use persistent volumes instead of object storage.
+- Object storage is now optional. There is a new option to set object storage type to `none`. If you disable object storage, then you must also disable any feature that uses object storage (mostly all backups).
 
 ### Changed
 
@@ -89,6 +93,7 @@ One can now for example configure:
 - Updated user grafana chart to 6.1.11 and app version to 7.3.3
 - The `stable/elasticsearch-exporter` helm chart has been replaced by `prometheus-community/prometheus-elasticsearch-exporter`
 - OIDC group claims added to Harbor
+- The options `s3` and `gcs` for `harbor.persistence.type` have been replaced with `objectStorage` and will then match the type set in the global object storage configuration.
 
 ### Fixed
 

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -219,12 +219,12 @@ set_harbor_config() {
     fi
     case ${CK8S_CLOUD_PROVIDER} in
         aws | exoscale)
-          persistence_type=s3
+          persistence_type=objectStorage
           disable_redirect=false
           ;;
 
         safespring)
-          persistence_type=s3
+          persistence_type=objectStorage
           disable_redirect=true
           ;;
 
@@ -234,7 +234,7 @@ set_harbor_config() {
           ;;
 
         baremetal)
-          persistence_type=s3
+          persistence_type=objectStorage
 	  disable_redirect=false
 	  ;;
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -11,6 +11,11 @@ global:
   clusterDns: "10.43.0.10"
 
 objectStorage:
+  # Options are "s3", "gcs", or "none"
+  # If "none", remember to disable features that depend on object storage:
+  #   all backups (velero, harbor, influxdb, elasticsearch), sc logs (fluentd)
+  #   Also set harbor persistence to "filesystem" or "swift"
+  # Otherwise configure the features to match this type.
   type: "s3"
   # gcs:
   #   project: "set-me"
@@ -100,12 +105,15 @@ harbor:
         memory: 512Mi
         cpu: 200m
   persistence:
+    # Valid options are "filesystem" (persistent volume), "swift", or "objectStorage" (matching global config)
     type: "set-me"
     disableRedirect: set-me
   oidc:
     #group claim name used by OIDC Provider
     groupClaimName: "set-me"
     scope: openid,email,profile,offline_access,groups
+  backup:
+    enabled: true
 
 prometheus:
   storage:
@@ -279,6 +287,7 @@ elasticsearch:
     additionalPolicies: {}
   # Snapshot and snapshot lifecycle configuration
   snapshot:
+    enabled: true
     min: 7
     max: 14
     ageSeconds: 864000
@@ -312,6 +321,9 @@ elasticsearch:
     tolerations: []
 
 fluentd:
+  # Enable log collection in the service cluster
+  # and store in object storage via fluentd aggregator.
+  enabled: true
   resources:
     limits:
       cpu: 500m
@@ -335,6 +347,7 @@ fluentd:
     affinity: {}
     nodeSelector: {}
 
+# Log retention for service cluster logs stored in object storage.
 logRetention:
   days: 7
 
@@ -495,6 +508,7 @@ ingressNginx:
     nodeSelector: {}
 
 velero:
+  enabled: true
   tolerations: []
   nodeSelector: {}
   resources:

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -11,6 +11,8 @@ global:
   clusterDns: "10.43.0.10"
 
 objectStorage:
+  # Options are "s3", "gcs", or "none"
+  # If "none", remember to disable backups (velero)
   type: "s3"
   # gcs:
   #   project: "set-me"
@@ -215,6 +217,7 @@ ingressNginx:
     nodeSelector: {}
 
 velero:
+  enabled: true
   tolerations: []
   nodeSelector: {}
   resources:

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -92,13 +92,13 @@ releases:
 {{ end }}
 
 
-{{ if .Values.ck8sdash.enabled }}
 - name: ck8sdash
   namespace: ck8sdash
   labels:
     app: ck8sdash
   chart: ./charts/ck8sdash
   version: 0.3.1
+  installed: {{ .Values.ck8sdash.enabled }}
   missingFileHandler: Error
   needs:
   - cert-manager/cert-manager
@@ -110,7 +110,6 @@ releases:
 {{ if eq .Environment.Name "workload_cluster" }}
   - values/ck8sdash-wc.yaml.gotmpl
 {{ end }}
-{{ end }}
 
 # Velero
 - name: velero
@@ -119,6 +118,7 @@ releases:
     app: velero
   chart: vmware-tanzu/velero
   version: 2.8.2
+  installed: {{ .Values.velero.enabled }}
   missingFileHandler: Error
   values:
   - values/velero.yaml.gotmpl
@@ -217,7 +217,6 @@ releases:
   version: 0.1.0
   missingFileHandler: Error
 
-{{ if .Values.user.grafana.enabled }}
 # Grafana instance for user
 - name: user-grafana
   namespace: monitoring
@@ -227,12 +226,12 @@ releases:
     app.kubernetes.io/name: grafana
   chart: grafana/grafana
   version: 6.1.11
+  installed: {{ .Values.user.grafana.enabled }}
   missingFileHandler: Error
   needs:
   - cert-manager/cert-manager
   values:
   - values/grafana-user.yaml.gotmpl
-{{ end }}
 
 
 # prometheus-elasticsearch-exporter
@@ -255,6 +254,7 @@ releases:
     app: elasticsearch-slm
   chart: ./charts/elasticsearch-slm
   version: 0.1.0
+  installed: {{ .Values.elasticsearch.snapshot.enabled }}
   missingFileHandler: Error
   needs:
   - elastic-system/opendistro-es
@@ -268,13 +268,13 @@ releases:
     app: elasticsearch-backup
   chart: ./charts/elasticsearch-backup
   version: 0.1.0
+  installed: {{ .Values.elasticsearch.snapshot.enabled }}
   missingFileHandler: Error
   needs:
   - elastic-system/opendistro-es
   values:
   - values/elasticsearch-backup.yaml.gotmpl
 
-{{ if .Values.harbor.enabled }}
 # Harbor
 - name: harbor-certs
   namespace: harbor
@@ -282,6 +282,7 @@ releases:
     app: harbor
   chart: ./charts/harbor-certs
   version: 0.1.0
+  installed: {{ .Values.harbor.enabled }}
   missingFileHandler: Error
   needs:
   - cert-manager/cert-manager
@@ -294,6 +295,7 @@ releases:
     app: harbor
   chart: harbor/harbor
   version: 1.5.1
+  installed: {{ .Values.harbor.enabled }}
   missingFileHandler: Error
   wait: true
   timeout: 600
@@ -308,6 +310,7 @@ releases:
     app: harbor
   chart: ./charts/init-harbor
   version: 0.1.0
+  installed: {{ .Values.harbor.enabled }}
   missingFileHandler: Error
   needs:
   - harbor/harbor
@@ -321,10 +324,10 @@ releases:
     component: backup
   chart: ./charts/harbor-backup
   version: 0.1.0
+  installed: {{ and .Values.harbor.enabled .Values.harbor.backup.enabled }}
   missingFileHandler: Error
   values:
   - values/harbor-backup.yaml.gotmpl
-{{ end }}
 
 # InfluxDB with disk usage monitoring and metrics retention
 - name: influxdb
@@ -354,6 +357,7 @@ releases:
     app: fluentd
   chart: kiwigrid/fluentd-elasticsearch
   version: 5.1.1
+  installed: {{ .Values.fluentd.enabled }}
   missingFileHandler: Error
   values:
   - values/fluentd-sc.yaml.gotmpl
@@ -365,6 +369,7 @@ releases:
     app: fluentd-aggregator
   chart: stable/fluentd
   version: 2.3.2
+  installed: {{ .Values.fluentd.enabled }}
   missingFileHandler: Error
   values:
   - values/fluentd-aggregator.yaml.gotmpl
@@ -376,6 +381,7 @@ releases:
     app: sc-logs-retention
   chart: ./charts/sc-logs-retention
   version: 0.1.0
+  installed: {{ .Values.fluentd.enabled }}
   missingFileHandler: Error
   needs:
   - fluentd/fluentd-aggregator
@@ -400,7 +406,6 @@ releases:
 
 # Workload cluster releases
 {{ if eq .Environment.Name "workload_cluster" }}
-{{ if .Values.falco.enabled }}
 # Falco
 - name: falco
   namespace: falco
@@ -408,6 +413,7 @@ releases:
     app: falco
   chart: falcosecurity/falco
   version: 1.5.2
+  installed: {{ .Values.falco.enabled }}
   missingFileHandler: Error
   values:
   - values/falco.yaml.gotmpl
@@ -419,10 +425,10 @@ releases:
     app: falco-exporter
   chart: falcosecurity/falco-exporter
   version: 0.3.8
+  installed: {{ .Values.falco.enabled }}
   missingFileHandler: Error
   values:
     - values/falco-exporter.yaml.gotmpl
-{{ end }}
 
 #Basic auth credentials for accessing workload cluster prometheus
 - name: prometheus-auth
@@ -435,31 +441,29 @@ releases:
   values:
   - values/prometheus-auth.yaml.gotmpl
 
-{{ if .Values.user.alertmanager.enabled }}
 - name: user-alertmanager
   namespace: {{ .Values.user.alertmanager.namespace | default "monitoring" }}
   labels:
     app: user-alertmanager
   chart: ./charts/examples/user-alertmanager
   version: 0.1.0
+  installed: {{ .Values.user.alertmanager.enabled }}
   missingFileHandler: Error
   needs:
   - cert-manager/cert-manager
   values:
   - values/user-alertmanager.yaml.gotmpl
-{{ end }}
 
-{{ if .Values.falco.alerts.enabled }}
 - name: falcosidekick
   namespace: falco
   labels:
     app: falco
   chart: ./charts/falcosidekick
   version: 0.1.14
+  installed: {{ .Values.falco.alerts.enabled }}
   missingFileHandler: Error
   values:
   - values/falcosidekick.yaml.gotmpl
-{{ end }}
 
 # Fluentd
 - name: fluentd-system
@@ -483,7 +487,6 @@ releases:
   values:
   - values/fluentd-user.yaml.gotmpl
 
-{{ if .Values.opa.enabled }}
 # gatekeeper-operator
 - name: gatekeeper-operator
   namespace: gatekeeper-system
@@ -491,6 +494,7 @@ releases:
     app: gatekeeper-operator
   chart: ./charts/gatekeeper-operator
   version: 1.6.0
+  installed: {{ .Values.opa.enabled }}
   missingFileHandler: Error
   wait: true
   values:
@@ -503,6 +507,7 @@ releases:
     app: gatekeeper-templates
   chart: ./charts/gatekeeper-templates
   version: 1.6.0
+  installed: {{ .Values.opa.enabled }}
   missingFileHandler: Error
   needs:
   - gatekeeper-system/gatekeeper-operator
@@ -516,12 +521,12 @@ releases:
     app: gatekeeper-constraints
   chart: ./charts/gatekeeper-constraints
   version: 1.6.0
+  installed: {{ .Values.opa.enabled }}
   missingFileHandler: Error
   needs:
   - gatekeeper-system/gatekeeper-templates
   values:
   - values/gatekeeper-constraints.yaml.gotmpl
-{{ end }}
 
 # TODO: Make this optional! Users may not want any alerts by default.
 # It should also be separate from the alerts we use. Users should not need

--- a/helmfile/values/elasticsearch-backup.yaml.gotmpl
+++ b/helmfile/values/elasticsearch-backup.yaml.gotmpl
@@ -1,3 +1,6 @@
+{{ if not (or (eq .Values.objectStorage.type "s3") (eq .Values.objectStorage.type "gcs") ) }}
+{{ fail "\nERROR: Elasticsearch backup requires s3 or gcs object storage, see Values.objectStorage.type" }}
+{{ end }}
 schedule: {{ .Values.elasticsearch.snapshot.backupSchedule | quote }}
 
 resources:

--- a/helmfile/values/elasticsearch-slm.yaml.gotmpl
+++ b/helmfile/values/elasticsearch-slm.yaml.gotmpl
@@ -1,3 +1,6 @@
+{{ if not (or (eq .Values.objectStorage.type "s3") (eq .Values.objectStorage.type "gcs") ) }}
+{{ fail "\nERROR: Elasticsearch slm requires s3 or gcs object storage, see Values.objectStorage.type" }}
+{{ end }}
 snapshots:
   min: {{ .Values.elasticsearch.snapshot.min }}
   max: {{ .Values.elasticsearch.snapshot.max }}

--- a/helmfile/values/fluentd-aggregator.yaml.gotmpl
+++ b/helmfile/values/fluentd-aggregator.yaml.gotmpl
@@ -1,3 +1,6 @@
+{{ if not (or (eq .Values.objectStorage.type "s3") (eq .Values.objectStorage.type "gcs") ) }}
+{{ fail "\nERROR: Fluentd aggregator requires s3 or gcs object storage, see Values.objectStorage.type" }}
+{{ end }}
 image:
   repository: quay.io/fluentd_elasticsearch/fluentd
   tag: v2.9.0

--- a/helmfile/values/harbor-backup.yaml.gotmpl
+++ b/helmfile/values/harbor-backup.yaml.gotmpl
@@ -1,3 +1,6 @@
+{{ if not (or (eq .Values.objectStorage.type "s3") (eq .Values.objectStorage.type "gcs") ) }}
+{{ fail "\nERROR: Harbor backup requires s3 or gcs object storage, see Values.objectStorage.type" }}
+{{ end }}
 dbPassword: {{ .Values.harbor.databasePassword }}
 {{ if eq .Values.objectStorage.type "s3" -}}
 s3:

--- a/helmfile/values/harbor.yaml.gotmpl
+++ b/helmfile/values/harbor.yaml.gotmpl
@@ -1,3 +1,8 @@
+{{ if not (or (eq .Values.harbor.persistence.type "filesystem") (eq .Values.harbor.persistence.type "swift") ) }}
+{{ if not (and (eq .Values.harbor.persistence.type "objectStorage") (or (eq .Values.objectStorage.type "s3") (eq .Values.objectStorage.type "gcs") ) ) }}
+{{ fail "\nERROR: Harbor persistence type should be set to \"filesystem\" (persistent volume), \"swift\", or \"objectStorage\" (matcing global object storage, see Values.objectStorage.type)" }}
+{{ end }}
+{{ end }}
 expose:
   type: ingress
   tls:
@@ -32,7 +37,11 @@ persistence:
       size: {{ .Values.harbor.redis.persistentVolumeClaim.size }}
   imageChartStorage:
     disableredirect: {{ .Values.harbor.persistence.disableRedirect }}
-    {{ if eq .Values.harbor.persistence.type "swift" }}
+    {{ if eq .Values.harbor.persistence.type "filesystem" }}
+    type: filesystem
+    filesystem:
+      rootdirectory: /storage
+    {{ else if eq .Values.harbor.persistence.type "swift" }}
     type: swift
     swift:
       authurl: {{ .Values.citycloud.authURL }}/v3
@@ -43,7 +52,7 @@ persistence:
       authversion: {{ .Values.citycloud.authVersion }}
       tenant: {{ .Values.citycloud.tenantName }}
       domain: {{ .Values.citycloud.projectDomainName }}
-    {{ else }}
+    {{ else if eq .Values.harbor.persistence.type "objectStorage" }}
     {{ if eq .Values.objectStorage.type "s3" }}
     type: s3
     s3:
@@ -58,7 +67,7 @@ persistence:
       bucket: {{ .Values.objectStorage.buckets.harbor }}
       encodedkey: {{ .Values.objectStorage.gcs.keyfileData | b64enc }}
     {{- end }}
-    {{ end }}
+    {{- end }}
 
 externalURL: https://harbor.{{ .Values.global.baseDomain }}
 

--- a/helmfile/values/influxdb.yaml.gotmpl
+++ b/helmfile/values/influxdb.yaml.gotmpl
@@ -1,3 +1,9 @@
+
+{{ if or .Values.influxDB.backup.enabled .Values.influxDB.backupRetention.enabled }}
+{{ if not (or (eq .Values.objectStorage.type "s3") (eq .Values.objectStorage.type "gcs") ) }}
+{{ fail "\nERROR: InfluxDB backup and backup retention requires s3 or gcs object storage, see Values.objectStorage.type" }}
+{{ end }}
+{{ end }}
 elastisys_custom:
   influxdb_user: {{ .Values.influxDB.user }}
   influxdb_password: {{ .Values.influxDB.password }}
@@ -119,6 +125,7 @@ volumes:
       - key: prometheus-influxdb-retention-metric-name
         path: prometheus-influxdb-retention-metric-name
 
+{{ if .Values.influxDB.backup.enabled }}
 backup:
   enabled: {{ .Values.influxDB.backup.enabled }}
   resources: {{- toYaml .Values.influxDB.backup.resources | nindent 4 }}
@@ -140,7 +147,9 @@ backup:
     serviceAccountSecretKey: credentials
     serviceAccountSecret: influxdb-backup-secret
   {{- end }}
+{{ end }}
 
+{{ if .Values.influxDB.backupRetention.enabled }}
 backupRetention:
   enabled: {{ .Values.influxDB.backupRetention.enabled }}
   daysToRetain: {{ .Values.influxDB.backupRetention.daysToRetain }}
@@ -153,3 +162,4 @@ backupRetention:
     bucketName: {{ .Values.objectStorage.buckets.influxDB }}
     endpointUrl: {{ .Values.objectStorage.s3.regionEndpoint }}
   {{- end }}
+{{ end }}

--- a/helmfile/values/sc-logs-retention.yaml.gotmpl
+++ b/helmfile/values/sc-logs-retention.yaml.gotmpl
@@ -1,3 +1,6 @@
+{{ if not (or (eq .Values.objectStorage.type "s3") (eq .Values.objectStorage.type "gcs") ) }}
+{{ fail "\nERROR: Service cluster log retention requires s3 or gcs object storage, see Values.objectStorage.type" }}
+{{ end }}
 resources:
   requests:
     cpu: 100m

--- a/helmfile/values/velero.yaml.gotmpl
+++ b/helmfile/values/velero.yaml.gotmpl
@@ -1,3 +1,6 @@
+{{ if not (or (eq .Values.objectStorage.type "s3") (eq .Values.objectStorage.type "gcs") ) }}
+{{ fail "\nERROR: Velero requires s3 or gcs object storage, see Values.objectStorage.type" }}
+{{ end }}
 resources:    {{- toYaml .Values.velero.resources | nindent 2  }}
 tolerations:  {{- toYaml .Values.velero.tolerations | nindent 2  }}
 nodeSelector: {{- toYaml .Values.velero.nodeSelector | nindent 2  }}

--- a/pipeline/test/services/workload-cluster/testPodsReady.sh
+++ b/pipeline/test/services/workload-cluster/testPodsReady.sh
@@ -10,6 +10,7 @@ enable_falco_alerts=$(yq r -e "${CONFIG_FILE}" 'falco.alerts.enabled')
 enable_falco=$(yq r -e "${CONFIG_FILE}" 'falco.enabled')
 enable_opa=$(yq r -e "${CONFIG_FILE}" 'opa.enabled')
 enable_user_alertmanager=$(yq r -e "${CONFIG_FILE}" 'user.alertmanager.enabled')
+enable_velero=$(yq r -e "${CONFIG_FILE}" 'velero.enabled')
 
 echo
 echo
@@ -26,7 +27,6 @@ deployments=(
     "ingress-nginx ingress-nginx-defaultbackend"
     "monitoring kube-prometheus-stack-operator"
     "monitoring kube-prometheus-stack-kube-state-metrics"
-    "velero velero"
 )
 if [ "$cloud_provider" == "exoscale" ]; then
     deployments+=("kube-system nfs-client-provisioner")
@@ -39,6 +39,9 @@ if [ "$enable_opa" == true ]; then
 fi
 if [ "$enable_falco_alerts" == true ]; then
     deployments+=("falco falcosidekick")
+fi
+if [ "$enable_velero" == true ]; then
+    deployments+=("velero velero")
 fi
 
 resourceKind="Deployment"
@@ -68,6 +71,9 @@ daemonsets=(
 )
 if [ "$enable_falco" == true ]; then
     daemonsets+=("falco falco")
+fi
+if [ "$enable_velero" == true ]; then
+    daemonsets+=("velero restic")
 fi
 
 resourceKind="DaemonSet"


### PR DESCRIPTION
**What this PR does / why we need it**: This makes object storage optional. It mostly adds some config options to disable all backups.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
I have not fixed the tests yet. They should of course not give any error for a disabled feature.

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
