### PR TITLE
apps: Add missing cert-manager ignore labels

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Fixed
 - Fixed service cluster log retention using the wrong service account.
 - Fixed upgrade of user Grafana.
+- Fixed incorrect ignore label on cert-manager namespace.
 
 ### Changed
 - Bumped `helm` to `v3.5.2`.

--- a/bootstrap/namespaces/helmfile/values/namespaces-sc.yaml.gotmpl
+++ b/bootstrap/namespaces/helmfile/values/namespaces-sc.yaml.gotmpl
@@ -2,6 +2,7 @@ namespaces:
 - name: cert-manager
   labels:
       certmanager.k8s.io/disable-validation: "true"
+      cert-manager.io/disable-validation: "true"
 - name: dex
 - name: elastic-system
 - name: fluentd

--- a/bootstrap/namespaces/helmfile/values/namespaces-wc.yaml.gotmpl
+++ b/bootstrap/namespaces/helmfile/values/namespaces-wc.yaml.gotmpl
@@ -2,6 +2,7 @@ namespaces:
 - name: cert-manager
   labels:
     certmanager.k8s.io/disable-validation: "true"
+    cert-manager.io/disable-validation: "true"
 - name: fluentd
 - name: kube-node-lease
 - name: kube-public


### PR DESCRIPTION
**What this PR does / why we need it**:

Since we migrated to a newer version of cert-manager, the ignore label for the webhook changed. This patch adds the new label. Without this ... I'm actually `./bin/ck8s apply (sc|wc)` worked at all. :smile: 

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*

NA

**Special notes for reviewer**:

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
