### PR TITLE
Updated velero chart to 2.15.0

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -14,3 +14,4 @@
 
 - ClusterIssuers are used instead of Issuers
 - Persistent volumes for prometheus are now optional (disabled by default)
+- Updated velero chart and its CRDs to 2.15.0 (velero 1.5.0)

--- a/bootstrap/crds/velero/backups.yaml
+++ b/bootstrap/crds/velero/backups.yaml
@@ -1,16 +1,428 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: backups.velero.io
   labels:
     app.kubernetes.io/name: velero
   annotations:
-    "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.3.0
+  name: backups.velero.io
 spec:
   group: velero.io
-  version: v1
-  scope: Namespaced
   names:
-    plural: backups
     kind: Backup
+    listKind: BackupList
+    plural: backups
+    singular: backup
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: Backup is a Velero resource that respresents the capture of Kubernetes
+        cluster state at a point in time (API objects and associated volume state).
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: BackupSpec defines the specification for a Velero backup.
+          properties:
+            defaultVolumesToRestic:
+              description: DefaultVolumesToRestic specifies whether restic
+                should be used to take a backup of all pod volumes by default.
+              type: boolean
+            excludedNamespaces:
+              description: ExcludedNamespaces contains a list of namespaces that are
+                not included in the backup.
+              items:
+                type: string
+              nullable: true
+              type: array
+            excludedResources:
+              description: ExcludedResources is a slice of resource names that are
+                not included in the backup.
+              items:
+                type: string
+              nullable: true
+              type: array
+            hooks:
+              description: Hooks represent custom behaviors that should be executed
+                at different phases of the backup.
+              properties:
+                resources:
+                  description: Resources are hooks that should be executed when backing
+                    up individual instances of a resource.
+                  items:
+                    description: BackupResourceHookSpec defines one or more BackupResourceHooks
+                      that should be executed based on the rules defined for namespaces,
+                      resources, and label selector.
+                    properties:
+                      excludedNamespaces:
+                        description: ExcludedNamespaces specifies the namespaces to
+                          which this hook spec does not apply.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      excludedResources:
+                        description: ExcludedResources specifies the resources to
+                          which this hook spec does not apply.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      includedNamespaces:
+                        description: IncludedNamespaces specifies the namespaces to
+                          which this hook spec applies. If empty, it applies to all
+                          namespaces.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      includedResources:
+                        description: IncludedResources specifies the resources to
+                          which this hook spec applies. If empty, it applies to all
+                          resources.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      labelSelector:
+                        description: LabelSelector, if specified, filters the resources
+                          to which this hook spec applies.
+                        nullable: true
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      name:
+                        description: Name is the name of this hook.
+                        type: string
+                      post:
+                        description: PostHooks is a list of BackupResourceHooks to
+                          execute after storing the item in the backup. These are
+                          executed after all "additional items" from item actions
+                          are processed.
+                        items:
+                          description: BackupResourceHook defines a hook for a resource.
+                          properties:
+                            exec:
+                              description: Exec defines an exec hook.
+                              properties:
+                                command:
+                                  description: Command is the command and arguments
+                                    to execute.
+                                  items:
+                                    type: string
+                                  minItems: 1
+                                  type: array
+                                container:
+                                  description: Container is the container in the pod
+                                    where the command should be executed. If not specified,
+                                    the pod's first container is used.
+                                  type: string
+                                onError:
+                                  description: OnError specifies how Velero should
+                                    behave if it encounters an error executing this
+                                    hook.
+                                  enum:
+                                  - Continue
+                                  - Fail
+                                  type: string
+                                timeout:
+                                  description: Timeout defines the maximum amount
+                                    of time Velero should wait for the hook to complete
+                                    before considering the execution a failure.
+                                  type: string
+                              required:
+                              - command
+                              type: object
+                          required:
+                          - exec
+                          type: object
+                        type: array
+                      pre:
+                        description: PreHooks is a list of BackupResourceHooks to
+                          execute prior to storing the item in the backup. These are
+                          executed before any "additional items" from item actions
+                          are processed.
+                        items:
+                          description: BackupResourceHook defines a hook for a resource.
+                          properties:
+                            exec:
+                              description: Exec defines an exec hook.
+                              properties:
+                                command:
+                                  description: Command is the command and arguments
+                                    to execute.
+                                  items:
+                                    type: string
+                                  minItems: 1
+                                  type: array
+                                container:
+                                  description: Container is the container in the pod
+                                    where the command should be executed. If not specified,
+                                    the pod's first container is used.
+                                  type: string
+                                onError:
+                                  description: OnError specifies how Velero should
+                                    behave if it encounters an error executing this
+                                    hook.
+                                  enum:
+                                  - Continue
+                                  - Fail
+                                  type: string
+                                timeout:
+                                  description: Timeout defines the maximum amount
+                                    of time Velero should wait for the hook to complete
+                                    before considering the execution a failure.
+                                  type: string
+                              required:
+                              - command
+                              type: object
+                          required:
+                          - exec
+                          type: object
+                        type: array
+                    required:
+                    - name
+                    type: object
+                  nullable: true
+                  type: array
+              type: object
+            includeClusterResources:
+              description: IncludeClusterResources specifies whether cluster-scoped
+                resources should be included for consideration in the backup.
+              nullable: true
+              type: boolean
+            includedNamespaces:
+              description: IncludedNamespaces is a slice of namespace names to include
+                objects from. If empty, all namespaces are included.
+              items:
+                type: string
+              nullable: true
+              type: array
+            includedResources:
+              description: IncludedResources is a slice of resource names to include
+                in the backup. If empty, all resources are included.
+              items:
+                type: string
+              nullable: true
+              type: array
+            labelSelector:
+              description: LabelSelector is a metav1.LabelSelector to filter with
+                when adding individual objects to the backup. If empty or nil, all
+                objects are included. Optional.
+              nullable: true
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            orderedResources:
+              additionalProperties:
+                type: string
+              description: OrderedResources specifies the backup order of resources of
+                specific Kind. The map key is the Kind name and value is a list of resource
+                names separeted by commas. Each resource name has format "namespace/resourcename".
+                For cluster resources, simply use "resourcename".
+              nullable: true
+              type: object
+            snapshotVolumes:
+              description: SnapshotVolumes specifies whether to take cloud snapshots
+                of any PV's referenced in the set of objects included in the Backup.
+              nullable: true
+              type: boolean
+            storageLocation:
+              description: StorageLocation is a string containing the name of a BackupStorageLocation
+                where the backup should be stored.
+              type: string
+            ttl:
+              description: TTL is a time.Duration-parseable string describing how
+                long the Backup should be retained for.
+              type: string
+            volumeSnapshotLocations:
+              description: VolumeSnapshotLocations is a list containing names of VolumeSnapshotLocations
+                associated with this backup.
+              items:
+                type: string
+              type: array
+          type: object
+        status:
+          description: BackupStatus captures the current status of a Velero backup.
+          properties:
+            completionTimestamp:
+              description: CompletionTimestamp records the time a backup was completed.
+                Completion time is recorded even on failed backups. Completion time
+                is recorded before uploading the backup object. The server's time
+                is used for CompletionTimestamps
+              format: date-time
+              nullable: true
+              type: string
+            errors:
+              description: Errors is a count of all error messages that were generated
+                during execution of the backup.  The actual errors are in the backup's
+                log file in object storage.
+              type: integer
+            expiration:
+              description: Expiration is when this Backup is eligible for garbage-collection.
+              format: date-time
+              nullable: true
+              type: string
+            formatVersion:
+              description: FormatVersion is the backup format version, including major,
+                minor, and patch version.
+              type: string
+            phase:
+              description: Phase is the current state of the Backup.
+              enum:
+              - New
+              - FailedValidation
+              - InProgress
+              - Completed
+              - PartiallyFailed
+              - Failed
+              - Deleting
+              type: string
+            progress:
+              description: Progress contains information about the backup's execution
+                progress. Note that this information is best-effort only -- if Velero
+                fails to update it during a backup for any reason, it may be inaccurate/stale.
+              nullable: true
+              properties:
+                itemsBackedUp:
+                  description: ItemsBackedUp is the number of items that have actually
+                    been written to the backup tarball so far.
+                  type: integer
+                totalItems:
+                  description: TotalItems is the total number of items to be backed
+                    up. This number may change throughout the execution of the backup
+                    due to plugins that return additional related items to back up,
+                    the velero.io/exclude-from-backup label, and various other filters
+                    that happen as items are processed.
+                  type: integer
+              type: object
+            startTimestamp:
+              description: StartTimestamp records the time a backup was started. Separate
+                from CreationTimestamp, since that value changes on restores. The
+                server's time is used for StartTimestamps
+              format: date-time
+              nullable: true
+              type: string
+            validationErrors:
+              description: ValidationErrors is a slice of all validation errors (if
+                applicable).
+              items:
+                type: string
+              nullable: true
+              type: array
+            version:
+              description: 'Version is the backup format major version. Deprecated:
+                Please see FormatVersion'
+              type: integer
+            volumeSnapshotsAttempted:
+              description: VolumeSnapshotsAttempted is the total number of attempted
+                volume snapshots for this backup.
+              type: integer
+            volumeSnapshotsCompleted:
+              description: VolumeSnapshotsCompleted is the total number of successfully
+                completed volume snapshots for this backup.
+              type: integer
+            warnings:
+              description: Warnings is a count of all warning messages that were generated
+                during execution of the backup. The actual warnings are in the backup's
+                log file in object storage.
+              type: integer
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/bootstrap/crds/velero/backupstoragelocations.yaml
+++ b/bootstrap/crds/velero/backupstoragelocations.yaml
@@ -1,17 +1,149 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: backupstoragelocations.velero.io
   labels:
     app.kubernetes.io/name: "velero"
-
   annotations:
-    "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.3.0
+  name: backupstoragelocations.velero.io
 spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.phase
+      description: Backup Storage Location status such as Available/Unavailable
+      name: Phase
+      type: string
+    - JSONPath: .status.lastValidationTime
+      description: LastValidationTime is the last time the backup store location was validated
+      name: Last Validated
+      type: date
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
   group: velero.io
-  version: v1
-  scope: Namespaced
   names:
-    plural: backupstoragelocations
     kind: BackupStorageLocation
+    listKind: BackupStorageLocationList
+    plural: backupstoragelocations
+    shortNames:
+      - bsl
+    singular: backupstoragelocation
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: BackupStorageLocation is a location where Velero stores backup
+        objects.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: BackupStorageLocationSpec defines the desired state of a Velero
+            BackupStorageLocation.
+          properties:
+            accessMode:
+              description: AccessMode defines the permissions for the backup storage
+                location.
+              enum:
+              - ReadOnly
+              - ReadWrite
+              type: string
+            backupSyncPeriod:
+              description: BackupSyncPeriod defines how frequently to sync backup
+                API objects from object storage. A value of 0 disables sync.
+              nullable: true
+              type: string
+            config:
+              additionalProperties:
+                type: string
+              description: Config is for provider-specific configuration fields.
+              type: object
+            objectStorage:
+              description: ObjectStorageLocation specifies the settings necessary
+                to connect to a provider's object storage.
+              properties:
+                bucket:
+                  description: Bucket is the bucket to use for object storage.
+                  type: string
+                caCert:
+                  description: CACert defines a CA bundle to use when verifying TLS
+                    connections to the provider.
+                  format: byte
+                  type: string
+                prefix:
+                  description: Prefix is the path inside a bucket to use for Velero
+                    storage. Optional.
+                  type: string
+              required:
+              - bucket
+              type: object
+            provider:
+              description: Provider is the provider of the backup storage.
+              type: string
+            validationFrequency:
+              description: ValidationFrequency defines how frequently to validate
+                the corresponding object storage. A value of 0 disables validation.
+              nullable: true
+              type: string
+          required:
+          - objectStorage
+          - provider
+          type: object
+        status:
+          description: BackupStorageLocationStatus defines the observed state of
+            BackupStorageLocation
+          properties:
+            accessMode:
+              description: "AccessMode is an unused field. \n Deprecated: there is
+                now an AccessMode field on the Spec and this field will be removed
+                entirely as of v2.0."
+              enum:
+              - ReadOnly
+              - ReadWrite
+              type: string
+            lastSyncedRevision:
+              description: "LastSyncedRevision is the value of the `metadata/revision`
+                file in the backup storage location the last time the BSL's contents
+                were synced into the cluster. \n Deprecated: this field is no longer
+                updated or used for detecting changes to the location's contents and
+                will be removed entirely in v2.0."
+              type: string
+            lastSyncedTime:
+              description: LastSyncedTime is the last time the contents of the location
+                were synced into the cluster.
+              format: date-time
+              nullable: true
+              type: string
+            lastValidationTime:
+              description: LastValidationTime is the last time the backup store location
+                was validated the cluster.
+              format: date-time
+              nullable: true
+              type: string
+            phase:
+              description: Phase is the current state of the BackupStorageLocation.
+              enum:
+              - Available
+              - Unavailable
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/bootstrap/crds/velero/deletebackuprequests.yaml
+++ b/bootstrap/crds/velero/deletebackuprequests.yaml
@@ -1,16 +1,69 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: deletebackuprequests.velero.io
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.3.0
+  name: deletebackuprequests.velero.io
 spec:
   group: velero.io
-  version: v1
-  scope: Namespaced
   names:
-    plural: deletebackuprequests
     kind: DeleteBackupRequest
+    listKind: DeleteBackupRequestList
+    plural: deletebackuprequests
+    singular: deletebackuprequest
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: DeleteBackupRequest is a request to delete one or more backups.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DeleteBackupRequestSpec is the specification for which backups
+            to delete.
+          properties:
+            backupName:
+              type: string
+          required:
+          - backupName
+          type: object
+        status:
+          description: DeleteBackupRequestStatus is the current status of a DeleteBackupRequest.
+          properties:
+            errors:
+              description: Errors contains any errors that were encountered during
+                the deletion process.
+              items:
+                type: string
+              nullable: true
+              type: array
+            phase:
+              description: Phase is the current state of the DeleteBackupRequest.
+              enum:
+              - New
+              - InProgress
+              - Processed
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/bootstrap/crds/velero/downloadrequests.yaml
+++ b/bootstrap/crds/velero/downloadrequests.yaml
@@ -1,17 +1,90 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: downloadrequests.velero.io
   labels:
     app.kubernetes.io/name: "velero"
-
   annotations:
-    "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.3.0
+  name: downloadrequests.velero.io
 spec:
   group: velero.io
-  version: v1
-  scope: Namespaced
   names:
-    plural: downloadrequests
     kind: DownloadRequest
+    listKind: DownloadRequestList
+    plural: downloadrequests
+    singular: downloadrequest
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: DownloadRequest is a request to download an artifact from backup
+        object storage, such as a backup log file.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DownloadRequestSpec is the specification for a download request.
+          properties:
+            target:
+              description: Target is what to download (e.g. logs for a backup).
+              properties:
+                kind:
+                  description: Kind is the type of file to download.
+                  enum:
+                  - BackupLog
+                  - BackupContents
+                  - BackupVolumeSnapshots
+                  - BackupResourceList
+                  - RestoreLog
+                  - RestoreResults
+                  type: string
+                name:
+                  description: Name is the name of the kubernetes resource with which
+                    the file is associated.
+                  type: string
+              required:
+              - kind
+              - name
+              type: object
+          required:
+          - target
+          type: object
+        status:
+          description: DownloadRequestStatus is the current status of a DownloadRequest.
+          properties:
+            downloadURL:
+              description: DownloadURL contains the pre-signed URL for the target
+                file.
+              type: string
+            expiration:
+              description: Expiration is when this DownloadRequest expires and can
+                be deleted by the system.
+              format: date-time
+              nullable: true
+              type: string
+            phase:
+              description: Phase is the current state of the DownloadRequest.
+              enum:
+              - New
+              - Processed
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/bootstrap/crds/velero/podvolumebackups.yaml
+++ b/bootstrap/crds/velero/podvolumebackups.yaml
@@ -1,16 +1,163 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: podvolumebackups.velero.io
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.3.0
+  name: podvolumebackups.velero.io
 spec:
   group: velero.io
-  version: v1
-  scope: Namespaced
   names:
-    plural: podvolumebackups
     kind: PodVolumeBackup
+    listKind: PodVolumeBackupList
+    plural: podvolumebackups
+    singular: podvolumebackup
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: PodVolumeBackupSpec is the specification for a PodVolumeBackup.
+          properties:
+            backupStorageLocation:
+              description: BackupStorageLocation is the name of the backup storage
+                location where the restic repository is stored.
+              type: string
+            node:
+              description: Node is the name of the node that the Pod is running on.
+              type: string
+            pod:
+              description: Pod is a reference to the pod containing the volume to
+                be backed up.
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info:
+                    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info:
+                    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info:
+                    https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info:
+                    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info:
+                    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            repoIdentifier:
+              description: RepoIdentifier is the restic repository identifier.
+              type: string
+            tags:
+              additionalProperties:
+                type: string
+              description: Tags are a map of key-value pairs that should be applied
+                to the volume backup as tags.
+              type: object
+            volume:
+              description: Volume is the name of the volume within the Pod to be backed
+                up.
+              type: string
+          required:
+          - backupStorageLocation
+          - node
+          - pod
+          - repoIdentifier
+          - volume
+          type: object
+        status:
+          description: PodVolumeBackupStatus is the current status of a PodVolumeBackup.
+          properties:
+            completionTimestamp:
+              description: CompletionTimestamp records the time a backup was completed.
+                Completion time is recorded even on failed backups. Completion time
+                is recorded before uploading the backup object. The server's time
+                is used for CompletionTimestamps
+              format: date-time
+              nullable: true
+              type: string
+            message:
+              description: Message is a message about the pod volume backup's status.
+              type: string
+            path:
+              description: Path is the full path within the controller pod being backed
+                up.
+              type: string
+            phase:
+              description: Phase is the current state of the PodVolumeBackup.
+              enum:
+              - New
+              - InProgress
+              - Completed
+              - Failed
+              type: string
+            progress:
+              description: Progress holds the total number of bytes of the volume
+                and the current number of backed up bytes. This can be used to display
+                progress information about the backup operation.
+              properties:
+                bytesDone:
+                  format: int64
+                  type: integer
+                totalBytes:
+                  format: int64
+                  type: integer
+              type: object
+            snapshotID:
+              description: SnapshotID is the identifier for the snapshot of the pod
+                volume.
+              type: string
+            startTimestamp:
+              description: StartTimestamp records the time a backup was started. Separate
+                from CreationTimestamp, since that value changes on restores. The
+                server's time is used for StartTimestamps
+              format: date-time
+              nullable: true
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/bootstrap/crds/velero/podvolumerestores.yaml
+++ b/bootstrap/crds/velero/podvolumerestores.yaml
@@ -1,16 +1,146 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: podvolumerestores.velero.io
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.3.0
+  name: podvolumerestores.velero.io
 spec:
   group: velero.io
-  version: v1
-  scope: Namespaced
   names:
-    plural: podvolumerestores
     kind: PodVolumeRestore
+    listKind: PodVolumeRestoreList
+    plural: podvolumerestores
+    singular: podvolumerestore
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: PodVolumeRestoreSpec is the specification for a PodVolumeRestore.
+          properties:
+            backupStorageLocation:
+              description: BackupStorageLocation is the name of the backup storage
+                location where the restic repository is stored.
+              type: string
+            pod:
+              description: Pod is a reference to the pod containing the volume to
+                be restored.
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info:
+                    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info:
+                    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info:
+                    https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info:
+                    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info:
+                    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            repoIdentifier:
+              description: RepoIdentifier is the restic repository identifier.
+              type: string
+            snapshotID:
+              description: SnapshotID is the ID of the volume snapshot to be restored.
+              type: string
+            volume:
+              description: Volume is the name of the volume within the Pod to be restored.
+              type: string
+          required:
+          - backupStorageLocation
+          - pod
+          - repoIdentifier
+          - snapshotID
+          - volume
+          type: object
+        status:
+          description: PodVolumeRestoreStatus is the current status of a PodVolumeRestore.
+          properties:
+            completionTimestamp:
+              description: CompletionTimestamp records the time a restore was completed.
+                Completion time is recorded even on failed restores. The server's
+                time is used for CompletionTimestamps
+              format: date-time
+              nullable: true
+              type: string
+            message:
+              description: Message is a message about the pod volume restore's status.
+              type: string
+            phase:
+              description: Phase is the current state of the PodVolumeRestore.
+              enum:
+              - New
+              - InProgress
+              - Completed
+              - Failed
+              type: string
+            progress:
+              description: Progress holds the total number of bytes of the snapshot
+                and the current number of restored bytes. This can be used to display
+                progress information about the restore operation.
+              properties:
+                bytesDone:
+                  format: int64
+                  type: integer
+                totalBytes:
+                  format: int64
+                  type: integer
+              type: object
+            startTimestamp:
+              description: StartTimestamp records the time a restore was started.
+                The server's time is used for StartTimestamps
+              format: date-time
+              nullable: true
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/bootstrap/crds/velero/resticrepositories.yaml
+++ b/bootstrap/crds/velero/resticrepositories.yaml
@@ -1,16 +1,85 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: resticrepositories.velero.io
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.3.0
+  name: resticrepositories.velero.io
 spec:
   group: velero.io
-  version: v1
-  scope: Namespaced
   names:
-    plural: resticrepositories
     kind: ResticRepository
+    listKind: ResticRepositoryList
+    plural: resticrepositories
+    singular: resticrepository
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ResticRepositorySpec is the specification for a ResticRepository.
+          properties:
+            backupStorageLocation:
+              description: BackupStorageLocation is the name of the BackupStorageLocation
+                that should contain this repository.
+              type: string
+            maintenanceFrequency:
+              description: MaintenanceFrequency is how often maintenance should be
+                run.
+              type: string
+            resticIdentifier:
+              description: ResticIdentifier is the full restic-compatible string for
+                identifying this repository.
+              type: string
+            volumeNamespace:
+              description: VolumeNamespace is the namespace this restic repository
+                contains pod volume backups for.
+              type: string
+          required:
+          - backupStorageLocation
+          - maintenanceFrequency
+          - resticIdentifier
+          - volumeNamespace
+          type: object
+        status:
+          description: ResticRepositoryStatus is the current status of a ResticRepository.
+          properties:
+            lastMaintenanceTime:
+              description: LastMaintenanceTime is the last time maintenance was run.
+              format: date-time
+              nullable: true
+              type: string
+            message:
+              description: Message is a message about the current status of the ResticRepository.
+              type: string
+            phase:
+              description: Phase is the current state of the ResticRepository.
+              enum:
+              - New
+              - Ready
+              - NotReady
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/bootstrap/crds/velero/restores.yaml
+++ b/bootstrap/crds/velero/restores.yaml
@@ -1,16 +1,1406 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: restores.velero.io
   labels:
     app.kubernetes.io/name: velero
   annotations:
-    "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.3.0
+  name: restores.velero.io
 spec:
   group: velero.io
-  version: v1
-  scope: Namespaced
   names:
-    plural: restores
     kind: Restore
+    listKind: RestoreList
+    plural: restores
+    singular: restore
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: Restore is a Velero resource that represents the application of
+        resources from a Velero backup to a target Kubernetes cluster.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: RestoreSpec defines the specification for a Velero restore.
+          properties:
+            backupName:
+              description: BackupName is the unique name of the Velero backup to restore
+                from.
+              type: string
+            excludedNamespaces:
+              description: ExcludedNamespaces contains a list of namespaces that are
+                not included in the restore.
+              items:
+                type: string
+              nullable: true
+              type: array
+            excludedResources:
+              description: ExcludedResources is a slice of resource names that are
+                not included in the restore.
+              items:
+                type: string
+              nullable: true
+              type: array
+            hooks:
+              description: Hooks represent custom behaviors that should be executed
+                during or post restore.
+              properties:
+                resources:
+                  items:
+                    description: RestoreResourceHookSpec defines one or more RestoreResrouceHooks
+                      that should be executed based on the rules defined for namespaces, resources,
+                      and label selector.
+                    properties:
+                      excludedNamespaces:
+                        description: ExcludedNamespaces specifies the namespaces to which
+                          this hook spec does not apply.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      excludedResources:
+                        description: ExcludedResources specifies the resources to which
+                          this hook spec does not apply.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      includedNamespaces:
+                        description: IncludedNamespaces specifies the namespaces to which
+                          this hook spec applies. If empty, it applies to all namespaces.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      includedResources:
+                        description: IncludedResources specifies the resources to which
+                          this hook spec applies. If empty, it applies to all resources.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      labelSelector:
+                        description: LabelSelector, if specified, filters the resources
+                          to which this hook spec applies.
+                        nullable: true
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that relates
+                                the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to
+                                    a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is
+                                    In or NotIn, the values array must be non-empty. If the operator is
+                                    Exists or DoesNotExist, the values array must be empty. This array is
+                                    replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                              in the matchLabels map is equivalent to an element of matchExpressions,
+                              whose key field is "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      name:
+                        description: Name is the name of this hook.
+                        type: string
+                      postHooks:
+                        description: PostHooks is a list of RestoreResourceHooks to execute during and
+                          after restoring a resource.
+                        items:
+                          description: RestoreResourceHook defines a restore hook for a resource.
+                          properties:
+                            exec:
+                              description: Exec defines an exec restore hook.
+                              properties:
+                                command:
+                                  description: Command is the command and arguments to execute from within
+                                    a container after a pod has been restored.
+                                  items:
+                                    type: string
+                                  minItems: 1
+                                  type: array
+                                container:
+                                  description: Container is the container in the pod where the command should
+                                    be executed. If not specified, the pod's first container is used.
+                                  type: string
+                                execTimeout:
+                                  description: ExecTimeout defines the maximum amount of time Velero should
+                                    wait for the hook to complete before considering the execution a failure.
+                                  type: string
+                                onError:
+                                  description: OnError specifies how Velero should behave if it encounters
+                                    an error executing this hook.
+                                  enum:
+                                    - Continue
+                                    - Fail
+                                  type: string
+                                waitTimeout:
+                                  description: WaitTimeout defines the maximum amount of time Velero should
+                                    wait for the container to be Ready before attempting to run the command.
+                                  type: string
+                              required:
+                                - command
+                              type: object
+                            init:
+                              description: Init defines an init restore hook.
+                              properties:
+                                initContainers:
+                                  description: InitContainers is list of init containers to be added
+                                    to a pod during its restore.
+                                  items:
+                                    description: A single application container that you want to run within a pod.
+                                    properties:
+                                      args:
+                                        description: 'Arguments to the entrypoint. The docker image''s CMD is
+                                          used if this is not provided. Variable references $(VAR_NAME) are expanded
+                                          using the container''s environment. If a variable cannot be resolved,
+                                          the reference in the input string will be unchanged. The $(VAR_NAME)
+                                          syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                                          references will never be expanded, regardless of whether the variable
+                                          exists or not. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                        items:
+                                          type: string
+                                        type: array
+                                      command:
+                                        description: 'Entrypoint array. Not executed within a shell.
+                                          The docker image''s ENTRYPOINT is used if this is not provided.
+                                          Variable references $(VAR_NAME) are expanded using the container''s
+                                          environment. If a variable cannot be resolved, the reference in the
+                                          input string will be unchanged. The $(VAR_NAME) syntax can be
+                                          escaped with a double $$, ie: $$(VAR_NAME). Escaped references will
+                                          never be expanded, regardless of whether the variable exists or not.
+                                          Cannot be updated. More info:
+                                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                        items:
+                                          type: string
+                                        type: array
+                                      env:
+                                        description: List of environment variables to set in the
+                                          container. Cannot be updated.
+                                        items:
+                                          description: EnvVar represents an environment variable
+                                            present in a Container.
+                                          properties:
+                                            name:
+                                              description: Name of the environment variable.
+                                                Must be a C_IDENTIFIER.
+                                              type: string
+                                            value:
+                                              description: 'Variable references $(VAR_NAME) are expanded
+                                                using the previous defined environment variables in the
+                                                container and any service environment variables. If a variable
+                                                cannot be resolved, the reference in the input string will be
+                                                unchanged. The $(VAR_NAME) syntax can be escaped with a
+                                                double $$, ie: $$(VAR_NAME). Escaped references will never be
+                                                expanded, regardless of whether the variable exists or not.
+                                                Defaults to "".'
+                                              type: string
+                                            valueFrom:
+                                              description: Source for the environment variable's value.
+                                                Cannot be used if value is not empty.
+                                              properties:
+                                                configMapKeyRef:
+                                                  description: Selects a key of a ConfigMap.
+                                                  properties:
+                                                    key:
+                                                      description: The key to select.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent. More info:
+                                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the ConfigMap or its
+                                                        key must be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                fieldRef:
+                                                  description: 'Selects a field of the pod: supports metadata.name,
+                                                    metadata.namespace, metadata.labels, metadata.annotations,
+                                                    spec.nodeName, spec.serviceAccountName, status.hostIP,
+                                                    status.podIP, status.podIPs.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                resourceFieldRef:
+                                                  description: 'Selects a resource of the container: only
+                                                    resources limits and requests (limits.cpu, limits.memory,
+                                                    limits.ephemeral-storage, requests.cpu, requests.memory
+                                                    and requests.ephemeral-storage) are currently supported.'
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name: required for volumes,
+                                                        optional for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      description: Specifies the output format of the exposed
+                                                        resources, defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource to select'
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                secretKeyRef:
+                                                  description: Selects a key of a secret in the pod's namespace
+                                                  properties:
+                                                    key:
+                                                      description: The key of the secret to select from.
+                                                        Must be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent. More info:
+                                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the Secret or its key
+                                                        must be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                      envFrom:
+                                        description: List of sources to populate environment variables in
+                                          the container. The keys defined within a source must be a C_IDENTIFIER.
+                                          All invalid keys will be reported as an event when the container
+                                          is starting. When a key exists in multiple sources, the value
+                                          associated with the last source will take precedence. Values
+                                          defined by an Env with a duplicate key will take precedence. Cannot
+                                          be updated.
+                                        items:
+                                          description: EnvFromSource represents the source of a set of ConfigMaps
+                                          properties:
+                                            configMapRef:
+                                              description: The ConfigMap to select from
+                                              properties:
+                                                name:
+                                                  description: 'Name of the referent. More info:
+                                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the ConfigMap must be defined
+                                                  type: boolean
+                                              type: object
+                                            prefix:
+                                              description: An optional identifier to prepend to each
+                                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                                              type: string
+                                            secretRef:
+                                              description: The Secret to select from
+                                              properties:
+                                                name:
+                                                  description: 'Name of the referent. More info:
+                                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the Secret must be defined
+                                                  type: boolean
+                                              type: object
+                                          type: object
+                                        type: array
+                                      image:
+                                        description: 'Docker image name. More info:
+                                          https://kubernetes.io/docs/concepts/containers/images
+                                          This field is optional to allow higher level config management
+                                          to default or override container images in workload controllers
+                                          like Deployments and StatefulSets.'
+                                        type: string
+                                      imagePullPolicy:
+                                        description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                                          Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                          Cannot be updated. More info:
+                                          https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                        type: string
+                                      lifecycle:
+                                        description: Actions that the management system should take in response
+                                          to container lifecycle events. Cannot be updated.
+                                        properties:
+                                          postStart:
+                                            description: 'PostStart is called immediately after a container is
+                                              created. If the handler fails, the container is terminated and
+                                              restarted according to its restart policy. Other management of
+                                              the container blocks until the hook completes. More info:
+                                              https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                            properties:
+                                              exec:
+                                                description: One and only one of the following should be specified.
+                                                  Exec specifies the action to take.
+                                                properties:
+                                                  command:
+                                                    description: Command is the command line to execute inside
+                                                      the container, the working directory for the command
+                                                      is root ('/') in the container's filesystem. The command
+                                                      is simply exec'd, it is not run inside a shell, so traditional
+                                                      shell instructions ('|', etc) won't work. To use a shell,
+                                                      you need to explicitly call out to that shell. Exit status
+                                                      of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies the http request to perform.
+                                                properties:
+                                                  host:
+                                                    description: Host name to connect to, defaults to
+                                                      the pod IP. You probably want to set "Host" in
+                                                      httpHeaders instead.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request.
+                                                      HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header to
+                                                        be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: The header field name
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: Name or number of the port to access on
+                                                      the container. Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: Scheme to use for connecting to the host.
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              tcpSocket:
+                                                description: 'TCPSocket specifies an action involving
+                                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                                  a realistic TCP lifecycle hook'
+                                                properties:
+                                                  host:
+                                                    description: 'Optional: Host name to connect to,
+                                                      defaults to the pod IP.'
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: Number or name of the port to access on
+                                                      the container. Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                            type: object
+                                          preStop:
+                                            description: 'PreStop is called immediately before a container
+                                              is terminated due to an API request or management event such
+                                              as liveness/startup probe failure, preemption, resource
+                                              contention, etc. The handler is not called if the container
+                                              crashes or exits. The reason for termination is passed to
+                                              the handler. The Pod''s termination grace period countdown
+                                              begins before the PreStop hooked is executed. Regardless
+                                              of the outcome of the handler, the container will eventually
+                                              terminate within the Pod''s termination grace period. Other
+                                              management of the container blocks until the hook completes
+                                              or until the termination grace period is reached. More info:
+                                              https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                            properties:
+                                              exec:
+                                                description: One and only one of the following should be
+                                                  specified. Exec specifies the action to take.
+                                                properties:
+                                                  command:
+                                                    description: Command is the command line to execute
+                                                      inside the container, the working directory for
+                                                      the command  is root ('/') in the container's
+                                                      filesystem. The command is simply exec'd, it is
+                                                      not run inside a shell, so traditional shell
+                                                      instructions ('|', etc) won't work. To use a shell,
+                                                      you need to explicitly call out to that shell. Exit
+                                                      status of 0 is treated as live/healthy and non-zero
+                                                      is unhealthy.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies the http request to perform.
+                                                properties:
+                                                  host:
+                                                    description: Host name to connect to, defaults to
+                                                      the pod IP. You probably want to set "Host"
+                                                      in httpHeaders instead.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request.
+                                                      HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header
+                                                        to be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: The header field name
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: Name or number of the port to access on
+                                                      the container. Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: Scheme to use for connecting to the host.
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              tcpSocket:
+                                                description: 'TCPSocket specifies an action involving
+                                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                                  a realistic TCP lifecycle hook'
+                                                properties:
+                                                  host:
+                                                    description: 'Optional: Host name to connect to,
+                                                      defaults to the pod IP.'
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: Number or name of the port to access on
+                                                      the container. Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                            type: object
+                                        type: object
+                                      livenessProbe:
+                                        description: 'Periodic probe of container liveness. Container
+                                          will be restarted if the probe fails. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following should be
+                                              specified. Exec specifies the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command line to execute inside
+                                                  the container, the working directory for the command  is
+                                                  root ('/') in the container's filesystem. The command is
+                                                  simply exec'd, it is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't work. To use a shell,
+                                                  you need to explicitly call out to that shell. Exit status
+                                                  of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures for the probe to be
+                                              considered failed after having succeeded. Defaults to 3.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          httpGet:
+                                            description: HTTPGet specifies the http request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults
+                                                  to the pod IP. You probably want to set "Host"
+                                                  in httpHeaders instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request.
+                                                  HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom
+                                                    header to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: Name or number of the port to access on the
+                                                  container. Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: 'Number of seconds after the container has
+                                              started before liveness probes are initiated. More info:
+                                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: How often (in seconds) to perform the probe.
+                                              Default to 10 seconds. Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes for the probe
+                                              to be considered successful after having failed.
+                                              Defaults to 1. Must be 1 for liveness and startup.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action involving a
+                                              TCP port. TCP hooks not yet supported TODO: implement
+                                              a realistic TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name to connect to,
+                                                 defaults to the pod IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: Number or name of the port to access on the
+                                                  container. Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                              - port
+                                            type: object
+                                          timeoutSeconds:
+                                            description: 'Number of seconds after which the probe times out.
+                                              Defaults to 1 second. Minimum value is 1. More info:
+                                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      name:
+                                        description: Name of the container specified as a DNS_LABEL. Each
+                                          container in a pod must have a unique name (DNS_LABEL).
+                                          Cannot be updated.
+                                        type: string
+                                      ports:
+                                        description: List of ports to expose from the container. Exposing
+                                          a port here gives the system additional information about the
+                                          network connections a container uses, but is primarily informational.
+                                          Not specifying a port here DOES NOT prevent that port from being
+                                          exposed. Any port which is listening on the default "0.0.0.0" address
+                                          inside a container will be accessible from the network.
+                                          Cannot be updated.
+                                        items:
+                                          description: ContainerPort represents a network port in a
+                                            single container.
+                                          properties:
+                                            containerPort:
+                                              description: Number of port to expose on the pod's IP
+                                                address. This must be a valid port number, 0 < x < 65536.
+                                              format: int32
+                                              type: integer
+                                            hostIP:
+                                              description: What host IP to bind the external port to.
+                                              type: string
+                                            hostPort:
+                                              description: Number of port to expose on the host.
+                                                If specified, this must be a valid port number,
+                                                0 < x < 65536. If HostNetwork is specified, this must
+                                                match ContainerPort. Most containers do not need this.
+                                              format: int32
+                                              type: integer
+                                            name:
+                                              description: If specified, this must be an IANA_SVC_NAME
+                                                and unique within the pod. Each named port in a pod
+                                                must have a unique name. Name for the port that can
+                                                be referred to by services.
+                                              type: string
+                                            protocol:
+                                              description: Protocol for port. Must be UDP, TCP,
+                                                or SCTP. Defaults to "TCP".
+                                              type: string
+                                          required:
+                                            - containerPort
+                                            - protocol
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                        x-kubernetes-list-type: map
+                                      readinessProbe:
+                                        description: 'Periodic probe of container service readiness. Container
+                                          will be removed from service endpoints if the probe fails. Cannot be
+                                          updated. More info:
+                                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following should be specified.
+                                              Exec specifies the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command line to execute inside
+                                                  the container, the working directory for the command
+                                                  is root ('/') in the container's filesystem. The command
+                                                  is simply exec'd, it is not run inside a shell, so
+                                                  traditional shell instructions ('|', etc) won't work.
+                                                  To use a shell, you need to explicitly call out to that
+                                                  shell. Exit status of 0 is treated as live/healthy and
+                                                  non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures for the probe
+                                              to be considered failed after having succeeded. Defaults to 3.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          httpGet:
+                                            description: HTTPGet specifies the http request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults to the pod IP.
+                                                  You probably want to set "Host" in httpHeaders instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request.
+                                                  HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom header
+                                                    to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: Name or number of the port to access on
+                                                  the container. Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: 'Number of seconds after the container has
+                                              started before liveness probes are initiated. More info:
+                                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: How often (in seconds) to perform the probe.
+                                              Default to 10 seconds. Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes for the probe
+                                              to be considered successful after having failed.
+                                              Defaults to 1. Must be 1 for liveness and startup.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action involving
+                                              a TCP port. TCP hooks not yet supported TODO: implement
+                                              a realistic TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name to connect to,
+                                                  defaults to the pod IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: Number or name of the port to access on
+                                                  the container. Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                              - port
+                                            type: object
+                                          timeoutSeconds:
+                                            description: 'Number of seconds after which the probe
+                                              times out. Defaults to 1 second. Minimum value is 1.
+                                              More info:
+                                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      resources:
+                                        description: 'Compute Resources required by this container.
+                                          Cannot be updated. More info:
+                                          https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Limits describes the maximum amount of compute
+                                              resources allowed. More info:
+                                              https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Requests describes the minimum amount of compute
+                                              resources required. If Requests is omitted for a container,
+                                              it defaults to Limits if that is explicitly specified, otherwise
+                                              to an implementation-defined value. More info:
+                                              https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            type: object
+                                        type: object
+                                      securityContext:
+                                        description: 'Security options the pod should run with. More
+                                          info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            description: 'AllowPrivilegeEscalation controls whether
+                                              a process can gain more privileges than its parent process.
+                                              This bool directly controls if the no_new_privs flag will
+                                              be set on the container process. AllowPrivilegeEscalation
+                                              is true always when the container is: 1) run as Privileged 2)
+                                              has CAP_SYS_ADMIN'
+                                            type: boolean
+                                          capabilities:
+                                            description: The capabilities to add/drop when
+                                              running containers. Defaults to the default
+                                              set of capabilities granted by the container runtime.
+                                            properties:
+                                              add:
+                                                description: Added capabilities
+                                                items:
+                                                  description: Capability represent POSIX
+                                                    capabilities type
+                                                  type: string
+                                                type: array
+                                              drop:
+                                                description: Removed capabilities
+                                                items:
+                                                  description: Capability represent POSIX capabilities
+                                                    type
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          privileged:
+                                            description: Run container in privileged mode. Processes
+                                              in privileged containers are essentially equivalent
+                                              to root on the host. Defaults to false.
+                                            type: boolean
+                                          procMount:
+                                            description: procMount denotes the type of proc mount to
+                                              use for the containers. The default is DefaultProcMount
+                                              which uses the container runtime defaults for readonly
+                                              paths and masked paths. This requires the ProcMountType
+                                              feature flag to be enabled.
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            description: Whether this container has a read-only root filesystem.
+                                              Default is false.
+                                            type: boolean
+                                          runAsGroup:
+                                            description: The GID to run the entrypoint of the container
+                                              process. Uses runtime default if unset. May also be set
+                                              in PodSecurityContext.  If set in both SecurityContext
+                                              and PodSecurityContext, the value specified in
+                                              SecurityContext takes precedence.
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            description: Indicates that the container must run as
+                                              a non-root user. If true, the Kubelet will validate
+                                              the image at runtime to ensure that it does not run
+                                              as UID 0 (root) and fail to start the container if
+                                              it does. If unset or false, no such validation will
+                                              be performed. May also be set in PodSecurityContext.
+                                              If set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext takes precedence.
+                                            type: boolean
+                                          runAsUser:
+                                            description: The UID to run the entrypoint of the container
+                                              process. Defaults to user specified in image metadata if
+                                              unspecified. May also be set in PodSecurityContext.  If
+                                              set in both SecurityContext and PodSecurityContext, the
+                                              value specified in SecurityContext takes precedence.
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            description: The SELinux context to be applied to
+                                              the container. If unspecified, the container runtime
+                                              will allocate a random SELinux context for each
+                                              container.  May also be set in PodSecurityContext.
+                                              If set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext takes precedence.
+                                            properties:
+                                              level:
+                                                description: Level is SELinux level label that
+                                                  applies to the container.
+                                                type: string
+                                              role:
+                                                description: Role is a SELinux role label that
+                                                  applies to the container.
+                                                type: string
+                                              type:
+                                                description: Type is a SELinux type label that
+                                                  applies to the container.
+                                                type: string
+                                              user:
+                                                description: User is a SELinux user label that
+                                                  applies to the container.
+                                                type: string
+                                            type: object
+                                          windowsOptions:
+                                            description: The Windows specific settings applied to
+                                              all containers. If unspecified, the options from
+                                              the PodSecurityContext will be used. If set in both
+                                              SecurityContext and PodSecurityContext, the value
+                                              specified in SecurityContext takes precedence.
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                description: GMSACredentialSpec is where the GMSA
+                                                  admission webhook
+                                                  (https://github.com/kubernetes-sigs/windows-gmsa)
+                                                  inlines the contents of the GMSA credential spec
+                                                  named by the GMSACredentialSpecName field.
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                description: GMSACredentialSpecName is the name
+                                                  of the GMSA credential spec to use.
+                                                type: string
+                                              runAsUserName:
+                                                description: The UserName in Windows to run
+                                                  the entrypoint of the container process.
+                                                  Defaults to the user specified in image
+                                                  metadata if unspecified. May also be set
+                                                  in PodSecurityContext. If set in both SecurityContext
+                                                  and PodSecurityContext, the value specified in
+                                                  SecurityContext takes precedence.
+                                                type: string
+                                            type: object
+                                        type: object
+                                      startupProbe:
+                                        description: 'StartupProbe indicates that the Pod
+                                          has successfully initialized. If specified, no other
+                                          probes are executed until this completes successfully.
+                                          If this probe fails, the Pod will be restarted, just
+                                          as if the livenessProbe failed. This can be used to
+                                          provide different probe parameters at the beginning
+                                          of a Pod''s lifecycle, when it might take a long time
+                                          to load data or warm a cache, than during steady-state
+                                          operation. This cannot be updated. This is a beta feature
+                                          enabled by the StartupProbe feature flag. More info:
+                                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following should
+                                              be specified. Exec specifies the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command line to execute
+                                                  inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it is not run inside a
+                                                  shell, so traditional shell instructions ('|', etc)
+                                                  won't work. To use a shell, you need to explicitly
+                                                  call out to that shell. Exit status of 0 is treated
+                                                  as live/healthy and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures for the probe
+                                              to be considered failed after having succeeded.
+                                              Defaults to 3. Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          httpGet:
+                                            description: HTTPGet specifies the http request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults to
+                                                  the pod IP. You probably want to set "Host" in
+                                                  httpHeaders instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request.
+                                                  HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom header
+                                                    to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: Name or number of the port to access on the
+                                                  container. Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: 'Number of seconds after the container has
+                                              started before liveness probes are initiated. More info:
+                                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: How often (in seconds) to perform the probe.
+                                              Default to 10 seconds. Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes for the probe
+                                              to be considered successful after having failed.
+                                              Defaults to 1. Must be 1 for liveness and startup.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action involving
+                                              a TCP port. TCP hooks not yet supported TODO: implement
+                                              a realistic TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name to connect to,
+                                                  defaults to the pod IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: Number or name of the port to access on
+                                                  the container. Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                              - port
+                                            type: object
+                                          timeoutSeconds:
+                                            description: 'Number of seconds after which the probe times
+                                             out. Defaults to 1 second. Minimum value is 1. More info:
+                                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      stdin:
+                                        description: Whether this container should allocate a buffer
+                                          for stdin in the container runtime. If this is not set,
+                                          reads from stdin in the container will always result in EOF.
+                                          Default is false.
+                                        type: boolean
+                                      stdinOnce:
+                                        description: Whether the container runtime should close
+                                          the stdin channel after it has been opened by a single
+                                          attach. When stdin is true the stdin stream will remain
+                                          open across multiple attach sessions. If stdinOnce is
+                                          set to true, stdin is opened on container start, is empty
+                                          until the first client attaches to stdin, and then remains
+                                          open and accepts data until the client disconnects, at
+                                          which time stdin is closed and remains closed until the
+                                          container is restarted. If this flag is false, a container
+                                          processes that reads from stdin will never receive an EOF.
+                                          Default is false
+                                        type: boolean
+                                      terminationMessagePath:
+                                        description: 'Optional: Path at which the file to which
+                                          the container''s termination message will be written
+                                          is mounted into the container''s filesystem. Message
+                                          written is intended to be brief final status, such as
+                                          an assertion failure message. Will be truncated by
+                                          the node if greater than 4096 bytes. The total message
+                                           length across all containers will be limited to 12kb.
+                                            Defaults to /dev/termination-log. Cannot be updated.'
+                                        type: string
+                                      terminationMessagePolicy:
+                                        description: Indicate how the termination message
+                                          should be populated. File will use the contents
+                                          of terminationMessagePath to populate the container
+                                          status message on both success and failure.
+                                          FallbackToLogsOnError will use the last chunk
+                                          of container log output if the termination message
+                                          file is empty and the container exited with an error.
+                                          The log output is limited to 2048 bytes or 80 lines,
+                                          whichever is smaller. Defaults to File. Cannot be updated.
+                                        type: string
+                                      tty:
+                                        description: Whether this container should allocate
+                                          a TTY for itself, also requires 'stdin' to be true.
+                                          Default is false.
+                                        type: boolean
+                                      volumeDevices:
+                                        description: volumeDevices is the list of block devices
+                                          to be used by the container.
+                                        items:
+                                          description: volumeDevice describes a mapping of a raw
+                                            block device within a container.
+                                          properties:
+                                            devicePath:
+                                              description: devicePath is the path inside
+                                                of the container that the device will be mapped to.
+                                              type: string
+                                            name:
+                                              description: name must match the name of a
+                                                persistentVolumeClaim
+                                                in the pod
+                                              type: string
+                                          required:
+                                            - devicePath
+                                            - name
+                                          type: object
+                                        type: array
+                                      volumeMounts:
+                                        description: Pod volumes to mount into the container's
+                                          filesystem. Cannot be updated.
+                                        items:
+                                          description: VolumeMount describes a mounting of a Volume
+                                            within a container.
+                                          properties:
+                                            mountPath:
+                                              description: Path within the container at which the
+                                                volume should be mounted.  Must not contain ':'.
+                                              type: string
+                                            mountPropagation:
+                                              description: mountPropagation determines how mounts
+                                                are propagated from the host to container and the
+                                                other way around. When not set, MountPropagationNone
+                                                is used. This field is beta in 1.10.
+                                              type: string
+                                            name:
+                                              description: This must match the Name of a Volume.
+                                              type: string
+                                            readOnly:
+                                              description: Mounted read-only if true, read-write
+                                                otherwise (false or unspecified). Defaults to false.
+                                              type: boolean
+                                            subPath:
+                                              description: Path within the volume from which the
+                                                container's volume should be mounted. Defaults to ""
+                                                (volume's root).
+                                              type: string
+                                            subPathExpr:
+                                              description: Expanded path within the volume
+                                                from which the container's volume should be
+                                                mounted. Behaves similarly to SubPath but
+                                                environment variable references $(VAR_NAME)
+                                                are expanded using the container's environment.
+                                                Defaults to "" (volume's root). SubPathExpr and
+                                                SubPath are mutually exclusive.
+                                              type: string
+                                          required:
+                                            - mountPath
+                                            - name
+                                          type: object
+                                        type: array
+                                      workingDir:
+                                        description: Container's working directory.
+                                          If not specified, the container runtime's
+                                          default will be used, which might be configured
+                                          in the container image. Cannot be updated.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                timeout:
+                                  description: Timeout defines the maximum amount
+                                    of time Velero should wait for the initContainers
+                                    to complete.
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
+                    required:
+                      - name
+                    type: object
+                  type: array
+              type: object
+            includeClusterResources:
+              description: IncludeClusterResources specifies whether cluster-scoped
+                resources should be included for consideration in the restore. If
+                null, defaults to true.
+              nullable: true
+              type: boolean
+            includedNamespaces:
+              description: IncludedNamespaces is a slice of namespace names to include
+                objects from. If empty, all namespaces are included.
+              items:
+                type: string
+              nullable: true
+              type: array
+            includedResources:
+              description: IncludedResources is a slice of resource names to include
+                in the restore. If empty, all resources in the backup are included.
+              items:
+                type: string
+              nullable: true
+              type: array
+            labelSelector:
+              description: LabelSelector is a metav1.LabelSelector to filter with
+                when restoring individual objects from the backup. If empty or nil,
+                all objects are included. Optional.
+              nullable: true
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            namespaceMapping:
+              additionalProperties:
+                type: string
+              description: NamespaceMapping is a map of source namespace names to
+                target namespace names to restore into. Any source namespaces not
+                included in the map will be restored into namespaces of the same name.
+              type: object
+            restorePVs:
+              description: RestorePVs specifies whether to restore all included PVs
+                from snapshot (via the cloudprovider).
+              nullable: true
+              type: boolean
+            scheduleName:
+              description: ScheduleName is the unique name of the Velero schedule
+                to restore from. If specified, and BackupName is empty, Velero will
+                restore from the most recent successful backup created from this schedule.
+              type: string
+          required:
+            - backupName
+          type: object
+        status:
+          description: RestoreStatus captures the current status of a Velero restore
+          properties:
+            completionTimestamp:
+              description: CompletionTimestamp records the time the restore operation
+                was completed. Completion time is recorded even on failed restore.
+                The server's time is used for StartTimestamps
+              format: date-time
+              nullable: true
+              type: string
+            errors:
+              description: Errors is a count of all error messages that were generated
+                during execution of the restore. The actual errors are stored in object
+                storage.
+              type: integer
+            failureReason:
+              description: FailureReason is an error that caused the entire restore
+                to fail.
+              type: string
+            phase:
+              description: Phase is the current state of the Restore
+              enum:
+                - New
+                - FailedValidation
+                - InProgress
+                - Completed
+                - PartiallyFailed
+                - Failed
+              type: string
+            startTimestamp:
+              description: StartTimestamp records the time the restore operation
+                was started. The server's time is used for StartTimestamps
+              format: date-time
+              nullable: true
+              type: string
+            validationErrors:
+              description: ValidationErrors is a slice of all validation errors (if
+                applicable)
+              items:
+                type: string
+              nullable: true
+              type: array
+            warnings:
+              description: Warnings is a count of all warning messages that were generated
+                during execution of the restore. The actual warnings are stored in
+                object storage.
+              type: integer
+          type: object
+      type: object
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/bootstrap/crds/velero/schedules.yaml
+++ b/bootstrap/crds/velero/schedules.yaml
@@ -1,16 +1,384 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: schedules.velero.io
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.3.0
+  name: schedules.velero.io
 spec:
   group: velero.io
-  version: v1
-  scope: Namespaced
   names:
-    plural: schedules
     kind: Schedule
+    listKind: ScheduleList
+    plural: schedules
+    singular: schedule
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: Schedule is a Velero resource that represents a pre-scheduled or
+        periodic Backup that should be run.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ScheduleSpec defines the specification for a Velero schedule
+          properties:
+            schedule:
+              description: Schedule is a Cron expression defining when to run the
+                Backup.
+              type: string
+            template:
+              description: Template is the definition of the Backup to be run on the
+                provided schedule
+              properties:
+                defaultVolumesToRestic:
+                  description: DefaultVolumesToRestic specifies whether restic should
+                    be used to take a backup of all pod volumes by default.
+                  type: boolean
+                excludedNamespaces:
+                  description: ExcludedNamespaces contains a list of namespaces that
+                    are not included in the backup.
+                  items:
+                    type: string
+                  nullable: true
+                  type: array
+                excludedResources:
+                  description: ExcludedResources is a slice of resource names that
+                    are not included in the backup.
+                  items:
+                    type: string
+                  nullable: true
+                  type: array
+                hooks:
+                  description: Hooks represent custom behaviors that should be executed
+                    at different phases of the backup.
+                  properties:
+                    resources:
+                      description: Resources are hooks that should be executed when
+                        backing up individual instances of a resource.
+                      items:
+                        description: BackupResourceHookSpec defines one or more BackupResourceHooks
+                          that should be executed based on the rules defined for namespaces,
+                          resources, and label selector.
+                        properties:
+                          excludedNamespaces:
+                            description: ExcludedNamespaces specifies the namespaces
+                              to which this hook spec does not apply.
+                            items:
+                              type: string
+                            nullable: true
+                            type: array
+                          excludedResources:
+                            description: ExcludedResources specifies the resources
+                              to which this hook spec does not apply.
+                            items:
+                              type: string
+                            nullable: true
+                            type: array
+                          includedNamespaces:
+                            description: IncludedNamespaces specifies the namespaces
+                              to which this hook spec applies. If empty, it applies
+                              to all namespaces.
+                            items:
+                              type: string
+                            nullable: true
+                            type: array
+                          includedResources:
+                            description: IncludedResources specifies the resources
+                              to which this hook spec applies. If empty, it applies
+                              to all resources.
+                            items:
+                              type: string
+                            nullable: true
+                            type: array
+                          labelSelector:
+                            description: LabelSelector, if specified, filters the
+                              resources to which this hook spec applies.
+                            nullable: true
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          name:
+                            description: Name is the name of this hook.
+                            type: string
+                          post:
+                            description: PostHooks is a list of BackupResourceHooks
+                              to execute after storing the item in the backup. These
+                              are executed after all "additional items" from item
+                              actions are processed.
+                            items:
+                              description: BackupResourceHook defines a hook for a
+                                resource.
+                              properties:
+                                exec:
+                                  description: Exec defines an exec hook.
+                                  properties:
+                                    command:
+                                      description: Command is the command and arguments
+                                        to execute.
+                                      items:
+                                        type: string
+                                      minItems: 1
+                                      type: array
+                                    container:
+                                      description: Container is the container in the
+                                        pod where the command should be executed.
+                                        If not specified, the pod's first container
+                                        is used.
+                                      type: string
+                                    onError:
+                                      description: OnError specifies how Velero should
+                                        behave if it encounters an error executing
+                                        this hook.
+                                      enum:
+                                      - Continue
+                                      - Fail
+                                      type: string
+                                    timeout:
+                                      description: Timeout defines the maximum amount
+                                        of time Velero should wait for the hook to
+                                        complete before considering the execution
+                                        a failure.
+                                      type: string
+                                  required:
+                                  - command
+                                  type: object
+                              required:
+                              - exec
+                              type: object
+                            type: array
+                          pre:
+                            description: PreHooks is a list of BackupResourceHooks
+                              to execute prior to storing the item in the backup.
+                              These are executed before any "additional items" from
+                              item actions are processed.
+                            items:
+                              description: BackupResourceHook defines a hook for a
+                                resource.
+                              properties:
+                                exec:
+                                  description: Exec defines an exec hook.
+                                  properties:
+                                    command:
+                                      description: Command is the command and arguments
+                                        to execute.
+                                      items:
+                                        type: string
+                                      minItems: 1
+                                      type: array
+                                    container:
+                                      description: Container is the container in the
+                                        pod where the command should be executed.
+                                        If not specified, the pod's first container
+                                        is used.
+                                      type: string
+                                    onError:
+                                      description: OnError specifies how Velero should
+                                        behave if it encounters an error executing
+                                        this hook.
+                                      enum:
+                                      - Continue
+                                      - Fail
+                                      type: string
+                                    timeout:
+                                      description: Timeout defines the maximum amount
+                                        of time Velero should wait for the hook to
+                                        complete before considering the execution
+                                        a failure.
+                                      type: string
+                                  required:
+                                  - command
+                                  type: object
+                              required:
+                              - exec
+                              type: object
+                            type: array
+                        required:
+                        - name
+                        type: object
+                      nullable: true
+                      type: array
+                  type: object
+                includeClusterResources:
+                  description: IncludeClusterResources specifies whether cluster-scoped
+                    resources should be included for consideration in the backup.
+                  nullable: true
+                  type: boolean
+                includedNamespaces:
+                  description: IncludedNamespaces is a slice of namespace names to
+                    include objects from. If empty, all namespaces are included.
+                  items:
+                    type: string
+                  nullable: true
+                  type: array
+                includedResources:
+                  description: IncludedResources is a slice of resource names to include
+                    in the backup. If empty, all resources are included.
+                  items:
+                    type: string
+                  nullable: true
+                  type: array
+                labelSelector:
+                  description: LabelSelector is a metav1.LabelSelector to filter with
+                    when adding individual objects to the backup. If empty or nil,
+                    all objects are included. Optional.
+                  nullable: true
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                orderedResources:
+                  additionalProperties:
+                    type: string
+                  description: OrderedResources specifies the backup order of resources of
+                    specific Kind. The map key is the Kind name and value is a list of
+                    resource names separeted by commas. Each resource name has format
+                    "namespace/resourcename".  For cluster resources, simply use "resourcename".
+                  nullable: true
+                  type: object
+                snapshotVolumes:
+                  description: SnapshotVolumes specifies whether to take cloud snapshots
+                    of any PV's referenced in the set of objects included in the Backup.
+                  nullable: true
+                  type: boolean
+                storageLocation:
+                  description: StorageLocation is a string containing the name of
+                    a BackupStorageLocation where the backup should be stored.
+                  type: string
+                ttl:
+                  description: TTL is a time.Duration-parseable string describing
+                    how long the Backup should be retained for.
+                  type: string
+                volumeSnapshotLocations:
+                  description: VolumeSnapshotLocations is a list containing names
+                    of VolumeSnapshotLocations associated with this backup.
+                  items:
+                    type: string
+                  type: array
+              type: object
+          required:
+          - schedule
+          - template
+          type: object
+        status:
+          description: ScheduleStatus captures the current state of a Velero schedule
+          properties:
+            lastBackup:
+              description: LastBackup is the last time a Backup was run for this Schedule
+                schedule
+              format: date-time
+              nullable: true
+              type: string
+            phase:
+              description: Phase is the current phase of the Schedule
+              enum:
+              - New
+              - Enabled
+              - FailedValidation
+              type: string
+            validationErrors:
+              description: ValidationErrors is a slice of all validation errors (if
+                applicable)
+              items:
+                type: string
+              type: array
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/bootstrap/crds/velero/serverstatusrequests.yaml
+++ b/bootstrap/crds/velero/serverstatusrequests.yaml
@@ -1,16 +1,85 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: serverstatusrequests.velero.io
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.3.0
+  name: serverstatusrequests.velero.io
 spec:
   group: velero.io
-  version: v1
-  scope: Namespaced
   names:
-    plural: serverstatusrequests
     kind: ServerStatusRequest
+    listKind: ServerStatusRequestList
+    plural: serverstatusrequests
+    shortNames:
+      - ssr
+    singular: serverstatusrequest
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ServerStatusRequest is a request to access current status information
+        about the Velero server.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ServerStatusRequestSpec is the specification for a ServerStatusRequest.
+          type: object
+        status:
+          description: ServerStatusRequestStatus is the current status of a ServerStatusRequest.
+          properties:
+            phase:
+              description: Phase is the current lifecycle phase of the ServerStatusRequest.
+              enum:
+              - New
+              - Processed
+              type: string
+            plugins:
+              description: Plugins list information about the plugins running on the
+                Velero server
+              items:
+                description: PluginInfo contains attributes of a Velero plugin
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              nullable: true
+              type: array
+            processedTimestamp:
+              description: ProcessedTimestamp is when the ServerStatusRequest was
+                processed by the ServerStatusRequestController.
+              format: date-time
+              nullable: true
+              type: string
+            serverVersion:
+              description: ServerVersion is the Velero server version.
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/bootstrap/crds/velero/volumesnapshotlocations.yaml
+++ b/bootstrap/crds/velero/volumesnapshotlocations.yaml
@@ -1,16 +1,70 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: volumesnapshotlocations.velero.io
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": crd-install
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    controller-gen.kubebuilder.io/version: v0.3.0
+  name: volumesnapshotlocations.velero.io
 spec:
   group: velero.io
-  version: v1
-  scope: Namespaced
   names:
-    plural: volumesnapshotlocations
     kind: VolumeSnapshotLocation
+    listKind: VolumeSnapshotLocationList
+    plural: volumesnapshotlocations
+    singular: volumesnapshotlocation
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshotLocation is a location where Velero stores volume
+        snapshots.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: VolumeSnapshotLocationSpec defines the specification for a
+            Velero VolumeSnapshotLocation.
+          properties:
+            config:
+              additionalProperties:
+                type: string
+              description: Config is for provider-specific configuration fields.
+              type: object
+            provider:
+              description: Provider is the provider of the volume storage.
+              type: string
+          required:
+          - provider
+          type: object
+        status:
+          description: VolumeSnapshotLocationStatus describes the current status of
+            a Velero VolumeSnapshotLocation.
+          properties:
+            phase:
+              description: VolumeSnapshotLocationPhase is the lifecyle phase of a
+                Velero VolumeSnapshotLocation.
+              enum:
+              - Available
+              - Unavailable
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -112,7 +112,7 @@ releases:
   labels:
     app: velero
   chart: vmware-tanzu/velero
-  version: 2.8.2
+  version: 2.15.0
   installed: {{ .Values.velero.enabled }}
   missingFileHandler: Error
   values:

--- a/helmfile/values/velero.yaml.gotmpl
+++ b/helmfile/values/velero.yaml.gotmpl
@@ -90,6 +90,11 @@ schedules:
   daily-backup:
     schedule: "0 0 * * *" #once per day
     template:
+      {{- if eq .Values.objectStorage.type "s3" }}
+      storageLocation: aws
+      {{- else if eq .Values.objectStorage.type "gcs" }}
+      storageLocation: gcs
+      {{- end }}
       labelSelector:
         matchLabels:
           velero: backup


### PR DESCRIPTION
**What this PR does / why we need it**:

To support S3 region we need to upgrade velero to use at least version 1.3.0. 

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: 
fixes #289 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
