### PR TITLE
[1] Added possibility to specify cluster admin groups

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -7,5 +7,10 @@
 - The sc-logs-retention cronjob now runs without error even if no backups were found for automatic removal
 
 ### Fixed
+
 - The `clusterDns` config variable now matches Kubespray defaults.
   Using the wrong value causes node-local-dns to not be used.
+
+### Added
+
+- Option to set cluster admin groups

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -629,7 +629,8 @@ calicoAccountant:
   enabled: true
 
 clusterAdmin:
-  admins: []
+  users: []
+  groups: []
 s3Exporter:
   # Also requries objectStorage.type=s3
   enabled: true

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -414,7 +414,8 @@ calicoAccountant:
   enabled: true
 
 clusterAdmin:
-  admins: []
+  users: []
+  groups: []
 
 starboard:
   # Note: The developers of starboard explicitly recommend against setting your own resources

--- a/helmfile/charts/cluster-admin-rbac/templates/clusterrolebindings/cluster-admin.yaml
+++ b/helmfile/charts/cluster-admin-rbac/templates/clusterrolebindings/cluster-admin.yaml
@@ -13,3 +13,8 @@ subjects:
   kind: User
   name: {{ $user }}
 {{- end }}
+{{- range $group := .Values.groups }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: {{ $group }}
+{{- end }}

--- a/helmfile/charts/cluster-admin-rbac/values.yaml
+++ b/helmfile/charts/cluster-admin-rbac/values.yaml
@@ -1,1 +1,2 @@
 users: []
+groups: []

--- a/helmfile/values/cluster-admin-rbac.yaml.gotmpl
+++ b/helmfile/values/cluster-admin-rbac.yaml.gotmpl
@@ -1,1 +1,2 @@
-users: {{ toYaml .Values.clusterAdmin.admins | nindent 2 }}
+users: {{ toYaml .Values.clusterAdmin.users | nindent 2 }}
+groups: {{ toYaml .Values.clusterAdmin.groups | nindent 2 }}

--- a/migration/v0.16.x-v0.17.x/upgrade-apps.md
+++ b/migration/v0.16.x-v0.17.x/upgrade-apps.md
@@ -1,0 +1,17 @@
+# Upgrade v0.16.x to v0.17.0
+
+1. Checkout the new release: `git checkout v0.17.0`
+
+1. Rename `clusterAdmin.admins` to `clusterAdmin.users` for both `wc-config.yaml` and `sc-config.yaml`
+
+1. Run init to get new defaults:
+
+    ```bash
+    bin/ck8s init
+    ```
+
+1. Upgrade applications:
+
+    ```bash
+    bin/ck8s apply {sc|wc}
+    ```

--- a/migration/v0.16.x-v0.17.x/upgrade-apps.md
+++ b/migration/v0.16.x-v0.17.x/upgrade-apps.md
@@ -4,6 +4,9 @@
 
 1. Rename `clusterAdmin.admins` to `clusterAdmin.users` for both `wc-config.yaml` and `sc-config.yaml`
 
+1. Check that `global.clusterDns` in both `wc-config.yaml` and `sc-config.yaml` matches the IP for the `coredns` service in `kube-system` namespace.
+   Old default values did not match defaults in Kubespray.
+
 1. Run init to get new defaults:
 
     ```bash

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -586,7 +586,8 @@ metricsServer:
 calicoAccountant:
   enabled: true
 clusterAdmin:
-  admins: []
+  users: []
+  groups: []
 s3Exporter:
   enabled: true
   interval: 120s

--- a/pipeline/config/exoscale/wc-config.yaml
+++ b/pipeline/config/exoscale/wc-config.yaml
@@ -347,7 +347,8 @@ metricsServer:
 calicoAccountant:
   enabled: true
 clusterAdmin:
-  admins: []
+  users: []
+  groups: []
 starboard:
   resources: {}
   tolerations: []


### PR DESCRIPTION
**What this PR does / why we need it**:

Simple option to add cluster admin groups

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: N/A

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
