### PR TITLE
apps: Fix conditions for storage class provider installation

### DIFF
--- a/bootstrap/storageclass/bootstrap.sh
+++ b/bootstrap/storageclass/bootstrap.sh
@@ -20,7 +20,7 @@ esac
 storageClass=$(yq r -e "${config_file}" 'global.storageClass')
 
 cloud_provider=$(yq r -e "${config_file}" 'global.cloudProvider')
-if [ "${cloud_provider}" = "exoscale" ]
+if [ "${cloud_provider}" == "exoscale" ]
 then
     NFS_SC_SERVER_IP=$(jq -r '.service_cluster.nfs_ip_addresses.nfs.private_ip' < "${config[infrastructure_file]}")
     export NFS_SC_SERVER_IP
@@ -29,6 +29,6 @@ then
 fi
 
 install_storage_class_provider "${storageClass}" "${environment}"
-if [ "${environment}" = service_cluster ]; then
+if [ "${environment}" == service_cluster ]; then
     install_storage_class_provider "${elasticStorageClass}" service_cluster
 fi

--- a/bootstrap/storageclass/helmfile/helmfile.yaml
+++ b/bootstrap/storageclass/helmfile/helmfile.yaml
@@ -19,6 +19,7 @@ environments:
       - "{{ requiredEnv "CK8S_CONFIG_PATH" }}/secrets.yaml"
 
 releases:
+{{ if eq .Values.global.storageClass "nfs-client" }}
 # NFS
 - name: nfs-client-provisioner
   namespace: kube-system
@@ -36,6 +37,7 @@ releases:
 {{ end }}
 {{ if eq .Environment.Name "workload_cluster" }}
       server: {{ requiredEnv "NFS_WC_SERVER_IP" }}
+{{ end }}
 {{ end }}
 
 # Local volume provisioner


### PR DESCRIPTION
**What this PR does / why we need it**: This PR fixes conditions so `nfs-client provisioner` Helm chart is only applied when `storageClass` is set to `nfs-client`.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
