### PR TITLE
[QA] tests: Fix and update wc pod tests

### DIFF
--- a/pipeline/test/services/workload-cluster/testPodsReady.sh
+++ b/pipeline/test/services/workload-cluster/testPodsReady.sh
@@ -4,12 +4,13 @@ INNER_SCRIPTS_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 # shellcheck disable=SC1090
 source "${INNER_SCRIPTS_PATH}/../funcs.sh"
 
-cloud_provider=$(yq r -e "${CONFIG_FILE}" 'global.cloudProvider')
 enable_falco_alerts=$(yq r -e "${CONFIG_FILE}" 'falco.alerts.enabled')
 enable_falco=$(yq r -e "${CONFIG_FILE}" 'falco.enabled')
 enable_opa=$(yq r -e "${CONFIG_FILE}" 'opa.enabled')
 enable_user_alertmanager=$(yq r -e "${CONFIG_FILE}" 'user.alertmanager.enabled')
 enable_velero=$(yq r -e "${CONFIG_FILE}" 'velero.enabled')
+enable_local_pv_provisioner=$(yq r -e "${CONFIG_FILE}" 'storageClasses.local.enabled')
+enable_nfs_provisioner=$(yq r -e "${CONFIG_FILE}" 'storageClasses.nfs.enabled')
 
 echo
 echo
@@ -27,24 +28,23 @@ deployments=(
     "monitoring kube-prometheus-stack-operator"
     "monitoring kube-prometheus-stack-kube-state-metrics"
 )
-if [ "$cloud_provider" == "exoscale" ]; then
+if "${enable_nfs_provisioner}"; then
     deployments+=("kube-system nfs-client-provisioner")
 fi
-if [ "$enable_opa" == true ]; then
+if "{$enable_opa}"; then
     deployments+=("gatekeeper-system gatekeeper-controller-manager")
 fi
-if [ "$enable_falco_alerts" == true ]; then
+if "${enable_falco_alerts}"; then
     deployments+=("falco falcosidekick")
 fi
-if [ "$enable_velero" == true ]; then
+if "${enable_velero}"; then
     deployments+=("velero velero")
 fi
 
 resourceKind="Deployment"
 # Get json data in a smaller dataset
 simpleData="$(getStatus $resourceKind)"
-for deployment in "${deployments[@]}"
-do
+for deployment in "${deployments[@]}"; do
     read -r -a arr <<< "$deployment"
     namespace="${arr[0]}"
     name="${arr[1]}"
@@ -65,18 +65,20 @@ daemonsets=(
     "monitoring kube-prometheus-stack-prometheus-node-exporter"
     "velero restic"
 )
-if [ "$enable_falco" == true ]; then
+if "${enable_falco}"; then
     daemonsets+=("falco falco")
 fi
-if [ "$enable_velero" == true ]; then
+if "${enable_velero}"; then
     daemonsets+=("velero restic")
+fi
+if "${enable_local_pv_provisioner}"; then
+  daemonsets+=("kube-system local-volume-provisioner")
 fi
 
 resourceKind="DaemonSet"
 # Get json data in a smaller dataset
 simpleData="$(getStatus $resourceKind)"
-for daemonset in "${daemonsets[@]}"
-do
+for daemonset in "${daemonsets[@]}"; do
     read -r -a arr <<< "$daemonset"
     namespace="${arr[0]}"
     name="${arr[1]}"
@@ -92,16 +94,14 @@ statefulsets=(
     "monitoring prometheus-kube-prometheus-stack-prometheus"
 )
 
-if [[ $enable_user_alertmanager == "true" ]]
-then
+if "${enable_user_alertmanager}"; then
     statefulsets+=("monitoring alertmanager-alertmanager")
 fi
 
 resourceKind="StatefulSet"
 # Get json data in a smaller dataset
 simpleData="$(getStatus $resourceKind)"
-for statefulset in "${statefulsets[@]}"
-do
+for statefulset in "${statefulsets[@]}"; do
     read -r -a arr <<< "$statefulset"
     namespace="${arr[0]}"
     name="${arr[1]}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Test nfs-client-provisioner only if it is enable instead of looking at
what cloud provider is used. Also added test for local volume
provisioner.

**Which issue this PR fixes**:
None, part of QA for 0.10

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
