### PR TITLE
QA 0.14

### DIFF
--- a/pipeline/test/services/workload-cluster/testPodsReady.sh
+++ b/pipeline/test/services/workload-cluster/testPodsReady.sh
@@ -31,7 +31,7 @@ deployments=(
 if "${enable_nfs_provisioner}"; then
     deployments+=("kube-system nfs-client-provisioner")
 fi
-if "{$enable_opa}"; then
+if "${enable_opa}"; then
     deployments+=("gatekeeper-system gatekeeper-controller-manager")
 fi
 if "${enable_falco_alerts}"; then

--- a/scripts/S3/generate-s3cfg.sh
+++ b/scripts/S3/generate-s3cfg.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
 
+set -eu -o pipefail
+
 # Simple script for generating a sample s3cfg for a couple of known
 # and tested S3 providers.
 
 function usage() {
     echo "Usage:" 1>&2
-    echo "  $0 aws|exoscale|safespring|citycloud access_key secret_key host_base region" 1>&2
+    echo "  $0 {aws|exoscale|safespring|citycloud} {access_key} {secret_key} {host_base} [region]" 1>&2
+    echo "  host_base - the host (and port if other than default) of the service" 1>&2
+    echo "  region - the location where the buckets should be stored. This is ignored for exoscale, safespring and citycloud." 1>&2
+    echo "Examples:" 1>&2
+    echo "  $0 aws abc 123 s3.amazonaws.com eu-north-1" 1>&2
+    echo "  $0 exoscale abc 123 sos-ch-gva-2.exo.io" 1>&2
+    echo "  $0 safespring abc 123 s3.sto1.safedc.net" 1>&2
+    echo "  $0 cityloud abc 123 s3-kna1.citycloud.com:8080" 1>&2
     exit 1
 }
 
@@ -14,17 +23,19 @@ function usage() {
 cat <<EOF
 access_key = $2
 secret_key = $3
-host_base = $4
+EOF
+if [ "$1" = "aws" ]; then
+cat <<EOF
 bucket_location = $5
 EOF
-# Providers that support virtual-hosted-style access to buckets.
-if [ "$1" = "aws" ] || [ "$1" = "exoscale" ]; then
+elif [ "$1" = "exoscale" ]; then
 cat <<EOF
+host_base = $4
 host_bucket = %(bucket)s.$4
 EOF
-# Providers that only support path-style access to buckets.
 elif [ "$1" = "safespring" ] || [ "$1" = "citycloud" ]; then
 cat <<EOF
+host_base = $4
 host_bucket = $4
 EOF
 else


### PR DESCRIPTION
**What this PR does / why we need it**:
QA fixes for the next release.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #372 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

Should I create and push a tag already in this PR? I'm not sure if this is what the release docs say or not. :thinking: 
> When the QA is finished, create the release tag.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
