### PR TITLE
apps sc: Update opendistro helm chart to 1.12

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,4 +1,10 @@
 ### Release notes
+- With the update of the opendistro helm chart you can now decide whether or not you want dedicated deployments for data and client/ingest nodes.
+  By setting `elasticsearch.dataNode.dedicatedPods: false` and `elasticsearch.clientNode.dedicatedPods: false`,
+  The master node statefulset will assume all roles.
+- To get some of the new default values for resource requests on Harbor pods you will first need to remove the resource requests that you have in your Harbor config and then run `ck8s init` to get the new values.
+- Check out the [upgrade guide](migration/v0.9.x-v0.10.x/upgrade-apps.md) for a complete set of instructions needed to upgrade.
+
 
 - Ck8sdash has been deprecated and will be removed when upgrading.
   Some resources like it's namespace will have to be manually removed.
@@ -14,6 +20,11 @@
 
 - The falco dashboard has been updated with a new graph, multicluster support, and a link to kibana.
 - Changed path that fluentd looks for kubernetes audit logs to include default path for kubespray.
+- Opendistro helm chart updated to 1.12.0.
+- Options to disable dedicated deployments for elasticsearch data and client/ingest nodes.
+- By default, no storageclass is specified for elasticsearch, meaning it'll consume whatever is cluster default.
+- Updated elasticsearch config in dev-flavor.
+  Now the deployment consists of a single master/data/client/ingest node.
 
 ### Fixed
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,8 +1,7 @@
 ### Release notes
 - With the update of the opendistro helm chart you can now decide whether or not you want dedicated deployments for data and client/ingest nodes.
   By setting `elasticsearch.dataNode.dedicatedPods: false` and `elasticsearch.clientNode.dedicatedPods: false`,
-  The master node statefulset will assume all roles.
-- To get some of the new default values for resource requests on Harbor pods you will first need to remove the resource requests that you have in your Harbor config and then run `ck8s init` to get the new values.
+  the master node statefulset will assume all roles.
 - Check out the [upgrade guide](migration/v0.9.x-v0.10.x/upgrade-apps.md) for a complete set of instructions needed to upgrade.
 
 

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -115,7 +115,6 @@ set_storage_class() {
     case ${CK8S_CLOUD_PROVIDER} in
         safespring | citycloud)
           storage_class=cinder-storage
-          es_storage_class=cinder-storage
 
           [ "$(yq read "$file" 'storageClasses.nfs.enabled')" = "null" ] &&
             yq write --inplace "$file" 'storageClasses.nfs.enabled' false
@@ -129,7 +128,6 @@ set_storage_class() {
 
         exoscale)
           storage_class=nfs-client
-          es_storage_class=local-storage
 
           [ "$(yq read "$file" 'storageClasses.nfs.enabled')" = "null" ] &&
             yq write --inplace "$file" 'storageClasses.nfs.enabled' true
@@ -143,7 +141,6 @@ set_storage_class() {
 
         aws)
           storage_class=ebs-gp2
-          es_storage_class=ebs-gp2
 
           [ "$(yq read "$file" 'storageClasses.nfs.enabled')" = "null" ] &&
             yq write --inplace "$file" 'storageClasses.nfs.enabled' false
@@ -157,7 +154,6 @@ set_storage_class() {
 
         baremetal)
           storage_class=node-local
-          es_storage_class=node-local
 
           [ "$(yq read "$file" 'storageClasses.nfs.enabled')" = "null" ] &&
             yq write --inplace "$file" 'storageClasses.nfs.enabled' false
@@ -171,11 +167,6 @@ set_storage_class() {
     esac
 
     replace_set_me "$1" 'storageClasses.default' "$storage_class"
-
-    # Only write if field exists already
-    if yq read --exitStatus "$file" 'elasticsearch.dataNode.storageClass' > /dev/null 2> /dev/null; then
-        yq write --inplace "$file" 'elasticsearch.dataNode.storageClass' "$es_storage_class"
-    fi
 }
 
 # Usage: set_nginx_config <config-file>

--- a/config/config/flavors/dev-sc.yaml
+++ b/config/config/flavors/dev-sc.yaml
@@ -20,34 +20,19 @@ prometheus:
 
 elasticsearch:
   masterNode:
-    storageSize: 1Gi
-    javaOpts: "-Xms512m -Xmx512m"
+    storageSize: 20Gi
+    javaOpts: "-Xms1536m -Xmx1536m"
     resources:
       requests:
-        memory: 1024Mi
-        cpu: 100m
+        memory: 3072Mi
+        cpu: 300m
       limits:
-        memory: 1024Mi
-        cpu: 1
+        memory: 3072Mi
+        cpu: 2
   dataNode:
-    storageSize: 18Gi
-    javaOpts: "-Xms512m -Xmx512m"
-    resources:
-      requests:
-        memory: 1024Mi
-        cpu: 200m
-      limits:
-        memory: 1024Mi
-        cpu: 1
+    dedicatedPods: false
   clientNode:
-    javaOpts: "-Xms512m -Xmx512m"
-    resources:
-      requests:
-        memory: 1024Mi
-        cpu: 200m
-      limits:
-        memory: 1024Mi
-        cpu: 1
+    dedicatedPods: false
   curator:
     retention:
       kubeAuditSizeGB: 4

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -234,6 +234,10 @@ elasticsearch:
   masterNode:
     count: 1
     storageSize: 8Gi
+    ## If null, no storageclass is specified in pvc and default storageClass is used
+    ## if the DefaultStorageClass admission plugin is enabled.
+    ## If "-", "" will be used as storageClassName.
+    storageClass: null
     javaOpts: "-Xms512m -Xmx512m"
     resources:
       requests:
@@ -254,9 +258,15 @@ elasticsearch:
     tolerations: []
     nodeSelector: {}
   dataNode:
+    ## Enables dedicated statefulset for data nodes.
+    ## If false, master nodes will assume data role.
+    dedicatedPods: true
     count: 2
     storageSize: 25Gi
-    storageClass: local-storage
+    ## If null, no storageclass is specified in pvc and default storageClass is used
+    ## if the DefaultStorageClass admission plugin is enabled.
+    ## If "-", "" will be used as storageClassName.
+    storageClass: null
     javaOpts: "-Xms512m -Xmx512m"
     resources:
       requests:
@@ -277,6 +287,9 @@ elasticsearch:
     tolerations: []
     nodeSelector: {}
   clientNode:
+    ## Enables dedicated deployment for client/ingest nodes.
+    ## If false, master nodes will assume client/ingest roles
+    dedicatedPods: true
     count: 1
     javaOpts: "-Xms512m -Xmx512m"
     resources:

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -403,7 +403,7 @@ releases:
   labels:
     app: opendistro
   chart: elastisys/opendistro-es
-  version: 1.10.4
+  version: 1.12.0
   missingFileHandler: Error
   needs:
   - cert-manager/cert-manager

--- a/helmfile/values/opendistro-es.yaml.gotmpl
+++ b/helmfile/values/opendistro-es.yaml.gotmpl
@@ -58,7 +58,7 @@ elasticsearch:
 
   extraInitContainers:
   - name: install-object-storage-plugin
-    image: amazon/opendistro-for-elasticsearch:1.10.1
+    image: amazon/opendistro-for-elasticsearch:1.12.0
     command:
     - sh
     - -c
@@ -186,6 +186,7 @@ elasticsearch:
             cluster_permissions:
             - "cluster:admin/repository/put"
             - "cluster_manage_index_templates"
+            - "cluster:admin/opendistro/ism/policy/*"
             index_permissions:
             - index_patterns:
               - "*"
@@ -302,9 +303,14 @@ elasticsearch:
 
     persistence:
       size: {{ .Values.elasticsearch.masterNode.storageSize }}
+      storageClass: {{ toYaml .Values.elasticsearch.masterNode.storageClass }}
 
   # Data nodes configuration
   data:
+    ## Enables dedicated statefulset for data. Otherwise master nodes as data storage
+    dedicatedPod:
+      enabled: {{ .Values.elasticsearch.dataNode.dedicatedPods }}
+
     replicas: {{ .Values.elasticsearch.dataNode.count }}
 
     javaOpts: {{ .Values.elasticsearch.dataNode.javaOpts }}
@@ -315,11 +321,15 @@ elasticsearch:
     nodeSelector: {{- toYaml .Values.elasticsearch.dataNode.nodeSelector | nindent 6 }}
 
     persistence:
-      storageClass: {{ .Values.elasticsearch.dataNode.storageClass }}
       size: {{ .Values.elasticsearch.dataNode.storageSize }}
+      storageClass: {{ toYaml .Values.elasticsearch.dataNode.storageClass }}
 
   # Client nodes configuration
   client:
+    ## Enables dedicated deployment for client/ingest. Otherwise master nodes as client/ingest
+    dedicatedPod:
+      enabled: {{ .Values.elasticsearch.clientNode.dedicatedPods }}
+
     replicas: {{ .Values.elasticsearch.clientNode.count }}
 
     javaOpts: {{ .Values.elasticsearch.clientNode.javaOpts }}

--- a/migration/v0.9.x-v0.10.x/upgrade-apps.md
+++ b/migration/v0.9.x-v0.10.x/upgrade-apps.md
@@ -16,30 +16,35 @@ You will need to follow these steps in order to upgrade each Compliant Kubernete
     - `ck8sdash.*`
     - `externalTrafficPolicy.whitelistRange.ck8sdash`
 
+4. Check elasticsearch configuration in sc-config.yaml
+  Make sure that the new `elasticsearch.dataNode.dedicatedPods` and `elasticsearch.clientNode.dedicatedPods` are set to the desired value (true or false) to avoid unintentional changes to the cluster topology.
+
 4. Upgrade workload cluster applications
   ```bash
   ./bin/ck8s apply wc
   ```
 
 5. Upgrade service cluster applications
+  **Note**, during the upgrade, the opendistro roles will be reloaded, so make sure you've got sufficient backups of the ones you've manually added.
+
   ```bash
-
-
   # Upgrade Elasticsearch
   ./bin/ck8s ops helmfile sc -l app=opendistro apply
 
+  # Open another teminal so that you can run kubectl while helmfile is running
+
   # Wait for master pod 0 to be up and for elasticsearch to have started
 
-  # Reload security config
+  # Reload roles.
   ./bin/ck8s ops kubectl sc -n elastic-system exec opendistro-es-master-0 -- chmod +x ./plugins/opendistro_security/tools/securityadmin.sh
   ./bin/ck8s ops kubectl sc -n elastic-system exec opendistro-es-master-0 -- ./plugins/opendistro_security/tools/securityadmin.sh \
-      -cd plugins/opendistro_security/securityconfig/ \
+      -f plugins/opendistro_security/securityconfig/roles.yml \
       -icl -nhnv \
       -cacert config/admin-root-ca.pem \
       -cert config/admin-crt.pem \
       -key config/admin-key.pem
 
-  # Wait for release to finish
+  # Wait for release to finish installing
 
   # Upgrade rest
   ./bin/ck8s apply sc

--- a/migration/v0.9.x-v0.10.x/upgrade-apps.md
+++ b/migration/v0.9.x-v0.10.x/upgrade-apps.md
@@ -4,7 +4,7 @@ You will need to follow these steps in order to upgrade each Compliant Kubernete
 
 1. Checkout the new release: `git checkout v0.10.0`.
 
-4. Run init to get new defaults: `./bin/ck8s init`
+2. Run init to get new defaults: `./bin/ck8s init`
 
 3. The following configuration options must be manually updated in your configuration files:
 
@@ -23,6 +23,25 @@ You will need to follow these steps in order to upgrade each Compliant Kubernete
 
 5. Upgrade service cluster applications
   ```bash
+
+
+  # Upgrade Elasticsearch
+  ./bin/ck8s ops helmfile sc -l app=opendistro apply
+
+  # Wait for master pod 0 to be up and for elasticsearch to have started
+
+  # Reload security config
+  ./bin/ck8s ops kubectl sc -n elastic-system exec opendistro-es-master-0 -- chmod +x ./plugins/opendistro_security/tools/securityadmin.sh
+  ./bin/ck8s ops kubectl sc -n elastic-system exec opendistro-es-master-0 -- ./plugins/opendistro_security/tools/securityadmin.sh \
+      -cd plugins/opendistro_security/securityconfig/ \
+      -icl -nhnv \
+      -cacert config/admin-root-ca.pem \
+      -cert config/admin-crt.pem \
+      -key config/admin-key.pem
+
+  # Wait for release to finish
+
+  # Upgrade rest
   ./bin/ck8s apply sc
   ```
 

--- a/pipeline/test/services/service-cluster/testPodsReady.sh
+++ b/pipeline/test/services/service-cluster/testPodsReady.sh
@@ -4,7 +4,6 @@ INNER_SCRIPTS_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 # shellcheck disable=SC1090
 source "${INNER_SCRIPTS_PATH}/../funcs.sh"
 
-cloud_provider=$(yq r -e "${CONFIG_FILE}" 'global.cloudProvider')
 enable_harbor=$(yq r -e "${CONFIG_FILE}" 'harbor.enabled')
 enable_harbor_backup=$(yq r -e "${CONFIG_FILE}" 'harbor.backup.enabled')
 enable_user_grafana=$(yq r -e "${CONFIG_FILE}" 'user.grafana.enabled')
@@ -13,8 +12,10 @@ enable_elasticsearch_snapshot=$(yq r -e "${CONFIG_FILE}" 'elasticsearch.snapshot
 enable_influxdb_backup=$(yq r -e "${CONFIG_FILE}" 'influxDB.backup.enabled')
 enable_influxdb_backup_retention=$(yq r -e "${CONFIG_FILE}" 'influxDB.backupRetention.enabled')
 enable_velero=$(yq r -e "${CONFIG_FILE}" 'velero.enabled')
-storage_class=$(yq r -e "${CONFIG_FILE}" 'global.storageClass')
-elasticsearch_storage_class=$(yq r -e "${CONFIG_FILE}" 'elasticsearch.dataNode.storageClass')
+enable_local_pv_provisioner=$(yq r -e "${CONFIG_FILE}" 'storageClasses.local.enabled')
+enable_nfs_provisioner=$(yq r -e "${CONFIG_FILE}" 'storageClasses.nfs.enabled')
+enable_es_data_sts=$(yq r -e "${CONFIG_FILE}" 'elasticsearch.dataNode.dedicatedPods')
+enable_es_client_deploy=$(yq r -e "${CONFIG_FILE}" 'elasticsearch.clientNode.dedicatedPods')
 
 echo
 echo
@@ -35,13 +36,15 @@ deployments=(
     "monitoring kube-prometheus-stack-kube-state-metrics"
     "monitoring blackbox-prometheus-blackbox-exporter"
     "elastic-system prometheus-elasticsearch-exporter"
-    "elastic-system opendistro-es-client"
     "elastic-system opendistro-es-kibana"
 )
-if [ "$cloud_provider" == "exoscale" ]; then
+if "${enable_es_client_deploy}"; then
+    deployments+=("elastic-system opendistro-es-client")
+fi
+if "${enable_nfs_provisioner}"; then
     deployments+=("kube-system nfs-client-provisioner")
 fi
-if [ "$enable_harbor" == true ]; then
+if "${enable_harbor}"; then
     deployments+=(
         "harbor harbor-harbor-chartmuseum"
         "harbor harbor-harbor-core"
@@ -52,10 +55,10 @@ if [ "$enable_harbor" == true ]; then
         "harbor harbor-harbor-registry"
     )
 fi
-if [ "$enable_user_grafana" == true ]; then
+if "${enable_user_grafana}"; then
     deployments+=("monitoring user-grafana")
 fi
-if [ "$enable_velero" == true ]; then
+if "${enable_velero}"; then
     deployments+=("velero velero")
 fi
 
@@ -80,14 +83,13 @@ daemonsets=(
     "ingress-nginx ingress-nginx-controller"
     "monitoring kube-prometheus-stack-prometheus-node-exporter"
 )
-if [ "$storage_class" = local-storage ] || \
-    [ "$elasticsearch_storage_class" = local-storage ]; then
+if "${enable_local_pv_provisioner}"; then
   daemonsets+=("kube-system local-volume-provisioner")
 fi
-if [ "$enable_fluentd" == true ]; then
+if "${enable_fluentd}"; then
     daemonsets+=("fluentd fluentd")
 fi
-if [ "$enable_velero" == true ]; then
+if "$enable_velero"; then
     daemonsets+=("velero restic")
 fi
 
@@ -111,17 +113,19 @@ statefulsets=(
     "monitoring prometheus-wc-reader-prometheus-instance"
     "monitoring alertmanager-kube-prometheus-stack-alertmanager"
     "influxdb-prometheus influxdb"
-    "elastic-system opendistro-es-data"
     "elastic-system opendistro-es-master"
 )
-if [ "$enable_harbor" == true ]; then
+if "${enable_es_data_sts}"; then
+    statefulsets+=("elastic-system opendistro-es-data")
+fi
+if "${enable_harbor}"; then
     statefulsets+=(
         "harbor harbor-harbor-database"
         "harbor harbor-harbor-redis"
         "harbor harbor-harbor-trivy"
     )
 fi
-if [ "$enable_fluentd" == true ]; then
+if "${enable_fluentd}"; then
     statefulsets+=("fluentd fluentd")
 fi
 
@@ -140,7 +144,7 @@ done
 jobs=(
     "elastic-system opendistro-es-configurer 120s"
 )
-if [ "$enable_harbor" == true ]; then
+if "${enable_harbor}"; then
     jobs+=("harbor init-harbor-job 120s")
 fi
 
@@ -169,22 +173,22 @@ cronjobs=(
   "influxdb-prometheus influxdb-metrics-retention-cronjob-wc"
   "elastic-system opendistro-es-curator"
 )
-if [ "$enable_harbor" == true ] && [ "$enable_harbor_backup" == true ]; then
+if "${enable_harbor}" && "${enable_harbor_backup}"; then
     cronjobs+=("harbor harbor-backup-cronjob")
 fi
-if [ "$enable_elasticsearch_snapshot" == true ]; then
+if "${enable_elasticsearch_snapshot}"; then
     cronjobs+=(
         "elastic-system elasticsearch-slm"
         "elastic-system elasticsearch-backup"
     )
 fi
-if [ "$enable_influxdb_backup" == true ]; then
+if "${enable_influxdb_backup}"; then
     cronjobs+=("influxdb-prometheus influxdb-backup")
 fi
-if [ "$enable_influxdb_backup_retention" == true ]; then
+if "${enable_influxdb_backup_retention}"; then
     cronjobs+=("influxdb-prometheus influxdb-backup-retention")
 fi
-if [ "$enable_fluentd" == true ]; then
+if "${enable_fluentd}"; then
     cronjobs+=("fluentd sc-logs-retention")
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrades the helm chart which gives us access to creating multirole nodes.

Updates test according to the new settings.

Updates the dev flavor to deploy a **single** multi-role node(kind of just to see if it works well for us or not).

**Which issue this PR fixes**:
fixes #164 

**Special notes for reviewer**:

I've changed the init flow a bit.
The default value for storageclasses for elasticsearch has been changed to `null`, which means that the cluster default will be used. This makes sense imo as it decreases the init-complexity and is in line with most other helm charts.

With the new version there are some repeated deprecation (every 30s) logs in the client nodes
```
[2021-02-10T18:59:20,396][DEPRECATION][o.e.d.c.m.IndexNameExpressionResolver] [opendistro-es-client-85b7d4f6c5-spkvf] this request accesses system indices: [.kibana_1], but in a future major version, direct access to system indices will be prevented by default
```
https://discuss.elastic.co/t/fresh-install-if-elk-7-10-floods-deprecation-log/259972/3
This is not a big deal imo.

The new version of od introduced changes to ism actions which means that the configurer needs additional permissions. This mean that upgrading will require running `securityadmin.sh`. I will add upgrade docs soon.

I'm running a single node in my cluster to see if it works or not
![image](https://user-images.githubusercontent.com/12396964/107983068-7bba9d00-6fc5-11eb-9040-1104fb824880.png)

With a single node we won't get a "green" cluster state as indicies by default consist of 1 primary and 1 replica shard, and as we only have one data node, the replica shard cannot be assgined anywhere. To me this does not matter as it's just a dev cluster, just thought that iäd mention it.


**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
