### PR TITLE
Removed WIP tag on migration docs

### DIFF
--- a/migration/v0.8.x-v0.9.x/upgrade-apps.md
+++ b/migration/v0.8.x-v0.9.x/upgrade-apps.md
@@ -1,5 +1,5 @@
 
-# [WIP] Upgrade v0.8.x to v0.9.0
+# Upgrade v0.8.x to v0.9.0
 
 You will need to follow these steps in order to upgrade each Compliant Kubernetes environment from v0.8.x to v0.9.0. The instructions assume that you work from the root of the `compliantkubernetes-apps` repository, has the latest changes already pulled and configured `CK8S_CONFIG_PATH` correctly.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Cleanup from QA (I guess)

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: 
N/A

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
