### PR TITLE
apps sc & wc: release 0.17 fixes

### DIFF
--- a/migration/v0.16.x-v0.17.x/migrate-openid.sh
+++ b/migration/v0.16.x-v0.17.x/migrate-openid.sh
@@ -9,6 +9,9 @@ set -euo pipefail
 # Restart the master pods so that they mount the latest version of the secret after apply
 "${here}/../../bin/ck8s" ops kubectl sc delete pod -n elastic-system -l role=master
 
+# Wait for master pod to be ready before updating the config
+"${here}/../../bin/ck8s" ops kubectl sc wait --for=condition=ready pod  -n elastic-system opendistro-es-master-0
+sleep 10
 # Make the script executable
 "${here}/../../bin/ck8s" ops kubectl sc -n elastic-system exec opendistro-es-master-0 -- chmod +x ./plugins/opendistro_security/tools/securityadmin.sh
 # Run the script to update the configuration

--- a/migration/v0.16.x-v0.17.x/upgrade-apps.md
+++ b/migration/v0.16.x-v0.17.x/upgrade-apps.md
@@ -19,12 +19,12 @@
 
 1. To upgrade kube-prometheus-stack from 12.8.0 to 16.6.1 you need to run:
 
-   ```bash
-   ./bin/ck8s ops kubectl sc apply -f 'helmfile/upstream/kube-prometheus-stack/crds'
-   ```
-   ```bash
-   ./bin/ck8s ops kubectl wc apply -f 'helmfile/upstream/kube-prometheus-stack/crds'
-   ```
+    ```bash
+    bin/ck8s ops kubectl sc apply -f 'helmfile/upstream/kube-prometheus-stack/crds'
+    ```
+    ```bash
+    bin/ck8s ops kubectl wc apply -f 'helmfile/upstream/kube-prometheus-stack/crds'
+    ```
 
    and then apply the new changes.
 
@@ -32,6 +32,12 @@
 
     ```bash
     bin/ck8s init
+    ```
+
+1. Remove the old version of dex to then replace it with the new one by apply
+
+    ```bash
+    bin/ck8s ops helmfile sc -l app=dex destroy
     ```
 
 1. Upgrade applications:
@@ -42,9 +48,9 @@
 
 1. Restart the blackbox-prometheus-blackbox-exporter pod to make changes active.
 
-   ```bash
-   bin/ck8s ops kubectl sc get pods -n monitoring | awk '/blackbox/{print $1}'| xargs  ./bin/ck8s ops kubectl sc delete -n monitoring pod
-   ```
+    ```bash
+    bin/ck8s ops kubectl sc delete pod -l app.kubernetes.io/name=prometheus-blackbox-exporter -n monitoring
+    ```
 
 1. Run migration script: `./migration/v0.16.x-v0.17.x/migrate-openid.sh`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes from QA. Finale push for release! :-D

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
