### PR TITLE
apps sc: fix fluentd configmap gcs keyfile indentation

### DIFF
--- a/helmfile/values/fluentd-configmap.yaml.gotmpl
+++ b/helmfile/values/fluentd-configmap.yaml.gotmpl
@@ -65,7 +65,7 @@ aggregator:
       </match>
     {{ if eq .Values.objectStorage.type "gcs" -}}
     gcp_credentials.json: |
-      {{ .Values.objectStorage.gcs.keyfileData | nindent 4 }}
+      {{ .Values.objectStorage.gcs.keyfileData | nindent 6 }}
     {{- end }}
 
   plugins:


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes an indentation error in the fluentd aggregator ConfigMap which caused problems when using gcs as object storage.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #244 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**: I feel like this is so minor that it didn't warrant adding to the changelog, but tell me if you think I should do that.

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
