### PR TITLE
apps sc & wc: release 0.17 fixes

### DIFF
--- a/migration/v0.16.x-v0.17.x/migrate-openid.sh
+++ b/migration/v0.16.x-v0.17.x/migrate-openid.sh
@@ -9,6 +9,9 @@ set -euo pipefail
 # Restart the master pods so that they mount the latest version of the secret after apply
 "${here}/../../bin/ck8s" ops kubectl sc delete pod -n elastic-system -l role=master
 
+# Wait 60 seconds before updating the config after master pod restart
+sleep 60
+
 # Make the script executable
 "${here}/../../bin/ck8s" ops kubectl sc -n elastic-system exec opendistro-es-master-0 -- chmod +x ./plugins/opendistro_security/tools/securityadmin.sh
 # Run the script to update the configuration

--- a/migration/v0.16.x-v0.17.x/upgrade-apps.md
+++ b/migration/v0.16.x-v0.17.x/upgrade-apps.md
@@ -28,6 +28,12 @@
 
    and then apply the new changes.
 
+1. Remove the old version of dex to then replace it with the new one by apply
+
+       ```bash
+    bin/ck8s ops helmfile sc -l app=dex destroy
+    ```
+
 1. Run init to get new defaults:
 
     ```bash


### PR DESCRIPTION
**What this PR does / why we need it**:
To make 0.16 to 0.17 migration work, dex needs to be removed before applying the updated version and the _migrate-openid.sh_ script needs to be modified slightly. 


**Which issue this PR fixes**: 
fixes #516 


**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).