### PR TITLE
config: Increase memory for prod influxdb

### DIFF
--- a/config/config/flavors/prod-sc.yaml
+++ b/config/config/flavors/prod-sc.yaml
@@ -99,3 +99,8 @@ influxDB:
     durationSC: 7d
   persistence:
     size: 30Gi
+  resources:
+    requests:
+      memory: 14Gi
+    limits:
+      memory: 15Gi


### PR DESCRIPTION
**What this PR does / why we need it**:
Set the request and limit higher for prod flavor.
Now it basically "forces" you to have a single node with 16 gb or greater for influxdb.

**Which issue this PR fixes**:
N/A

**Special notes for reviewer**:
Not sure if I used the correct commit prefix.

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
