### PR TITLE
apps: fix s3 logs

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Fixed
 
 - Elasticsearch SLM retention value conversion bug
+- FluentId logs stop being shipped to S3
 
 ### Changed
 

--- a/helmfile/values/fluentd-configmap.yaml.gotmpl
+++ b/helmfile/values/fluentd-configmap.yaml.gotmpl
@@ -15,7 +15,7 @@ aggregator:
         port 9880
       </source>
 
-      <match kubernetes.var.log.containers.fluentd-aggregator-**>
+      <match kubernetes.var.log.containers.fluentd-**>
         @type null
       </match>
       <match **>


### PR DESCRIPTION
**What this PR does / why we need it**:
FluentId logs stop being shipped to S3.

**Which issue this PR fixes**:
fixes #332 

**Testing**
To generate Fluentd logs, pods could be shut down to then reset automatically. The initial logging then got shipped to S3. If the initial logging didn't get shipped to S3 after my changes without any errors - success.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits