### PR TITLE
Don't capture fluentd metrics

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,2 +1,2 @@
 ### Removed
-- Metrics collecting from fluentd in service cluster
+- Fluentd prometheus metrics.

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,2 @@
+### Removed
+- Metrics collecting from fluentd in service cluster

--- a/helmfile/values/fluentd-configmap.yaml.gotmpl
+++ b/helmfile/values/fluentd-configmap.yaml.gotmpl
@@ -1,13 +1,6 @@
 aggregator:
   configMaps:
     fluentd.conf: |
-      # Prometheus Exporter Plugin
-      # input plugin that exports metrics
-      <source>
-        @type prometheus
-        port 24231
-      </source>
-
       # TCP input to receive logs from the forwarders
       <source>
         @type forward
@@ -83,37 +76,6 @@ aggregator:
 forwarder:
   configMaps:
     fluentd.conf: |
-      # Prometheus Exporter Plugin
-      # input plugin that exports metrics
-      <source>
-        @type prometheus
-        port 24231
-      </source>
-
-      # input plugin that collects metrics from MonitorAgent
-      <source>
-        @type prometheus_monitor
-        <labels>
-          host ${hostname}
-        </labels>
-      </source>
-
-      # input plugin that collects metrics for output plugin
-      <source>
-        @type prometheus_output_monitor
-        <labels>
-          host ${hostname}
-        </labels>
-      </source>
-
-      # input plugin that collects metrics for in_tail plugin
-      <source>
-        @type prometheus_tail_monitor
-        <labels>
-          host ${hostname}
-        </labels>
-      </source>
-
       # Throw the healthcheck to the standard output instead of forwarding it
       <match fluentd.healthcheck>
         @type stdout
@@ -224,20 +186,6 @@ forwarder:
             format none
           </pattern>
         </parse>
-      </filter>
-
-      # count number of incoming records per tag
-      <filter **>
-        @type prometheus
-        <metric>
-          name fluentd_input_status_num_records_total
-          type counter
-          desc The total number of incoming records
-          <labels>
-            tag ${tag}
-            hostname ${hostname}
-          </labels>
-        </metric>
       </filter>
 
       <filter **>

--- a/helmfile/values/fluentd-sc.yaml.gotmpl
+++ b/helmfile/values/fluentd-sc.yaml.gotmpl
@@ -42,6 +42,3 @@ forwarder:
       value: "2048"
     - name: OUTPUT_BUFFER_QUEUE_LIMIT
       value: "4096"
-
-metrics:
-  enabled: true

--- a/helmfile/values/fluentd-user.yaml.gotmpl
+++ b/helmfile/values/fluentd-user.yaml.gotmpl
@@ -29,11 +29,6 @@ env:
   STUCK_THRESHOLD_SECONDS: 1200
   OUTPUT_PORT: 443
 
-serviceMonitor:
-  enabled: true
-  interval: 30s
-  port: 24231
-
 extraConfigMaps:
   system.conf: |-
     <system>
@@ -112,20 +107,6 @@ extraConfigMaps:
           format none
         </pattern>
       </parse>
-    </filter>
-
-    # count number of incoming records per tag
-    <filter **>
-      @type prometheus
-      <metric>
-        name fluentd_input_status_num_records_total
-        type counter
-        desc The total number of incoming records
-        <labels>
-          tag ${tag}
-          hostname ${hostname}
-        </labels>
-      </metric>
     </filter>
 
     <filter **>

--- a/helmfile/values/fluentd-wc.yaml.gotmpl
+++ b/helmfile/values/fluentd-wc.yaml.gotmpl
@@ -32,11 +32,6 @@ configMaps:
     containersInputConf: false
     outputConf: false
 
-serviceMonitor:
-  enabled: true
-  interval: 30s
-  port: 24231
-
 extraConfigMaps:
   system.conf: |-
     <system>
@@ -140,20 +135,6 @@ extraConfigMaps:
           format none
         </pattern>
       </parse>
-    </filter>
-
-    # count number of incoming records per tag
-    <filter **>
-      @type prometheus
-      <metric>
-        name fluentd_input_status_num_records_total
-        type counter
-        desc The total number of incoming records
-        <labels>
-          tag ${tag}
-          hostname ${hostname}
-        </labels>
-      </metric>
     </filter>
 
     <filter **>
@@ -277,19 +258,6 @@ extraConfigMaps:
           queue_limit_length "#{ENV['OUTPUT_BUFFER_QUEUE_LIMIT']}"
           overflow_action block
         </buffer>
-    </match>
-
-    <match **>
-        @type prometheus
-        <metric>
-          name fluentd_output_status_num_records_total
-          type counter
-          desc The total number of outgoing records
-          <labels>
-            tag ${tag}
-            hostname ${hostname}
-          </labels>
-        </metric>
     </match>
 
 {{- range $key, $value := .Values.fluentd.extraConfigMaps }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove monitoring fluentd metrics

**Which issue this PR fixes**:
fixes #246 

**Special notes for reviewer**:
I have not tested upgrading. Although i dont see what whould could go wrong.

**Tests**
```
❯ ./bin/ck8s ops kubectl sc  get servicemonitor -n fluentd
No resources found in fluentd namespace.

❯ ./bin/ck8s ops kubectl wc -n fluentd get servicemonitors
No resources found in fluentd namespace.

❯ ./bin/ck8s ops kubectl wc -n kube-system get servicemonitors 
No resources found in kube-system namespace.
```

Prometheus-sc
![image](https://user-images.githubusercontent.com/12396964/108685703-c1f78b00-74f4-11eb-9742-82e467d3b614.png)

wc-reader
![image](https://user-images.githubusercontent.com/12396964/108702513-a8ad0980-7509-11eb-8a5a-6efd26b57fa0.png)


**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
