### PR TITLE
Set timeout for service endpoint tests

### DIFF
--- a/pipeline/test/services/funcs.sh
+++ b/pipeline/test/services/funcs.sh
@@ -236,6 +236,8 @@ function testEndpoint {
     retries=6
     while [ ${retries} -gt 0 ]; do
         args=(
+            --connect-timeout 20
+            --max-time 60
             -ksIL
             -o /dev/null
             -X GET
@@ -266,6 +268,8 @@ function testEndpointProtected {
     retries=6
     while [ ${retries} -gt 0 ]; do
         args=(
+            --connect-timeout 20
+            --max-time 60
             -ksI
             -o /dev/null
             -X GET


### PR DESCRIPTION
**What this PR does / why we need it**:
To fail faster when testing service endpoints when the apps installation has completely failed.

This commit sets a couple of options for curl
- `--max-time <seconds> Maximum time allowed for the transfer`
- `--connect-timeout <seconds> Maximum time allowed for connection`

**Which issue this PR fixes**:
fixes #217 

**Special notes for reviewer**:
I have not tested this.

We might want to lower the settings even more as we do 6 retries.

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
infra: (changes to our infrastructure code that apply to more than one cloud)
infra aws (changes to our infrastructure code that apply only to AWS)
infra exo: (changes to our infrastructure code that apply only to Exoscale)
infra safe: (changes to our infrastructure code that apply only to Safespring)
infra city: (changes to our infrastructure code that apply only to CityCloud)
lb: (things related to the HAProxy load balancer)
k8s: (kubernetes related changes, e.g. cluster initialization or join)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
