### PR TITLE
apps wc: falco-alert routing to alertmanager in sc

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,6 @@
+### Fixed
+
+
+### Changed
+
+- The Service Cluster Prometheus now alerts based on Falco metrics. These alerts are sent to Alertmanager as usual so they now have the same flow as all other alerts. This is in addition to the "Falco specific alerting" through Falco sidekick.

--- a/helmfile/charts/prometheus-alerts/templates/rules/falco-alerts.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/rules/falco-alerts.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.defaultRules.create .Values.defaultRules.rules.falcoAlerts }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-alerts.fullname" .) "falco-alert" | trunc 63 | trimSuffix "-" }}
+  labels:
+    app: {{ template "prometheus-alerts.name" . }}
+{{ include "prometheus-alerts.labels" . | indent 4 }}
+{{- if .Values.defaultRules.labels }}
+{{ toYaml .Values.defaultRules.labels | indent 4 }}
+{{- end }}
+{{- if .Values.defaultRules.annotations }}
+  annotations:
+{{ toYaml .Values.defaultRules.annotations | indent 4 }}
+{{- end }}
+spec:
+  groups:
+  - name: falco-alert
+    rules:
+    - alert: FalcoAlert
+      annotations:
+        message: 'Pod: {{`{{ $labels.pod }}`}}, Rule: {{`{{ $labels.rule }}`}}'
+      expr: |-
+        falco_events != 0
+      labels:
+        severity: warning
+{{- end }}

--- a/helmfile/charts/prometheus-alerts/values.yaml
+++ b/helmfile/charts/prometheus-alerts/values.yaml
@@ -41,6 +41,7 @@ defaultRules:
     kubeletService: false
     coreDNS: false
     certMonitor: true
+    falcoAlerts: true
 
 certMonitor:
   name: "cert-monitor"


### PR DESCRIPTION
**What this PR does / why we need it**:
Falco alerts get routed through Prometheus to the alert manager in the wc-cluster as it cannot be delivered by falcon itself.

**Which issue this PR fixes** 
fixes elastisys/ck8s-ops#106

**Special notes for reviewer**:
This could be developed further. Instead of having one generic FalcoAlert-rule, we could have one alert for each rule defined in  https://github.com/falcosecurity/charts/blob/d7f1fbb31b94ecc28cfd1693bdcf8d867ce6d39d/falco/rules/falco_rules.yaml. Is it wanted?

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits