### PR TITLE
Use ClusterIssuer in SC and disable in WC

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,5 +1,15 @@
+### Release notes
+
+- ClusterIssuers are used instead of Issuers.
+  Administrators should be careful regarding the use of ClusterIssuers in workload clusters, since users will be able to use them and may cause rate limits.
+- Check out the [upgrade guide](migration/v0.11.x-v0.12.x/upgrade-apps.md) for a complete set of instructions needed to upgrade.
+
 ### Added
 
 - NetworkPolicy dashboard in Grafana
 - Added a new helm chart `calico-accountant`
 - Clean-up scripts that can remove compliantkubernetes-apps from a cluster
+
+### Changed
+
+- ClusterIssuers are used instead of Issuers

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -298,34 +298,6 @@ generate_secrets() {
     sops_encrypt "$file"
 }
 
-# Usage: set_issuer_namespaces <config_file> service_cluster|workload_cluster
-set_issuer_namespaces() {
-    if [[ $# -ne 2 ]]; then
-        log_error "ERROR: number of args in set_issuer_namespaces must be 2. #=[$#]"
-        exit 1
-    fi
-
-    file=$1
-    cluster=$2
-
-    if [ "${cluster}" = "service_cluster" ]; then
-        harbor=$(yq r -e "${file}" 'harbor.enabled')
-
-        issuer_namespaces='dex elastic-system kube-system monitoring influxdb-prometheus'
-        [ "$harbor" = "true" ] && issuer_namespaces+=" harbor"
-    elif [ "${cluster}" = "workload_cluster" ]; then
-        issuer_namespaces='kube-system monitoring'
-    else
-        log_error "ERROR: unkown cluster variable."
-    fi
-
-    if [ "$(yq read "$file" 'issuers.letsencrypt.namespaces')" = "[]" ]; then
-        for namespace in ${issuer_namespaces}; do
-            yq write --inplace "$file" "issuers.letsencrypt.namespaces.[+]" "${namespace}"
-        done
-    fi
-}
-
 log_info "Initializing CK8S configuration with flavor: $CK8S_FLAVOR"
 
 
@@ -353,7 +325,6 @@ set_storage_class        "${config[config_file_sc]}"
 set_nginx_config         "${config[config_file_sc]}"
 set_elasticsearch_config "${config[config_file_sc]}"
 set_harbor_config        "${config[config_file_sc]}"
-set_issuer_namespaces    "${config[config_file_sc]}" service_cluster
 
 if [ -f "${config[config_file_wc]}" ]; then
     log_info "${config[config_file_wc]} already exists, merging with existing config"
@@ -363,7 +334,6 @@ set_storage_class        "${config[config_file_wc]}"
 set_nginx_config         "${config[config_file_wc]}"
 set_elasticsearch_config "${config[config_file_wc]}"
 set_harbor_config        "${config[config_file_wc]}"
-set_issuer_namespaces    "${config[config_file_wc]}" workload_cluster
 
 if [ -f "${secrets[secrets_file]}" ]; then
     log_info "${secrets[secrets_file]} already exists, merging with existing secrets"

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -591,7 +591,6 @@ restore:
 issuers:
   letsencrypt:
     enabled: true
-    namespaces: []
     prod:
       email: "set-me"
     staging:

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -384,9 +384,6 @@ issuers:
   letsencrypt:
     enabled: true
 
-    ## Namespaces in which to install the letsencrypt issuers in.
-    namespaces: []
-
     prod:
       ## Mail through which letsencrypt can contact you.
       email: "set-me"

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -382,14 +382,13 @@ issuers:
   ## Deploy let's encrypt ACME issuers
   ## "letsencrypt-prod" and "letsencrypt-staging".
   letsencrypt:
-    enabled: true
-
-    prod:
-      ## Mail through which letsencrypt can contact you.
-      email: "set-me"
-    staging:
-      ## Mail through which letsencrypt can contact you.
-      email: "set-me"
+    enabled: false
+    # prod:
+    #   ## Mail through which letsencrypt can contact you.
+    #   email: ""
+    # staging:
+    #   ## Mail through which letsencrypt can contact you.
+    #   email: ""
 
   ## Additional issuers to create.
   ## ref: https://cert-manager.io/docs/configuration/

--- a/helmfile/charts/examples/user-alertmanager/templates/ingress.yaml
+++ b/helmfile/charts/examples/user-alertmanager/templates/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    cert-manager.io/issuer: {{ .Values.ingress.issuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.issuer }}
     # type of authentication
     nginx.ingress.kubernetes.io/auth-type: basic
     # name of the secret that contains the user/password definitions

--- a/helmfile/charts/issuers/templates/letsencrypt-prod.yaml
+++ b/helmfile/charts/issuers/templates/letsencrypt-prod.yaml
@@ -1,11 +1,9 @@
 {{- if .Values.letsencrypt.enabled }}
-{{- range $namespace := .Values.letsencrypt.namespaces }}
 ---
 apiVersion: cert-manager.io/v1
-kind: Issuer
+kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod
-  namespace: {{ $namespace }}
 spec:
   acme:
     email: {{ $.Values.letsencrypt.prod.email | quote }}
@@ -19,5 +17,4 @@ spec:
       http01:
         ingress:
           class: nginx
-{{- end }}
 {{- end }}

--- a/helmfile/charts/issuers/templates/letsencrypt-staging.yaml
+++ b/helmfile/charts/issuers/templates/letsencrypt-staging.yaml
@@ -1,11 +1,9 @@
 {{- if .Values.letsencrypt.enabled }}
-{{- range $namespace := .Values.letsencrypt.namespaces }}
 ---
 apiVersion: cert-manager.io/v1
-kind: Issuer
+kind: ClusterIssuer
 metadata:
   name: letsencrypt-staging
-  namespace: {{ $namespace }}
 spec:
   acme:
     email: {{ $.Values.letsencrypt.staging.email | quote }}
@@ -19,5 +17,4 @@ spec:
       http01:
         ingress:
           class: nginx
-{{- end }}
 {{- end }}

--- a/helmfile/charts/kubeapi-metrics/templates/ingress.yaml
+++ b/helmfile/charts/kubeapi-metrics/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "kubeapi-metrics.labels" . | nindent 4 }}
   annotations:
-    cert-manager.io/issuer: "{{ .Values.ingress.issuer }}"
+    cert-manager.io/cluster-issuer: "{{ .Values.ingress.issuer }}"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/auth-type: "basic"
     nginx.ingress.kubernetes.io/auth-secret: "{{ $fullName }}-auth"

--- a/helmfile/charts/kubeapi-metrics/templates/ingress.yaml
+++ b/helmfile/charts/kubeapi-metrics/templates/ingress.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     {{- include "kubeapi-metrics.labels" . | nindent 4 }}
   annotations:
-    cert-manager.io/cluster-issuer: "{{ .Values.ingress.issuer }}"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/auth-type: "basic"
     nginx.ingress.kubernetes.io/auth-secret: "{{ $fullName }}-auth"

--- a/helmfile/charts/kubeapi-metrics/values.yaml
+++ b/helmfile/charts/kubeapi-metrics/values.yaml
@@ -7,10 +7,10 @@ service:
 
 ingress:
   enabled: false
-  issuer: "letsencrypt-staging"
   clusterDomain: ""
   username: ""
   password: ""
   extraAnnotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt-staging
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"

--- a/helmfile/values/dex.yaml.gotmpl
+++ b/helmfile/values/dex.yaml.gotmpl
@@ -7,7 +7,7 @@ crd:
 ingress:
   enabled: true
   annotations:
-    cert-manager.io/issuer: {{ .Values.global.issuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.global.issuer }}
     {{ if and .Values.externalTrafficPolicy.local .Values.externalTrafficPolicy.whitelistRange.dex }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.externalTrafficPolicy.whitelistRange.dex }}
     {{ end }}

--- a/helmfile/values/grafana-user.yaml.gotmpl
+++ b/helmfile/values/grafana-user.yaml.gotmpl
@@ -12,7 +12,7 @@ deploymentStrategy:
 ingress:
   enabled: true
   annotations:
-    cert-manager.io/issuer: {{ .Values.global.issuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.global.issuer }}
   {{ if and .Values.externalTrafficPolicy.local .Values.externalTrafficPolicy.whitelistRange.userGrafana }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.externalTrafficPolicy.whitelistRange.userGrafana }}
   {{ end }}

--- a/helmfile/values/harbor.yaml.gotmpl
+++ b/helmfile/values/harbor.yaml.gotmpl
@@ -13,7 +13,7 @@ expose:
       notarySecretName: harbor-notary-ingress-cert
   ingress:
     annotations:
-      cert-manager.io/issuer: {{ .Values.global.issuer }}
+      cert-manager.io/cluster-issuer: {{ .Values.global.issuer }}
       {{ if and .Values.externalTrafficPolicy.local .Values.externalTrafficPolicy.whitelistRange.harbor }}
       nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.externalTrafficPolicy.whitelistRange.harbor }}
       {{ end }}

--- a/helmfile/values/influxdb.yaml.gotmpl
+++ b/helmfile/values/influxdb.yaml.gotmpl
@@ -103,7 +103,7 @@ ingress:
   enabled: true
   tls: true
   annotations:
-    cert-manager.io/issuer: {{ .Values.global.issuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.global.issuer }}
   secretName: influxdb-ingress-cert
   hostname: influxdb.{{ .Values.global.opsDomain }}
 

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -154,7 +154,7 @@ grafana:
     enabled: true
     annotations:
       ingress.kubernetes.io/rewrite-target: /
-      cert-manager.io/issuer: {{ .Values.global.issuer }}
+      cert-manager.io/cluster-issuer: {{ .Values.global.issuer }}
     {{ if and .Values.externalTrafficPolicy.local .Values.externalTrafficPolicy.whitelistRange.opsGrafana }}
       nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.externalTrafficPolicy.whitelistRange.opsGrafana }}
     {{ end }}

--- a/helmfile/values/kubeapi-metrics.yaml.gotmpl
+++ b/helmfile/values/kubeapi-metrics.yaml.gotmpl
@@ -1,6 +1,5 @@
 ingress:
   enabled: true
-  issuer: "{{ .Values.global.issuer }}"
   clusterDomain: "{{ .Values.global.baseDomain }}"
   username: "kubeapiuser"
   password: "{{ .Values.kubeapiMetricsPassword }}"

--- a/helmfile/values/letsencrypt.yaml.gotmpl
+++ b/helmfile/values/letsencrypt.yaml.gotmpl
@@ -1,6 +1,5 @@
 letsencrypt:
   enabled: {{ .Values.issuers.letsencrypt.enabled }}
-  namespaces: {{- toYaml .Values.issuers.letsencrypt.namespaces | nindent 4 }}
   prod:
     email: {{ .Values.issuers.letsencrypt.prod.email }}
   staging:

--- a/helmfile/values/letsencrypt.yaml.gotmpl
+++ b/helmfile/values/letsencrypt.yaml.gotmpl
@@ -1,8 +1,10 @@
 letsencrypt:
   enabled: {{ .Values.issuers.letsencrypt.enabled }}
+  {{ if .Values.issuers.letsencrypt.enabled }}
   prod:
     email: {{ .Values.issuers.letsencrypt.prod.email }}
   staging:
     email: {{ .Values.issuers.letsencrypt.staging.email }}
+  {{ end }}
 
 extraIssuers: {{- toYaml .Values.issuers.extraIssuers | nindent 2 }}

--- a/helmfile/values/opendistro-es.yaml.gotmpl
+++ b/helmfile/values/opendistro-es.yaml.gotmpl
@@ -343,7 +343,7 @@ elasticsearch:
       enabled: true
       annotations:
         nginx.ingress.kubernetes.io/backend-protocol: HTTP
-        cert-manager.io/issuer: {{ .Values.global.issuer }}
+        cert-manager.io/cluster-issuer: {{ .Values.global.issuer }}
         nginx.ingress.kubernetes.io/proxy-body-size: 8m
         {{ if and .Values.externalTrafficPolicy.local .Values.externalTrafficPolicy.whitelistRange.elasticsearch }}
         nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.externalTrafficPolicy.whitelistRange.elasticsearch }}
@@ -363,7 +363,7 @@ kibana:
     enabled: true
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: HTTP
-      cert-manager.io/issuer: {{ .Values.global.issuer }}
+      cert-manager.io/cluster-issuer: {{ .Values.global.issuer }}
       {{ if and .Values.externalTrafficPolicy.local .Values.externalTrafficPolicy.whitelistRange.kibana }}
       nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.externalTrafficPolicy.whitelistRange.kibana }}
       {{ end }}

--- a/migration/v0.11.x-v0.12.x/upgrade-apps.md
+++ b/migration/v0.11.x-v0.12.x/upgrade-apps.md
@@ -1,0 +1,12 @@
+# Upgrade v0.11.x to v0.12.0
+
+1. Checkout the new release: `git checkout v0.12.0`
+
+1. Run init to get new defaults: `./bin/ck8s init`
+
+1. Delete `issuers.letsencrypt.namespaces` from both `sc-config.yaml` and `wc-config.yaml`.
+
+1. Upgrade applications
+  ```bash
+  ./bin/ck8s apply {sc|wc}
+  ```

--- a/migration/v0.11.x-v0.12.x/upgrade-apps.md
+++ b/migration/v0.11.x-v0.12.x/upgrade-apps.md
@@ -6,6 +6,8 @@
 
 1. Delete `issuers.letsencrypt.namespaces` from both `sc-config.yaml` and `wc-config.yaml`.
 
+1. Set `issuers.letsencrypt.enabled` to `false` in `wc-config.yml` and remove `issuers.letsencrypt.prod` and `issuers.letsencrypt.staging`, unless you want to use the ClusterIssuer in WC.
+
 1. Upgrade applications
   ```bash
   ./bin/ck8s apply {sc|wc}

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -574,13 +574,6 @@ restore:
 issuers:
   letsencrypt:
     enabled: true
-    namespaces:
-      - dex
-      - elastic-system
-      - kube-system
-      - monitoring
-      - influxdb-prometheus
-      - harbor
     prod:
       email: letsencrypt@elastisys.com
     staging:

--- a/pipeline/config/exoscale/wc-config.yaml
+++ b/pipeline/config/exoscale/wc-config.yaml
@@ -329,17 +329,7 @@ issuers:
   ## Deploy let's encrypt ACME issuers
   ## "letsencrypt-prod" and "letsencrypt-staging".
   letsencrypt:
-    enabled: true
-    ## Namespaces in which to install the letsencrypt issuers in.
-    namespaces:
-      - kube-system
-      - monitoring
-    prod:
-      ## Mail through which letsencrypt can contact you.
-      email: letsencrypt@elastisys.com
-    staging:
-      ## Mail through which letsencrypt can contact you.
-      email: letsencrypt@elastisys.com
+    enabled: false
   ## Additional issuers to create.
   ## ref: https://cert-manager.io/docs/configuration/
   extraIssuers: []


### PR DESCRIPTION
**What this PR does / why we need it**:
See #287 for why we want to use ClusterIssuers. I also disabled the (Cluster)Issuers in WC since we don't really need them there. We only used them with kubeapi-metrics for health checking the API server. But this check [doesn't need a trusted certificate](https://github.com/elastisys/compliantkubernetes-apps/blob/main/helmfile/values/blackbox.yaml.gotmpl#L23).

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #287

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
A nicer solution would be to make the blackbox exporter use `tls_verify` depending on what issuer we use and add a config option to specify [extra annotations for kubeapi-metrics](https://github.com/elastisys/compliantkubernetes-apps/blob/main/helmfile/charts/kubeapi-metrics/values.yaml#L14) so that we can [use an Issuer](https://github.com/elastisys/compliantkubernetes-apps/compare/lj/use-cluster-issuer?expand=1) instead of a ClusterIssuer in WC. This is a bit larger change though and I wasn't sure if it was worth it (especially considering the config overhaul and that blackbox exporter doesn't verify TLS). Should I go for it anyway?

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [x] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** :heavy_check_mark: 

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
