### PR TITLE
Updated release documentation to reset CHANGELOG before QA

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -8,40 +8,56 @@ https://semver.org/
 1. To release a major or minor version create a release branch `release-X.Y` from the last minor release tag.
 
     ```bash
-    git checkout vA.B.0
+    git checkout main
     git checkout -b release-X.Y
     git push -u origin release-X.Y
     ```
 
-2. Checkout the branch to cut the release from.
+1. Reset changelog
 
     ```bash
-    git checkout main
-    git pull
-    git checkout -b branch_name
-    ```
-
-3. Run QA checks on `branch_name` and commit any fixes found during QA.
-
-4. Run the release script.
-
-    ```bash
-    ./release/release.sh X.Y.Z
+    git checkout -b reset-changelog-X.Y
+    release/reset-changelog.sh X.Y.0
     ```
 
     The release script will:
     * Append what is in `WIP-CHANGELOG.md` to `CHANGELOG.md`
     * Clear `WIP-CHANGELOG.md`
-    * Create a git commit with message `Release vX.Y.Z`
+    * Create a git commit with message `Reset changelog for release vX.Y.Z`
+
+    Make sure that the changes only include changes mentioned above, and then push.
+
+    ```
+    git diff HEAD~1
+    git push
+    ```
+
+1. Merge `reset-changelog-X.Y` into `release-X.Y` then, into `main` as soon as possible to minimize risk of conflicts
+
+    **NOTE**: The release action will fail since we haven't tagged the release commit.
+    We will do that after QA.
+
+1. Run QA checks on `branch_name` and commit any fixes found during QA into `release-X.Y`.
+
+    **NOTE**: All changes made in QA should be added to `CHANGELOG.md` and **NOT** `WIP-CHANGELOG.md`.
+
+1. Run the release script.
+
+    ```bash
+    ./release/release.sh X.Y.0
+    ```
+
+    The release script will:
+    * Amend last commit and prepend message `Release vX.Y.Z`
     * Create a tag named `vX.Y.Z`
 
-5. Push the tagged commit, create a PR against the release branch and request a review.
+1. Push the tagged commit, create a PR against the release branch and request a review.
 
     ```bash
     git push --atomic origin branch_name vX.Y.Z
     ```
 
-6. Merge it to finalize the release.
+1. Merge it to finalize the release.
     A [GitHub actions workflow pipeline](.github/workflows/release.yml) will create a GitHub release from the tag.
 
     *GitHub currently does not support merging with fast-forward only.
@@ -58,7 +74,7 @@ https://semver.org/
     git push --force-with-lease
     ```
 
-7. Merge any fixes from the release branch back to the `main` branch
+1. Merge any fixes from the release branch back to the `main` branch
     `git cherry-pick` can be used, e.g.
 
     ```bash

--- a/release/release.sh
+++ b/release/release.sh
@@ -11,20 +11,6 @@ function usage() {
 
 new_version="${1}"
 
-here="$(dirname "$(readlink -f "$0")")"
-root="${here}/.."
-changelog="${root}/CHANGELOG.md"
-wip_changelog="${root}/WIP-CHANGELOG.md"
-
-function file_exists() {
-    if [ ! -f "${1}" ]; then
-        echo "ERROR: ${1} does not exist" >&2
-        exit 1
-    fi
-}
-file_exists "${changelog}"
-file_exists "${wip_changelog}"
-
 # Regex found from https://gist.github.com/rverst/1f0b97da3cbeb7d93f4986df6e8e5695
 function check_version() {
     if [[ ! $1 =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
@@ -40,30 +26,7 @@ function check_version() {
 
 check_version "${new_version}"
 
-short_version="${new_version//./}"
-DATE=$(date +'%Y-%m-%d')
+last_message=$(git log -1 --pretty=%B)
+git commit --amend -m "Release v${new_version}" -m "${last_message}"
 
-### Generating new changelog by combining CHANGELOG.md and WIP-CHANGELOG.md ###
-echo "generating new changelog"
-
-# Split Changelog and Table of contents(TOC) into seperate files
-sed -n '/<!-- BEGIN TOC -->/,/<!-- END TOC -->/{ /<!--/d; p }' "${changelog}" > temp-toc.md
-sed '1,/^<!-- END TOC -->$/d' "${changelog}" > temp-cl.md
-
-# Adding version to changelog
-echo -e "## v${new_version} - ${DATE}\n" | cat - "${wip_changelog}" temp-cl.md > temp-cl2.md
-# Adding link to TOC
-echo -e "- [v${new_version}](#v${short_version}---${DATE})" | cat - temp-toc.md > temp-toc2.md
-echo -e "<!-- END TOC -->" >> temp-toc2.md
-echo -e "<!-- BEGIN TOC -->" | cat - temp-toc2.md > temp-toc.md
-echo -e "\n-------------------------------------------------" >> temp-toc.md
-# Creating new changelog
-echo -e "# Compliant Kubernetes changelog" > "${changelog}"
-cat temp-toc.md temp-cl2.md >> "${changelog}"
-rm temp-toc.md temp-toc2.md temp-cl.md temp-cl2.md
-# Clearing WIP-CHANGELOG.md
-true > "${wip_changelog}"
-
-git add "${changelog}" "${wip_changelog}"
-git commit -m "Release v${new_version}"
 git tag "v${new_version}"

--- a/release/reset-changelog.sh
+++ b/release/reset-changelog.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -euo pipefail
+
+function usage() {
+    echo "Usage: ${0} VERSION" >&2
+    exit 1
+}
+
+[ ${#} -eq 1 ] || usage
+
+new_version="${1}"
+
+here="$(dirname "$(readlink -f "$0")")"
+root="${here}/.."
+changelog="${root}/CHANGELOG.md"
+wip_changelog="${root}/WIP-CHANGELOG.md"
+
+function file_exists() {
+    if [ ! -f "${1}" ]; then
+        echo "ERROR: ${1} does not exist" >&2
+        exit 1
+    fi
+}
+file_exists "${changelog}"
+file_exists "${wip_changelog}"
+
+# Regex found from https://gist.github.com/rverst/1f0b97da3cbeb7d93f4986df6e8e5695
+function check_version() {
+    if [[ ! $1 =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
+        echo "${1} is not a valid version" >&2
+        exit 1
+    fi
+
+    if git rev-parse "v${1}" >/dev/null 2>&1; then
+        echo "v${1} tag already exists" >&2
+        exit 1
+    fi
+}
+
+check_version "${new_version}"
+
+short_version="${new_version//./}"
+DATE=$(date +'%Y-%m-%d')
+
+### Generating new changelog by combining CHANGELOG.md and WIP-CHANGELOG.md ###
+echo "generating new changelog"
+
+# Split Changelog and Table of contents(TOC) into seperate files
+sed -n '/<!-- BEGIN TOC -->/,/<!-- END TOC -->/{ /<!--/d; p }' "${changelog}" > temp-toc.md
+sed '1,/^<!-- END TOC -->$/d' "${changelog}" > temp-cl.md
+
+# Adding version to changelog
+echo -e "## v${new_version} - ${DATE}\n" | cat - "${wip_changelog}" temp-cl.md > temp-cl2.md
+# Adding link to TOC
+echo -e "- [v${new_version}](#v${short_version}---${DATE})" | cat - temp-toc.md > temp-toc2.md
+echo -e "<!-- END TOC -->" >> temp-toc2.md
+echo -e "<!-- BEGIN TOC -->" | cat - temp-toc2.md > temp-toc.md
+echo -e "\n-------------------------------------------------" >> temp-toc.md
+# Creating new changelog
+echo -e "# Compliant Kubernetes changelog" > "${changelog}"
+cat temp-toc.md temp-cl2.md >> "${changelog}"
+rm temp-toc.md temp-toc2.md temp-cl.md temp-cl2.md
+# Clearing WIP-CHANGELOG.md
+true > "${wip_changelog}"
+
+git add "${changelog}" "${wip_changelog}"
+git commit -m "Reset changelog for release v${new_version}"


### PR DESCRIPTION
**What this PR does / why we need it**:

From the last release I updated the documentation to reflect the flow.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
