### PR TITLE
Fix privilege escalation bug in Ansible get-requirements.yaml script

### DIFF
--- a/get-requirements.yaml
+++ b/get-requirements.yaml
@@ -46,7 +46,7 @@
         path: "/home/{{ install_user }}/.local/share/helm/plugins/helm-diff"
       register: helm_diff_exists
     - name: Get helm-diff
-      become: "{{ install_user }}"
+      become_user: "{{ install_user }}"
       command: "helm plugin install https://github.com/databus23/helm-diff --version v{{ helmdiff_version }}"
       register: "output"
       when: not helm_diff_exists.stat.exists
@@ -55,7 +55,7 @@
         path: "/home/{{ install_user }}/.local/share/helm/plugins/helm-secrets"
       register: helm_secrets_exists
     - name: Get helm-secrets
-      become: "{{ install_user }}"
+      become_user: "{{ install_user }}"
       command: "helm plugin install https://github.com/zendesk/helm-secrets --version v{{ helmsecrets_version }}"
       register: "output"
       when: not helm_secrets_exists.stat.exists


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug in Ansible `get-requirements.yaml` script, which uses wrong keyword for privilege escalation.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #366

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
