### PR TITLE
apps wc: Only install alertmgr rbac if enabled

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Only install rbac for user alertmanager if it's enabled.

--- a/helmfile/charts/user-rbac/templates/rolebindings/alertmanager-configurer.yaml
+++ b/helmfile/charts/user-rbac/templates/rolebindings/alertmanager-configurer.yaml
@@ -1,9 +1,10 @@
+{{- if .Values.alertmanager.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: alertmanager-configurer
-  namespace: {{ .Values.alertmanagerNamespace }}
+  namespace: {{ .Values.alertmanager.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13,4 +14,5 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: {{ $user }}
+{{- end }}
 {{- end }}

--- a/helmfile/charts/user-rbac/templates/roles/alertmanager-configurer.yaml
+++ b/helmfile/charts/user-rbac/templates/roles/alertmanager-configurer.yaml
@@ -4,11 +4,12 @@
 # Note! This makes it possible for the user to break alertmanager both by adding
 # bad config and by deleting the rolebinding used to give alertmanager access to the
 # restricted PSP.
+{{- if .Values.alertmanager.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: alertmanager-configurer
-  namespace: {{ .Values.alertmanagerNamespace }}
+  namespace: {{ .Values.alertmanager.namespace }}
 rules:
 # Allow editing the alertmanager-alertmanager secret
 - apiGroups:
@@ -58,3 +59,4 @@ rules:
   - roles
   verbs:
   - bind
+{{- end }}

--- a/helmfile/charts/user-rbac/values.yaml
+++ b/helmfile/charts/user-rbac/values.yaml
@@ -2,4 +2,6 @@ namespaces: []
 users: []
 createNamespaces: true
 enableFalcoViewer: false
-alertmanagerNamespace: monitoring
+alertmanager:
+  enabled: false
+  namespace: monitoring

--- a/helmfile/values/user-rbac.yaml.gotmpl
+++ b/helmfile/values/user-rbac.yaml.gotmpl
@@ -2,4 +2,6 @@ namespaces: {{ toYaml .Values.user.namespaces | nindent 2 }}
 users: {{ toYaml .Values.user.adminUsers | nindent 2 }}
 createNamespaces: {{ .Values.user.createNamespaces }}
 enableFalcoViewer: {{ toYaml .Values.falco.enabled | nindent 2 }}
-alertmanagerNamespace: {{ .Values.user.alertmanager.namespace }}
+alertmanager:
+  enabled: {{ .Values.user.alertmanager.enabled }}
+  namespace: {{ .Values.user.alertmanager.namespace }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes it so that rbac for user alertmanager is only installed when it is actually enabled.

**Which issue this PR fixes**:

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
