### PR TITLE
Fixed issue with starboard-operator

### DIFF
--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -115,7 +115,7 @@ releases:
   labels:
     app: starboard-operator
   chart: ./upstream/starboard-operator
-  version: 0.5.3
+  version: 0.5.1
   missingFileHandler: Error
   values:
   - values/starboard-operator.yaml.gotmpl

--- a/helmfile/upstream/starboard-operator/Chart.yaml
+++ b/helmfile/upstream/starboard-operator/Chart.yaml
@@ -6,12 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.3
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.10.3
+appVersion: 0.10.1
 
 # kubeVersion: A SemVer range of compatible Kubernetes versions (optional)
 

--- a/helmfile/upstream/starboard-operator/crds/vulnerabilityreports.crd.yaml
+++ b/helmfile/upstream/starboard-operator/crds/vulnerabilityreports.crd.yaml
@@ -31,15 +31,11 @@ spec:
             report:
               type: object
               required:
-                - updateTimestamp
                 - scanner
                 - artifact
                 - summary
                 - vulnerabilities
               properties:
-                updateTimestamp:
-                  type: string
-                  format: date-time
                 scanner:
                   type: object
                   required:

--- a/helmfile/upstream/starboard-operator/values.yaml
+++ b/helmfile/upstream/starboard-operator/values.yaml
@@ -271,7 +271,7 @@ polaris:
 
 conftest:
   # imageRef the image reference
-  imageRef: docker.io/openpolicyagent/conftest:v0.25.0
+  imageRef: docker.io/openpolicyagent/conftest:v0.23.0
 
 rbac:
   create: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed starboard from using a too new version.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
