### PR TITLE
apps: Update prometheus to 2.23.0

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -36,6 +36,7 @@ See [migrations docs for elasticsearch-exporter](migration/v0.8.x-v0.9.x/migrate
   Now wc-reader only reads from the workload_cluster database in InfluxDB.
 - InfluxDB helm chart upgraded to `4.8.11`.
 - `kube-prometheus-stack` updated to version `12.8.0`.
+- Bump prometheus to `2.23.0`.
 
 ### Fixed
 

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -234,7 +234,7 @@ defaultRules:
 prometheus:
   prometheusSpec:
     image:
-      tag: v2.19.1
+      tag: v2.23.0
     resources: {{- toYaml .Values.prometheus.resources | nindent 8  }}
     nodeSelector: {{- toYaml .Values.prometheus.nodeSelector | nindent 8 }}
     affinity: {{- toYaml .Values.prometheus.affinity | nindent 8 }}

--- a/helmfile/values/kube-prometheus-stack-wc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-wc.yaml.gotmpl
@@ -42,7 +42,7 @@ prometheus:
 
   prometheusSpec:
     image:
-      tag: v2.19.1
+      tag: v2.23.0
     externalLabels:
       cluster: {{ .Values.global.clusterName }}
 

--- a/helmfile/values/prometheus-wc-reader.yaml.gotmpl
+++ b/helmfile/values/prometheus-wc-reader.yaml.gotmpl
@@ -1,5 +1,5 @@
 prometheusSpec:
-  version: "v2.19.1"
+  version: "v2.23.0"
   alerting:
     # Use the default alertmanager that comes with prometheus-operator
     alertmanagers:


### PR DESCRIPTION
**What this PR does / why we need it**:
To stay up to date :)

**Which issue this PR fixes**:
None

**Special notes for reviewer**:
We had this version of prometheus for a brief period of time but i panic reverted when i saw 

```
ts=2020-12-29T11:44:44.209Z caller=dedupe.go:112 component=remote level=error remote_name=ce6a8f url="https://influxdb.ops.mtt-0.a1ck.io/api/v1/prom/write?db=workload_cluster&u=wcWriter&p=somelongsecret" msg="error tailing WAL" err="failed to find segment for index"
```

as I thought that this error was due to the version update, but as it turns out it does occur on the current version as well. Why? Not sure but it could be related to prometheus not supporting nfs for storage.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
