### PR TITLE
pipeline: add back missing files

### DIFF
--- a/pipeline/apply-sc.bash
+++ b/pipeline/apply-sc.bash
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -u -o pipefail
+
+here="$(dirname "$(readlink -f "$0")")"
+pipeline_dir="${here}"
+ck8s="${here}/../bin/ck8s"
+bin_path="${here}/../bin"
+
+# shellcheck disable=SC1090
+source "${here}/common.bash"
+# shellcheck disable=SC1090
+source "${bin_path}/common.bash"
+
+"${ck8s}" apply sc
+apply_exit_code="${?}"
+
+"${pipeline_dir}/list-releases.bash" "service_cluster"
+echo "'${pipeline_dir}/list-releases.bash service_cluster' exited with code: ${?}"
+
+exit "${apply_exit_code}"

--- a/pipeline/apply-wc.bash
+++ b/pipeline/apply-wc.bash
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -u -o pipefail
+
+here="$(dirname "$(readlink -f "$0")")"
+pipeline_dir="${here}"
+ck8s="${here}/../bin/ck8s"
+bin_path="${here}/../bin"
+
+# shellcheck disable=SC1090
+source "${here}/common.bash"
+# shellcheck disable=SC1090
+source "${bin_path}/common.bash"
+
+"${ck8s}" apply wc
+apply_exit_code="${?}"
+
+"${pipeline_dir}/list-releases.bash" "workload_cluster"
+echo "'${pipeline_dir}/list-releases.bash workload_cluster' exited with code: ${?}"
+
+exit "${apply_exit_code}"

--- a/pipeline/list-releases.bash
+++ b/pipeline/list-releases.bash
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# This script:
+## Lists helm releases
+## Gets failed helm releases
+## Print k8s objects in namespaces with a failed release
+
+set -eu -o pipefail
+
+here="$(dirname "$(readlink -f "${0}")")"
+bin_path="${here}/../bin"
+
+# shellcheck disable=SC1090
+source "${here}/common.bash"
+# shellcheck disable=SC1090
+source "${bin_path}/common.bash"
+
+if [ "${#}" -ne 1 ]; then
+    echo "Missing cluster paramter"
+    exit 1
+fi
+
+cluster="${1}"
+cluster_abbr=""
+secrets=""
+
+if [ "${cluster}" = "service_cluster" ]; then
+    config_load sc
+    kubeconfig="${secrets[kube_config_sc]}"
+    cluster_abbr="sc"
+elif [ "${cluster}" = "workload_cluster" ]; then
+    config_load wc
+    kubeconfig="${secrets[kube_config_wc]}"
+    cluster_abbr="wc"
+fi
+
+
+echo "###############################"
+echo -e "Listing helm releases\n"
+
+"${bin_path}"/ck8s ops helmfile "${cluster_abbr}" status || true
+
+failed_releases=$("${bin_path}"/ck8s ops helmfile "${cluster_abbr}" status --args="--output=json" 2>/dev/null \
+    | jq 'select(.info.status=="failed")' || true)
+
+echo -e "###############################\n"
+
+namespaces=$(echo "${failed_releases}" | jq '.namespace ' | jq -rs 'unique | .[]')
+
+ck8s_kubectl () {
+    # shellcheck disable=SC2068
+    with_kubeconfig "${kubeconfig}" kubectl ${@}
+}
+
+# Maybe we should set this through pipeline a variable?
+get_resource_list="all pvc secrets certificates ingresses"
+
+# shellcheck disable=SC2068
+for namespace in ${namespaces}; do
+    for resource in ${get_resource_list}; do
+        echo -e "Listing '${resource}' in namespace '${namespace}'\n"
+        ck8s_kubectl -n "${namespace}" get "${resource}"
+        echo
+    done
+done


### PR DESCRIPTION
**What this PR does / why we need it**: We removed some files from the pipeline folder that we didn't think was used. But seems like we didn't look properly. This should return the files that we need.
Here is a pipeline that failed because of the missing files: https://github.com/elastisys/compliantkubernetes-apps/actions/runs/911463783
Also see this line: https://github.com/elastisys/compliantkubernetes-apps/blob/417f3c148c6510222d0b2031ae869cc35e904045/.github/workflows/end-to-end.yml#L158

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: not planned

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
