### PR TITLE
docs: Update release document

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -55,9 +55,11 @@ https://semver.org/
     ```
 
 1. Push the tagged commit, create a PR against the release branch and request a review.
+   If there are no changes, create the release manually instead by going to [releases](https://github.com/elastisys/compliantkubernetes-apps/releases) and clicking "Draft a new release".
+   Check older releases for how to word it.
 
     ```bash
-    git push --tags QA-X.Y
+    git push --tags
     ```
 
 1. Merge it to finalize the release.
@@ -73,7 +75,7 @@ https://semver.org/
     git push
     ```
 
-    A [GitHub actions workflow pipeline](.github/workflows/release.yml) will create a GitHub release from the tag.
+    A [GitHub actions workflow pipeline](/.github/workflows/release.yml) will create a GitHub release from the tag.
 
 1. Merge any fixes from the release branch back to the `main` branch `git cherry-pick` can be used, e.g.
 
@@ -140,7 +142,7 @@ by just writing that commits short hash or full hash.
 
 ### Release notes
 
-* To migrate the resources depending on yyyy you have to run [this script](..).
+* To migrate the resources depending on yyyy you have to run this script.
 
 ### Added
 


### PR DESCRIPTION
- Fix broken links
- Fix git command for pushing tags
- Add note for how to create a release in case of no QA commits.

**What this PR does / why we need it**:
Fixing some minor things in the release documentation.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: none

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
