### PR TITLE
Add S3-exporter for metrics about buckets and dashboard for daily tasks

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Authlog now indexed by elasticsearch
 - Added a ClusterRoleBinding for using an OIDC-based cluster admin kubeconfig and a script for generating such a kubeconfig (see `bin/ck8s kubeconfig admin`)
+- S3-exporter for collecting metrics about S3 buckets.
 
 ### Removed
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -14,6 +14,7 @@
 - Authlog now indexed by elasticsearch
 - Added a ClusterRoleBinding for using an OIDC-based cluster admin kubeconfig and a script for generating such a kubeconfig (see `bin/ck8s kubeconfig admin`)
 - S3-exporter for collecting metrics about S3 buckets.
+- Dashboard with common things to check daily, e.g. object storage usage, Elasticsearch snapshots and InfluxDB database sizes.
 
 ### Removed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -35,6 +35,8 @@ objectStorage:
   # s3:
   #   region: "set-me"
   #   regionEndpoint: "set-me"
+  #   # Generally false when using AWS and Exoscale and true for other providers.
+  #   forcePathStyle: true
   buckets:
     harbor: "${CK8S_ENVIRONMENT_NAME}-harbor"
     velero: "${CK8S_ENVIRONMENT_NAME}-velero"
@@ -597,3 +599,16 @@ calicoAccountant:
 
 clusterAdmin:
   admins: []
+s3Exporter:
+  # Also requries objectStorage.type=s3
+  enabled: true
+  interval: 60m
+  scrapeTimeout: 10m
+  resources:
+    limits: {}
+    requests:
+      cpu: 50m
+      memory: 20Mi
+  tolerations: []
+  affinity: {}
+  nodeSelector: {}

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -241,7 +241,7 @@ releases:
     app: grafana-ops
     prometheus: sc
   chart: ./charts/grafana-ops
-  version: 0.1.0
+  version: 0.2.0
   missingFileHandler: Error
   values:
   - values/grafana-ops.yaml.gotmpl

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -379,6 +379,17 @@ releases:
   values:
   - values/blackbox.yaml.gotmpl
 
+- name: s3-exporter
+  namespace: monitoring
+  labels:
+    app: s3-exporter
+  chart: ./charts/s3-exporter
+  version: 0.1.0
+  installed: {{ and (eq .Values.objectStorage.type "s3") .Values.s3Exporter.enabled }}
+  missingFileHandler: Error
+  values:
+  - values/s3-exporter.yaml.gotmpl
+
 # Fluentd
 - name: fluentd
   namespace: fluentd

--- a/helmfile/charts/grafana-ops/Chart.yaml
+++ b/helmfile/charts/grafana-ops/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.1.0
 description: A Helm chart for Grafana dashboards for operators
 name: grafana-ops
-version: 0.1.0
+version: 0.2.0

--- a/helmfile/charts/grafana-ops/dashboards/daily-dashboard.json
+++ b/helmfile/charts/grafana-ops/dashboards/daily-dashboard.json
@@ -1,0 +1,553 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 17,
+      "panels": [],
+      "title": "Elasticsearch snapshots",
+      "type": "row"
+    },
+    {
+      "datasource": "prometheus-sc",
+      "description": "The age of the oldest snapshot currently available. This can help you determine if the retention policy is working. Is the age always increasing or does it regularly decrease when the oldest snapshot is removed?",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "time() - elasticsearch_snapshot_stats_oldest_snapshot_timestamp",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Elasticsearch oldest snapshot age",
+      "type": "stat"
+    },
+    {
+      "datasource": "prometheus-sc",
+      "description": "Shows the number of snapshots stored. This is for keeping track of retention. If the count just keeps increasing, something is wrong with the SLM retention.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "elasticsearch_snapshot_stats_number_of_snapshots",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Elasticsearch number of snapshots",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 15,
+      "panels": [],
+      "title": "S3 buckets",
+      "type": "row"
+    },
+    {
+      "datasource": "prometheus-sc",
+      "description": "This shows the time since an object was last modified for each bucket. If the backups are working objects should be added at least every 24 hours.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 13,
+      "interval": "60m",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "max by (bucket) (time() - max_over_time(s3_last_modified_object_date[1h]))",
+          "interval": "",
+          "legendFormat": "{{bucket}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Time since last modified object",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus-sc",
+      "description": "Show the total size of the *selected* buckets. This is for keeping track of the usage and avoid hitting quota limits.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "hiddenSeries": false,
+      "id": 11,
+      "interval": "60m",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pluginVersion": "7.0.3",
+      "pointradius": 2,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(max_over_time(s3_objects_size_sum_bytes[1h]))",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "S3 total usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:104",
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:105",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus-sc",
+      "description": "Shows the size of all buckets used by Compliant Kubernetes. Note that this does *not* show *all* buckets, only those configured for the environment.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "hiddenSeries": false,
+      "id": 9,
+      "interval": "60m",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max by (bucket) (max_over_time(s3_objects_size_sum_bytes[1h]))",
+          "interval": "",
+          "legendFormat": "{{bucket}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Bucket sizes",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:49",
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:50",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 19,
+      "panels": [],
+      "title": "Misc",
+      "type": "row"
+    },
+    {
+      "datasource": "prometheus-sc",
+      "description": "The size of the individual databases (service_cluster and workload_cluster). Note that you should not rely on this to calculate the total size of the volume. This is just for checking the size of these specific databases.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "deckbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "influxdb_service_cluster_size",
+          "interval": "",
+          "legendFormat": "Service cluster",
+          "refId": "A"
+        },
+        {
+          "expr": "influxdb_workload_cluster_size",
+          "interval": "",
+          "legendFormat": "Workload cluster",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "InfluxDB database size",
+      "type": "stat"
+    },
+    {
+      "content": "In addition to these panels, you should also check the Persistent Volumes and Backups dashboards.\n\n\n\n\n",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 21,
+      "mode": "markdown",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Additional checks",
+      "type": "text"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 25,
+  "style": "dark",
+  "tags": [
+    "daily"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Daily-checks",
+  "uid": "m_qjqIuGz",
+  "version": 3
+}

--- a/helmfile/charts/grafana-ops/templates/dashboard-configmap.yaml
+++ b/helmfile/charts/grafana-ops/templates/dashboard-configmap.yaml
@@ -42,3 +42,7 @@ data:
   networkpolicy-dashboard.json: |-
     {{- .Files.Get "dashboards/networkpolicy-dashboard.json" | nindent 4 }}
 {{- end }}
+{{- if .Values.dashboards.daily.enabled }}
+  daily-dashboard.json: |-
+    {{- .Files.Get "dashboards/daily-dashboard.json" | nindent 4 }}
+{{- end }}

--- a/helmfile/charts/grafana-ops/values.yaml
+++ b/helmfile/charts/grafana-ops/values.yaml
@@ -26,3 +26,5 @@ dashboards:
     enabled: true
   networkpolicy:
     enabled: true
+  daily:
+    enabled: true

--- a/helmfile/charts/s3-exporter/.helmignore
+++ b/helmfile/charts/s3-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helmfile/charts/s3-exporter/Chart.yaml
+++ b/helmfile/charts/s3-exporter/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: s3-exporter
+description: "A Helm chart for s3_exporter: https://github.com/ribbybibby/s3_exporter"
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.4.0"

--- a/helmfile/charts/s3-exporter/templates/NOTES.txt
+++ b/helmfile/charts/s3-exporter/templates/NOTES.txt
@@ -1,0 +1,16 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "s3-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "s3-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "s3-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "s3-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/helmfile/charts/s3-exporter/templates/_helpers.tpl
+++ b/helmfile/charts/s3-exporter/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "s3-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "s3-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "s3-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "s3-exporter.labels" -}}
+helm.sh/chart: {{ include "s3-exporter.chart" . }}
+{{ include "s3-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "s3-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "s3-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "s3-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "s3-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helmfile/charts/s3-exporter/templates/configmap.yaml
+++ b/helmfile/charts/s3-exporter/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "s3-exporter.fullname" . }}-env
+  labels:
+    {{- include "s3-exporter.labels" . | nindent 4 }}
+data:
+  AWS_REGION: {{ .Values.s3.region }}
+  S3_EXPORTER_S3_ENDPOINT_URL: {{ .Values.s3.regionEndpoint }}
+  S3_EXPORTER_S3_FORCE_PATH_STYLE: {{ .Values.s3.forcePathStyle | quote }}

--- a/helmfile/charts/s3-exporter/templates/deployment.yaml
+++ b/helmfile/charts/s3-exporter/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "s3-exporter.fullname" . }}
+  labels:
+    {{- include "s3-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "s3-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "s3-exporter.selectorLabels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "s3-exporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "s3-exporter.fullname" . }}-env
+            - secretRef:
+                name: {{ include "s3-exporter.fullname" . }}-env
+          ports:
+            - name: http
+              containerPort: 9340
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helmfile/charts/s3-exporter/templates/secret.yaml
+++ b/helmfile/charts/s3-exporter/templates/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "s3-exporter.fullname" . }}-env
+  labels:
+    {{- include "s3-exporter.labels" . | nindent 4 }}
+stringData:
+  AWS_ACCESS_KEY_ID: "{{ required "You must provide an access key for accessing S3." .Values.s3.accessKey }}"
+  AWS_SECRET_ACCESS_KEY: "{{ required "You must provide a secret key for accessing S3." .Values.s3.secretKey }}"

--- a/helmfile/charts/s3-exporter/templates/service.yaml
+++ b/helmfile/charts/s3-exporter/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "s3-exporter.fullname" . }}
+  labels:
+    {{- include "s3-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "s3-exporter.selectorLabels" . | nindent 4 }}

--- a/helmfile/charts/s3-exporter/templates/serviceaccount.yaml
+++ b/helmfile/charts/s3-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "s3-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "s3-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helmfile/charts/s3-exporter/templates/servicemonitors.yaml
+++ b/helmfile/charts/s3-exporter/templates/servicemonitors.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "s3-exporter.fullname" . }}
+  labels:
+    {{- include "s3-exporter.labels" . | nindent 4 }}
+spec:
+  endpoints:
+  # One endpoint per bucket so that we can pass the name of the bucket as param
+  {{- $interval := .Values.serviceMonitor.interval }}
+  {{- $scrapeTimeout := .Values.serviceMonitor.scrapeTimeout }}
+  {{- range .Values.s3.buckets }}
+  - port: http
+    scheme: http
+    path: "/probe"
+    interval: {{ $interval }}
+    scrapeTimeout: {{ $scrapeTimeout }}
+    params:
+      bucket:
+      - {{ . }}
+      # We could add a prefix here if we are just interested in specific files/folders
+      # prefix: []
+    metricRelabelings:
+      - sourceLabels: [__address__]
+        regex: '^bucket=(.*);prefix=(.*);$'
+        replacement: '${1}'
+        targetLabel: __param_target
+      - sourceLabels: [__address__]
+        regex: '^bucket=(.*);prefix=(.*);$'
+        replacement: '${2}'
+        targetLabel: '__param_prefix'
+      - targetLabel: __address__
+        replacement: 127.0.0.1:9340  # S3 exporter.
+  {{- end }}
+  jobLabel: s3_exporter
+  selector:
+    matchLabels:
+      {{- include "s3-exporter.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}

--- a/helmfile/charts/s3-exporter/values.yaml
+++ b/helmfile/charts/s3-exporter/values.yaml
@@ -1,0 +1,73 @@
+# Default values for s3-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+s3:
+  region: ""
+  regionEndpoint: ""
+  forcePathStyle: true
+  accessKey: ""
+  secretKey: ""
+  buckets: []
+    # - my-bucket
+    # - second-bucket
+
+serviceMonitor:
+  interval: 10m
+  scrapeTimeout: 60s
+
+replicaCount: 1
+
+image:
+  repository: elastisys/s3_exporter
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 100
+
+service:
+  type: ClusterIP
+  port: 9340
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/helmfile/values/fluentd-configmap.yaml.gotmpl
+++ b/helmfile/values/fluentd-configmap.yaml.gotmpl
@@ -34,8 +34,8 @@ aggregator:
         aws_sec_key "#{ENV['AWS_ACCESS_SECRET_KEY']}"
         {{ if eq .Values.fluentd.forwarder.useRegionEndpoint true -}}
         s3_endpoint {{ .Values.objectStorage.s3.regionEndpoint }}
-        force_path_style true
         {{ end -}}
+        force_path_style {{ .Values.objectStorage.s3.forcePathStyle }}
         s3_region {{ .Values.objectStorage.s3.region }}
         s3_bucket {{ .Values.objectStorage.buckets.scFluentd }}
         {{- end }}

--- a/helmfile/values/grafana-ops.yaml.gotmpl
+++ b/helmfile/values/grafana-ops.yaml.gotmpl
@@ -20,3 +20,5 @@ dashboards:
     enabled: true
   networkpolicy:
     enabled: true
+  daily:
+    enabled: true

--- a/helmfile/values/s3-exporter.yaml.gotmpl
+++ b/helmfile/values/s3-exporter.yaml.gotmpl
@@ -1,0 +1,16 @@
+s3:
+  region: {{ .Values.objectStorage.s3.region | quote }}
+  regionEndpoint: {{ .Values.objectStorage.s3.regionEndpoint | quote }}
+  accessKey: {{ .Values.objectStorage.s3.accessKey | quote }}
+  secretKey: {{ .Values.objectStorage.s3.secretKey | quote }}
+  buckets: {{ values .Values.objectStorage.buckets | toYaml | nindent 2 }}
+  forcePathStyle: {{ .Values.objectStorage.s3.forcePathStyle }}
+
+serviceMonitor:
+  interval: {{ .Values.s3Exporter.interval }}
+  scrapeTimeout: {{ .Values.s3Exporter.scrapeTimeout }}
+
+resources: {{- toYaml .Values.s3Exporter.resources | nindent 2  }}
+nodeSelector: {{- toYaml .Values.s3Exporter.nodeSelector | nindent 2  }}
+tolerations: {{- toYaml .Values.s3Exporter.tolerations | nindent 2  }}
+affinity: {{- toYaml .Values.s3Exporter.affinity | nindent 2  }}

--- a/migration/v0.13.x-v0.14.x/upgrade-apps.md
+++ b/migration/v0.13.x-v0.14.x/upgrade-apps.md
@@ -1,0 +1,13 @@
+# Upgrade v0.13.x to v0.14.0
+
+1. Checkout the new release: `git checkout v0.14.0`
+
+1. Run init to get new defaults: `./bin/ck8s init`.
+   This will add default values for the S3-exporter.
+   Please modify them if needed.
+
+1. If you have `objectStorage.type == s3`, please add `objectstorage.s3.forcePathStyle` to `sc-config.yaml`.
+   The value should be `true` if you have `fluentd.forwarder.useRegionEndpoint == true`.
+   Generally it should be `false` when using AWS and Exoscale S3 and `true` otherwise.
+
+1. Apply the rest: `./bin/ck8s apply sc` and `./bin/ck8s apply wc`.

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -575,3 +575,15 @@ calicoAccountant:
   enabled: true
 clusterAdmin:
   admins: []
+s3Exporter:
+  enabled: true
+  interval: 120s
+  scrapeTimeout: 30s
+  resources:
+    limits: {}
+    requests:
+      cpu: 50m
+      memory: 20Mi
+  tolerations: []
+  affinity: {}
+  nodeSelector: {}

--- a/pipeline/init-unit-tests.bash
+++ b/pipeline/init-unit-tests.bash
@@ -16,6 +16,14 @@ export CK8S_ENVIRONMENT_NAME="${CK8S_ENVIRONMENT_NAME:-apps-${CK8S_CLOUD_PROVIDE
 # Add additional config changes here
 config_update "sc" "issuers.letsencrypt.staging.email" "me@example.com"
 config_update "sc" "issuers.letsencrypt.prod.email" "me@example.com"
+config_update "sc" "objectStorage.type" "s3"
+config_update "sc" "objectStorage.s3.forcePathStyle" "true"
+config_update "sc" "objectStorage.s3.region" "unit-region"
+config_update "sc" "objectStorage.s3.regionAddress" "unit-regionAddress"
+config_update "sc" "objectStorage.s3.regionEndpoint" "unit-regionEndpoint"
+config_update "sc" "objectStorage.s3.accessKey" "unit-accessKey"
+config_update "sc" "objectStorage.s3.secretKey" "unit-secretKey"
+
 config_update "wc" "issuers.letsencrypt.staging.email" "me@example.com"
 config_update "wc" "issuers.letsencrypt.prod.email" "me@example.com"
 config_update "wc" "falco.alerts.enabled" "true"


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds an s3-exporter and service monitor so that we get metrics about our buckets. These metrics can be used to check if backups and retention jobs are working as they should, and keep an eye on the size.

**Which issue this PR fixes**: fixes #373. 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

I'm not happy with the templating of the dashboard to add thresholds. It feels bad in many ways so I would suggest that we drop the last commit and go with a dashboard without thresholds for now.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [x] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
