### PR TITLE
apps wc: adds more config options to falco sidekick

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -23,6 +23,7 @@ See [migrations docs for elasticsearch-exporter](migration/v0.8.x-v0.9.x/migrate
 - Object storage is now optional. There is a new option to set object storage type to `none`. If you disable object storage, then you must also disable any feature that uses object storage (mostly all backups).
 - Two new InfluxDB users to used by prometheus for writing metrics to InfluxDB.
 - Multicluster support for some dashboards in Grafana.
+- More config options for falco sidekick (tolerations, resources, affinity, and nodeSelector)
 
 ### Changed
 

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -71,6 +71,17 @@ falco:
     priority: notice
     hostPort: "http://kube-prometheus-stack-alertmanager.monitoring:9093"
     # if type=slack falco.alerts.slackWebhook must be set in the secrets yaml file
+  falcoSidekick:
+    resources:
+      limits:
+        cpu: 20m
+        memory: 50Mi
+      requests:
+        cpu: 10m
+        memory: 25Mi
+    tolerations: []
+    affinity: {}
+    nodeSelector: {}
 
 prometheus:
   remoteWrite:

--- a/helmfile/values/falcosidekick.yaml.gotmpl
+++ b/helmfile/values/falcosidekick.yaml.gotmpl
@@ -14,3 +14,8 @@ config:
     hostport: {{ .Values.falco.alerts.hostPort }}
     minimumpriority: {{ .Values.falco.alerts.priority }}
   {{ end }}
+
+resources:    {{- toYaml .Values.falco.falcoSidekick.resources | nindent 2  }}
+nodeSelector: {{- toYaml .Values.falco.falcoSidekick.nodeSelector | nindent 2  }}
+affinity:     {{- toYaml .Values.falco.falcoSidekick.affinity | nindent 2  }}
+tolerations:  {{- toYaml .Values.falco.falcoSidekick.tolerations | nindent 2  }}


### PR DESCRIPTION
**What this PR does / why we need it**: Needed to upgrade getinges cluster properly. Did some quick tests and it seems to parse correctly.
Wondering slightly if the config under `falco.alert` should be moved to `falco.falcoSidekick`, but not sure that it's worth it right now.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
