### PR TITLE
Use dry-run=client in apply scripts

### DIFF
--- a/scripts/deploy-sc.sh
+++ b/scripts/deploy-sc.sh
@@ -27,7 +27,7 @@ if [[ ${objectStoreProvider} == "s3" ]]; then
   kubectl create secret generic s3-credentials -n fluentd \
       --from-literal=s3_access_key="${s3_access_key}" \
       --from-literal=s3_secret_key="${s3_secret_key}" \
-      --dry-run -o yaml | kubectl apply -f -
+      --dry-run=client -o yaml | kubectl apply -f -
 fi
 
 echo "Installing helm charts" >&2

--- a/scripts/deploy-wc.sh
+++ b/scripts/deploy-wc.sh
@@ -18,9 +18,9 @@ echo "Creating Elasticsearch and fluentd secrets" >&2
 elasticsearch_password=$(sops_exec_file "${secrets[secrets_file]}" 'yq r -e {} elasticsearch.fluentdPassword')
 
 kubectl -n kube-system create secret generic elasticsearch \
-    --from-literal=password="${elasticsearch_password}" --dry-run -o yaml | kubectl apply -f -
+    --from-literal=password="${elasticsearch_password}" --dry-run=client -o yaml | kubectl apply -f -
 kubectl -n fluentd create secret generic elasticsearch \
-    --from-literal=password="${elasticsearch_password}" --dry-run -o yaml | kubectl apply -f -
+    --from-literal=password="${elasticsearch_password}" --dry-run=client -o yaml | kubectl apply -f -
 
 # Add example resources.
 # We use `create` here instead of `apply` to avoid overwriting any changes the


### PR DESCRIPTION
**What this PR does / why we need it**:
To get rid of warning when applying.
```
[ck8s] Applying applications in workload cluster
Creating Elasticsearch and fluentd secrets
W0222 13:42:32.890541  576671 helpers.go:553] --dry-run is deprecated and can be replaced with --dry-run=client.
secret/elasticsearch configured
W0222 13:42:33.519425  576693 helpers.go:553] --dry-run is deprecated and can be replaced with --dry-run=client.
```

**Which issue this PR fixes**:

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
