### PR TITLE
config: Remove dnsPrefix

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -45,3 +45,4 @@ See [migrations docs for elasticsearch-exporter](migration/v0.8.x-v0.9.x/migrate
 
 - Release `prometheus-auth` has been removed.
 - Helm chart `basic-auth-secret` has been removed.
+- Unused config option `dnsPrefix`.

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -2,7 +2,6 @@ global:
   ck8sVersion: ${CK8S_VERSION}
   cloudProvider: ${CK8S_CLOUD_PROVIDER}
   clusterName: ${CK8S_ENVIRONMENT_NAME}-sc
-  dnsPrefix: ${CK8S_ENVIRONMENT_NAME}
   baseDomain: "set-me"
   opsDomain: "set-me"
   issuer: letsencrypt-staging

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -2,7 +2,6 @@ global:
   ck8sVersion: ${CK8S_VERSION}
   cloudProvider: ${CK8S_CLOUD_PROVIDER}
   clusterName: ${CK8S_ENVIRONMENT_NAME}-wc
-  dnsPrefix: ${CK8S_ENVIRONMENT_NAME}
   baseDomain: "set-me"
   opsDomain: "set-me"
   issuer: letsencrypt-staging

--- a/migration/v0.8.x-v0.9.x/migrate-apps.md
+++ b/migration/v0.8.x-v0.9.x/migrate-apps.md
@@ -9,6 +9,7 @@ You will need to follow these steps in order to upgrade each Compliant Kubernete
   - Remove
     - `user.prometheusPassword`
     - `externalTrafficPolicy.whitelistRange.prometheus`
+    - `global.dnsPrefix`
   - Replace
     - `influxDB.user` -> `influxDB.users.adminUser`
     - `influxDB.password` -> `influxDB.users.adminPassword`


### PR DESCRIPTION
**What this PR does / why we need it**:
I've been confused by this variable for a while now and I finally took the time to check if it was used or not.
As you can see, it's not https://github.com/elastisys/compliantkubernetes-apps/search?q=dnsPrefix.

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
