### PR TITLE
apps: Add NetworkPolicy dashboard in Grafana

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,4 @@
+### Added
+
+- NetworkPolicy dashboard in Grafana
+- Added a new helm chart `calico-accountant`

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -618,3 +618,6 @@ certmanager:
 ## Configuration for metric-server
 metricsServer:
   enabled: true
+
+calicoAccountant:
+  enabled: true

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -427,3 +427,6 @@ certmanager:
 ## Configuration for metric-server
 metricsServer:
   enabled: true
+
+calicoAccountant:
+  enabled: true

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -148,6 +148,18 @@ releases:
   values:
   - values/metrics-server.yaml.gotmpl
 
+# calico-accountant
+- name: calico-accountant
+  namespace: kube-system
+  labels:
+    app: calico-accountant
+  chart: ./charts/calico-accountant
+  version: 0.1.0
+  installed: {{ .Values.calicoAccountant.enabled }}
+  missingFileHandler: Error
+  values:
+  - values/calico-accountant.yaml.gotmpl
+
 # Service cluster releases
 {{ if eq .Environment.Name "service_cluster" }}
 # Dex

--- a/helmfile/charts/calico-accountant/.helmignore
+++ b/helmfile/charts/calico-accountant/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helmfile/charts/calico-accountant/Chart.yaml
+++ b/helmfile/charts/calico-accountant/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for calico-accountant, see https://github.com/monzo/calico-accountant
+name: calico-accountant
+version: 0.1.0

--- a/helmfile/charts/calico-accountant/README.md
+++ b/helmfile/charts/calico-accountant/README.md
@@ -1,0 +1,5 @@
+# calico-accountant
+
+This helm chart deploys `calico-accountant`, an application that gathers metrics about NetworkPolicies.
+
+Source code for `calico-accountant` [can be found here.](https://github.com/monzo/calico-accountant)

--- a/helmfile/charts/calico-accountant/templates/daemonset.yaml
+++ b/helmfile/charts/calico-accountant/templates/daemonset.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: apps/v1
+kind: "DaemonSet"
+metadata:
+  name: "calico-accountant"
+  namespace: "kube-system"
+spec:
+  selector:
+    matchLabels:
+        app: "calico-accountant"
+  template:
+    metadata:
+      labels:
+        app: "calico-accountant"
+    spec:
+      containers:
+        - command:
+           - "/calico-accountant"
+           - "-logtostderr=true"
+           - "-v=2"
+          env:
+          - name: METRICS_SERVER_PORT
+            value: "9009"
+          {{- if eq .Values.calicoDataStore "kubernetes" }}
+          - name: DATASTORE_TYPE
+            value: "kubernetes"
+          - name: WAIT_FOR_DATASTORE
+            value: "true"
+          {{- else if eq .Values.calicoDataStore "etcd" }}
+          - name: ETCD_ENDPOINTS
+            valueFrom:
+              configMapKeyRef:
+                name: calico-config
+                key: etcd_endpoints
+          - name: ETCD_CA_CERT_FILE
+            valueFrom:
+              configMapKeyRef:
+                key: etcd_ca
+                name: calico-config
+          - name: ETCD_KEY_FILE
+            valueFrom:
+              configMapKeyRef:
+                key: etcd_key
+                name: calico-config
+          - name: ETCD_CERT_FILE
+            valueFrom:
+              configMapKeyRef:
+                key: etcd_cert
+                name: calico-config
+          {{- end }}
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          name: "calico-accountant"
+          ports:
+          - containerPort: 9009
+            name: metrics
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - mountPath: /calico-secrets
+            name: etcd-certs
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      hostNetwork: true
+      volumes:
+      - hostPath:
+          path: /etc/calico/certs
+          type: ""
+        name: etcd-certs
+      serviceAccount: "calico-node"

--- a/helmfile/charts/calico-accountant/templates/rbac.yaml
+++ b/helmfile/charts/calico-accountant/templates/rbac.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-accountant
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: calico-accountant
+  namespace: kube-system
+rules:
+- apiGroups:
+  - extensions
+  resourceNames:
+  - privileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - watch
+  - list
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: calico-accountant
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: calico-accountant
+subjects:
+- kind: ServiceAccount
+  name: calico-accountant
+  namespace: kube-system

--- a/helmfile/charts/calico-accountant/templates/service.yaml
+++ b/helmfile/charts/calico-accountant/templates/service.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+      app: "calico-accountant"
+  name: "calico-accountant"
+  namespace: kube-system
+spec:
+  endpoints:
+  - port: metrics
+  selector:
+    matchLabels:
+      app: "calico-accountant"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+      app: "calico-accountant"
+  name: calico-accountant-metrics
+  namespace: kube-system
+spec:
+  ports:
+  - port: 9009
+    name: metrics
+    protocol: TCP
+    targetPort: 9009
+  selector:
+      app: "calico-accountant"
+  sessionAffinity: None
+  type: ClusterIP

--- a/helmfile/charts/calico-accountant/values.yaml
+++ b/helmfile/charts/calico-accountant/values.yaml
@@ -1,0 +1,12 @@
+calicoDataStore: "kubernetes"
+image:
+  repository: elastisys/calico-accountant
+  tag: v0.1.6
+tolerations: []
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi

--- a/helmfile/charts/grafana-ops/dashboards/networkpolicy-dashboard.json
+++ b/helmfile/charts/grafana-ops/dashboards/networkpolicy-dashboard.json
@@ -1,0 +1,500 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 25,
+  "iteration": 1614241245071,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(policy_accept_counter{type=\"fw\",cluster=~\"$cluster\",pod_namespace=~\"$namespace\"}[1m])",
+          "interval": "",
+          "legendFormat": "Policy: {{policy}}, pod: {{exported_pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Packets allowed by NetworkPolicy going from pod",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "pps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(policy_accept_counter{type=\"tw\",cluster=~\"$cluster\",pod_namespace=~\"$namespace\"}[1m])",
+          "interval": "",
+          "legendFormat": "Policy: {{policy}}, pod: {{exported_pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Packets allowed by NetworkPolicy going to pod",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "pps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(no_policy_drop_counter{type=\"fw\",cluster=~\"$cluster\",pod_namespace=~\"$namespace\"}[1m])",
+          "interval": "",
+          "legendFormat": "{{exported_pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Dropped packets going from pod",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "pps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(no_policy_drop_counter{type=\"tw\",cluster=~\"$cluster\",pod_namespace=~\"$namespace\"}[1m])",
+          "interval": "",
+          "legendFormat": "{{exported_pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Dropped packets going to pod",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "pps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 25,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "prometheus-sc",
+          "value": "prometheus-sc"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(no_policy_drop_counter,cluster)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": "label_values(no_policy_drop_counter,cluster)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(no_policy_drop_counter,pod_namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "namespace",
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(no_policy_drop_counter,pod_namespace)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "NetworkPolicy Dashboard",
+  "uid": "RkxtPKEGz",
+  "version": 7
+}

--- a/helmfile/charts/grafana-ops/templates/dashboard-configmap.yaml
+++ b/helmfile/charts/grafana-ops/templates/dashboard-configmap.yaml
@@ -38,3 +38,7 @@ data:
   velero-dashboard.json: |-
     {{- .Files.Get "dashboards/velero-dashboard.json" | nindent 4 }}
 {{- end }}
+{{- if .Values.dashboards.networkpolicy.enabled }}
+  networkpolicy-dashboard.json: |-
+    {{- .Files.Get "dashboards/networkpolicy-dashboard.json" | nindent 4 }}
+{{- end }}

--- a/helmfile/charts/grafana-ops/values.yaml
+++ b/helmfile/charts/grafana-ops/values.yaml
@@ -24,3 +24,5 @@ dashboards:
     enabled: true
   velero:
     enabled: true
+  networkpolicy:
+    enabled: true

--- a/helmfile/values/grafana-ops.yaml.gotmpl
+++ b/helmfile/values/grafana-ops.yaml.gotmpl
@@ -18,3 +18,5 @@ dashboards:
     enabled: true
   velero:
     enabled: true
+  networkpolicy:
+    enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**: Adds a NetworkPolicy dashboard in Grafana which displays packets that are accepted/rejected by NetworkPolicies in the clusters.

![Screenshot from 2021-03-01 08-23-30](https://user-images.githubusercontent.com/37733838/109464798-89612f80-7a67-11eb-9321-fd7a379a6f08.png)

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #234 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

If you want to test it yourself, you can test the dashboard using [these Pods and NetworkPolicies.](https://github.com/elastisys/compliantkubernetes-apps/tree/vf/netpol-dashboard/netpol-dashboard/test-manifests)

The metrics exporter (calico-accountant) currently uses our Docker image because there is no official Docker image available of the latest version, awaiting response from the creators on the possibility of making an official image.

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
