### PR TITLE
apps wc: adds option to choose if user namespaces are created

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -29,6 +29,7 @@ See [migrations docs for elasticsearch-exporter](migration/v0.8.x-v0.9.x/migrate
 - More config options for falco sidekick (tolerations, resources, affinity, and nodeSelector)
 - Option to configure serviceMonitor for elasticsearch exporter
 - Option to add more redirect URIs for the `kubelogin` client in dex.
+- Option to disable the creation of user namespaces (RBAC will still be created)
 
 ### Changed
 

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -40,6 +40,8 @@ objectStorage:
     scFluentd: "${CK8S_ENVIRONMENT_NAME}-sc-logs"
 
 user:
+  # This only controls if the namespaces should be created, user RBAC is always created.
+  createNamespaces: true
   namespaces:
     - demo
   adminUsers:

--- a/helmfile/charts/user-rbac/templates/namespaces.yaml
+++ b/helmfile/charts/user-rbac/templates/namespaces.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.create_namespaces }}
+{{- if .Values.createNamespaces }}
 {{- range $namespace := .Values.namespaces }}
 apiVersion: v1
 kind: Namespace

--- a/helmfile/charts/user-rbac/values.yaml
+++ b/helmfile/charts/user-rbac/values.yaml
@@ -1,5 +1,5 @@
 namespaces: []
 users: []
-create_namespaces: true
+createNamespaces: true
 enableFalcoViewer: false
 alertmanagerNamespace: monitoring

--- a/helmfile/values/user-rbac.yaml.gotmpl
+++ b/helmfile/values/user-rbac.yaml.gotmpl
@@ -1,4 +1,5 @@
 namespaces: {{ toYaml .Values.user.namespaces | nindent 2 }}
 users: {{ toYaml .Values.user.adminUsers | nindent 2 }}
+createNamespaces: {{ .Values.user.createNamespaces }}
 enableFalcoViewer: {{ toYaml .Values.falco.enabled | nindent 2 }}
 alertmanagerNamespace: {{ .Values.user.alertmanager.namespace }}


### PR DESCRIPTION
**What this PR does / why we need it**: With this you can choose if you want to create the user namespaces or not. Note that user RBAC is always created.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
