### PR TITLE
tests: Improve s3 bucket tests

### DIFF
--- a/pipeline/test/infrastructure/s3-buckets.sh
+++ b/pipeline/test/infrastructure/s3-buckets.sh
@@ -13,38 +13,23 @@ case ${1:-noarg} in
   sc|wc) : ;;
   *) echo "Usage: $(basename "$0") (sc|wc)" 1>&2; exit 1 ;;
 esac
-config_file="$CK8S_CONFIG_PATH/$1-config.yaml"
-cloud_provider=$(yq r "$config_file" 'global.cloudProvider')
 
-# In config:
-# objectStorage.buckets.<bucket>
-buckets=(
-  harbor
-  velero
-  elasticsearch
-  influxDB
-  scFluentd
-)
+config_file="$CK8S_CONFIG_PATH/${1}-config.yaml"
+cloud_provider=$(yq r "${config_file}" 'global.cloudProvider')
 
 function check_if_bucket_exists() { # arguments: bucket name
-  local bucket_name="$1"
+  local bucket_name="${1}"
 
   echo "Checking status of bucket [${bucket_name}] at [$cloud_provider]"
-  bucket_exists=$(echo "$S3_BUCKET_LIST" | awk "\$3~/^s3:\/\/${bucket_name}$/ {print \$3}")
 
-  if [ "$bucket_exists" ]; then
-      echo "bucket [${bucket_name}] exists at [$cloud_provider]"
+  if with_s3cfg "${secrets[s3cfg_file]}" "s3cmd --config {} ls s3://${bucket_name}" > /dev/null 2>&1; then
+      echo "Bucket [${bucket_name}] exists at [${cloud_provider}]"
   else
-      echo "bucket [${bucket_name}] does not exist at [$cloud_provider]"
-      exit 1
+      echo "Bucket [${bucket_name}] does not exist at [${cloud_provider}]" && exit 1
   fi
 }
 
-# get a list of all the S3 buckets
-S3_BUCKET_LIST=$(with_s3cfg "${secrets[s3cfg_file]}" "s3cmd --config {} ls")
-
-for bucket in "${buckets[@]}"
-do
-  bucket_name=$(yq r "$config_file" "objectStorage.buckets.$bucket")
-  check_if_bucket_exists "$bucket_name"
+# shellcheck disable=SC2086
+for bucket_name in $(yq r ${config_file} 'objectStorage.buckets.*'); do
+  check_if_bucket_exists "${bucket_name}"
 done


### PR DESCRIPTION
**What this PR does / why we need it**:
We do no longer specify the same buckets for both wc and sc, thus the tests needs to adhere to this change.
This commit updates the tests a bit and simplifies it (imo).

**Which issue this PR fixes**:

**Special notes for reviewer**:

**Tests**:

```
❯ ./pipeline/test/infrastructure/s3-buckets.sh sc
Checking status of bucket [olle-dev-harbor] at [exoscale]
Bucket [olle-dev-harbor] exists at [exoscale]
Checking status of bucket [olle-dev-velero] at [exoscale]
Bucket [olle-dev-velero] exists at [exoscale]
Checking status of bucket [olle-dev-es-backup] at [exoscale]
Bucket [olle-dev-es-backup] exists at [exoscale]
Checking status of bucket [olle-dev-influxdb] at [exoscale]
Bucket [olle-dev-influxdb] exists at [exoscale]
Checking status of bucket [olle-dev-sc-logs] at [exoscale]
Bucket [olle-dev-sc-logs] exists at [exoscale]

❯ ./pipeline/test/infrastructure/s3-buckets.sh wc
Checking status of bucket [olle-dev-velero] at [exoscale]
Bucket [olle-dev-velero] exists at [exoscale]

❯ ./pipeline/test/infrastructure/s3-buckets.sh sc
Checking status of bucket [i-dont-exist] at [exoscale]
Bucket [i-dont-exist] does not exist at [exoscale]
```

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
