### PR TITLE
config: update default cluster DNS IP to match kubespray defaults

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -5,3 +5,7 @@
 ### Changed
 
 - The sc-logs-retention cronjob now runs without error even if no backups were found for automatic removal
+
+### Fixed
+- The `clusterDns` config variable now matches Kubespray defaults.
+  Using the wrong value causes node-local-dns to not be used.

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -10,7 +10,7 @@ global:
   opsDomain: "set-me"
   issuer: letsencrypt-staging
   verifyTls: true
-  clusterDns: "10.43.0.10"
+  clusterDns: "10.233.0.3"
 
 storageClasses:
   # Name of the default storageclass.

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -51,7 +51,7 @@ global:
   verifyTls: true
 
   ## IP of the cluster DNS in kubernetes
-  clusterDns: "10.43.0.10"
+  clusterDns: "10.233.0.3"
 
 ## Configuration of storageclasses.
 storageClasses:

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -6,7 +6,7 @@ global:
   opsDomain: ops.pipeline-exoscale.elastisys.se
   issuer: letsencrypt-staging
   verifyTls: false
-  clusterDns: 10.43.0.10
+  clusterDns: 10.233.0.3
 storageClasses:
   # Name of the default storageclass.
   # Normally one of 'nfs-client', 'cinder-storage', 'local-storage', 'ebs-gp2'.

--- a/pipeline/config/exoscale/wc-config.yaml
+++ b/pipeline/config/exoscale/wc-config.yaml
@@ -42,7 +42,7 @@ global:
   ## Verify ingress certificates
   verifyTls: false
   ## IP of the cluster DNS in kubernetes
-  clusterDns: 10.43.0.10
+  clusterDns: 10.233.0.3
 ## Configuration of storageclasses.
 storageClasses:
   ## Name of the 'default' storageclass in kubernetes.


### PR DESCRIPTION
**What this PR does / why we need it**: In kubespray the default ip for cluster DNS (the coredns service) is 10.233.0.3, this updates our values to match that. Without this node-local-dns is never used.

```
kubectl get svc -n kube-system
NAME                               TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                        AGE
...
coredns                            ClusterIP   10.233.0.3      <none>        53/UDP,53/TCP,9153/TCP         17d
...
```

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: not planned

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

Pipeline config is also updated.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
