### PR TITLE
bin: Fix check for bash array in team.bash

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 - When using harbor together with rook there is a potential bug that appears if the database pod is killed and restarted on a new node. This is fixed by upgrading the Harbor helm chart to version 1.6.1.
+- The command `team-add` for adding new PGP fingerprints no longer crashes when validating some environment variables.
 
 ### Added
 

--- a/bin/team.bash
+++ b/bin/team.bash
@@ -75,7 +75,7 @@ sops_remove_pgp() {
 # Update all secrets with the public keys from the fingerprints in the SOPS
 # config file.
 sops_update_keys() {
-    : "${secrets:?Missing secrets}"
+    : "${secrets[@]:?Missing secrets}"
     for secret in "${secrets[@]}"; do
         if [ ! -f "${secret}" ]; then
             log_warning "Secret does not exist: ${secret}"
@@ -93,7 +93,7 @@ sops_update_keys() {
 
 # Rotate the data key in all secrets.
 sops_rotate_data_key() {
-    : "${secrets:?Missing secrets}"
+    : "${secrets[@]:?Missing secrets}"
     for secret in "${secrets[@]}"; do
         if [ ! -f "${secret}" ]; then
             log_warning "Secret does not exist: ${secret}"


### PR DESCRIPTION
**What this PR does / why we need it**:
The check was for a normal bash environment variable, but it is actually an array.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: none

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
