### PR TITLE
apps sc: logs-retention run even when their is no logs to delete

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,3 +1,7 @@
 ### Release notes
 
 - Changed from depricated nfs provisioner to the new one. Migration is automatic (no manual intervention)
+
+### Changed
+
+- The sc-logs-retention cronjob now runs without error even if no backups were found for automatic removal

--- a/helmfile/charts/sc-logs-retention/scripts/logs-retention.sh
+++ b/helmfile/charts/sc-logs-retention/scripts/logs-retention.sh
@@ -33,28 +33,28 @@ fi
 declare -a SC_LOG_BACKUPS_LATEST
 declare -a SC_LOG_BACKUPS_REST
 mapfile -t SC_LOG_BACKUPS_LATEST < <(echo "${SC_LOG_BACKUPS}" | tail -n "${RETENTION_DAYS}")
-mapfile -t SC_LOG_BACKUPS_REST <   <(echo "${SC_LOG_BACKUPS}" | head -n "-${RETENTION_DAYS}")
+mapfile -t SC_LOG_BACKUPS_REST < <(echo "${SC_LOG_BACKUPS}" | head -n "-${RETENTION_DAYS}")
 
-echo "Listing ${RETENTION_DAYS} latest backups"
-echo "${SC_LOG_BACKUPS_LATEST[@]}"
-echo
-echo "Listing the rest"
-echo "${SC_LOG_BACKUPS_REST[@]}"
-echo
-if [ ${#SC_LOG_BACKUPS_REST[@]} -eq 0 ]; then
+if [ ${#SC_LOG_BACKUPS_REST[*]} -eq 0 ]; then
   echo "No backups were found for automatic removal"
 else
+  echo "Listing ${RETENTION_DAYS} latest backups"
+  echo "${SC_LOG_BACKUPS_LATEST[@]}"
+  echo
+  echo "Listing the rest"
+  echo "${SC_LOG_BACKUPS_REST[@]}"
+  echo
   for BACKUP in "${SC_LOG_BACKUPS_REST[@]}"; do
-      if [[ ${S3_BACKUP} == "true" ]]; then
-          BACKUP_URI="s3://${BUCKET_NAME}/logs/${BACKUP}"
+    if [[ ${S3_BACKUP} == "true" ]]; then
+      BACKUP_URI="s3://${BUCKET_NAME}/logs/${BACKUP}"
 
-          echo "Deleting backup ${BACKUP_URI}"
-          aws s3 rm --recursive "${BACKUP_URI}" --endpoint-url="${S3_REGION_ENDPOINT}"
-      elif [[ ${GCS_BACKUP} == "true" ]]; then
-          BACKUP_URI="gs://${BUCKET_NAME}/logs/${BACKUP}"
+      echo "Deleting backup ${BACKUP_URI}"
+      aws s3 rm --recursive "${BACKUP_URI}" --endpoint-url="${S3_REGION_ENDPOINT}"
+    elif [[ ${GCS_BACKUP} == "true" ]]; then
+      BACKUP_URI="gs://${BUCKET_NAME}/logs/${BACKUP}"
 
-          echo "Deleting backup ${BACKUP_URI}"
-          gsutil -o "Credentials:gs_service_key_file=${GCS_KEYFILE}" rm "$BACKUP_URI"
-      fi
+      echo "Deleting backup ${BACKUP_URI}"
+      gsutil -o "Credentials:gs_service_key_file=${GCS_KEYFILE}" rm "$BACKUP_URI"
+    fi
   done
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
The sc-logs-retention CronJob failed when their was no logs to be deleted. This is now fixed.

**Which issue this PR fixes** 
fixes #418 

**Test** 
s3cmd -c ~/.s3cfg del --recursive s3://exoscale-sc-logs/logs/{The latest folder} until all logs are gone
./bin/ck8s ops kubectl sc create job sc-logs-retention-1 --namespace fluentd --from=cronjob/sc-logs-retention

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [x] Some test is done to check if the problem still persists.