### PR TITLE
apps sc: openid url port fix

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -19,6 +19,7 @@
 - Kube-prometheus-stack are now being upgraded from 12.8.0 to 16.6.1 to fix dashboard errors.
 Grafana 8.0.1 and Prometheus 2.27.1.
 - "serviceMonitor/" have been added to all prometheus targets in our tests to make them work
+- The openid url port have been changed from 32000 to 5556 to match the current setup.
 
 ### Added
 

--- a/helmfile/values/opendistro-es.yaml.gotmpl
+++ b/helmfile/values/opendistro-es.yaml.gotmpl
@@ -136,7 +136,7 @@ elasticsearch:
                     type: openid
                     challenge: false
                     config:
-                      openid_connect_url: http://dex.dex.svc.cluster.local:32000/.well-known/openid-configuration
+                      openid_connect_url: http://dex.dex.svc.cluster.local:5556/.well-known/openid-configuration
                       openid_connect_idp.verify_hostnames: false
                       openid_connect_idp.enable_ssl: false
                       subject_key: {{ .Values.elasticsearch.sso.subject_key }}

--- a/migration/v0.16.x-v0.17.x/migrate-openid.sh
+++ b/migration/v0.16.x-v0.17.x/migrate-openid.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+here="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
+# Restart the master pods so that they mount the latest version of the secret after apply
+"${here}/../../bin/ck8s" ops kubectl sc delete pod -n elastic-system -l role=master
+
+# Make the script executable
+"${here}/../../bin/ck8s" ops kubectl sc -n elastic-system exec opendistro-es-master-0 -- chmod +x ./plugins/opendistro_security/tools/securityadmin.sh
+# Run the script to update the configuration
+"${here}/../../bin/ck8s" ops kubectl sc -n elastic-system exec opendistro-es-master-0 -- ./plugins/opendistro_security/tools/securityadmin.sh \
+    -f plugins/opendistro_security/securityconfig/config.yml \
+    -icl -nhnv \
+    -cacert config/admin-root-ca.pem \
+    -cert config/admin-crt.pem \
+    -key config/admin-key.pem
+
+# Restart Kibana to run by the new configurations
+"${here}/../../bin/ck8s" ops kubectl sc delete pod -n elastic-system -l role=kibana

--- a/migration/v0.16.x-v0.17.x/upgrade-apps.md
+++ b/migration/v0.16.x-v0.17.x/upgrade-apps.md
@@ -45,3 +45,7 @@
    ```bash
    bin/ck8s ops kubectl sc get pods -n monitoring | awk '/blackbox/{print $1}'| xargs  ./bin/ck8s ops kubectl sc delete -n monitoring pod
    ```
+
+1. Run migration script: `./migration/v0.16.x-v0.17.x/migrate-openid.sh`
+
+   This script will reload the security config config.yml to make openid run by the new port


### PR DESCRIPTION
**What this PR does / why we need it**:
In my work with the release, i discovered that the port used for connecting with openid for authentication have been changed from 32000 to 5556. This made the authentication for Kibana fail.

**Which issue this PR fixes**: 
fixes #503 


**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).