### PR TITLE
tests: Always continue on helmfile status in list releases test

### DIFF
--- a/pipeline/list-releases.bash
+++ b/pipeline/list-releases.bash
@@ -38,11 +38,10 @@ fi
 echo "###############################"
 echo -e "Listing helm releases\n"
 
-"${bin_path}"/ck8s ops helmfile "${cluster_abbr}" status
+"${bin_path}"/ck8s ops helmfile "${cluster_abbr}" status || true
 
 failed_releases=$("${bin_path}"/ck8s ops helmfile "${cluster_abbr}" status --args="--output=json" 2>/dev/null \
-    | jq 'select(.info.status=="failed")')
-
+    | jq 'select(.info.status=="failed")' || true)
 
 echo -e "###############################\n"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
To get some kubernetes output when a release has failed installing in the pipeline.
Now if there are releases that are not found it will still check for failed releases.

**Which issue this PR fixes**:
None

**Special notes for reviewer**:

**Tests**
- Fluents user is failed due to timeout
- Issuers has not been installed

Before fix - it stops at listing releases which fails becase issers has not been installed.
```
in /home/olle/Documents/github/elastisys/compliantkubernetes-apps/helmfile/01-applications.yaml: release "issuers" failed: command "/usr/local/bin/helm" exited with non-zero status:

PATH:
  /usr/local/bin/helm

ARGS:
  0: helm (4 bytes)
  1: status (6 bytes)
  2: issuers (7 bytes)
  3: --namespace (11 bytes)
  4: cert-manager (12 bytes)

ERROR:
  exit status 1

EXIT STATUS
  1

STDERR:
  Error: release: not found

COMBINED OUTPUT:
  Error: release: not found
exit status 1
```

After fix - it continues to show failed releases despite some releases not being installed.
```
in /home/olle/Documents/github/elastisys/compliantkubernetes-apps/helmfile/01-applications.yaml: release "issuers" failed: command "/usr/local/bin/helm" exited with non-zero status:

PATH:
  /usr/local/bin/helm

ARGS:
  0: helm (4 bytes)
  1: status (6 bytes)
  2: issuers (7 bytes)
  3: --namespace (11 bytes)
  4: cert-manager (12 bytes)

ERROR:
  exit status 1

EXIT STATUS
  1

STDERR:
  Error: release: not found

COMBINED OUTPUT:
  Error: release: not found
exit status 1
###############################

Listing 'all' in namespace 'fluentd'

NAME                                      READY   STATUS    RESTARTS   AGE
pod/fluentd-fluentd-elasticsearch-2dw8s   1/1     Running   0          4m53s
pod/fluentd-fluentd-elasticsearch-5sbtt   1/1     Running   0          4m53s
pod/fluentd-fluentd-elasticsearch-rfbd2   1/1     Running   0          4m53s

NAME                                           DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
daemonset.apps/fluentd-fluentd-elasticsearch   3         3         3       3            3           <none>          4m53s

Listing 'pvc' in namespace 'fluentd'

No resources found in fluentd namespace.

Listing 'secrets' in namespace 'fluentd'

NAME                                        TYPE                                  DATA   AGE
default-token-fv2mg                         kubernetes.io/service-account-token   3      82m
elasticsearch                               Opaque                                1      81m
fluentd-fluentd-elasticsearch-token-zf8f6   kubernetes.io/service-account-token   3      4m56s
sh.helm.release.v1.fluentd.v1               helm.sh/release.v1                    1      4m56s

Listing 'certificates' in namespace 'fluentd'

No resources found in fluentd namespace.

Listing 'ingresses' in namespace 'fluentd'

No resources found in fluentd namespace.
```

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
