### PR TITLE
Fix pipeline

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -40,11 +40,14 @@ jobs:
       CK8S_CONFIG_PATH: ./apps/pipeline/config/exoscale
       CK8S_AUTO_APPROVE: true
     steps:
+    # Note: We use a specific commit for kubespray that includes the terraform
+    # code for Exoscale. This is only used for the terraform part, not for
+    # running kubespray!
     - name: Checkout kubespray
       uses: actions/checkout@v2
       with:
         repository: kubernetes-sigs/kubespray
-        ref: master
+        ref: b77460ec3480868530b6c0b9435d6e900edd8fe4
         path: kubespray
     ## TODO: We cannot currently use ck8s-kubespray since the terraform code
     ## for exoscale is not in the version we have in the submodule

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -106,6 +106,7 @@ objectStorage:
   # s3:
   #   region: "set-me"
   #   regionEndpoint: "set-me"
+  #   forcePathStyle: true
 
   ## Buckets where each respctive application will store its backups.
   buckets:

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -41,6 +41,7 @@ objectStorage:
   s3:
     region: ch-gva-2
     regionEndpoint: https://sos-ch-gva-2.exo.io
+    forcePathStyle: true
 user:
   grafana:
     enabled: true
@@ -146,7 +147,7 @@ harbor:
     disableRedirect: false
   oidc:
     #group claim name used by OIDC Provider
-    groupClaimName: set-me
+    groupClaimName: not-used
     scope: openid,email,profile,offline_access,groups
   backup:
     enabled: true
@@ -477,9 +478,9 @@ alerts:
   opsGenieHeartbeat:
     enabled: false
     url: https://api.eu.opsgenie.com/v2/heartbeats
-    name: set-me
+    name: not-used
   slack:
-    channel: set-me
+    channel: not-used
   opsGenie:
     apiUrl: https://api.eu.opsgenie.com
 externalTrafficPolicy:
@@ -517,8 +518,8 @@ ingressNginx:
     useHostPort: true
     service:
       enabled: false
-      type: set-me
-      annotations: set-me
+      type: not-used
+      annotations: not-used
     # Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
     additionalConfig: {}
   defaultBackend:

--- a/pipeline/config/exoscale/wc-config.yaml
+++ b/pipeline/config/exoscale/wc-config.yaml
@@ -102,6 +102,7 @@ objectStorage:
   s3:
     region: ch-gva-2
     regionEndpoint: https://sos-ch-gva-2.exo.io
+    forcePathStyle: true
 ## User configuration.
 user:
   ## This only controls if the namespaces should be created, user RBAC is always created.


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes the pipeline work again. It is currently failing because the admin kubeconfig is missing. Most likely, this is because we used the master branch of kubespray to get the terraform code for Exoscale. It was recently changed so that the [group names no longer match](https://github.com/kubernetes-sigs/kubespray/pull/7552/files#diff-ffddece82112cdcc07c642b22e3b12843e253f17177885fddb2b4695797dd297) what kubespray v2.15.0 expects.

We checkout master of kubespray here:
https://github.com/elastisys/compliantkubernetes-apps/blob/77011fc0aa6c4c93779ab6fab30942e292dcb896/.github/workflows/end-to-end.yml#L43-L48
This is used to run terraform [here](https://github.com/elastisys/compliantkubernetes-apps/blob/main/.github/workflows/end-to-end.yml#L79). But then we use Kubespray v2.15.0 when running the playbook (note the tag on the container image):
https://github.com/elastisys/compliantkubernetes-apps/blob/77011fc0aa6c4c93779ab6fab30942e292dcb896/.github/workflows/end-to-end.yml#L106-L111


**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: none

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
