### PR TITLE
bootstrap: Fixed namespace chart to work with annotations

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -65,6 +65,7 @@ See [migrations docs for elasticsearch-exporter](migration/v0.8.x-v0.9.x/migrate
 - Retention setting for wc scraper always overriding the user config and being set to 10 days.
 - Blackbox exporter checks kibana correctly
 - Removed duplicate enforcement config for OPA from wc-config
+- Fixed issue with adding annotation to bootstrap namespace chart
 
 ### Removed
 - The following helm release has been deprecated and will be uninstalled when upgrading:

--- a/bootstrap/namespaces/helmfile/charts/namespaces/Chart.yaml
+++ b/bootstrap/namespaces/helmfile/charts/namespaces/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: namespaces
 description: A Helm chart for creating namespaces for sc and wc
-version: 0.1.0
+version: 0.1.1

--- a/bootstrap/namespaces/helmfile/charts/namespaces/templates/namespace.yaml
+++ b/bootstrap/namespaces/helmfile/charts/namespaces/templates/namespace.yaml
@@ -1,27 +1,29 @@
 {{- $common_annotations := .Values.commonAnnotations -}}
 {{- $common_labels := .Values.commonLabels -}}
-{{- range $key := .Values.namespaces}}
-
+{{- range $key := .Values.namespaces }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .name  }}
-  labels:
-{{- with $common_labels }}
-    {{ toYaml . | nindent 4 }}
-{{- end }}
-{{- if .labels -}}
-    {{ toYaml .labels | nindent 4 }}
-{{- end }}
-{{- if and .annotations $common_annotations }}
-  annotations:
-{{- end }}
-{{- with $common_annotations }}
+  name: {{ .name }}
 
-{{ toYaml . | indent 4 }}
+  {{- if or .labels $common_labels }}
+  labels:
+    {{- if $common_labels }}
+      {{- toYaml $common_labels | nindent 4 }}
+    {{- end }}
+    {{- if .labels }}
+      {{- toYaml .labels | nindent 4 }}
+    {{- end }}
+  {{- end }}
+
+  {{- if or .annotations $common_annotations }}
+  annotations:
+    {{- if $common_annotations }}
+      {{- toYaml $common_annotations | nindent 4 }}
+    {{- end }}
+    {{- if .annotations }}
+      {{- toYaml .annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
 {{- end }}
-{{- if .annotations -}}
-    {{ toYaml .annotations | nindent 4 }}
-{{- end }}
-{{- end -}}

--- a/bootstrap/namespaces/helmfile/helmfile.yaml
+++ b/bootstrap/namespaces/helmfile/helmfile.yaml
@@ -24,7 +24,7 @@ releases:
   labels:
     app: ck8s-namespaces
   chart: ./charts/namespaces
-  version: 0.1.0
+  version: 0.1.1
   missingFileHandler: Error
   values:
   {{ if eq .Environment.Name "service_cluster"  }}


### PR DESCRIPTION
**What this PR does / why we need it**:

I found that the annotations in the namespace chart wasn't working.
So I fixed that and cleaned it up a bit.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: 
N/A

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
