### PR TITLE
apps sc: change default retention values

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - The project now requires `helm-diff >= 3.1.2`. Remove the old one (via `rm -rf ~/.local/share/helm/plugins/helm-diff/`), before reinstalling dependencies.
 - Changed the way connectors are provided to dex
+- Default retention values for other* and authlog* are changed to fit the needs better
 
 ### Fixed
 

--- a/config/config/flavors/dev-sc.yaml
+++ b/config/config/flavors/dev-sc.yaml
@@ -52,7 +52,7 @@ elasticsearch:
       otherSizeGB: 1
       otherAgeDays: 7
       authLogSizeGB: 1
-      authLogAgeDays: 7
+      authLogAgeDays: 30
   snapshot:
     enabled: false
     retentionSchedule: "0 1 * * *" # 1am

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -359,9 +359,9 @@ elasticsearch:
       kubeAuditAgeDays: 30
       kubernetesSizeGB: 50
       kubernetesAgeDays: 50
-      otherSizeGB: 10
-      otherAgeDays: 30
-      authLogSizeGB: 10
+      otherSizeGB: 1
+      otherAgeDays: 7
+      authLogSizeGB: 1
       authLogAgeDays: 30
       # (Optional) retention for indices matched by 'postgresql-*'
       # postgresql: false


### PR DESCRIPTION
**What this PR does / why we need it**:
The resources allocated to certain tasks or functions should be accurate. It turns out the storage needed for retention is about 10MB a day. The retention values have been changed to fit this.

**Which issue this PR fixes** 
fixes #401 

**Checklist:**
- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [x] Some test is done to check if the problem still persists.