### PR TITLE
apps sc: upgrade harbor to fix rook bug

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -3,6 +3,11 @@
 - Only install rbac for user alertmanager if it's enabled.
 - Convert all values to integers for elasticsearch slm cronjob
 - The script for generating a user kubeconfig is now `bin/ck8s kubeconfig user` (from `bin/ck8s user-kubeconfig`)
+- Harbor have been updated to v2.2.1.
+
+### Fixed
+
+- When using harbor together with rook there is a potential bug that appears if the database pod is killed and restarted on a new node. This is fixed by upgrading the Harbor helm chart to version 1.6.1.
 
 ### Added
 

--- a/helmfile/01-applications.yaml
+++ b/helmfile/01-applications.yaml
@@ -323,7 +323,7 @@ releases:
   labels:
     app: harbor
   chart: harbor/harbor
-  version: 1.5.1
+  version: 1.6.1
   installed: {{ .Values.harbor.enabled }}
   missingFileHandler: Error
   wait: true


### PR DESCRIPTION
**What this PR does / why we need it**:
When using harbor together with rook there is a potential bug that appears if the database pod is killed and restarted on a new node. This is fixed by upgrading Harbor to version 1.6.1.

**Which issue this PR fixes** 
fixes #173

**Way to test**:
Run ._/bin/ck8s ops kubectl sc delete pod harbor-harbor-database-0 --namespace harbor_
If the pod restarts with status: CrashLoopBackOff, the bug persist. If not, it runs correctly.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [x] Some test is done to check if the problem still persists.