### PR TITLE
apps sc: add script to restore Harbor from backup

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,3 +1,7 @@
+### Added
+
+- Script to restore Harbor from backup
+
 ### Fixed
 
 - Elasticsearch slm now deletes excess snapshots also when none of them are older than the maximum age
@@ -6,7 +10,6 @@
 
 - The Service Cluster Prometheus now alerts based on Falco metrics. These alerts are sent to Alertmanager as usual so they now have the same flow as all other alerts. This is in addition to the "Falco specific alerting" through Falco sidekick.
 - Elasticsearch slm now deletes indices in bulk
-
 
 ### Removed
 

--- a/scripts/restore/README.md
+++ b/scripts/restore/README.md
@@ -1,0 +1,30 @@
+### Restore Harbor
+With the script `restore-harbor.sh` you can restore the database in Harbor from a backup in S3.
+
+Before restoring the database, make sure that Harbor is installed. It can be installed normally.
+
+In order to run the restore script you need the aws client and the postgres client installed:
+```bash
+curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+unzip awscli-bundle.zip
+sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+sudo apt install postgresql-client-10
+sudo apt install postgresql-client-common
+```
+Set these variables for the restore-script:
+```bash
+export CK8S_CONFIG_PATH=<your config path>
+export S3_BUCKET=$(yq read "${CK8S_CONFIG_PATH}/sc-config.yaml" objectStorage.buckets.harbor)
+export S3_REGION_ENDPOINT=$(yq read "${CK8S_CONFIG_PATH}/sc-config.yaml" objectStorage.s3.regionEndpoint)
+export AWS_ACCESS_KEY_ID=$(sops -d "${CK8S_CONFIG_PATH}/secrets.yaml" | yq read - objectStorage.s3.accessKey)
+export AWS_SECRET_ACCESS_KEY=$(sops -d "${CK8S_CONFIG_PATH}/secrets.yaml" | yq read - objectStorage.s3.secretKey)
+```
+While restoring we need to stop all harbor pods except for the database. Then restart them after the restoration.
+Run these commands to stop the pods, restore the database, and restart the pods:
+```bash
+./bin/ck8s ops kubectl sc scale deployment --replicas 0 -n harbor --all
+./bin/ck8s ops kubectl sc port-forward -n harbor harbor-harbor-database-0 5432:5432 &
+PORT_FORWARD_PID=$!
+./restore-harbor.sh
+kill $PORT_FORWARD_PID
+./bin/ck8s ops kubectl sc scale deployment --replicas 1 -n harbor --all

--- a/scripts/restore/restore-harbor.sh
+++ b/scripts/restore/restore-harbor.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Check https://compliantkubernetes.io/operator-manual/disaster-recovery/ for instructions
+# Restores latest backup from S3_BUCKET. $1 can be used to specify backup
+# To get a list of available backups use:
+# aws s3 ls ${S3_BUCKET}"/backups" --recursive --endpoint-url=$S3_REGION_ENDPOINT
+set -e
+
+HOSTNAME=localhost
+backup_dir=backups
+
+s3_download() {
+    : "${S3_BUCKET:?Missing S3_BUCKET}"
+    : "${S3_REGION_ENDPOINT:?Missing S3_REGION_ENDPOINT}"
+    if [[ -n "$1" ]]; then
+        backup_key=$1
+    else
+        backup_key=$(aws s3 ls "${S3_BUCKET}/backups" \
+          --recursive \
+          --endpoint-url="${S3_REGION_ENDPOINT}" \
+          | sort | tail -n 1 | awk '{print $4}')
+    fi
+    echo "Downloading backup from s3 bucket ${backup_key}" >&2
+    aws s3 cp "s3://${S3_BUCKET}/${backup_key}" harbor.tgz --endpoint-url="${S3_REGION_ENDPOINT}"
+}
+
+extract_backup(){
+    echo "Extracting backups">&2
+    tar xvf harbor.tgz
+}
+
+wait_for_db_ready() {
+    echo "Waiting for DB to be ready" >&2
+    TIMEOUT=12
+    while [ $TIMEOUT -gt 0 ]; do
+        if pg_isready -h $HOSTNAME | grep "accepting connections"; then
+                break
+        fi
+        TIMEOUT=$((TIMEOUT - 1))
+        sleep 5
+    done
+    if [ $TIMEOUT -eq 0 ]; then
+        echo "Harbor DB cannot reach within one minute."
+        exit 1
+    fi
+}
+
+clean_database_data() {
+  echo "Droping existing databases">&2
+  psql -U postgres -d template1 -h $HOSTNAME -c "drop database registry;"
+  psql -U postgres -d template1 -h $HOSTNAME -c "drop database postgres;"
+  psql -U postgres -d template1 -h $HOSTNAME -c "drop database notarysigner;"
+  psql -U postgres -d template1 -h $HOSTNAME -c "drop database notaryserver;"
+
+  echo "Creating clean database">&2
+  psql -U postgres -d template1 -h $HOSTNAME -c "create database registry;"
+  psql -U postgres -d template1 -h $HOSTNAME -c "create database postgres;"
+  psql -U postgres -d template1 -h $HOSTNAME -c "create database notarysigner;"
+  psql -U postgres -d template1 -h $HOSTNAME -c "create database notaryserver;"
+}
+
+restore_database() {
+  echo "Restoring database">&2
+  psql -U postgres -h $HOSTNAME registry < ${backup_dir}/registry.back
+  psql -U postgres -h $HOSTNAME postgres < ${backup_dir}/postgres.back
+  psql -U postgres -h $HOSTNAME notarysigner < ${backup_dir}/notarysigner.back
+  psql -U postgres -h $HOSTNAME notaryserver < ${backup_dir}/notaryserver.back
+}
+
+cleanup_local_files(){
+  echo "Cleaning up local files">&2
+  rm harbor.tgz
+  rm ${backup_dir}/registry.back
+  rm ${backup_dir}/postgres.back
+  rm ${backup_dir}/notarysigner.back
+  rm ${backup_dir}/notaryserver.back
+  rmdir ${backup_dir}
+}
+
+s3_download "$1"
+extract_backup
+wait_for_db_ready
+clean_database_data
+restore_database
+cleanup_local_files
+
+echo "All Harbor data restored"


### PR DESCRIPTION
**What this PR does / why we need it**: This adds the restore script for harbor. I debated putting some documentation here but I though it might be better to just have it on compliantkubernetes.io (PR with that is coming later)

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: part of elastisys/compliantkubernetes#77

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->
Coming later

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
