### PR TITLE
Lj/test internal pr

### DIFF
--- a/.github/workflows/read-secrets.yml
+++ b/.github/workflows/read-secrets.yml
@@ -20,3 +20,4 @@ jobs:
         echo "Normal env var: ${NORMAL_ENV_VAR}"
         echo "This should be hidden: ${SECRET}"
         echo "SECRET == password: $([ $SECRET == "password" ] && echo "true" || echo "false")"
+        echo "Internal PRs should get 'true' above."

--- a/.github/workflows/read-secrets.yml
+++ b/.github/workflows/read-secrets.yml
@@ -20,4 +20,4 @@ jobs:
         echo "Normal env var: ${NORMAL_ENV_VAR}"
         echo "This should be hidden: ${SECRET}"
         echo "SECRET == password: $([ $SECRET == "password" ] && echo "true" || echo "false")"
-        echo "Internal PRs should get 'true' above."
+        echo "PRs from forks should get 'false' above (or just fail)."


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config PR** *(if applicable)*
<!-- https://github.com/elastisys/ck8s-pipelines/pull/ -->
If you change some config options (e.g. rename variable or change the default value) we may need to update the pipeline.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
