### PR TITLE
apps sc: fix sc log retention service account

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,2 +1,6 @@
+### Fixed
+
+- Fixed service cluster log retention using the wrong service account.
+
 ### Removed
 - Fluentd prometheus metrics.

--- a/helmfile/charts/sc-logs-retention/values.yaml
+++ b/helmfile/charts/sc-logs-retention/values.yaml
@@ -10,7 +10,7 @@ fullnameOverride: ""
 schedule: "@daily"
 startingDeadlineSeconds: 1200
 
-serviceAccountName: "fluentd-aggregator"
+serviceAccountName: "fluentd-forwarder"
 
 s3:
   enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes the incorrect sc log retention service account. (`fluentd-aggregator` -> `fluentd-forwarder`)

**Which issue this PR fixes**: fixes #224 

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
