### PR TITLE
Bump kubectl to v1.19.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The apps are installed using a combination of helm charts and manifests with the
 ### Requirements
 
 * A running cluster based on [compliantkubernetes-kubespray][compliantkubernetes-kubespray]
-* [kubectl](https://github.com/kubernetes/kubernetes/releases) (tested with 1.18.13)
+* [kubectl](https://github.com/kubernetes/kubernetes/releases) (tested with 1.19.8)
 * [helm](https://github.com/helm/helm/releases) (tested with 3.5.2)
 * [helmfile](https://github.com/roboll/helmfile) (tested with v0.129.3)
 * [helm-diff](https://github.com/databus23/helm-diff) (tested with 3.1.1)

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Changed
 - Bumped `helm` to `v3.5.2`.
+- Bumped `kubectl` to `v1.19.8`.
 
 ### Removed
 - Fluentd prometheus metrics.

--- a/get-requirements.yaml
+++ b/get-requirements.yaml
@@ -3,7 +3,7 @@
     vars:
       install_path: /usr/local/bin
       install_user: "{{ lookup('env','USER') }}"
-      kubectl_version: 1.18.13
+      kubectl_version: 1.19.8
       helm_version: 3.5.2
       helmfile_version: 0.129.3
       helmdiff_version: 3.1.1

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -12,7 +12,7 @@ RUN  apt-get update && \
      rm -rf /var/lib/apt/lists/*
 
 # Kubectl
-ENV KUBECTL_VERSION "v1.18.13"
+ENV KUBECTL_VERSION "v1.19.8"
 RUN wget "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
**What this PR does / why we need it**:
Default kubernetes version in kubespray 2.15 is 1.19

**Which issue this PR fixes**:
fixes #264 

**Special notes for reviewer**:

With this new version i noticed that we get a warning when bootstrapping our crds
```
❯ ./bin/ck8s apply sc
[ck8s] Validating sc config
[ck8s] Bootstrapping service cluster
customresourcedefinition.apiextensions.k8s.io/certificaterequests.cert-manager.io configured
customresourcedefinition.apiextensions.k8s.io/certificates.cert-manager.io configured
customresourcedefinition.apiextensions.k8s.io/challenges.acme.cert-manager.io configured
customresourcedefinition.apiextensions.k8s.io/clusterissuers.cert-manager.io configured
customresourcedefinition.apiextensions.k8s.io/issuers.cert-manager.io configured
customresourcedefinition.apiextensions.k8s.io/orders.acme.cert-manager.io configured
customresourcedefinition.apiextensions.k8s.io/alertmanagerconfigs.monitoring.coreos.com configured
customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com configured
customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com configured
customresourcedefinition.apiextensions.k8s.io/probes.monitoring.coreos.com configured
customresourcedefinition.apiextensions.k8s.io/prometheuses.monitoring.coreos.com configured
customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com configured
customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com configured
customresourcedefinition.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com configured
Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
...
```

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
