### PR TITLE
apps: Updated nfs provisioner to the new one

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,3 @@
+### Release notes
+
+- Changed from depricated nfs provisioner to the new one. Migration is automatic (no manual intervention)

--- a/bootstrap/storageclass/helmfile/helmfile.yaml
+++ b/bootstrap/storageclass/helmfile/helmfile.yaml
@@ -1,6 +1,9 @@
 repositories:
+  # TODO remove when the nfs-client-provisioner is removed
 - name: stable
   url: https://charts.helm.sh/stable
+- name: nfs-subdir-external-provisioner
+  url: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
 
 helmDefaults:
   timeout: 600
@@ -19,18 +22,31 @@ environments:
       - "{{ requiredEnv "CK8S_CONFIG_PATH" }}/secrets.yaml"
 
 releases:
-# NFS
+# TODO Remove after this has been released, it's just to make sure old nfs installations are removed
 - name: nfs-client-provisioner
   namespace: kube-system
   labels:
     app: nfs-client-provisioner
   chart: stable/nfs-client-provisioner
   version: 1.2.6
-  installed: {{ .Values.storageClasses.nfs.enabled }}
+  installed: false
   missingFileHandler: Error
   wait: true
   values:
   - values/nfs-client-provisioner.yaml.gotmpl
+
+# NFS
+- name: nfs-subdir-external-provisioner
+  namespace: kube-system
+  labels:
+    app: nfs-subdir-external-provisioner
+  chart: nfs-subdir-external-provisioner/nfs-subdir-external-provisioner
+  version: 4.0.10
+  installed: {{ .Values.storageClasses.nfs.enabled }}
+  missingFileHandler: Error
+  wait: true
+  values:
+  - values/nfs-subdir-external-provisioner.yaml.gotmpl
 
 # Local volume provisioner
 - name: local-volume-provisioner

--- a/bootstrap/storageclass/helmfile/values/nfs-subdir-external-provisioner.yaml.gotmpl
+++ b/bootstrap/storageclass/helmfile/values/nfs-subdir-external-provisioner.yaml.gotmpl
@@ -11,7 +11,7 @@ storageClass:
   {{ end }}
 
 serviceAccount:
-  name: nfs-client-provisioner
+  name: nfs-subdir-external-provisioner
 
 nfs:
   path: {{ .Values.nfsProvisioner.path }}

--- a/bootstrap/storageclass/scripts/install-storage-class-provider.sh
+++ b/bootstrap/storageclass/scripts/install-storage-class-provider.sh
@@ -4,9 +4,12 @@ install_storage_class_provider() {
     : "${storageclass_path:?Missing storageclass path}"
     case "${1}" in
     "nfs-client")
-        echo "Install nfs-client-provisioner" >&2
+        echo "Install nfs-subdir-external-provisioner" >&2
+        # TODO Remove this when we removed this chart from the helmfile
         helmfile -f "${storageclass_path}/helmfile/helmfile.yaml" \
             -e "${2}" -l app=nfs-client-provisioner apply --suppress-diff
+        helmfile -f "${storageclass_path}/helmfile/helmfile.yaml" \
+            -e "${2}" -l app=nfs-subdir-external-provisioner apply --suppress-diff
     ;;
     "local-storage")
         echo "Install local-storage storage class" >&2

--- a/helmfile/charts/common-psp-rbac/templates/nfs-client-provisioner-psp-rbac.yaml
+++ b/helmfile/charts/common-psp-rbac/templates/nfs-client-provisioner-psp-rbac.yaml
@@ -24,5 +24,5 @@ roleRef:
   name: nfs-provisioner-privileged
 subjects:
 - kind: ServiceAccount
-  name: nfs-client-provisioner
+  name: nfs-subdir-external-provisioner
   namespace: kube-system

--- a/pipeline/test/services/service-cluster/testPodsReady.sh
+++ b/pipeline/test/services/service-cluster/testPodsReady.sh
@@ -42,7 +42,7 @@ if "${enable_es_client_deploy}"; then
     deployments+=("elastic-system opendistro-es-client")
 fi
 if "${enable_nfs_provisioner}"; then
-    deployments+=("kube-system nfs-client-provisioner")
+    deployments+=("kube-system nfs-subdir-external-provisioner")
 fi
 if "${enable_harbor}"; then
     deployments+=(

--- a/pipeline/test/services/workload-cluster/testPodsReady.sh
+++ b/pipeline/test/services/workload-cluster/testPodsReady.sh
@@ -32,7 +32,7 @@ deployments=(
     "monitoring kube-prometheus-stack-kube-state-metrics"
 )
 if "${enable_nfs_provisioner}"; then
-    deployments+=("kube-system nfs-client-provisioner")
+    deployments+=("kube-system nfs-subdir-external-provisioner")
 fi
 if "${enable_opa}"; then
     deployments+=("gatekeeper-system gatekeeper-controller-manager")


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaced depricated nfs-client-provisioner to the new [nfs-subdir-external-provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/tree/master/charts/nfs-subdir-external-provisioner)

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
