### PR TITLE
apps sc: if-case for if harbor is enabled or not in blackbox-exporter

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - The `clusterDns` config variable now matches Kubespray defaults.
   Using the wrong value causes node-local-dns to not be used.
+- Blackbox-exporter now ignores checking the harbor endpoint if harbor is disabled.
 
 ### Added
 

--- a/helmfile/values/blackbox.yaml.gotmpl
+++ b/helmfile/values/blackbox.yaml.gotmpl
@@ -35,11 +35,13 @@ targets:
     interval: 60s
     scrapeTimeout: 30s
     module: http_2xx
+  {{- if .Values.harbor.enabled }}
   - name: harbor
     url: https://harbor.{{ .Values.global.baseDomain }}/api/v2.0/ping
     interval: 60s
     scrapeTimeout: 30s
     module: http_2xx
+  {{- end }}
   - name: kibana
     url: https://kibana.{{ .Values.global.baseDomain }}/api/status
     interval: 60s

--- a/migration/v0.16.x-v0.17.x/upgrade-apps.md
+++ b/migration/v0.16.x-v0.17.x/upgrade-apps.md
@@ -28,3 +28,9 @@
     ```bash
     bin/ck8s apply {sc|wc}
     ```
+
+1. Restart the blackbox-prometheus-blackbox-exporter pod to make changes active.
+
+   ```bash
+   bin/ck8s ops kubectl sc get pods -n monitoring | awk '/blackbox/{print $1}'| xargs  ./bin/ck8s ops kubectl sc delete -n monitoring pod
+   ```


### PR DESCRIPTION
**What this PR does / why we need it**:
Blackbox-exporter checks harbor endpoint even if harbor is disabled. This is now disabled if harbor is disabled.

**Which issue this PR fixes**: 
fixes #482 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).