### PR TITLE
bin: Make S3 entry script more verbose

### DIFF
--- a/scripts/S3/entry.sh
+++ b/scripts/S3/entry.sh
@@ -10,44 +10,57 @@ CK8S_AUTO_APPROVE=${CK8S_AUTO_APPROVE:-"false"}
 
 here="$(dirname "$(readlink -f "$0")")"
 
+log_info() {
+    echo -e "[\e[34mck8s\e[0m] ${*}" 1>&2
+}
+
+log_error() {
+    echo -e "[\e[31mck8s\e[0m] ${*}" 1>&2
+}
+
 objectstorage_type_sc=$(yq r "${CK8S_CONFIG_PATH}/sc-config.yaml" 'objectStorage.type')
 objectstorage_type_wc=$(yq r "${CK8S_CONFIG_PATH}/wc-config.yaml" 'objectStorage.type')
 
-[ "$objectstorage_type_sc" != "s3" ] && echo "S3 is not enabled in service cluster" 1>&2
-[ "$objectstorage_type_wc" != "s3" ] && echo "S3 is not enabled in workload cluster" 1>&2
+[ "$objectstorage_type_sc" != "s3" ] && log_info "S3 is not enabled in service cluster"
+[ "$objectstorage_type_wc" != "s3" ] && log_info "S3 is not enabled in workload cluster"
 
 if [ "$objectstorage_type_sc" != "s3" ] && [ "$objectstorage_type_wc" != "s3" ]; then
-    echo "S3 is not enabled in either cluster, aborting!" 1>&2
+    log_error "S3 is not enabled in either cluster, aborting!"
     exit 1
 fi
 
 [ "$objectstorage_type_sc" = "s3" ] && buckets_sc=$(yq r "${CK8S_CONFIG_PATH}/sc-config.yaml" 'objectStorage.buckets.*')
 [ "$objectstorage_type_wc" = "s3" ] && buckets_wc=$(yq r "${CK8S_CONFIG_PATH}/wc-config.yaml" 'objectStorage.buckets.*')
 
-buckets=$( { echo "$buckets_sc"; echo "$buckets_wc"; } | sort | uniq | tr '\n' ' ')
+buckets=$( { echo "$buckets_sc"; echo "$buckets_wc"; } | sort | uniq | tr '\n' ' ' | sed s'/.$//')
+
+log_info "Operating on buckets: ${buckets// /', '}"
 
 function usage() {
-    echo "Usage:" 1>&2
-    echo "  $0 [--s3cfg config-path] create|delete" 1>&2
+    log_error "Usage: $0 [--s3cfg config-path] create|delete"
     exit 1
 }
 
 if [ "$1" = "--s3cfg" ]; then
-    [ "$#" -ne 3 ] && echo "Invalid number of arguments" 1>&2 && usage
+    [ "$#" -ne 3 ] && log_error "Invalid number of arguments" && usage
     action="$3"
     cmd="${here}/manager.sh $1 $2 --$3 $buckets"
+    log_info "Using s3cmd config file: $2"
 else
-    [ "$#" -ne 1 ] && echo "Invalid number of arguments" 1>&2 && usage
+    [ "$#" -ne 1 ] && log_error "Invalid number of arguments" && usage
     action="$1"
     cmd="${here}/manager.sh --$1 $buckets"
+    log_info "Using s3cmd config file: ~/.s3cfg"
 fi
 
 if [ "$action" = "delete" ] && ! ${CK8S_AUTO_APPROVE}; then
-    echo -n -e "Are you sure you want to delete all buckets? (y/n): " 1>&2
+    echo -n -e "[\e[34mck8s\e[0m] Are you sure you want to delete all buckets? (y/n): " 1>&2
     read -r reply
-    if [[ "${reply}" == "n" ]]; then
+    if [[ ! "$reply" =~ ^[yY]$ ]]; then
         exit 1
     fi
 fi
+
+log_info "Running: $cmd"
 
 $cmd


### PR DESCRIPTION
**What this PR does / why we need it**:
To make the S3 scripts safer.
This just adds some more output to the entry script:
- Print buckets the will be operated on
- Print which s3cfg config is used
- Print command executed - this really contains the above information as well

**Which issue this PR fixes**:
fixes #424 

**Special notes for reviewer**:
Printing region or endpoint is not very useful imo as that would require the script to parse the s3cfg file.
I find it more sensical to really just present that "Hey, this is the s3cfg file you passed", if you need more information then a simple cat should do :)

I did not create a Yes/no promt for creating buckets as that is not really an intrusive operation.

Feedback appreciated :) 

**Example run**:
![image](https://user-images.githubusercontent.com/12396964/116850167-6a5e5580-abf0-11eb-9aa6-1584dc8b9db8.png)


**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
