### PR TITLE
Fixed issue where curator would fail to start with postgres enabled

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -22,6 +22,7 @@ Grafana 8.0.1 and Prometheus 2.27.1.
 - "serviceMonitor/" have been added to all prometheus targets in our tests to make them work
 - The openid url port have been changed from 32000 to 5556 to match the current setup.
 - sc-log-rentention fixed to delete all logs within a 5 second loop.
+- Fixed issue where curator would fail if postgres retention was enabled
 
 ### Added
 

--- a/helmfile/elastisys/opendistro-es/templates/curator/curator-cm.yaml
+++ b/helmfile/elastisys/opendistro-es/templates/curator/curator-cm.yaml
@@ -8,10 +8,8 @@ metadata:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
 data:
   action_file.yml: {{ tpl (toYaml (.Files.Get "files/action_file.yml") | indent 2) $ }}
-
   {{- if .Values.curator.postgresql }}
-  {{ tpl (toYaml (.Files.Get "files/postgresql-actions.yml") | indent 4) $ }}
+  {{ tpl (print (.Files.Get "files/postgresql-actions.yml") | nindent 6) $ }}
   {{- end }}
-  
   config.yml: {{ tpl (toYaml .Values.curator.config_yml | indent 2) $ }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Bug fix that made curator always fail when enabling postgres retention.

The `toYaml` function added a `|` to the config which would render it a unvalid yaml

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

Diff after applying, highlighting the issue.

```
            source: creation_date
            direction: older
            unit: days
            unit_count: 30
          - filtertype: kibana
            exclude: True
-       |
+   
        9:
          action: delete_indices
          description: "Clean up the oldest postgresql-* indices that exceeds total disk space 30 GB"
```

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
