### PR TITLE
apps sc: disables clair and updates Harbor config with resource requests and more    

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -13,7 +13,7 @@ See [migrations docs for elasticsearch-exporter](migration/v0.8.x-v0.9.x/migrate
 - With the removal of `scripts/post-infra-common.sh` you'll now have to, if enabled, manually set the address to the nfs server in `nfsProvisioner.server`
 - The cert-manager CustomResourceDefinitions has been upgraded to `v1`, see [API reference docs](https://cert-manager.io/docs/reference/api-docs/). It is advisable that you update your resources to `v1` in the near future to maintain functionality.
 - The cert-manager letsencrypt issuers have been updated to the `v1` API and the old `letsencrypt` releases must be removed before upgrading. Instruction are found in the [upgrade guide](migration/v0.8.x-v0.9.x/upgrade-apps.md).
-
+- To get some of the new default values for resource requests on Harbor pods you will first need to remove the resource requests that you have in your Harbor config and then run `ck8s init` to get the new values.
 
 ### Added
 
@@ -30,6 +30,7 @@ See [migrations docs for elasticsearch-exporter](migration/v0.8.x-v0.9.x/migrate
 - Option to configure serviceMonitor for elasticsearch exporter
 - Option to add more redirect URIs for the `kubelogin` client in dex.
 - Option to disable the creation of user namespaces (RBAC will still be created)
+- The possibility to configure resources, affinity, tolerations, and nodeSelector for all Harbor pods.
 
 ### Changed
 
@@ -56,6 +57,7 @@ See [migrations docs for elasticsearch-exporter](migration/v0.8.x-v0.9.x/migrate
   You can now select which namespaces to install the letsencrypt issuers.
 - Helm upgraded to `v3.5.0`.
 - InfluxDB upgraded to `v4.8.12`.
+- Resource requests/limits have been updated for all Harbor pods.
 
 ### Fixed
 
@@ -73,3 +75,4 @@ See [migrations docs for elasticsearch-exporter](migration/v0.8.x-v0.9.x/migrate
 - Helm chart `basic-auth-secret` has been removed.
 - Unused config option `dnsPrefix`.
 - Removed `scripts/post-infra-common.sh` file.
+- The image scanner Clair in Harbor, image scanning is done by the scanner Trivy

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -68,54 +68,80 @@ user:
 
 harbor:
   enabled: true
+  # The tolerations, affinity, and nodeSelector are applied to all harbor pods.
   tolerations: []
   affinity: {}
   nodeSelector: {}
   chartmuseum:
     persistentVolumeClaim:
       size: 5Gi
+    resources:
+      requests:
+        memory: 16Mi
+        cpu: 5m
   core:
     resources:
       requests:
-        memory: 256Mi
-        cpu: 100m
-      limits:
-        memory: 512Mi
-        cpu: 200m
+        memory: 64Mi
+        cpu: 10m
   database:
     persistentVolumeClaim:
       size: 1Gi
+    resources:
+      requests:
+        memory: 512Mi
+        cpu: 250m
   jobservice:
     persistentVolumeClaim:
       size: 1Gi
     resources:
       requests:
-        memory: 256Mi
-        cpu: 100m
-      limits:
-        memory: 512Mi
-        cpu: 200m
+        memory: 64Mi
+        cpu: 10m
   registry:
     persistentVolumeClaim:
       size: 5Gi
     resources:
       requests:
-        memory: 256Mi
-        cpu: 100m
-      limits:
-        memory: 512Mi
-        cpu: 200m
+        memory: 64Mi
+        cpu: 10m
+    controller:
+      resources:
+        requests:
+          memory: 16Mi
+          cpu: 1m
   redis:
     persistentVolumeClaim:
       size: 1Gi
+    resources:
+      requests:
+        memory: 32Mi
+        cpu: 10m
   notary:
     resources:
       requests:
-        memory: 256Mi
-        cpu: 100m
-      limits:
-        memory: 512Mi
+        memory: 16Mi
+        cpu: 5m
+  notarySigner:
+    resources:
+      requests:
+        memory: 16Mi
+        cpu: 5m
+  portal:
+    resources:
+      requests:
+        memory: 16Mi
+        cpu: 5m
+  trivy:
+    persistentVolumeClaim:
+      size: 5Gi
+    resources:
+      requests:
         cpu: 200m
+        memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 1024Mi
   persistence:
     # Valid options are "filesystem" (persistent volume), "swift", or "objectStorage" (matching global config)
     type: "set-me"

--- a/helmfile/values/harbor.yaml.gotmpl
+++ b/helmfile/values/harbor.yaml.gotmpl
@@ -35,6 +35,8 @@ persistence:
       size: {{ .Values.harbor.database.persistentVolumeClaim.size }}
     redis:
       size: {{ .Values.harbor.redis.persistentVolumeClaim.size }}
+    trivy:
+      size: {{ .Values.harbor.trivy.persistentVolumeClaim.size }}
   imageChartStorage:
     disableredirect: {{ .Values.harbor.persistence.disableRedirect }}
     {{ if eq .Values.harbor.persistence.type "filesystem" }}
@@ -73,36 +75,80 @@ externalURL: https://harbor.{{ .Values.global.baseDomain }}
 
 harborAdminPassword: {{ .Values.harbor.password }}
 
+clair:
+  enabled: false
+
 core:
   secret: {{ .Values.harbor.coreSecret }}
   secretName: harbor-core-cert
   xsrfKey: {{ .Values.harbor.xsrf }}
-  resources: {{- toYaml .Values.harbor.core.resources | nindent 4 }}
+  resources:    {{- toYaml .Values.harbor.core.resources | nindent 4 }}
   nodeSelector: {{- toYaml .Values.harbor.nodeSelector | nindent 4 }}
-  affinity: {{- toYaml .Values.harbor.affinity | nindent 4 }}
-  tolerations: {{- toYaml .Values.harbor.tolerations | nindent 4 }}
+  affinity:     {{- toYaml .Values.harbor.affinity | nindent 4 }}
+  tolerations:  {{- toYaml .Values.harbor.tolerations | nindent 4 }}
 
 jobservice:
   secret: {{ .Values.harbor.jobserviceSecret }}
-  resources: {{- toYaml .Values.harbor.jobservice.resources | nindent 4 }}
+  resources:    {{- toYaml .Values.harbor.jobservice.resources | nindent 4 }}
   nodeSelector: {{- toYaml .Values.harbor.nodeSelector | nindent 4 }}
-  affinity: {{- toYaml .Values.harbor.affinity | nindent 4 }}
-  tolerations: {{- toYaml .Values.harbor.tolerations | nindent 4 }}
+  affinity:     {{- toYaml .Values.harbor.affinity | nindent 4 }}
+  tolerations:  {{- toYaml .Values.harbor.tolerations | nindent 4 }}
 
 registry:
   secret: {{ .Values.harbor.registrySecret }}
-  resources: {{- toYaml .Values.harbor.registry.resources | nindent 4 }}
+  registry:
+    resources:  {{- toYaml .Values.harbor.registry.resources | nindent 6 }}
+  controller:
+    resources:  {{- toYaml .Values.harbor.registry.controller.resources | nindent 6 }}
   nodeSelector: {{- toYaml .Values.harbor.nodeSelector | nindent 4 }}
-  affinity: {{- toYaml .Values.harbor.affinity | nindent 4 }}
-  tolerations: {{- toYaml .Values.harbor.tolerations | nindent 4 }}
+  affinity:     {{- toYaml .Values.harbor.affinity | nindent 4 }}
+  tolerations:  {{- toYaml .Values.harbor.tolerations | nindent 4 }}
 
 notary:
   secretName: harbor-notary-cert
-  resources: {{- toYaml .Values.harbor.notary.resources | nindent 4 }}
+  resources:    {{- toYaml .Values.harbor.notary.resources | nindent 4 }}
   nodeSelector: {{- toYaml .Values.harbor.nodeSelector | nindent 4 }}
-  affinity: {{- toYaml .Values.harbor.affinity | nindent 4 }}
-  tolerations: {{- toYaml .Values.harbor.tolerations | nindent 4 }}
+  affinity:     {{- toYaml .Values.harbor.affinity | nindent 4 }}
+  tolerations:  {{- toYaml .Values.harbor.tolerations | nindent 4 }}
 
 database:
   internal:
     password: {{ .Values.harbor.databasePassword }}
+    resources:    {{- toYaml .Values.harbor.database.resources | nindent 6 }}
+    nodeSelector: {{- toYaml .Values.harbor.nodeSelector | nindent 6 }}
+    affinity:     {{- toYaml .Values.harbor.affinity | nindent 6 }}
+    tolerations:  {{- toYaml .Values.harbor.tolerations | nindent 6 }}
+
+trivy:
+  resources:    {{- toYaml .Values.harbor.trivy.resources | nindent 4 }}
+  nodeSelector: {{- toYaml .Values.harbor.nodeSelector | nindent 4 }}
+  affinity:     {{- toYaml .Values.harbor.affinity | nindent 4 }}
+  tolerations:  {{- toYaml .Values.harbor.tolerations | nindent 4 }}
+
+portal:
+  resources:    {{- toYaml .Values.harbor.portal.resources | nindent 4 }}
+  nodeSelector: {{- toYaml .Values.harbor.nodeSelector | nindent 4 }}
+  affinity:     {{- toYaml .Values.harbor.affinity | nindent 4 }}
+  tolerations:  {{- toYaml .Values.harbor.tolerations | nindent 4 }}
+
+chartmuseum:
+  resources:    {{- toYaml .Values.harbor.chartmuseum.resources | nindent 4 }}
+  nodeSelector: {{- toYaml .Values.harbor.nodeSelector | nindent 4 }}
+  affinity:     {{- toYaml .Values.harbor.affinity | nindent 4 }}
+  tolerations:  {{- toYaml .Values.harbor.tolerations | nindent 4 }}
+
+notary:
+  server:
+    resources:  {{- toYaml .Values.harbor.notary.resources | nindent 6 }}
+  signer:
+    resources:  {{- toYaml .Values.harbor.notarySigner.resources | nindent 6 }}
+  nodeSelector: {{- toYaml .Values.harbor.nodeSelector | nindent 4 }}
+  affinity:     {{- toYaml .Values.harbor.affinity | nindent 4 }}
+  tolerations:  {{- toYaml .Values.harbor.tolerations | nindent 4 }}
+
+redis:
+  internal:
+    resources:    {{- toYaml .Values.harbor.redis.resources | nindent 6 }}
+    nodeSelector: {{- toYaml .Values.harbor.nodeSelector | nindent 6 }}
+    affinity:     {{- toYaml .Values.harbor.affinity | nindent 6 }}
+    tolerations:  {{- toYaml .Values.harbor.tolerations | nindent 6 }}

--- a/migration/v0.8.x-v0.9.x/upgrade-apps.md
+++ b/migration/v0.8.x-v0.9.x/upgrade-apps.md
@@ -3,9 +3,11 @@
 
 You will need to follow these steps in order to upgrade each Compliant Kubernetes environment from v0.8.x to v0.9.0. The instructions assume that you work from the root of the `compliantkubernetes-apps` repository, has the latest changes already pulled and configured `CK8S_CONFIG_PATH` correctly.
 
-1. Run init to get new defaults: `./bin/ck8s init`
+1. This is an optional step. The default resource requests for Harbor pods have been updated. To get these new values you must remove the current values in your config (`resources:` yaml blocks under `harbor:`) from `sc-config.yaml` before running `./bin/ck8s init` in the next step.
 
-2. The following configuration options must be manually updated in your configuration files:
+2. Run init to get new defaults: `./bin/ck8s init`
+
+3. The following configuration options must be manually updated in your configuration files:
   - Remove
     - `user.prometheusPassword`
     - `externalTrafficPolicy.whitelistRange.prometheus`
@@ -31,7 +33,7 @@ You will need to follow these steps in order to upgrade each Compliant Kubernete
   - Pay special attention to the `storageClasses` configuration to make sure that it is configured according to what's in your cluster.
   If you have set `storageClasses.nfs.enabled: true` then make sure that you set the ip address to the nfs server in `nfsProvisioner.server`.
 
-3. Upgrade workload cluster applications
+4. Upgrade workload cluster applications
   ```bash
 
   # Remove all letsencrypt relases
@@ -43,7 +45,7 @@ You will need to follow these steps in order to upgrade each Compliant Kubernete
   ./bin/ck8s apply wc
   ```
 
-4. Upgrade service cluster applications
+5. Upgrade service cluster applications
   ```bash
 
   # Destroy old fluentd releases


### PR DESCRIPTION
**What this PR does / why we need it**: This turns of clair in Harbor which was using a lot of resources even though trivy was the default scanner. It also adds resource requests to all Harbor pods based on numbers from running clusters.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
