### PR TITLE
Grafana multicluster

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -34,6 +34,7 @@ See [migrations docs for elasticsearch-exporter](migration/v0.8.x-v0.9.x/migrate
 - The prometheus release `wc-scraper` has been renamed to `wc-reader`.
   Now wc-reader only reads from the workload_cluster database in InfluxDB.
 - InfluxDB helm chart upgraded to `4.8.11`.
+- `kube-prometheus-stack` updated to version `12.8.0`.
 
 ### Fixed
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -21,6 +21,7 @@ See [migrations docs for elasticsearch-exporter](migration/v0.8.x-v0.9.x/migrate
 - Harbor image storage can now be set to `filesystem` in order to use persistent volumes instead of object storage.
 - Object storage is now optional. There is a new option to set object storage type to `none`. If you disable object storage, then you must also disable any feature that uses object storage (mostly all backups).
 - Two new InfluxDB users to used by prometheus for writing metrics to InfluxDB.
+- Multicluster support for some dashboards in Grafana.
 
 ### Changed
 

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -79,7 +79,7 @@ releases:
   labels:
     app: kube-prometheus-stack
   chart: prometheus-community/kube-prometheus-stack
-  version: 11.0.4
+  version: 12.8.0
   missingFileHandler: Error
   needs:
   - cert-manager/cert-manager

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -186,6 +186,7 @@ grafana:
     dashboards:
       enabled: true
       label: grafana_dashboard
+      multicluster: true
     datasources:
       enabled: true
       defaultDatasourceEnabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Part of the initial multi workload cluster support.
The capability to expose the cluster label as a variable in grafana was [recently added in the kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/pull/357)

Now you'll see the cluster variable on  _**some**_  of the default dashboards
![grafana-mc](https://user-images.githubusercontent.com/12396964/102314609-06a1fb80-3f73-11eb-94da-d1f1bf2ffba2.png)

**Which issue this PR fixes**:
fixes #146 

**Special notes for reviewer**:
The bump in chart version did bump the prometheus-operator version.
The resulting diff looks like
```
...
          - name: kube-prometheus-stack
-           image: "quay.io/prometheus-operator/prometheus-operator:v0.43.1"
+           image: "quay.io/prometheus-operator/prometheus-operator:v0.44.0"
            imagePullPolicy: "IfNotPresent"
            args:
              - --kubelet-service=kube-system/kube-prometheus-stack-kubelet
-             - --logtostderr=true
              - --localhost=127.0.0.1
-             - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.43.1
+             - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.44.0
              # Empty if statement to catch non-semver master tags that do not need the --config-reloader-image flag
              - --config-reloader-cpu=100m
              - --config-reloader-memory=25Mi
              - --web.enable-tls=true
              - --web.cert-file=cert/cert
              - --web.key-file=cert/key
              - --web.listen-address=:8443
+             - --web.tls-min-version=VersionTLS13
...
```

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
