### PR TITLE
release: Add QA step to release process

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -7,62 +7,78 @@ https://semver.org/
 
 1. To release a major or minor version create a release branch `release-X.Y` from the last minor release tag.
 
-```bash
-git checkout vA.B.0
-git checkout -b release-X.Y
-git push -u origin release-X.Y
-```
+    ```bash
+    git checkout vA.B.0
+    git checkout -b release-X.Y
+    git push -u origin release-X.Y
+    ```
 
 2. Checkout the branch to cut the release from.
 
-```bash
-git checkout main
-git pull
-git checkout -b branch_name
-```
+    ```bash
+    git checkout main
+    git pull
+    git checkout -b branch_name
+    ```
 
-3. Run the release script.
+3. Run QA checks on `branch_name` and commit any fixes found during QA.
 
-```bash
-./release/release.sh X.Y.Z
-```
+4. Run the release script.
 
-The release script will:
-* Append what is in `WIP-CHANGELOG.md` to `CHANGELOG.md`
-* Clear `WIP-CHANGELOG.md`
-* Create a git commit with message `Release vX.Y.Z`
-* Create a tag named `vX.Y.Z`
+    ```bash
+    ./release/release.sh X.Y.Z
+    ```
 
-4. Push the tagged commit, create a PR against the release branch and request a review.
+    The release script will:
+    * Append what is in `WIP-CHANGELOG.md` to `CHANGELOG.md`
+    * Clear `WIP-CHANGELOG.md`
+    * Create a git commit with message `Release vX.Y.Z`
+    * Create a tag named `vX.Y.Z`
 
-```bash
-git push --atomic origin branch_name vX.Y.Z
-```
+5. Push the tagged commit, create a PR against the release branch and request a review.
 
-5. Merge it to finalize the release.
-A [GitHub actions workflow pipeline](.github/workflows/release.yml) will create a GitHub release from the tag.
+    ```bash
+    git push --atomic origin branch_name vX.Y.Z
+    ```
 
-*GitHub currently does not support merging with fast-forward only.
-Merge the release PR locally and push it instead.*
+6. Merge it to finalize the release.
+    A [GitHub actions workflow pipeline](.github/workflows/release.yml) will create a GitHub release from the tag.
 
-```bash
-git checkout release-X.Y
-git merge --ff-only branch_name
-git push
-```
+    *GitHub currently does not support merging with fast-forward only.
+    Merge the release PR locally and push it instead.*
+
+    ```bash
+    git checkout release-X.Y
+    git merge --ff-only branch_name
+    git push
+
+    # If 'git merge --ff-only' isn't possible, 'git rebase' can be used.
+    git checkout release-X.Y
+    git rebase --onto branch_name
+    git push --force-with-lease
+    ```
+
+7. Merge any fixes from the release branch back to the `main` branch
+    `git cherry-pick` can be used, e.g.
+
+    ```bash
+    git checkout main
+    git checkout -b release-X.Y-fixes
+    git cherry-pick <fix 1 hash> [<fix 2 hash>..]
+    ```
 
 ## Patch releases
 
 1. Create a new branch based on a release branch and commit the patch commits to it.
 
-```bash
-git checkout release-X.Y
-git pull
-git checkout -b branch_name
-git cherry-pick [some fix in main]
-git add -p file-with-some-new-fixes
-git commit
-```
+    ```bash
+    git checkout release-X.Y
+    git pull
+    git checkout -b branch_name
+    git cherry-pick [some fix in main]
+    git add -p file-with-some-new-fixes
+    git commit
+    ```
 
 2. Continue from step 3 in the major/minor release flow.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the the release docs in the repo.
We don't have any "QA" test in this repo so i just mentioned that you should do some QA after creating the branch off main.

**Which issue this PR fixes**:
fixes #209 

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
