### PR TITLE
apps wc: Install fluentd cm before fluentd itself

### DIFF
--- a/scripts/deploy-wc.sh
+++ b/scripts/deploy-wc.sh
@@ -22,12 +22,6 @@ kubectl -n kube-system create secret generic elasticsearch \
 kubectl -n fluentd create secret generic elasticsearch \
     --from-literal=password="${elasticsearch_password}" --dry-run -o yaml | kubectl apply -f -
 
-echo "Installing helm charts" >&2
-cd "${SCRIPTS_PATH}/../helmfile"
-declare -a helmfile_opt_flags
-[[ -n "$INTERACTIVE" ]] && helmfile_opt_flags+=("$INTERACTIVE")
-helmfile -f . -e workload_cluster "${helmfile_opt_flags[@]}" apply --suppress-diff
-
 # Add example resources.
 # We use `create` here instead of `apply` to avoid overwriting any changes the
 # user may have done.
@@ -35,5 +29,11 @@ kubectl create -f "${SCRIPTS_PATH}/../manifests/examples/fluentd/fluentd-extra-c
     2> /dev/null || echo "fluentd-extra-config configmap already in place. Ignoring."
 kubectl create -f "${SCRIPTS_PATH}/../manifests/examples/fluentd/fluentd-extra-plugins.yaml" \
     2> /dev/null || echo "fluentd-extra-plugins configmap already in place. Ignoring." >&2
+
+echo "Installing helm charts" >&2
+cd "${SCRIPTS_PATH}/../helmfile"
+declare -a helmfile_opt_flags
+[[ -n "$INTERACTIVE" ]] && helmfile_opt_flags+=("$INTERACTIVE")
+helmfile -f . -e workload_cluster "${helmfile_opt_flags[@]}" apply --suppress-diff
 
 echo "Deploy wc completed!" >&2


### PR DESCRIPTION
**What this PR does / why we need it**:
To avoid fluentd(user) crashlooping in the workload cluster.

**Which issue this PR fixes**:

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
