### PR TITLE
apps: Remove ck8sdash entry from apps statefile

### DIFF
--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -106,16 +106,6 @@ releases:
   - values/kube-prometheus-stack-wc.yaml.gotmpl
 {{ end }}
 
-
-## Deprecated, remove later.
-- name: ck8sdash
-  namespace: ck8sdash
-  labels:
-    app: ck8sdash
-  chart: ./charts/ck8sdash
-  version: 0.3.1
-  installed: false
-
 # Velero
 - name: velero
   namespace: velero


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove deprecated releases from statefile.

**Which issue this PR fixes**:
fixes #275 

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
