### PR TITLE
all: Add S3 management scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ If this is all new to you, here's a [link](https://riseup.net/en/security/messag
 In addition to this, you will need to set up the following DNS entries (replace `example.com` with your domain).
 - Point these domains to the workload cluster ingress controller:
   - `*.example.com`
-  - `prometheus.ops.example.com`
 - Point these domains to the service cluster ingress controller:
   - `*.ops.example.com`
   - `grafana.example.com`
@@ -119,14 +118,14 @@ Assuming you already have everything needed to install the apps, this is what yo
    export CK8S_FLAVOR=[dev|prod] # defaults to dev
    ```
 
-2. Then set the path to where the ck8s configuration should be stored and the PGP fingerprint of the key(s) to use for encryption:
+1. Then set the path to where the ck8s configuration should be stored and the PGP fingerprint of the key(s) to use for encryption:
 
    ```bash
    export CK8S_CONFIG_PATH=${HOME}/.ck8s/my-ck8s-cluster
    export CK8S_PGP_FP=<PGP-fingerprint1,PGP-fingerprint2,...>
    ```
 
-3. Initialize your environment and configuration:
+1. Initialize your environment and configuration:
    Note that this will *not* overwrite existing values, but it will append to existing files.
    See [compliantkubernetes.io](compliantkubernetes.io) if you are uncertain about in what order you should do things.
 
@@ -134,8 +133,27 @@ Assuming you already have everything needed to install the apps, this is what yo
    ./bin/ck8s init
    ```
 
-4. Edit the configuration files that have been initialized in the configuration path.
-   Make sure that the `objectStorage` values are set in `sc-config.yaml`, `wc-config.yaml` and `secrets.yaml` according to your `objectStorage.type` (Set `objectStorage.s3.*` if you are using s3 or `objectStorage.gcs.*` if you are using gcs.)
+1. Edit the configuration files that have been initialized in the configuration path.
+   Make sure that the `objectStorage` values are set in `sc-config.yaml`, `wc-config.yaml` and `secrets.yaml` according to your `objectStorage.type`.
+   Set `objectStorage.s3.*` if you are using S3 or `objectStorage.gcs.*` if you are using GCS.
+
+
+1. Create S3 buckets - optional
+   If you have set `objectStorage.type: s3`, then you need to create the buckets specified under `objectStorage.buckets` in your configuration files.
+   You can run the script `scripts/S3/entry.sh create` to create the buckets required.
+   The script uses `s3cmd` in the background and it uses the `${HOME}/.s3cfg` file for configuration and authentication for your S3 provider.
+   There's also a helper script `scripts/S3/generate-s3cfg.sh` that will allow you to generate an appropriate `s3cfg` config file for a few providers.
+
+   ```bash
+   # Use your s3cmd config file.
+   scripts/S3/entry.sh create
+
+   # Use custom config file for s3cmd.
+   scripts/S3/gen-s3cfg.sh aws ${AWS_ACCESS_KEY} ${AWS_ACCESS_SECRET_KEY} s3.eu-north-1.amazonaws.com eu-north-1 > s3cfg-aws
+   scripts/S3/entry.sh --s3cfg s3cfg-aws create
+   ```
+
+1. Test S3 configuration - optional
    If you enable object storage you also need to make sure that the buckets specified in `objecStorage.buckets` exist.
    You can run the following snippet to ensure that you've configured S3 correctly:
 
@@ -155,8 +173,7 @@ Assuming you already have everything needed to install the apps, this is what yo
    )
    ```
 
-
-5. OBS! for this step each cluster need to be up and running already.
+1. **Note**, for this step each cluster need to be up and running already.
    Deploy the apps:
 
    ```bash
@@ -164,14 +181,14 @@ Assuming you already have everything needed to install the apps, this is what yo
    ./bin/ck8s apply wc
    ```
 
-6. Test that the cluster is running correctly with:
+1. Test that the cluster is running correctly with:
 
    ```bash
    ./bin/ck8s test sc
    ./bin/ck8s test wc
    ```
 
-7. You should now have a fully working environment.
+1. You should now have a fully working environment.
    Check the next section for some additional steps to finalize it and set up user access.
 
 ### On-boarding and final touches

--- a/scripts/S3/entry.sh
+++ b/scripts/S3/entry.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+# Wrapper for manager.sh, reads config from ${CK8S_CONFIG_PATH}/{sc,wc}-config.yaml
+# and creates the S3 buckets specified in 'objectStorage.buckets.*'.
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+CK8S_AUTO_APPROVE=${CK8S_AUTO_APPROVE:-"false"}
+
+here="$(dirname "$(readlink -f "$0")")"
+
+objectstorage_type_sc=$(yq r "${CK8S_CONFIG_PATH}/sc-config.yaml" 'objectStorage.type')
+objectstorage_type_wc=$(yq r "${CK8S_CONFIG_PATH}/wc-config.yaml" 'objectStorage.type')
+
+[ "$objectstorage_type_sc" != "s3" ] && echo "S3 is not enabled in service cluster" 1>&2
+[ "$objectstorage_type_wc" != "s3" ] && echo "S3 is not enabled in workload cluster" 1>&2
+
+if [ "$objectstorage_type_sc" != "s3" ] && [ "$objectstorage_type_wc" != "s3" ]; then
+    echo "S3 is not enabled in either cluster, aborting!" 1>&2
+    exit 1
+fi
+
+[ "$objectstorage_type_sc" = "s3" ] && buckets_sc=$(yq r "${CK8S_CONFIG_PATH}/sc-config.yaml" 'objectStorage.buckets.*')
+[ "$objectstorage_type_wc" = "s3" ] && buckets_wc=$(yq r "${CK8S_CONFIG_PATH}/wc-config.yaml" 'objectStorage.buckets.*')
+
+buckets=$( { echo "$buckets_sc"; echo "$buckets_wc"; } | sort | uniq | tr '\n' ' ')
+
+function usage() {
+    echo "Usage:" 1>&2
+    echo "  $0 [--s3cfg config-path] create|delete" 1>&2
+    exit 1
+}
+
+if [ "$1" = "--s3cfg" ]; then
+    [ "$#" -ne 3 ] && echo "Invalid number of arguments" 1>&2 && usage
+    action="$3"
+    cmd="${here}/manager.sh $1 $2 --$3 $buckets"
+else
+    [ "$#" -ne 1 ] && echo "Invalid number of arguments" 1>&2 && usage
+    action="$1"
+    cmd="${here}/manager.sh --$1 $buckets"
+fi
+
+if [ "$action" = "delete" ] && ! ${CK8S_AUTO_APPROVE}; then
+    echo -n -e "Are you sure you want to delete all buckets? (y/n): " 1>&2
+    read -r reply
+    if [[ "${reply}" == "n" ]]; then
+        exit 1
+    fi
+fi
+
+$cmd

--- a/scripts/S3/generate-s3cfg.sh
+++ b/scripts/S3/generate-s3cfg.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Simple script for generating a sample s3cfg for a couple of known
+# and tested S3 providers.
+
+function usage() {
+    echo "Usage:" 1>&2
+    echo "  $0 aws|exoscale|safespring|citycloud access_key secret_key host_base region" 1>&2
+    exit 1
+}
+
+[ "$#" -lt 4 ] && echo "Too few arguments" && usage
+
+cat <<EOF
+access_key = $2
+secret_key = $3
+host_base = $4
+bucket_location = $5
+EOF
+# Providers that support virtual-hosted-style access to buckets.
+if [ "$1" = "aws" ] || [ "$1" = "exoscale" ]; then
+cat <<EOF
+host_bucket = %(bucket)s.$4
+EOF
+# Providers that only support path-style access to buckets.
+elif [ "$1" = "safespring" ] || [ "$1" = "citycloud" ]; then
+cat <<EOF
+host_bucket = $4
+EOF
+else
+echo "Unsupported S3 provider '$1'" && usage
+fi

--- a/scripts/S3/manager.sh
+++ b/scripts/S3/manager.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# Simple script for managing the creation and deletion of S3 buckets using s3cmd.
+# Users can point to their s3cmd config file via the option '--s3cfg config-path'.
+# If the path to the config file is not passed,  '~/.s3cfg' will be used.
+
+set -e
+
+readonly CREATE_ACTION="create"
+readonly DELETE_ACTION="delete"
+readonly ABORT_UPLOAD_ACTION="abort"
+
+function usage() {
+    echo "Usage:" 1>&2
+    echo "  $0 [--s3cfg config-path] --create | -c bucket_name_1  [bucket_name_2 ...]" 1>&2
+    echo "  $0 [--s3cfg config-path] --delete | -d bucket_name_1  [bucket_name_2 ...]" 1>&2
+    echo "  $0 [--s3cfg config-path] --abort  | -a bucket_name_1  [bucket_name_2 ...]" 1>&2
+    exit 1
+}
+
+if [ "$1" = "--s3cfg" ]; then
+    [ "$#" -lt 4 ] && echo "Too few arguments" 1>&2 && usage
+    s3cmd='s3cmd --config '"${2}"
+    shift; shift
+else
+    [ "$#" -lt 2 ] && echo "Too few arguments" 1>&2 && usage
+    s3cmd='s3cmd'
+fi
+
+case "$1" in
+    -c | --create ) ACTION=$CREATE_ACTION
+                    ;;
+    -d | --delete ) ACTION=$DELETE_ACTION
+                    ;;
+    -a | --abort  ) ACTION=$ABORT_UPLOAD_ACTION
+                    ;;
+esac
+shift
+
+buckets="$*"
+
+function create_bucket() { # arguments: bucket name
+    local bucket_name="$1"
+
+    echo "checking status of bucket [${bucket_name}]" >&2
+    BUCKET_EXISTS=$(echo "$S3_BUCKET_LIST" | awk "\$3~/^s3:\/\/${bucket_name}$/ {print \$3}")
+
+    if [ "$BUCKET_EXISTS" ]; then
+        echo "bucket [${bucket_name}] already exists, do nothing" >&2
+    else
+        echo "bucket [${bucket_name}] does not exist, creating it now" >&2
+        ${s3cmd} mb "s3://${bucket_name}"
+    fi
+}
+
+function delete_bucket() { # arguments: bucket name
+    local bucket_name="$1"
+
+    echo "checking status of bucket [${bucket_name}]" >&2
+    BUCKET_EXISTS=$(echo "$S3_BUCKET_LIST" | awk "\$3~/^s3:\/\/${bucket_name}$/ {print \$3}")
+
+    if [ "$BUCKET_EXISTS" ]; then
+        echo "Bucket [${bucket_name}] exists, deleting it now" >&2
+        ${s3cmd} rb "s3://${bucket_name}" --force --recursive
+    else
+        echo "bucket [${bucket_name}] does not exist, do nothing" >&2
+    fi
+}
+
+function abort_multipart_uploads() { # arguments: bucket name
+    local bucket_name="$1"
+
+    echo "checking status of bucket [${bucket_name}]" >&2
+    ONGOING_UPLOADS=$(${s3cmd} multipart "s3://${bucket_name}" | \
+                      awk 'FNR > 2 { print $2 " " $3 }') # header has two lines
+
+    if [ -n "$ONGOING_UPLOADS" ]; then
+        echo "The are ongoing multipart uploads, aborting them now"
+        echo "$ONGOING_UPLOADS" | while read -r line ; do
+            echo "Aborting $line"
+            ${s3cmd} abortmp "$line"
+        done
+    else
+        echo "No ongoing multipart uploads, do nothing"
+    fi
+}
+
+# get a list of all the S3 buckets
+S3_BUCKET_LIST=$(${s3cmd} ls)
+
+if [[ "$ACTION" == "$CREATE_ACTION" ]]; then
+    echo 'Create buckets (only if they do not exist)' >&2
+    # shellcheck disable=SC2068
+    for bucket in ${buckets[@]}; do
+        create_bucket "$bucket"
+    done
+elif [[ "$ACTION" == "$DELETE_ACTION" ]]; then
+    echo 'Delete buckets' >&2
+    # shellcheck disable=SC2068
+    for bucket in ${buckets[@]}; do
+        delete_bucket "$bucket"
+    done
+elif [[ "$ACTION" == "$ABORT_UPLOAD_ACTION" ]]; then
+    echo 'Abort mutlipart uploads to buckets' >&2
+    # shellcheck disable=SC2068
+    for bucket in ${buckets[@]}; do
+        abort_multipart_uploads "$bucket"
+    done
+else
+    echo 'Unknown action - Aborting!' >&2 && usage
+    exit 1
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves s3 bucket management back to this repository as the buckets are tightly coupled with apps.
Should reduce the number of times users forget to create the appropriate buckets when s3 object storage is enabled.

The bucket manager part is virtually the same as the one we have in out private bucketmanager repo, i've just made a few tweaks to the genereate-s3cfg config, and made the files comply with shellcheck.

Part of #300 

**Which issue this PR fixes**:
fixes #321

**Special notes for reviewer**:
I have not yet updated the pipeline.

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
