### PR TITLE
apps sc: sc-log-retention deletion fix

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -21,6 +21,7 @@
 Grafana 8.0.1 and Prometheus 2.27.1.
 - "serviceMonitor/" have been added to all prometheus targets in our tests to make them work
 - The openid url port have been changed from 32000 to 5556 to match the current setup.
+- sc-log-rentention fixed to delete all logs within a 5 second loop.
 
 ### Added
 

--- a/helmfile/charts/sc-logs-retention/scripts/logs-retention.sh
+++ b/helmfile/charts/sc-logs-retention/scripts/logs-retention.sh
@@ -47,9 +47,19 @@ else
   for BACKUP in "${SC_LOG_BACKUPS_REST[@]}"; do
     if [[ ${S3_BACKUP} == "true" ]]; then
       BACKUP_URI="s3://${BUCKET_NAME}/logs/${BACKUP}"
-
+      # As some providers have a fualty or incomplete implementation of the S3 API, a loop is needed in cases it's lacking
       echo "Deleting backup ${BACKUP_URI}"
-      aws s3 rm --recursive "${BACKUP_URI}" --endpoint-url="${S3_REGION_ENDPOINT}"
+
+      # Get the number of files currenctly avalible for deletion
+      NR_OF_FILES=$(aws s3 ls "${BACKUP_URI}" --endpoint-url="${S3_REGION_ENDPOINT}" | wc -l)
+      # As long as there are files to be deleted, keep deleting them
+      while [ "$NR_OF_FILES" -gt 0 ]; do
+        aws s3 rm --recursive "${BACKUP_URI}" --endpoint-url="${S3_REGION_ENDPOINT}"
+        # Wait 5 seconds to see if new files have been created while the deletion was done
+        sleep 5
+        NR_OF_FILES=$(aws s3 ls "${BACKUP_URI}" --endpoint-url="${S3_REGION_ENDPOINT}" | wc -l)
+      done
+
     elif [[ ${GCS_BACKUP} == "true" ]]; then
       BACKUP_URI="gs://${BUCKET_NAME}/logs/${BACKUP}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now, all logs doesn't get removed at the same time which results in that the job have to be ran multiple times potentially. This is now fixed by adding a while-loop with a 5 second delay.

**Which issue this PR fixes**: 
fixes #340 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).