### PR TITLE
Added option to disable metric server

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -9,3 +9,6 @@
 
 ### Removed
 - Fluentd prometheus metrics.
+
+### Added
+- Possibility to disable metrics server

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -614,3 +614,7 @@ certmanager:
     nodeSelector: {}
     tolerations: {}
     affinity: {}
+
+## Configuration for metric-server
+metricsServer:
+  enabled: true

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -423,3 +423,7 @@ certmanager:
     nodeSelector: {}
     tolerations: {}
     affinity: {}
+
+## Configuration for metric-server
+metricsServer:
+  enabled: true

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -143,6 +143,7 @@ releases:
     app: metrics-server
   chart: stable/metrics-server
   version: 2.10.0
+  installed: {{ .Values.metricsServer.enabled }}
   missingFileHandler: Error
   values:
   - values/metrics-server.yaml.gotmpl

--- a/migration/v0.10.x-v0.11.x/upgrade-apps.md
+++ b/migration/v0.10.x-v0.11.x/upgrade-apps.md
@@ -1,0 +1,5 @@
+# Upgrade v0.10.x to v0.11.0
+
+1. Checkout the new release: `git checkout v0.11.0`
+
+1. Run init to get new defaults: `./bin/ck8s init`


### PR DESCRIPTION
**What this PR does / why we need it**:

To be able to deploy clusters on clusters with metrics server already installed we need a way of disabling it.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: 
fixes #283 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
