### PR TITLE
docs: Replace ck8s-cluster with ck8s-kubespray

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@
 This repository is part of the [Compliant Kubernetes][compliantkubernetes] (compliantkubernetes) platform.
 The platform consists of the following repositories:
 
-* [ck8s-cluster][ck8s-cluster] - Code for managing Kubernetes clusters and the infrastructure around them.
-* [compliantkubernetes-apps][compliantkubernetes-apps] - Code, configuration and tools for running various services and applications on top of service and workload ck8s-cluster.
-* [ck8s-base-vm][ck8s-base-vm] - A virtual machine template with relevant Kubernetes packages pre-installed.
+* [compliantkubernetes-kubespray][compliantkubernetes-kubespray] - Code for managing Kubernetes clusters and the infrastructure around them.
+* [compliantkubernetes-apps][compliantkubernetes-apps] - Code, configuration and tools for running various services and applications on top of Kubernetes clusters.
 
 The Elastisys Compliant Kubernetes (compliantkubernetes) platform runs two Kubernetes clusters.
 One called "service" and one called "workload".
@@ -31,12 +30,11 @@ The _workload cluster_ manages the user applications as well as providing intrus
 * Prometheus
 
 [compliantkubernetes]: https://compliantkubernetes.com/
-[ck8s-cluster]: https://github.com/elastisys/ck8s-cluster
+[compliantkubernetes-kubespray]: https://github.com/elastisys/compliantkubernetes-kubespray
 [compliantkubernetes-apps]: https://github.com/elastisys/compliantkubernetes-apps
-[ck8s-base-vm]: https://github.com/elastisys/ck8s-base-vm
 
 This repository installs all the applications of ck8s on top of already created clusters.
-To setup the clusters see [ck8s-cluster](https://github.com/elastisys/ck8s-cluster).
+To setup the clusters see [compliantkubernetes-kubespray][compliantkubernetes-kubespray].
 A service-cluster (sc) or workload-cluster (wc) can be created separately but all of the applications will not work correctly unless both are running.
 
 All config files will be located under `CK8S_CONFIG_PATH`.
@@ -54,7 +52,7 @@ The apps are installed using a combination of helm charts and manifests with the
 
 ### Requirements
 
-* A running cluster based on [ck8s-cluster](https://github.com/elastisys/ck8s-cluster)
+* A running cluster based on [compliantkubernetes-kubespray][compliantkubernetes-kubespray]
 * [kubectl](https://github.com/kubernetes/kubernetes/releases) (tested with 1.18.13)
 * [helm](https://github.com/helm/helm/releases) (tested with 3.5.0)
 * [helmfile](https://github.com/roboll/helmfile) (tested with v0.129.3)
@@ -71,7 +69,7 @@ Installs requirements using the ansible playbook get-requirements.yaml
 ansible-playbook -e 'ansible_python_interpreter=/usr/bin/python3' --ask-become-pass --connection local --inventory 127.0.0.1, get-requirements.yaml
 ```
 
-Note that you will need a service and workload ck8s-cluster.
+Note that you will need a service and workload cluster.
 
 #### Developer requirements and guidelines
 
@@ -98,7 +96,7 @@ If this is all new to you, here's a [link](https://riseup.net/en/security/messag
 
 ### Quickstart
 
-**You probably want to check the [ck8s-cluster][ck8s-cluster] repository first, since compliantkubernetes-apps depends on having two clusters already set up.**
+**You probably want to check the [compliantkubernetes-kubespray][compliantkubernetes-kubespray] repository first, since compliantkubernetes-apps depends on having two clusters already set up.**
 In addition to this, you will need to set up the following DNS entries (replace `example.com` with your domain).
 - Point these domains to the workload cluster ingress controller:
   - `*.example.com`


### PR DESCRIPTION
**What this PR does / why we need it**:
We no longer update ck8s-cluster and thus it does not make sense to refer people to that repository.

**Which issue this PR fixes**:
fixes #195 

**Special notes for reviewer**:
This is just an initial attempt to address the linked issue.
I don't know if we have to make it more complicated than this.
Preferably we should have the "migration" docs (if at all possible) from `ck8s-cluster` to `compliantkubernetes-kubespray` in the kubespray repo as that's what superseded the cluster repo, in order to have this repo be as agnostic as possible and just have a set of requirements on the kubernetes clusters themselves.

Related: https://github.com/elastisys/ck8s-cluster/pull/120

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
