### PR TITLE
Enable additional static clients for dex

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Added
 
 - Option to set cluster admin groups
+- Configuration option `dex.additionalStaticClients` in `secrets.yaml` can now be used to define additional static clients for Dex.
 
 ### Removed
 

--- a/config/secrets/sc-secrets.yaml
+++ b/config/secrets/sc-secrets.yaml
@@ -101,3 +101,9 @@ dex:
     #     clientSecret: "" # Azure app secret
     #     #groups: # App needs to have `Directory.Read.All` permission
     #     #  - example-group
+  additionalStaticClients: []
+    #  - id: example-app
+    #    secret: ZXhhbXBsZS1hcHAtc2VjcmV0
+    #    name: 'Example App'
+    #    redirectURIs:
+    #      - 'http://192.168.42.219:31850/oauth2/callback'

--- a/helmfile/values/dex.yaml.gotmpl
+++ b/helmfile/values/dex.yaml.gotmpl
@@ -75,6 +75,9 @@ config:
         - https://kibana.{{ .Values.global.baseDomain }}/auth/openid/login
         - https://kibana.{{ .Values.global.baseDomain }}/app/kibana
 {{ end }}
+{{ if .Values.dex.additionalStaticClients }}
+  {{- toYaml .Values.dex.additionalStaticClients | nindent 4 }}
+{{ end }}
 
 {{ if .Values.dex.enableStaticLogin }}
   enablePasswordDB: true

--- a/migration/v0.16.x-v0.17.x/dex-update-script.yaml
+++ b/migration/v0.16.x-v0.17.x/dex-update-script.yaml
@@ -1,0 +1,3 @@
+- command: update
+  path: dex.additionalStaticClients
+  value: []

--- a/migration/v0.16.x-v0.17.x/migrate-dex-additional-static-clients.sh
+++ b/migration/v0.16.x-v0.17.x/migrate-dex-additional-static-clients.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
+here="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+secret="${CK8S_CONFIG_PATH}/secrets.yaml"
+secret_tmp="${CK8S_CONFIG_PATH}/secrets_tmp.yaml"
+sops_conf="${CK8S_CONFIG_PATH}/.sops.yaml"
+
+update_script=$(mktemp -p /tmp update-script.XXXXXXXXXX.yaml)
+cp "${here}/dex-update-script.yaml" "${update_script}"
+
+# read all dex's static clients from ck8s cluster
+static_clients_yaml=$(./bin/ck8s ops kubectl sc get secret dex --namespace dex --output jsonpath='{.data.config\\.yaml}' | base64 --decode | yq read - staticClients)
+
+# delete clients that are part of a standard v0.16.x installation so only custom clients remain
+static_clients_yaml=$(echo "$static_clients_yaml" | \
+    yq delete - "id==kubelogin" | \
+    yq delete - "id==grafana" | \
+    yq delete - "id==grafana-ops" | \
+    yq delete - "id==harbor" | \
+    yq delete - "id==kibana-sso" | \
+    yq delete - "id==grafana")
+
+# merge custom clients from ck8s cluster into secrets config under additionalStaticClients
+echo "$static_clients_yaml" | yq prefix - "[0].value" | yq merge --inplace "${update_script}" -
+sops -d "${secret}" | \
+    yq write --script "${update_script}" - | \
+    sops --config "${sops_conf}" --input-type=yaml --output-type=yaml -e /dev/stdin > "${secret_tmp}"
+
+cp "${secret}" "${secret}.bak"
+mv "${secret_tmp}" "${secret}"
+
+rm "${update_script}"

--- a/migration/v0.16.x-v0.17.x/upgrade-apps.md
+++ b/migration/v0.16.x-v0.17.x/upgrade-apps.md
@@ -11,6 +11,12 @@
 1. Check that `global.clusterDns` in both `wc-config.yaml` and `sc-config.yaml` matches the IP for the `coredns` service in `kube-system` namespace.
    Old default values did not match defaults in Kubespray.
 
+1. Run migration script: `./migration/v0.16.x-v0.17.x/migrate-dex-additional-static-clients.sh`
+
+   This script introduces `dex.additionalStaticClients` and create entries for each additional static client already defined on the CK8S cluster.
+
+1. Verify if the script added all your custom static clients under `dex.additionalStaticClients`. If so, delete the backup at `${CK8S_CONFIG_PATH}/secrets.yaml.bak`.
+
 1. Run init to get new defaults:
 
     ```bash

--- a/pipeline/config/exoscale/secrets.yaml
+++ b/pipeline/config/exoscale/secrets.yaml
@@ -38,6 +38,7 @@ dex:
     staticPassword: $2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W
     kubeloginClientSecret: somelongsecret
     connectors: []
+    additionalStaticClients: []
 user:
     grafanaPassword: somelongsecret
     alertmanagerPassword: somelongsecret


### PR DESCRIPTION
**What this PR does / why we need it**:

In this PR I've added `dex.additionalStaticClients` to be able to specify Dex clients for application that do not belong to CK8s. More details in #456.

This PR also contains a migration script that will pull any custom static clients already defined for Dex and move it into the `secrets.yaml` at the appropriate place.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #456

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

I've added `dex.additionalStaticClients` to the secrets of the pipline just because it seemed like a good thing to do.
But the pipeline didn't actually fail when it was missing.

I actually expected it to fail because the Dex template would `range` a value that doesn't exist.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
