### PR TITLE
apps sc: adds option for additional kubelogin client URIs in dex

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -28,6 +28,7 @@ See [migrations docs for elasticsearch-exporter](migration/v0.8.x-v0.9.x/migrate
 - Multicluster support for some dashboards in Grafana.
 - More config options for falco sidekick (tolerations, resources, affinity, and nodeSelector)
 - Option to configure serviceMonitor for elasticsearch exporter
+- Option to add more redirect URIs for the `kubelogin` client in dex.
 
 ### Changed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -166,6 +166,7 @@ dex:
   oidcProvider: google
   allowedDomains:
     - example.com
+  additionalKubeloginRedirects: []
   enableStaticLogin: true
   resources:
     limits:

--- a/helmfile/values/dex.yaml.gotmpl
+++ b/helmfile/values/dex.yaml.gotmpl
@@ -73,6 +73,9 @@ config:
       - http://localhost:8080/oauth2/callback
       - https://ck8sdash.{{ .Values.global.baseDomain }}/oauth2/callback
       - https://ck8sdash.{{ .Values.global.opsDomain }}/oauth2/callback
+      {{- range $uri := .Values.dex.additionalKubeloginRedirects }}
+      - {{ $uri }}
+      {{- end }}
     - id: grafana
       secret: {{ .Values.grafana.clientSecret }}
       name: 'Grafana'


### PR DESCRIPTION
**What this PR does / why we need it**: This gives the ability to add more redirect URIs to the static client for kubernetes in dex. Needed if the user wants to add the standard kubernetes dashboard or something similar.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
