### PR TITLE
fluentd: Added tail of kubespray default audit log location

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -5,9 +5,12 @@
 - Several new dashboards for velero, nginx, gatekeeper, uptime of services, and kubernetes status.
 - Metric scraping for nginx, gatekeeper, and velero.
 - Check for Harbor endpoint in the blackbox exporter.
+
 ### Changed
 
 - The falco dashboard has been updated with a new graph, multicluster support, and a link to kibana.
+- Changed path that fluentd looks for kubernetes audit logs to include default path for kubespray.
+
 ### Fixed
 
 - Fixed issue with adding annotation to bootstrap namespace chart

--- a/helmfile/values/fluentd-configmap.yaml.gotmpl
+++ b/helmfile/values/fluentd-configmap.yaml.gotmpl
@@ -136,8 +136,8 @@ forwarder:
       <source>
         @id kube-audit
         @type tail
-        path /var/log/kube-audit/kube-apiserver.log
-        pos_file /var/log/kube-audit/fluentd-kube-apiserver.pos
+        path /var/log/kube-audit/kube-apiserver.log,/var/log/kubernetes/audit/kube-apiserver-audit.log
+        pos_file /var/log/audit/fluentd-kube-apiserver.pos
         tag kubeaudit.*
         read_from_head true
         <parse>

--- a/helmfile/values/fluentd-user.yaml.gotmpl
+++ b/helmfile/values/fluentd-user.yaml.gotmpl
@@ -43,31 +43,6 @@ extraConfigMaps:
       </log>
     </system>
 
-  10-kube-audit.conf: |-
-    <source>
-      @id kube-audit
-      @type tail
-      path /var/log/kube-audit/kube-apiserver.log
-      pos_file /var/log/kube-audit/fluentd-kube-apiserver.pos
-      tag kubeaudit.*
-      read_from_head true
-      <parse>
-        @type multi_format
-        <pattern>
-          format json
-          time_key time
-          time_format %Y-%m-%dT%H:%M:%S.%NZ
-        </pattern>
-      </parse>
-    </source>
-    # Remove keys that include raw data causing errors
-    # See: https://github.com/uken/fluent-plugin-elasticsearch/issues/452
-    <filter kubeaudit.**>
-      @id kube_api_audit_normalize
-      @type record_transformer
-      remove_keys responseObject,requestObject
-    </filter>
-
   containers.input.conf: |-
     #This config is taken from a default config that we have disabled
     #See the value "configMaps.useDefaults.containersInputConf: false" above

--- a/helmfile/values/fluentd-wc.yaml.gotmpl
+++ b/helmfile/values/fluentd-wc.yaml.gotmpl
@@ -50,7 +50,7 @@ extraConfigMaps:
     <source>
       @id kube-audit
       @type tail
-      path /var/log/kube-audit/kube-apiserver.log
+      path /var/log/kube-audit/kube-apiserver.log,/var/log/kubernetes/audit/kube-apiserver-audit.log
       pos_file /var/log/kube-audit/fluentd-kube-apiserver.pos
       tag kubeaudit.*
       read_from_head true


### PR DESCRIPTION
**What this PR does / why we need it**:

Since we want to update the audit path to use kubespray default we need to make sure that both the old and the new way is supported.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
