### PR TITLE
apps sc & wc: fix ck8s version validate

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -16,6 +16,7 @@
 - The project now requires `helm-diff >= 3.1.2`. Remove the old one (via `rm -rf ~/.local/share/helm/plugins/helm-diff/`), before reinstalling dependencies.
 - Changed the way connectors are provided to dex
 - Default retention values for other* and authlog* are changed to fit the needs better
+- CK8S version validation accepts version number if exactly at the release tag, otherwise commit hash of current commit. "any" can still be used to disable validation.
 
 ### Fixed
 

--- a/bin/common.bash
+++ b/bin/common.bash
@@ -69,7 +69,7 @@ log_error() {
 
 version_get() {
     pushd "${root_path}" > /dev/null || exit 1
-    git describe --tags --abbrev=0 HEAD | sed 's/^v//'
+    git describe --exact-match --tags 2> /dev/null || git rev-parse HEAD
     popd > /dev/null || exit 1
 }
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -1,4 +1,8 @@
 global:
+  ## Compliantkubernetes-apps version.
+  ## Use version number if you are exactly at a release tag.
+  ## Otherwise use full commit hash of current commit.
+  ## 'any', can be used to disable this validation.
   ck8sVersion: ${CK8S_VERSION}
   cloudProvider: ${CK8S_CLOUD_PROVIDER}
   clusterName: ${CK8S_ENVIRONMENT_NAME}-sc

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -20,7 +20,9 @@
 ##
 global:
   ## Compliantkubernetes-apps version.
-  ## 'any', can be used when running on non-official release.
+  ## Use version number if you are exactly at a release tag.
+  ## Otherwise use full commit hash of current commit.
+  ## 'any', can be used to disable this validation.
   ck8sVersion: ${CK8S_VERSION}
 
   ## Where the cluster is running.


### PR DESCRIPTION
**What this PR does / why we need it**:
The version validation now checks if you are at the exact tag/branch rather then just the latest tag.

**Which issue this PR fixes** 
fixes #189 

**Checklist:**
- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [x]  Some test is done to check if the problem still persists.
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [x] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.