### PR TITLE
apps: fix s3 logs

### DIFF
--- a/helmfile/values/fluentd-configmap.yaml.gotmpl
+++ b/helmfile/values/fluentd-configmap.yaml.gotmpl
@@ -15,7 +15,7 @@ aggregator:
         port 9880
       </source>
 
-      <match kubernetes.var.log.containers.fluentd-aggregator-**>
+      <match kubernetes.var.log.containers.fluentd>
         @type null
       </match>
       <match **>

--- a/helmfile/values/fluentd-configmap.yaml.gotmpl
+++ b/helmfile/values/fluentd-configmap.yaml.gotmpl
@@ -15,7 +15,7 @@ aggregator:
         port 9880
       </source>
 
-      <match kubernetes.var.log.containers.fluentd>
+      <match kubernetes.var.log.containers.fluentd-**>
         @type null
       </match>
       <match **>


### PR DESCRIPTION
**What this PR does / why we need it**:
FluentId logs stops being shipped to S3.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes compliantkubernetes-apps#332

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
