### PR TITLE
Bump helmfile to v0.138.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The apps are installed using a combination of helm charts and manifests with the
 * A running cluster based on [compliantkubernetes-kubespray][compliantkubernetes-kubespray]
 * [kubectl](https://github.com/kubernetes/kubernetes/releases) (tested with 1.19.8)
 * [helm](https://github.com/helm/helm/releases) (tested with 3.5.2)
-* [helmfile](https://github.com/roboll/helmfile) (tested with v0.129.3)
+* [helmfile](https://github.com/roboll/helmfile) (tested with v0.138.4)
 * [helm-diff](https://github.com/databus23/helm-diff) (tested with 3.1.1)
 * [helm-secrets](https://github.com/futuresimple/helm-secrets) (tested with 2.0.2)
 * [jq](https://github.com/stedolan/jq) (tested with jq-1.6)

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 - Bumped `helm` to `v3.5.2`.
 - Bumped `kubectl` to `v1.19.8`.
+- Bumped `helmfile` to `v0.138.4`.
 
 ### Removed
 - Fluentd prometheus metrics.

--- a/get-requirements.yaml
+++ b/get-requirements.yaml
@@ -5,7 +5,7 @@
       install_user: "{{ lookup('env','USER') }}"
       kubectl_version: 1.19.8
       helm_version: 3.5.2
-      helmfile_version: 0.129.3
+      helmfile_version: 0.138.4
       helmdiff_version: 3.1.1
       helmsecrets_version: 2.0.2
       jq_version: 1.6

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -38,7 +38,7 @@ RUN helm plugin install https://github.com/databus23/helm-diff --version v3.1.1
 RUN helm plugin install https://github.com/futuresimple/helm-secrets --version v2.0.2
 
 # Helmfile
-ENV HELMFILE_VERSION "v0.129.3"
+ENV HELMFILE_VERSION "v0.138.4"
 RUN wget "https://github.com/roboll/helmfile/releases/download/${HELMFILE_VERSION}/helmfile_linux_amd64" && \
     chmod +x helmfile_linux_amd64 && \
     mv helmfile_linux_amd64 /usr/local/bin/helmfile


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
fixes #261  

**Special notes for reviewer**:
Been using this version for the last 1-2 weeks and i have not run into any trouble.

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
