### PR TITLE
docs: Add sample instructions on multitenancy

### DIFF
--- a/docs/multitenancy.md
+++ b/docs/multitenancy.md
@@ -1,0 +1,117 @@
+# Multitenancy
+
+This document contains sample instructions on how to setup one service cluster together with multiple workload clusters. As stated, the instructions below are just samples, you need update them according to your situation and requirements. You will find more details on the commands executed in the cluster and apps repos. The sample instructions are shown for the exoscale cloud provider and the [exoscale cli](https://github.com/exoscale/cli/releases/tag/v1.21.0) is used to manage dns. If you are using any other cloud provider use their corresponding tool for managing dns.
+
+The following repositores and commits have been tested
+- [ck8s-cluster](https://github.com/elastisys/ck8s-cluster/tree/324ac074a337b99b83a464ce0189ed2c0f267e19)
+- [compliantkubernetes-apps](https://github.com/elastisys/compliantkubernetes-apps/tree/5b584dd568c39fea1630de48405679fb93b2c6bd)
+
+The cluster setup will be as follows
+- `mtt-0` will be the the repository from where the service cluster will be installed.
+- `mtt-{1,2}` will be repositories from where we'll install workload clusters.
+
+Simply do a _search and replace_ if you want to name your clusters something else.
+`mtt` - simply stands for _multi-tenancy-test_ :)
+
+### Infrastructure and kubernetes
+1. Set some variables
+
+    ```bash
+    domain=<your_domain>
+    pgp_fp=<your_pgp_fp>
+    config_path=<path_to_store_config_repos>
+    ```
+
+1. Init repos
+
+    ```bash
+    ./dist/ck8s_linux_amd64 init mtt-0 exoscale --flavor dev --pgp-fp ${pgp_fp} --config-path ${config_path}/mtt-0
+    ./dist/ck8s_linux_amd64 init mtt-1 exoscale --flavor dev --pgp-fp ${pgp_fp} --config-path ${config_path}/mtt-1
+    ./dist/ck8s_linux_amd64 init mtt-2 exoscale --flavor dev --pgp-fp ${pgp_fp} --config-path ${config_path}/mtt-2
+    ```
+
+2. For each repo edit the configuration files
+
+3. Create infrastructure and install kubernetes for the clusters
+
+    ```bash
+    ./dist/ck8s_linux_amd64 apply --cluster sc --config-path ${config_path}/mtt-0
+    ./dist/ck8s_linux_amd64 apply --cluster wc --config-path ${config_path}/mtt-1
+    ./dist/ck8s_linux_amd64 apply --cluster wc --config-path ${config_path}/mtt-2
+    ```
+
+3. Get the ip address of the cluster's loadbalancer
+
+    ```bash
+    mtt_0_lb_ip=$(./dist/ck8s_linux_amd64 internal terraform output --cluster sc --config-path ${config_path}/mtt-0 | jq -r '.sc_ingress_controller_lb_ip_address.value')
+    mtt_1_lb_ip=$(./dist/ck8s_linux_amd64 internal terraform output --cluster wc --config-path ${config_path}/mtt-1 | jq -r '.wc_ingress_controller_lb_ip_address.value')
+    mtt_2_lb_ip=$(./dist/ck8s_linux_amd64 internal terraform output --cluster wc --config-path ${config_path}/mtt-2 | jq -r '.wc_ingress_controller_lb_ip_address.value')
+    ```
+
+4. Create DNS records
+
+    ```bash
+    exo dns add A ${domain} -a ${mtt_0_lb_ip} -n *.ops.mtt-0
+    exo dns add A ${domain} -a ${mtt_0_lb_ip} -n *.mtt-0
+    exo dns add A ${domain} -a ${mtt_1_lb_ip} -n *.mtt-1
+    exo dns add A ${domain} -a ${mtt_2_lb_ip} -n *.mtt-2
+    ```
+
+### Apps
+1. Init config
+
+    ```bash
+    export CK8S_CLOUD_PROVIDER=exoscale
+
+    export CK8S_ENVIRONMENT_NAME=mtt-0
+    export CK8S_CONFIG_PATH=${config_path}/mtt-0
+    ./bin/ck8s init
+
+    export CK8S_ENVIRONMENT_NAME=mtt-1
+    export CK8S_CONFIG_PATH=${config_path}/mtt-1
+    ./bin/ck8s init
+
+    export CK8S_ENVIRONMENT_NAME=mtt-2
+    export CK8S_CONFIG_PATH=${config_path}/mtt-2
+    ./bin/ck8s init
+    ```
+
+2. Edit
+  - `secrets.yaml` for all clusters
+  - `sc-config.yaml` for the service cluster
+  - `wc-config.yaml` for all workload clusters
+  You should use the same value for `opsDomain` in all clusters.
+
+3. Install applications
+
+    ```
+    export CK8S_CONFIG_PATH=${config_path}/mtt-0
+    ./bin/ck8s apply sc
+
+    export CK8S_CONFIG_PATH=${config_path}/mtt-1
+    ./bin/ck8s apply wc
+
+    export CK8S_CONFIG_PATH=${config_path}/mtt-2
+    ./bin/ck8s apply wc
+    ```
+
+### Teardown
+
+```bash
+# Tear down infra and k8s
+./dist/ck8s_linux_amd64 destroy --cluster sc --config-path ${config_path}/mtt-0 --kubernetes-cleanup=false
+./dist/ck8s_linux_amd64 destroy --cluster wc --config-path ${config_path}/mtt-1 --kubernetes-cleanup=false
+./dist/ck8s_linux_amd64 destroy --cluster wc --config-path ${config_path}/mtt-2 --kubernetes-cleanup=false
+
+# Remove dns records
+exo dns remove ${domain} *.ops.mtt-0
+exo dns remove ${domain} *.mtt-0
+exo dns remove ${domain} *.mtt-1
+exo dns remove ${domain} *.mtt-2
+```
+
+## Notes
+
+- OIDC and kubelogin has not been tested..
+- Ingress of workload clusters has not been tested, but is expected to work without issues.
+- Blackbox exporter isn't able to check the kube-apiserver in any of the workload clusters.


### PR DESCRIPTION
**What this PR does / why we need it**:
To get some guidline on how to achive one serivce cluster with multiple workload clusters.

**Which issue this PR fixes**:
fixes #126 

**Special notes for reviewer**:
Don't really know what expected so i guess this is a first draft :)

**Tests**

- Metrics from both workload clusters show up in prometheus/influxDB/grafana
![grafana-mc](https://user-images.githubusercontent.com/12396964/102346789-b7be8b00-3f9f-11eb-9fca-7aea9bf1695b.png)

- Logs from both workload clusters show up in elasticsearch/kibana
![logs-cluster-label](https://user-images.githubusercontent.com/12396964/102346940-f94f3600-3f9f-11eb-8045-96bc1571c833.png)



**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
