### PR TITLE
apps wc: falco-alert routing to alertmanager in sc

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,6 @@
+### Fixed
+
+
+### Changed
+
+- Falco alerts gets routed to Prometheus alertmanager

--- a/helmfile/charts/prometheus-alerts/templates/rules/falco-alerts.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/rules/falco-alerts.yaml
@@ -1,0 +1,31 @@
+# Generated from 'kubernetes-resources' group from https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/prometheus-rules.yaml
+# Do not change in-place! In order to change this file first read following link:
+# https://github.com/helm/charts/tree/master/stable/prometheus-alerts/hack
+{{- if and .Values.defaultRules.create .Values.defaultRules.rules.kubernetesResources }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-alerts.fullname" .) "falco-alert" | trunc 63 | trimSuffix "-" }}
+  labels:
+    app: {{ template "prometheus-alerts.name" . }}
+{{ include "prometheus-alerts.labels" . | indent 4 }}
+{{- if .Values.defaultRules.labels }}
+{{ toYaml .Values.defaultRules.labels | indent 4 }}
+{{- end }}
+{{- if .Values.defaultRules.annotations }}
+  annotations:
+{{ toYaml .Values.defaultRules.annotations | indent 4 }}
+{{- end }}
+spec:
+  groups:
+  - name: falco-alert
+    rules:
+    - alert: FalcoAlert
+      annotations:
+        message: 'Pod: {{`{{ $labels.pod }}`}}, Rule: {{`{{ $labels.rule }}`}}'
+      expr: |-
+        falco_events
+      for: 5m
+      labels:
+        severity: warning
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Falco alerts get routed through Prometheus to the alert manager in the wc-cluster as it cannot be delivered by falcon itself.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #106

**Special notes for reviewer**:
This could be developed further. Instead of having one generic FalcoAlert-rule, we could have one alert for each rule defined in  https://github.com/falcosecurity/charts/blob/d7f1fbb31b94ecc28cfd1693bdcf8d867ce6d39d/falco/rules/falco_rules.yaml. Is it wanted?

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits