### PR TITLE
apps sc: update node-local-dns chart

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -17,6 +17,7 @@
 - Changed the way connectors are provided to dex
 - Default retention values for other* and authlog* are changed to fit the needs better
 - CK8S version validation accepts version number if exactly at the release tag, otherwise commit hash of current commit. "any" can still be used to disable validation.
+- The node-local-dns chart have been updated to match the upstream manifest. force_tcp have been removed to improve performence and the container image have beve been updated from 1.15.10 to 1.17.0.
 
 ### Fixed
 

--- a/helmfile/charts/node-local-dns/templates/node-local-dns.yaml
+++ b/helmfile/charts/node-local-dns/templates/node-local-dns.yaml
@@ -52,9 +52,6 @@ metadata:
 data:
   Corefile: |
     cluster.local:53 {
-        log {
-          class error
-        }
         errors
         cache {
                 success 9984 30
@@ -70,9 +67,6 @@ data:
         health {{ .Values.localIP }}:8080
         }
     in-addr.arpa:53 {
-        log {
-          class error
-        }
         errors
         cache 30
         reload
@@ -84,9 +78,6 @@ data:
         prometheus :9253
         }
     ip6.arpa:53 {
-        log {
-          class error
-        }
         errors
         cache 30
         reload
@@ -98,17 +89,12 @@ data:
         prometheus :9253
         }
     .:53 {
-        log {
-          class error
-        }
         errors
         cache 30
         reload
         loop
         bind {{ .Values.localIP }} {{ .Values.clusterDNS }}
-        forward . __PILLAR__UPSTREAM__SERVERS__ {
-                force_tcp
-        }
+        forward . __PILLAR__UPSTREAM__SERVERS__
         prometheus :9253
         }
 ---
@@ -131,16 +117,24 @@ spec:
     metadata:
        labels:
           k8s-app: node-local-dns
+       annotations:
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: node-local-dns
       hostNetwork: true
       dnsPolicy: Default  # Don't use cluster DNS.
       tolerations:
-      - operator: Exists
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      - effect: "NoExecute"
+        operator: "Exists"
+      - effect: "NoSchedule"
+        operator: "Exists"
       containers:
       - name: node-cache
-        image: k8s.gcr.io/k8s-dns-node-cache:1.15.10
+        image: k8s.gcr.io/dns/k8s-dns-node-cache:1.17.0
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         args: [ "-localip", "{{ .Values.localIP }},{{ .Values.clusterDNS }}", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream"]
@@ -186,3 +180,23 @@ spec:
           items:
             - key: Corefile
               path: Corefile.base
+---
+# A headless service is a service with a service IP but instead of load-balancing it will return the IPs of our associated Pods.
+# We use this to expose metrics to Prometheus.
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "9253"
+    prometheus.io/scrape: "true"
+  labels:
+    k8s-app: node-local-dns
+  name: node-local-dns
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: 9253
+      targetPort: 9253
+  selector:
+    k8s-app: node-local-dns


### PR DESCRIPTION
**What this PR does / why we need it**:
Since we've had some issues with node-local-dns for external DNS lookup we may want to update it to see if it works better.

**Which issue this PR fixes** 
fixes #227  

**Checklist:**
- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [x] Some test is done to check if the problem still persists.
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.