### PR TITLE
apps wc & sc: default to object storage disabled

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - The Service Cluster Prometheus now alerts based on Falco metrics. These alerts are sent to Alertmanager as usual so they now have the same flow as all other alerts. This is in addition to the "Falco specific alerting" through Falco sidekick.
 - Elasticsearch slm now deletes indices in bulk
+- Default to object storage disabled for the dev flavor.
 
 ### Removed
 

--- a/config/config/flavors/dev-sc.yaml
+++ b/config/config/flavors/dev-sc.yaml
@@ -2,8 +2,18 @@ global:
   issuer: letsencrypt-staging
   verifyTls: false
 
+objectStorage:
+  type: none
+
 dex:
   enableStaticLogin: true
+
+harbor:
+  backup:
+    enabled: false
+  persistence:
+    # Valid options are "filesystem" (persistent volume), "swift", or "objectStorage" (matching global config)
+    type: "filesystem"
 
 prometheus:
   storage:
@@ -42,8 +52,12 @@ elasticsearch:
       otherSizeGB: 1
       otherAgeDays: 7
   snapshot:
+    enabled: false
     retentionSchedule: "0 1 * * *" # 1am
     backupSchedule: "0 */12 * * *" # run twice/day
+
+fluentd:
+  enabled: false
 
 influxDB:
   retention:
@@ -53,3 +67,10 @@ influxDB:
     durationSC: 3d
   persistence:
     size: 10Gi
+  backup:
+    enabled: false
+  backupRetention:
+    enabled: false
+
+velero:
+  enabled: false

--- a/config/config/flavors/dev-wc.yaml
+++ b/config/config/flavors/dev-wc.yaml
@@ -2,6 +2,12 @@ global:
   issuer: letsencrypt-staging
   verifyTls: false
 
+objectStorage:
+  type: none
+
+velero:
+  enabled: false
+
 user:
   namespaces:
     - demo1


### PR DESCRIPTION
**What this PR does / why we need it**:
Object storage gets disabled by default to fasten a developers creation of a cluster for test-purposes.

**Which issue this PR fixes** 
fixes #361 

**How to enable ObjectStorage?**
Before or after https://github.com/elastisys/compliantkubernetes-apps quickstart 5-6:

sc-config:
Set objectStorage:type: s3
Set harbor:persistence:type: objectStorage
Set elasticsearch:snapshot:enabled: true
Set elasticsearch:fluentd:enabled: true
Set influxDB:backup:enabled: true
Set ingressNginx:velero:enabled: true

wc-config:
Set objectStorage:type: s3
Set ingressNginx:velero:enabled: true

When finished editing:
ln -sf $CK8S_CONFIG_PATH/.state/kube_config_${SERVICE_CLUSTER}.yaml $CK8S_CONFIG_PATH/.state/kube_config_sc.yaml
./bin/ck8s apply sc  # Respond "n" if you get a WARN

for CLUSTER in "${WORKLOAD_CLUSTERS[@]}"; do
    ln -sf $CK8S_CONFIG_PATH/.state/kube_config_${CLUSTER}.yaml $CK8S_CONFIG_PATH/.state/kube_config_wc.yaml
    ./bin/ck8s apply wc  # Respond "n" if you get a WARN
done


**How to make "at the minimum you should configure" shorter?**
The editing of ${CK8S_CONFIG_PATH}/secrets.yaml could be removed. Other than that, It could be left as it is as https://github.com/elastisys/compliantkubernetes-apps, quickstart 5-6 isn't needed anymore when ObjectStorage is disabled by default? The "shortening" is that quickstart 5-6 isn't a must anymore.



**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits

**Definition of done:**
- [x] S3 is disabled by default.
- [x] Documentation exists on how to enable and verify it.
- [x] All backups (InfluxDB, Harbor, etc.) which depend on S3 are disabled by default.
- [x] Harbor (which is the biggest consumer of S3) is either using PVCs for persistence or is disabled by default.
- [x] The "at the minimum you should configure" sections in documentation are way shorter.