### PR TITLE
apps sc: new influx chart version, pinning retention version

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -66,7 +66,7 @@ The following options has been removed or replaced
 - Dex chart updated to v2.15.2
 - The issuer for the user-alertmanager ingress is now taken from `global.issuer`.
 - The `stable/prometheus-operator` helm chart has been replaced by `prometheus-community/kube-prometheus-stack`
-- InfluxDB helm chart upgraded to `4.8.9`
+- InfluxDB helm chart upgraded to `4.8.10`
 - Rework of the InfluxDB configuration.
 - The sized based retention for InfluxDB has been lowered in the dev flavor.
 - Bump opendistro helm chart to `1.10.4`.

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -332,7 +332,7 @@ releases:
   labels:
     app: influxdb
   chart: elastisys/influxdb
-  version: 4.8.9
+  version: 4.8.10
   missingFileHandler: Error
   values:
   - values/influxdb.yaml.gotmpl


### PR DESCRIPTION
**What this PR does / why we need it**: New version of the influxdb chart that pins the retention image version. See this PR for the actual changes: https://github.com/elastisys/influxdb-helm-charts/pull/6

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*:  This fixes the issue of us pulling the image each time the retention is run (2 jobs every 5 mins per service cluster). 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
