### PR TITLE
apps: Revert prometheus back to 2.19.1

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -29,7 +29,6 @@ See [migrations docs for elasticsearch-exporter](migration/v0.8.x-v0.9.x/migrate
 - OIDC group claims added to Harbor
 - The options `s3` and `gcs` for `harbor.persistence.type` have been replaced with `objectStorage` and will then match the type set in the global object storage configuration.
 - Bump kubectl to v1.18.13
-- Prometheus upgraded to 2.23.0.
 - InfluxDB is now exposed via ingress.
 - Prometheus in workload cluster now pushes metrics directly to InfluxDB.
 - The prometheus release `wc-scraper` has been renamed to `wc-reader`.

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -233,7 +233,7 @@ defaultRules:
 prometheus:
   prometheusSpec:
     image:
-      tag: v2.23.0
+      tag: v2.19.1
     resources: {{- toYaml .Values.prometheus.resources | nindent 8  }}
     nodeSelector: {{- toYaml .Values.prometheus.nodeSelector | nindent 8 }}
     affinity: {{- toYaml .Values.prometheus.affinity | nindent 8 }}

--- a/helmfile/values/kube-prometheus-stack-wc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-wc.yaml.gotmpl
@@ -42,7 +42,7 @@ prometheus:
 
   prometheusSpec:
     image:
-      tag: v2.23.0
+      tag: v2.19.1
     externalLabels:
       cluster: {{ .Values.global.clusterName }}
 

--- a/helmfile/values/prometheus-wc-reader.yaml.gotmpl
+++ b/helmfile/values/prometheus-wc-reader.yaml.gotmpl
@@ -1,5 +1,5 @@
 prometheusSpec:
-  version: "v2.23.0"
+  version: "v2.19.1"
   alerting:
     # Use the default alertmanager that comes with prometheus-operator
     alertmanagers:


### PR DESCRIPTION
**What this PR does / why we need it**:

The new prometheus version does not like running on NFS and it leads to issues with the wal.
```
fs_type=NFS_SUPER_MAGIC msg="This filesystem is not supported and may lead to data corruption and data loss. Please carefully read https://prometheus.io/docs/prometheus/latest/storage/ to learn more about supported filesystems."
...
msg="error tailing WAL" err="failed to find segment for index
```

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
