### PR TITLE
bin: Update config validation

### DIFF
--- a/bin/common.bash
+++ b/bin/common.bash
@@ -142,8 +142,8 @@ validate_config() {
         # available in $1
         maybe_exit="false"
         for opt in ${options}; do
-            value=$(yq r "${file}" "${opt}")
-            if [[ -z "$value" ]]; then
+            value=$(yq r --unwrapScalar=false "${file}" "${opt}")
+            if [[ -z "${value}" ]] || [[ "${value}" = '"set-me"' ]] || [[ "${value}" = "set-me" ]]; then
                 log_warning "WARN: ${opt} is not set in ${file}"
                 maybe_exit="true"
             fi

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -82,7 +82,7 @@ storageClasses:
 ## Nfs-client-provisioner configuration.
 ## Deployment is controlled via 'storageClasses.nfs.enabled'.
 nfsProvisioner:
-  server: "set-me"
+  server: ""
   path: /nfs
   resources:
     limits:
@@ -369,10 +369,10 @@ issuers:
     enabled: false
     # prod:
     #   ## Mail through which letsencrypt can contact you.
-    #   email: ""
+    #   email: "set-me"
     # staging:
     #   ## Mail through which letsencrypt can contact you.
-    #   email: ""
+    #   email: "set-me"
 
   ## Additional issuers to create.
   ## ref: https://cert-manager.io/docs/configuration/


### PR DESCRIPTION
**What this PR does / why we need it**:
To lessen the likelihood that a user deploys apps with a bad config.

Before our validation gave warning on `""` and empty/missing paths.
Now it has been update to warn on the following
- `"set-me"`
- `set-me`
- and empty/missing path/field.

This means that if there is a field that we want the user to configure it should prefereably be set to `"set-me"` by default.

**Which issue this PR fixes**:
part of #300 

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
