### PR TITLE
apps: stop on lint errors

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -14,7 +14,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     env:
-      CK8S_CONFIG_PATH: ./ck8s-config
+      CK8S_CONFIG_PATH: /github/workspace/ck8s-config
     strategy:
       fail-fast: false
       matrix:
@@ -45,5 +45,3 @@ jobs:
       uses: ./pipeline
       with:
         args: ./pipeline/lint.bash
-      # TODO: Remove this when charts are updated to make the linter happy.
-      continue-on-error: true

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -58,6 +58,7 @@ See [migrations docs for elasticsearch-exporter](migration/v0.8.x-v0.9.x/migrate
 - Helm upgraded to `v3.5.0`.
 - InfluxDB upgraded to `v4.8.12`.
 - Resource requests/limits have been updated for all Harbor pods.
+- The pipeline now stops on lint errors.
 
 ### Fixed
 

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -117,6 +117,12 @@ set_storage_class() {
           storage_class=cinder-storage
           es_storage_class=cinder-storage
 
+          [ "$(yq read "$file" 'storageClasses.nfs.enabled')" = "null" ] &&
+            yq write --inplace "$file" 'storageClasses.nfs.enabled' false
+          [ "$(yq read "$file" 'storageClasses.local.enabled')" = "null" ] &&
+            yq write --inplace "$file" 'storageClasses.local.enabled' false
+          [ "$(yq read "$file" 'storageClasses.ebs.enabled')" = "null" ] &&
+            yq write --inplace "$file" 'storageClasses.ebs.enabled' false
           [ "$(yq read "$file" 'storageClasses.cinder.enabled')" = "null" ] &&
             yq write --inplace "$file" 'storageClasses.cinder.enabled' true
           ;;
@@ -129,21 +135,38 @@ set_storage_class() {
             yq write --inplace "$file" 'storageClasses.nfs.enabled' true
           [ "$(yq read "$file" 'storageClasses.local.enabled')" = "null" ] &&
             yq write --inplace "$file" 'storageClasses.local.enabled' true
+          [ "$(yq read "$file" 'storageClasses.ebs.enabled')" = "null" ] &&
+            yq write --inplace "$file" 'storageClasses.ebs.enabled' false
+          [ "$(yq read "$file" 'storageClasses.cinder.enabled')" = "null" ] &&
+            yq write --inplace "$file" 'storageClasses.cinder.enabled' false
           ;;
 
         aws)
           storage_class=ebs-gp2
           es_storage_class=ebs-gp2
 
+          [ "$(yq read "$file" 'storageClasses.nfs.enabled')" = "null" ] &&
+            yq write --inplace "$file" 'storageClasses.nfs.enabled' false
+          [ "$(yq read "$file" 'storageClasses.local.enabled')" = "null" ] &&
+            yq write --inplace "$file" 'storageClasses.local.enabled' false
           [ "$(yq read "$file" 'storageClasses.ebs.enabled')" = "null" ] &&
             yq write --inplace "$file" 'storageClasses.ebs.enabled' true
+          [ "$(yq read "$file" 'storageClasses.cinder.enabled')" = "null" ] &&
+            yq write --inplace "$file" 'storageClasses.cinder.enabled' false
           ;;
 
         baremetal)
           storage_class=node-local
           es_storage_class=node-local
+
+          [ "$(yq read "$file" 'storageClasses.nfs.enabled')" = "null" ] &&
+            yq write --inplace "$file" 'storageClasses.nfs.enabled' false
           [ "$(yq read "$file" 'storageClasses.local.enabled')" = "null" ] &&
             yq write --inplace "$file" 'storageClasses.local.enabled' true
+          [ "$(yq read "$file" 'storageClasses.ebs.enabled')" = "null" ] &&
+            yq write --inplace "$file" 'storageClasses.ebs.enabled' false
+          [ "$(yq read "$file" 'storageClasses.cinder.enabled')" = "null" ] &&
+           yq write --inplace "$file" 'storageClasses.cinder.enabled' false
           ;;
     esac
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -13,6 +13,7 @@ storageClasses:
   # Normally one of 'nfs-client', 'cinder-storage', 'local-storage', 'ebs-gp2'.
   default: "set-me"
 
+  # These are set to null before the first init to be able to set defaults only once
   nfs:
     enabled: null # true | false
   cinder:

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -13,6 +13,7 @@ storageClasses:
   # Normally one of 'nfs-client', 'cinder-storage', 'local-storage', 'ebs-gp2'.
   default: "set-me"
 
+  # These are set to null before the first init to be able to set defaults only once
   nfs:
     enabled: null # true | false
   cinder:

--- a/config/secrets/sc-secrets.yaml
+++ b/config/secrets/sc-secrets.yaml
@@ -42,9 +42,9 @@ alerts:
     apiKey: somelongsecret
 dex:
   staticPassword: $2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W
-  googleClientID:
-  googleClientSecret:
-  oktaClientID:
-  oktaClientSecret:
-  kubeloginClientSecret:
-  issuer:
+  googleClientID: somelongsecret
+  googleClientSecret: somelongsecret
+  oktaClientID: somelongsecret
+  oktaClientSecret: somelongsecret
+  kubeloginClientSecret: somelongsecret
+  issuer: somelongsecret


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes the linter stop on errors, as apposed to continuing, thereby exposing configuration errors. Also fixes some blank/errorneous configuration errors that made the linter unhappy.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #107

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
