### PR TITLE
all: Bump kubectl to v1.18.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The apps are installed using a combination of helm charts and manifests with the
 ### Requirements
 
 * A running cluster based on [ck8s-cluster](https://github.com/elastisys/ck8s-cluster)
-* [kubectl](https://github.com/kubernetes/kubernetes/releases) (tested with 1.17.11)
+* [kubectl](https://github.com/kubernetes/kubernetes/releases) (tested with 1.18.13)
 * [helm](https://github.com/helm/helm/releases) (tested with 3.4.1)
 * [helmfile](https://github.com/roboll/helmfile) (tested with v0.129.3)
 * [helm-diff](https://github.com/databus23/helm-diff) (tested with 3.1.1)

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -94,6 +94,7 @@ One can now for example configure:
 - The `stable/elasticsearch-exporter` helm chart has been replaced by `prometheus-community/prometheus-elasticsearch-exporter`
 - OIDC group claims added to Harbor
 - The options `s3` and `gcs` for `harbor.persistence.type` have been replaced with `objectStorage` and will then match the type set in the global object storage configuration.
+- Bump kubectl to v1.18.13
 
 ### Fixed
 

--- a/get-requirements.yaml
+++ b/get-requirements.yaml
@@ -3,7 +3,7 @@
     vars:
       install_path: /usr/local/bin
       install_user: "{{ lookup('env','USER') }}"
-      kubectl_version: 1.17.11
+      kubectl_version: 1.18.13
       helm_version: 3.4.1
       helmfile_version: 0.129.3
       helmdiff_version: 3.1.1

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -12,7 +12,7 @@ RUN  apt-get update && \
      rm -rf /var/lib/apt/lists/*
 
 # Kubectl
-ENV KUBECTL_VERSION "v1.17.11"
+ENV KUBECTL_VERSION "v1.18.13"
 RUN wget "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
**What this PR does / why we need it**: We now have k8s v1.18 as default in ck8s-cluster, so it makes sense to have the same version here.

**Which issue this PR fixes**: -

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
