### PR TITLE
apps sc: fixes check for kibana in blackbox exporter

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -45,6 +45,7 @@ See [migrations docs for elasticsearch-exporter](migration/v0.8.x-v0.9.x/migrate
 
 - Wrong password being used for user-alertmanager.
 - Retention setting for wc scraper always overriding the user config and being set to 10 days.
+- Blackbox exporter checks kibana correctly
 
 ### Removed
 - The following helm release has been deprecated and will be uninstalled when upgrading:

--- a/helmfile/values/blackbox.yaml.gotmpl
+++ b/helmfile/values/blackbox.yaml.gotmpl
@@ -10,15 +10,6 @@ prometheus-blackbox-exporter:
           valid_http_versions: ["HTTP/1.1", "HTTP/2"]
           no_follow_redirects: false
           preferred_ip_protocol: "ip4"
-      kibana:
-        prober: http
-        timeout: 5s
-        http:
-          # We are not logged in, just checking that it can be reached
-          valid_status_codes: [401]
-          valid_http_versions: ["HTTP/1.1", "HTTP/2"]
-          no_follow_redirects: false
-          preferred_ip_protocol: "ip4"
       user_api_server:
         prober: http
         timeout: 5s
@@ -48,7 +39,7 @@ targets:
     url: https://kibana.{{ .Values.global.baseDomain }}/api/status
     interval: 60s
     scrapeTimeout: 30s
-    module: kibana
+    module: http_2xx
   - name: user-api-server
     url: https://kube-apiserver.{{ .Values.global.baseDomain }}:/healthz
     interval: 60s


### PR DESCRIPTION
**What this PR does / why we need it**: Blackbox needed an update after we switched to opendistro to check kibana properly.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
