### PR TITLE
Remove gatekeeper namespace

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -4,3 +4,9 @@
 ### Changed
 
 - The Service Cluster Prometheus now alerts based on Falco metrics. These alerts are sent to Alertmanager as usual so they now have the same flow as all other alerts. This is in addition to the "Falco specific alerting" through Falco sidekick.
+
+
+### Removed
+
+- Removed namespace `gatekeeper` from bootstrap.
+  The namespace can be safely removed from clusters running ck8s  v0.13.0 or later.

--- a/bootstrap/namespaces/helmfile/values/namespaces-wc.yaml.gotmpl
+++ b/bootstrap/namespaces/helmfile/values/namespaces-wc.yaml.gotmpl
@@ -13,7 +13,6 @@ namespaces:
 - name: falco
 {{ end }}
 {{ if .Values.opa.enabled }}
-- name: gatekeeper
 - name: gatekeeper-system
   labels:
     admission.gatekeeper.sh/ignore: "true"

--- a/scripts/clean-wc.sh
+++ b/scripts/clean-wc.sh
@@ -19,7 +19,7 @@ here="$(dirname "$(readlink -f "$0")")"
 "${here}/.././bin/ck8s" ops helmfile wc -l app!=cert-manager destroy
 
 # Clean up namespaces and any other resources left behind by the apps
-"${here}/.././bin/ck8s" ops kubectl wc delete ns falco fluentd gatekeeper gatekeeper-system ingress-nginx monitoring velero
+"${here}/.././bin/ck8s" ops kubectl wc delete ns falco fluentd gatekeeper-system ingress-nginx monitoring velero
 
 # Destroy cert-manager helm release
 "${here}/.././bin/ck8s" ops helmfile wc -l app=cert-manager destroy


### PR DESCRIPTION
**What this PR does / why we need it**:
I noticed that the bootstrap step creates both `gatekeeper` and `gatekeeper-system` namespaces. The gatekeeper namespace seems to be empty so I figured that it was simply not removed when we moved to the new gatekeeper chart.

**Which issue this PR fixes**:

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
