### PR TITLE
Ingress nginx chart and image upgrade

### DIFF
--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -36,7 +36,7 @@ releases:
   labels:
     app: ingress-nginx
   chart: ./upstream/ingress-nginx
-  version: 2.10.0
+  version: 3.34.0
   missingFileHandler: Error
   wait: true
   values:

--- a/helmfile/upstream/ingress-nginx/CHANGELOG.md
+++ b/helmfile/upstream/ingress-nginx/CHANGELOG.md
@@ -1,0 +1,250 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 3.34.0
+
+- [7256] https://github.com/kubernetes/ingress-nginx/pull/7256 Add namespace field in the namespace scoped resource templates
+
+### 3.33.0
+
+- [7164] https://github.com/kubernetes/ingress-nginx/pull/7164 Update nginx to v1.20.1
+
+### 3.32.0
+
+- [7117] https://github.com/kubernetes/ingress-nginx/pull/7117 Add annotations for HPA
+
+### 3.31.0
+
+- [7137] https://github.com/kubernetes/ingress-nginx/pull/7137 Add support for custom probes
+
+### 3.30.0
+
+- [#7092](https://github.com/kubernetes/ingress-nginx/pull/7092) Removes the possibility of using localhost in ExternalNames as endpoints
+
+### 3.29.0
+
+- [X] [#6945](https://github.com/kubernetes/ingress-nginx/pull/7020) Add option to specify job label for ServiceMonitor
+
+### 3.28.0
+
+- [ ] [#6900](https://github.com/kubernetes/ingress-nginx/pull/6900) Support existing PSPs
+
+### 3.27.0
+
+- Update ingress-nginx v0.45.0
+
+### 3.26.0
+
+- [X] [#6979](https://github.com/kubernetes/ingress-nginx/pull/6979) Changed servicePort value for metrics
+
+### 3.25.0
+
+- [X] [#6957](https://github.com/kubernetes/ingress-nginx/pull/6957) Add ability to specify automountServiceAccountToken
+
+### 3.24.0
+
+- [X] [#6908](https://github.com/kubernetes/ingress-nginx/pull/6908) Add volumes to default-backend deployment
+
+### 3.23.0
+
+- Update ingress-nginx v0.44.0
+
+### 3.22.0
+
+- [X] [#6802](https://github.com/kubernetes/ingress-nginx/pull/6802) Add value for configuring a custom Diffie-Hellman parameters file
+- [X] [#6815](https://github.com/kubernetes/ingress-nginx/pull/6815) Allow use of numeric namespaces in helm chart
+
+### 3.21.0
+
+- [X] [#6783](https://github.com/kubernetes/ingress-nginx/pull/6783) Add custom annotations to ScaledObject
+- [X] [#6761](https://github.com/kubernetes/ingress-nginx/pull/6761) Adding quotes in the serviceAccount name in Helm values
+- [X] [#6767](https://github.com/kubernetes/ingress-nginx/pull/6767) Remove ClusterRole when scope option is enabled
+- [X] [#6785](https://github.com/kubernetes/ingress-nginx/pull/6785) Update kube-webhook-certgen image to v1.5.1
+
+### 3.20.1
+
+- Do not create KEDA in case of DaemonSets.
+- Fix KEDA v2 definition
+
+### 3.20.0
+
+- [X] [#6730](https://github.com/kubernetes/ingress-nginx/pull/6730) Do not create HPA for defaultBackend if not enabled.
+
+### 3.19.0
+
+- Update ingress-nginx v0.43.0
+
+### 3.18.0
+
+- [X] [#6688](https://github.com/kubernetes/ingress-nginx/pull/6688) Allow volume-type emptyDir in controller podsecuritypolicy
+- [X] [#6691](https://github.com/kubernetes/ingress-nginx/pull/6691) Improve parsing of helm parameters
+
+### 3.17.0
+
+- Update ingress-nginx v0.42.0
+
+### 3.16.1
+
+- Fix chart-releaser action
+
+### 3.16.0
+
+- [X] [#6646](https://github.com/kubernetes/ingress-nginx/pull/6646) Added LoadBalancerIP value for internal service
+
+### 3.15.1
+
+- Fix chart-releaser action
+
+### 3.15.0
+
+- [X] [#6586](https://github.com/kubernetes/ingress-nginx/pull/6586) Fix 'maxmindLicenseKey' location in values.yaml
+
+### 3.14.0
+
+- [X] [#6469](https://github.com/kubernetes/ingress-nginx/pull/6469) Allow custom service names for controller and backend
+
+### 3.13.0
+
+- [X] [#6544](https://github.com/kubernetes/ingress-nginx/pull/6544) Fix default backend HPA name variable
+
+### 3.12.0
+
+- [X] [#6514](https://github.com/kubernetes/ingress-nginx/pull/6514) Remove helm2 support and update docs
+
+### 3.11.1
+
+- [X] [#6505](https://github.com/kubernetes/ingress-nginx/pull/6505) Reorder HPA resource list to work with GitOps tooling
+
+### 3.11.0
+
+- Support Keda Autoscaling
+
+### 3.10.1
+
+- Fix regression introduced in 0.41.0 with external authentication
+
+### 3.10.0
+
+- Fix routing regression introduced in 0.41.0 with PathType Exact
+
+### 3.9.0
+
+- [X] [#6423](https://github.com/kubernetes/ingress-nginx/pull/6423) Add Default backend HPA autoscaling
+
+### 3.8.0
+
+- [X] [#6395](https://github.com/kubernetes/ingress-nginx/pull/6395) Update jettech/kube-webhook-certgen image
+- [X] [#6377](https://github.com/kubernetes/ingress-nginx/pull/6377) Added loadBalancerSourceRanges for internal lbs
+- [X] [#6356](https://github.com/kubernetes/ingress-nginx/pull/6356) Add securitycontext settings on defaultbackend
+- [X] [#6401](https://github.com/kubernetes/ingress-nginx/pull/6401) Fix controller service annotations
+- [X] [#6403](https://github.com/kubernetes/ingress-nginx/pull/6403) Initial helm chart changelog
+
+### 3.7.1
+
+- [X] [#6326](https://github.com/kubernetes/ingress-nginx/pull/6326) Fix liveness and readiness probe path in daemonset chart
+
+### 3.7.0
+
+- [X] [#6316](https://github.com/kubernetes/ingress-nginx/pull/6316) Numerals in podAnnotations in quotes [#6315](https://github.com/kubernetes/ingress-nginx/issues/6315)
+
+### 3.6.0
+
+- [X] [#6305](https://github.com/kubernetes/ingress-nginx/pull/6305) Add default linux nodeSelector
+
+### 3.5.1
+
+- [X] [#6299](https://github.com/kubernetes/ingress-nginx/pull/6299) Fix helm chart release
+
+### 3.5.0
+
+- [X] [#6260](https://github.com/kubernetes/ingress-nginx/pull/6260) Allow Helm Chart to customize admission webhook's annotations, timeoutSeconds, namespaceSelector, objectSelector and cert files locations
+
+### 3.4.0
+
+- [X] [#6268](https://github.com/kubernetes/ingress-nginx/pull/6268) Update to 0.40.2 in helm chart #6288
+
+### 3.3.1
+
+- [X] [#6259](https://github.com/kubernetes/ingress-nginx/pull/6259) Release helm chart
+- [X] [#6258](https://github.com/kubernetes/ingress-nginx/pull/6258) Fix chart markdown link
+- [X] [#6253](https://github.com/kubernetes/ingress-nginx/pull/6253) Release v0.40.0
+
+### 3.3.1
+
+- [X] [#6233](https://github.com/kubernetes/ingress-nginx/pull/6233) Add admission controller e2e test
+
+### 3.3.0
+
+- [X] [#6203](https://github.com/kubernetes/ingress-nginx/pull/6203) Refactor parsing of key values
+- [X] [#6162](https://github.com/kubernetes/ingress-nginx/pull/6162) Add helm chart options to expose metrics service as NodePort
+- [X] [#6180](https://github.com/kubernetes/ingress-nginx/pull/6180) Fix helm chart admissionReviewVersions regression
+- [X] [#6169](https://github.com/kubernetes/ingress-nginx/pull/6169) Fix Typo in example prometheus rules
+
+### 3.0.0
+
+- [X] [#6167](https://github.com/kubernetes/ingress-nginx/pull/6167) Update chart requirements
+
+### 2.16.0
+
+- [X] [#6154](https://github.com/kubernetes/ingress-nginx/pull/6154) add `topologySpreadConstraint` to controller
+
+### 2.15.0
+
+- [X] [#6087](https://github.com/kubernetes/ingress-nginx/pull/6087) Adding parameter for externalTrafficPolicy in internal controller service spec
+
+### 2.14.0
+
+- [X] [#6104](https://github.com/kubernetes/ingress-nginx/pull/6104) Misc fixes for nginx-ingress chart for better keel and prometheus-operator integration
+
+### 2.13.0
+
+- [X] [#6093](https://github.com/kubernetes/ingress-nginx/pull/6093) Release v0.35.0
+
+### 2.13.0
+
+- [X] [#6093](https://github.com/kubernetes/ingress-nginx/pull/6093) Release v0.35.0
+- [X] [#6080](https://github.com/kubernetes/ingress-nginx/pull/6080) Switch images to k8s.gcr.io after Vanity Domain Flip
+
+### 2.12.1
+
+- [X] [#6075](https://github.com/kubernetes/ingress-nginx/pull/6075) Sync helm chart affinity examples
+
+### 2.12.0
+
+- [X] [#6039](https://github.com/kubernetes/ingress-nginx/pull/6039) Add configurable serviceMonitor metricRelabelling and targetLabels
+- [X] [#6044](https://github.com/kubernetes/ingress-nginx/pull/6044) Fix YAML linting
+
+### 2.11.3
+
+- [X] [#6038](https://github.com/kubernetes/ingress-nginx/pull/6038) Bump chart version PATCH
+
+### 2.11.2
+
+- [X] [#5951](https://github.com/kubernetes/ingress-nginx/pull/5951) Bump chart patch version
+
+### 2.11.1
+
+- [X] [#5900](https://github.com/kubernetes/ingress-nginx/pull/5900) Release helm chart for v0.34.1
+
+### 2.11.0
+
+- [X] [#5879](https://github.com/kubernetes/ingress-nginx/pull/5879) Update helm chart for v0.34.0
+- [X] [#5671](https://github.com/kubernetes/ingress-nginx/pull/5671) Make liveness probe more fault tolerant than readiness probe
+
+### 2.10.0
+
+- [X] [#5843](https://github.com/kubernetes/ingress-nginx/pull/5843) Update jettech/kube-webhook-certgen image
+
+### 2.9.1
+
+- [X] [#5823](https://github.com/kubernetes/ingress-nginx/pull/5823) Add quoting to sysctls because numeric values need to be presented as strings (#5823)
+
+### 2.9.0
+
+- [X] [#5795](https://github.com/kubernetes/ingress-nginx/pull/5795) Use fully qualified images to avoid cri-o issues
+
+
+### TODO
+
+Keep building the changelog using *git log charts* checking the tag

--- a/helmfile/upstream/ingress-nginx/Chart.yaml
+++ b/helmfile/upstream/ingress-nginx/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   artifacthub.io/changes: |
     - Add namespace field in the namespace scoped resource templates
 apiVersion: v2
-appVersion: 0.47.0
+appVersion: 0.48.1
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 home: https://github.com/kubernetes/ingress-nginx
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/helmfile/upstream/ingress-nginx/Chart.yaml
+++ b/helmfile/upstream/ingress-nginx/Chart.yaml
@@ -1,16 +1,19 @@
-apiVersion: v1
-appVersion: 0.33.0
-description: Ingress controller for Kubernetes using NGINX as a reverse proxy and
-  load balancer
+annotations:
+  artifacthub.io/changes: |
+    - Add namespace field in the namespace scoped resource templates
+apiVersion: v2
+appVersion: 0.47.0
+description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 home: https://github.com/kubernetes/ingress-nginx
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
 keywords:
 - ingress
 - nginx
-kubeVersion: '>=1.10.0-0'
+kubeVersion: '>=1.16.0-0'
 maintainers:
 - name: ChiefAlexander
 name: ingress-nginx
 sources:
 - https://github.com/kubernetes/ingress-nginx
-version: 2.10.0
+type: application
+version: 3.34.0

--- a/helmfile/upstream/ingress-nginx/README.md
+++ b/helmfile/upstream/ingress-nginx/README.md
@@ -4,280 +4,97 @@
 
 To use, add the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
 
-## TL;DR;
-
-```console
-$ helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-$ helm install my-release ingress-nginx/ingress-nginx
-```
-
-## Introduction
-
 This chart bootstraps an ingress-nginx deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
-  - Kubernetes 1.6+
+- Kubernetes v1.16+
 
-## Installing the Chart
-
-To install the chart with the release name `my-release`:
+## Get Repo Info
 
 ```console
-$ helm install --name my-release ingress-nginx/ingress-nginx
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
 ```
 
-The command deploys ingress-nginx on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+## Install Chart
 
-> **Tip**: List all releases using `helm list`
-
-## Uninstalling the Chart
-
-To uninstall/delete the `my-release` deployment:
+**Important:** only helm3 is supported
 
 ```console
-$ helm delete my-release
+helm install [RELEASE_NAME] ingress-nginx/ingress-nginx
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+The command deploys ingress-nginx on the Kubernetes cluster in the default configuration.
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+helm uninstall [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+### Upgrading With Zero Downtime in Production
+
+By default the ingress-nginx controller has service interruptions whenever it's pods are restarted or redeployed. In order to fix that, see the excellent blog post by Lindsay Landry from Codecademy: [Kubernetes: Nginx and Zero Downtime in Production](https://medium.com/codecademy-engineering/kubernetes-nginx-and-zero-downtime-in-production-2c910c6a5ed8).
+
+### Migrating from stable/nginx-ingress
+
+There are two main ways to migrate a release from `stable/nginx-ingress` to `ingress-nginx/ingress-nginx` chart:
+
+1. For Nginx Ingress controllers used for non-critical services, the easiest method is to [uninstall](#uninstall-chart) the old release and [install](#install-chart) the new one
+1. For critical services in production that require zero-downtime, you will want to:
+    1. [Install](#install-chart) a second Ingress controller
+    1. Redirect your DNS traffic from the old controller to the new controller
+    1. Log traffic from both controllers during this changeover
+    1. [Uninstall](#uninstall-chart) the old controller once traffic has fully drained from it
+    1. For details on all of these steps see [Upgrading With Zero Downtime in Production](#upgrading-with-zero-downtime-in-production)
+
+Note that there are some different and upgraded configurations between the two charts, described by Rimas Mocevicius from JFrog in the "Upgrading to ingress-nginx Helm chart" section of [Migrating from Helm chart nginx-ingress to ingress-nginx](https://rimusz.net/migrating-to-ingress-nginx). As the `ingress-nginx/ingress-nginx` chart continues to update, you will want to check current differences by running [helm configuration](#configuration) commands on both charts.
 
 ## Configuration
 
-The following table lists the configurable parameters of the ingress-nginx chart and their default values.
-
-Parameter | Description | Default
---- | --- | ---
-`controller.image.repository` | controller container image repository | `quay.io/kubernetes-ingress-controller/nginx-ingress-controller`
-`controller.image.tag` | controller container image tag | `0.30.0`
-`controller.image.digest` | controller container image digest | `""`
-`controller.image.pullPolicy` | controller container image pull policy | `IfNotPresent`
-`controller.image.runAsUser` | User ID of the controller process. Value depends on the Linux distribution used inside of the container image. | `101`
-`controller.containerPort.http` | The port that the controller container listens on for http connections. | `80`
-`controller.containerPort.https` | The port that the controller container listens on for https connections. | `443`
-`controller.config` | nginx [ConfigMap](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md) entries | none
-`controller.configAnnotations` | annotations to be added to controller custom configuration configmap | `{}`
-`controller.hostNetwork` | If the nginx deployment / daemonset should run on the host's network namespace. Do not set this when `controller.service.externalIPs` is set and `kube-proxy` is used as there will be a port-conflict for port `80` | false
-`controller.dnsPolicy` | If using `hostNetwork=true`, change to `ClusterFirstWithHostNet`. See [pod's dns policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for details | `ClusterFirst`
-`controller.dnsConfig` | custom pod dnsConfig. See [pod's dns config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-config) for details | `{}`
-`controller.reportNodeInternalIp` | If using `hostNetwork=true`, setting `reportNodeInternalIp=true`, will pass the flag `report-node-internal-ip-address` to ingress-nginx. This sets the status of all Ingress objects to the internal IP address of all nodes running the NGINX Ingress controller.
-`controller.electionID` | election ID to use for the status update | `ingress-controller-leader`
-`controller.extraEnvs` | any additional environment variables to set in the pods | `{}`
-`controller.extraContainers` | Sidecar containers to add to the controller pod. See [LemonLDAP::NG controller](https://github.com/lemonldap-ng-controller/lemonldap-ng-controller) as example | `{}`
-`controller.extraVolumeMounts` | Additional volumeMounts to the controller main container | `{}`
-`controller.extraVolumes` | Additional volumes to the controller pod | `{}`
-`controller.extraInitContainers` | Containers, which are run before the app containers are started | `[]`
-`controller.healthCheckPath` | Path of the health check endpoint. All requests received on the port defined by the healthz-port parameter are forwarded internally to this path. | `/healthz"`
-`controller.ingressClass` | name of the ingress class to route through this controller | `nginx`
-`controller.maxmindLicenseKey` | Maxmind license key to download GeoLite2 Databases. See [Accessing and using GeoLite2 database](https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/) | `""`
-`controller.scope.enabled` | limit the scope of the ingress controller | `false` (watch all namespaces)
-`controller.scope.namespace` | namespace to watch for ingress | `""` (use the release namespace)
-`controller.extraArgs` | Additional controller container arguments | `{}`
-`controller.kind` | install as Deployment, DaemonSet or Both | `Deployment`
-`controller.annotations` | annotations to be added to the Deployment or Daemonset | `{}`
-`controller.autoscaling.enabled` | If true, creates Horizontal Pod Autoscaler | false
-`controller.autoscaling.minReplicas` | If autoscaling enabled, this field sets minimum replica count | `2`
-`controller.autoscaling.maxReplicas` | If autoscaling enabled, this field sets maximum replica count | `11`
-`controller.autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization percentage to scale | `"50"`
-`controller.autoscaling.targetMemoryUtilizationPercentage` | Target memory utilization percentage to scale | `"50"`
-`controller.autoscaling.autoscalingTemplate` | If autoscaling template provided, creates custom autoscaling metric | false
-`controller.hostPort.enabled` | This enable `hostPort` for ports defined in TCP/80 and TCP/443 | false
-`controller.hostPort.ports.http` | If `controller.hostPort.enabled` is `true` and this is non-empty, it sets the hostPort | `"80"`
-`controller.hostPort.ports.https` | If `controller.hostPort.enabled` is `true` and this is non-empty, it sets the hostPort | `"443"`
-`controller.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
-`controller.affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
-`controller.terminationGracePeriodSeconds` | how many seconds to wait before terminating a pod | `60`
-`controller.minReadySeconds` | how many seconds a pod needs to be ready before killing the next, during update | `0`
-`controller.nodeSelector` | node labels for pod assignment | `{}`
-`controller.podAnnotations` | annotations to be added to pods | `{}`
-`controller.podLabels` | labels to add to the pod container metadata | `{}`
-`controller.podSecurityContext` | Security context policies to add to the controller pod | `{}`
-`controller.sysctls` | Map of optional sysctls to enable in the controller and in the PodSecurityPolicy | `{}`
-`controller.replicaCount` | desired number of controller pods | `1`
-`controller.minAvailable` | minimum number of available controller pods for PodDisruptionBudget | `1`
-`controller.resources` | controller pod resource requests & limits | `{}`
-`controller.priorityClassName` | controller priorityClassName | `nil`
-`controller.lifecycle` | controller pod lifecycle hooks | `{}`
-`controller.publishService.enabled` | if true, the controller will set the endpoint records on the ingress objects to reflect those on the service | `true`
-`controller.publishService.pathOverride` | override of the default publish-service name | `""`
-`controller.service.annotations` | annotations for controller service | `{}`
-`controller.service.labels` | labels for controller service | `{}`
-`controller.service.enabled` | if disabled no service will be created. This is especially useful when `controller.kind` is set to `DaemonSet` and `controller.hostPorts.enabled` is `true` | true
-`controller.service.clusterIP` | internal controller cluster service IP (set to `"-"` to pass an empty value) | `nil`
-`controller.service.omitClusterIP` | (Deprecated) To omit the `clusterIP` from the controller service | `false`
-`controller.service.externalIPs` | controller service external IP addresses. Do not set this when `controller.hostNetwork` is set to `true` and `kube-proxy` is used as there will be a port-conflict for port `80` | `[]`
-`controller.service.externalTrafficPolicy` | If `controller.service.type` is `NodePort` or `LoadBalancer`, set this to `Local` to enable [source IP preservation](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typenodeport) | `"Cluster"`
-`controller.service.sessionAffinity` | Enables client IP based session affinity. Must be `ClientIP` or `None` if set.  | `""`
-`controller.service.healthCheckNodePort` | If `controller.service.type` is `NodePort` or `LoadBalancer` and `controller.service.externalTrafficPolicy` is set to `Local`, set this to [the managed health-check port the kube-proxy will expose](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typenodeport). If blank, a random port in the `NodePort` range will be assigned | `""`
-`controller.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
-`controller.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
-`controller.service.enableHttp` | if port 80 should be opened for service | `true`
-`controller.service.enableHttps` | if port 443 should be opened for service | `true`
-`controller.service.targetPorts.http` | Sets the targetPort that maps to the Ingress' port 80 | `80`
-`controller.service.targetPorts.https` | Sets the targetPort that maps to the Ingress' port 443 | `443`
-`controller.service.ports.http` | Sets service http port | `80`
-`controller.service.ports.https` | Sets service https port | `443`
-`controller.service.type` | type of controller service to create | `LoadBalancer`
-`controller.service.nodePorts.http` | If `controller.service.type` is either `NodePort` or `LoadBalancer` and this is non-empty, it sets the nodePort that maps to the Ingress' port 80 | `""`
-`controller.service.nodePorts.https` | If `controller.service.type` is either `NodePort` or `LoadBalancer` and this is non-empty, it sets the nodePort that maps to the Ingress' port 443 | `""`
-`controller.service.nodePorts.tcp` | Sets the nodePort for an entry referenced by its key from `tcp` | `{}`
-`controller.service.nodePorts.udp` | Sets the nodePort for an entry referenced by its key from `udp` | `{}`
-`controller.service.internal.enabled` | Enables an (additional) internal load balancer | false
-`controller.service.internal.annotations` | Annotations for configuring the additional internal load balancer | `{}`
-`controller.livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated | 10
-`controller.livenessProbe.periodSeconds` | How often to perform the probe | 10
-`controller.livenessProbe.timeoutSeconds` | When the probe times out | 5
-`controller.livenessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed. | 1
-`controller.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded. | 3
-`controller.livenessProbe.port` | The port number that the liveness probe will listen on. | 10254
-`controller.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated | 10
-`controller.readinessProbe.periodSeconds` | How often to perform the probe | 10
-`controller.readinessProbe.timeoutSeconds` | When the probe times out | 1
-`controller.readinessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed. | 1
-`controller.readinessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded. | 3
-`controller.readinessProbe.port` | The port number that the readiness probe will listen on. | 10254
-`controller.metrics.enabled` | if `true`, enable Prometheus metrics | `false`
-`controller.metrics.service.annotations` | annotations for Prometheus metrics service | `{}`
-`controller.metrics.service.clusterIP` | cluster IP address to assign to service (set to `"-"` to pass an empty value) | `nil`
-`controller.metrics.service.omitClusterIP` | (Deprecated) To omit the `clusterIP` from the metrics service | `false`
-`controller.metrics.service.externalIPs` | Prometheus metrics service external IP addresses | `[]`
-`controller.metrics.service.labels` | labels for metrics service | `{}`
-`controller.metrics.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
-`controller.metrics.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
-`controller.metrics.service.servicePort` | Prometheus metrics service port | `9913`
-`controller.metrics.service.type` | type of Prometheus metrics service to create | `ClusterIP`
-`controller.metrics.serviceMonitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false`
-`controller.metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
-`controller.metrics.serviceMonitor.honorLabels` | honorLabels chooses the metric's labels on collisions with target labels. | `false`
-`controller.metrics.serviceMonitor.namespace` | namespace where servicemonitor resource should be created | `the same namespace as nginx ingress`
-`controller.metrics.serviceMonitor.namespaceSelector` | [namespaceSelector](https://github.com/coreos/prometheus-operator/blob/v0.34.0/Documentation/api.md#namespaceselector) to configure what namespaces to scrape | `will scrape the helm release namespace only`
-`controller.metrics.serviceMonitor.scrapeInterval` | interval between Prometheus scraping | `30s`
-`controller.metrics.prometheusRule.enabled` | Set this to `true` to create prometheusRules for Prometheus operator | `false`
-`controller.metrics.prometheusRule.additionalLabels` | Additional labels that can be used so prometheusRules will be discovered by Prometheus | `{}`
-`controller.metrics.prometheusRule.namespace` | namespace where prometheusRules resource should be created | `the same namespace as nginx ingress`
-`controller.metrics.prometheusRule.rules` | [rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) to be prometheus in YAML format, check values for an example. | `[]`
-`controller.admissionWebhooks.enabled` | Create Ingress admission webhooks. Validating webhook will check the ingress syntax. | `true`
-`controller.admissionWebhooks.failurePolicy` | Failure policy for admission webhooks | `Fail`
-`controller.admissionWebhooks.port` | Admission webhook port | `8443`
-`controller.admissionWebhooks.service.annotations` | Annotations for admission webhook service | `{}`
-`controller.admissionWebhooks.service.omitClusterIP` | (Deprecated) To omit the `clusterIP` from the admission webhook service | `false`
-`controller.admissionWebhooks.service.clusterIP` | cluster IP address to assign to admission webhook service (set to `"-"` to pass an empty value) | `nil`
-`controller.admissionWebhooks.service.externalIPs` | Admission webhook service external IP addresses | `[]`
-`controller.admissionWebhooks.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
-`controller.admissionWebhooks.service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported) | `[]`
-`controller.admissionWebhooks.service.servicePort` | Admission webhook service port | `443`
-`controller.admissionWebhooks.service.type` | Type of admission webhook service to create | `ClusterIP`
-`controller.admissionWebhooks.patch.enabled` | If true, will use a pre and post install hooks to generate a CA and certificate to use for the prometheus operator tls proxy, and patch the created webhooks with the CA. | `true`
-`controller.admissionWebhooks.patch.image.repository` | Repository to use for the webhook integration jobs | `jettech/kube-webhook-certgen`
-`controller.admissionWebhooks.patch.image.tag` |  Tag to use for the webhook integration jobs | `v1.2.0`
-`controller.admissionWebhooks.patch.image.digest` |  Digest to use for the webhook integration jobs | `""`
-`controller.admissionWebhooks.patch.image.pullPolicy` | Image pull policy for the webhook integration jobs | `IfNotPresent`
-`controller.admissionWebhooks.patch.priorityClassName` | Priority class for the webhook integration jobs | `""`
-`controller.admissionWebhooks.patch.podAnnotations` | Annotations for the webhook job pods | `{}`
-`controller.admissionWebhooks.patch.nodeSelector` | Node selector for running admission hook patch jobs | `{}`
-`controller.admissionWebhooks.patch.tolerations` | Node taints/tolerations for running admission hook patch jobs | `[]`
-`controller.customTemplate.configMapName` | configMap containing a custom nginx template | `""`
-`controller.customTemplate.configMapKey` | configMap key containing the nginx template | `""`
-`controller.addHeaders` | configMap key:value pairs containing [custom headers](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#add-headers) added before sending response to the client | `{}`
-`controller.proxySetHeaders` | configMap key:value pairs containing [custom headers](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#proxy-set-headers) added before sending request to the backends| `{}`
-`controller.headers` | DEPRECATED, Use `controller.proxySetHeaders` instead. | `{}`
-`controller.updateStrategy` | allows setting of RollingUpdate strategy | `{}`
-`controller.configMapNamespace` | The nginx-configmap namespace name | `""`
-`controller.tcp.configMapNamespace` | The tcp-services-configmap namespace name | `""`
-`controller.tcp.annotations` | annotations to be added to tcp configmap | `{}`
-`controller.udp.configMapNamespace` | The udp-services-configmap namespace name | `""`
-`controller.udp.annotations` | annotations to be added to udp configmap | `{}`
-`defaultBackend.enabled` | Use default backend component | `false`
-`defaultBackend.image.repository` | default backend container image repository | `k8s.gcr.io/defaultbackend-amd64`
-`defaultBackend.image.tag` | default backend container image tag | `1.5`
-`defaultBackend.image.digest` | default backend container image digest | `""`
-`defaultBackend.image.pullPolicy` | default backend container image pull policy | `IfNotPresent`
-`defaultBackend.image.runAsUser` | User ID of the controller process. Value depends on the Linux distribution used inside of the container image. By default uses nobody user. | `65534`
-`defaultBackend.extraArgs` | Additional default backend container arguments | `{}`
-`defaultBackend.extraEnvs` | any additional environment variables to set in the defaultBackend pods | `[]`
-`defaultBackend.port` | Http port number | `8080`
-`defaultBackend.livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated | 30
-`defaultBackend.livenessProbe.periodSeconds` | How often to perform the probe | 10
-`defaultBackend.livenessProbe.timeoutSeconds` | When the probe times out | 5
-`defaultBackend.livenessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed. | 1
-`defaultBackend.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded. | 3
-`defaultBackend.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated | 0
-`defaultBackend.readinessProbe.periodSeconds` | How often to perform the probe | 5
-`defaultBackend.readinessProbe.timeoutSeconds` | When the probe times out | 5
-`defaultBackend.readinessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed. | 1
-`defaultBackend.readinessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded. | 6
-`defaultBackend.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
-`defaultBackend.affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
-`defaultBackend.nodeSelector` | node labels for pod assignment | `{}`
-`defaultBackend.podAnnotations` | annotations to be added to pods | `{}`
-`defaultBackend.podLabels` | labels to add to the pod container metadata | `{}`
-`defaultBackend.replicaCount` | desired number of default backend pods | `1`
-`defaultBackend.minAvailable` | minimum number of available default backend pods for PodDisruptionBudget | `1`
-`defaultBackend.resources` | default backend pod resource requests & limits | `{}`
-`defaultBackend.priorityClassName` | default backend  priorityClassName | `nil`
-`defaultBackend.podSecurityContext` | Security context policies to add to the default backend | `{}`
-`defaultBackend.service.annotations` | annotations for default backend service | `{}`
-`defaultBackend.service.clusterIP` | internal default backend cluster service IP (set to `"-"` to pass an empty value) | `nil`
-`defaultBackend.service.omitClusterIP` | (Deprecated) To omit the `clusterIP` from the default backend service | `false`
-`defaultBackend.service.externalIPs` | default backend service external IP addresses | `[]`
-`defaultBackend.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
-`defaultBackend.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
-`defaultBackend.service.type` | type of default backend service to create | `ClusterIP`
-`defaultBackend.serviceAccount.create` | if `true`, create a backend service account. Only useful if you need a pod security policy to run the backend. | `true`
-`defaultBackend.serviceAccount.name` | The name of the backend service account to use. If not set and `create` is `true`, a name is generated using the fullname template. Only useful if you need a pod security policy to run the backend. | ``
-`imagePullSecrets` | name of Secret resource containing private registry credentials | `nil`
-`rbac.create` | if `true`, create & use RBAC resources | `true`
-`rbac.scope` | if `true`, do not create & use clusterrole and -binding. Set to `true` in combination with `controller.scope.enabled=true` to disable load-balancer status updates and scope the ingress entirely. | `false`
-`podSecurityPolicy.enabled` | if `true`, create & use Pod Security Policy resources | `false`
-`serviceAccount.create` | if `true`, create a service account for the controller | `true`
-`serviceAccount.name` | The name of the controller service account to use. If not set and `create` is `true`, a name is generated using the fullname template. | ``
-`revisionHistoryLimit` | The number of old history to retain to allow rollback. | `10`
-`tcp` | TCP service key:value pairs. The value is evaluated as a template. | `{}`
-`udp` | UDP service key:value pairs The value is evaluated as a template. | `{}`
-
-These parameters can be passed via Helm's `--set` option
-```console
-$ helm install ingress-nginx --name my-release \
-    --set controller.metrics.enabled=true
-```
-
-Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-$ helm install ingress-nginx --name my-release -f values.yaml
+helm show values ingress-nginx/ingress-nginx
 ```
 
-A useful trick to debug issues with ingress is to increase the logLevel
-as described [here](https://github.com/kubernetes/ingress-nginx/blob/master/docs/troubleshooting.md#debug)
-
-```console
-$ helm install ingress-nginx --set controller.extraArgs.v=2
-```
-> **Tip**: You can use the default [values.yaml](values.yaml)
-
-## PodDisruptionBudget
+### PodDisruptionBudget
 
 Note that the PodDisruptionBudget resource will only be defined if the replicaCount is greater than one,
 else it would make it impossible to evacuate a node. See [gh issue #7127](https://github.com/helm/charts/issues/7127) for more info.
 
-## Prometheus Metrics
+### Prometheus Metrics
 
-The Nginx ingress controller can export Prometheus metrics.
-
-```console
-$ helm install ingress-nginx --name my-release \
-    --set controller.metrics.enabled=true
-```
+The Nginx ingress controller can export Prometheus metrics, by setting `controller.metrics.enabled` to `true`.
 
 You can add Prometheus annotations to the metrics service using `controller.metrics.service.annotations`. Alternatively, if you use the Prometheus Operator, you can enable ServiceMonitor creation using `controller.metrics.serviceMonitor.enabled`.
 
-## ingress-nginx nginx\_status page/stats server
+### ingress-nginx nginx\_status page/stats server
 
 Previous versions of this chart had a `controller.stats.*` configuration block, which is now obsolete due to the following changes in nginx ingress controller:
-* in [0.16.1](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0161), the vts (virtual host traffic status) dashboard was removed
-* in [0.23.0](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0230), the status page at port 18080 is now a unix socket webserver only available at localhost.
+
+- In [0.16.1](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0161), the vts (virtual host traffic status) dashboard was removed
+- In [0.23.0](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0230), the status page at port 18080 is now a unix socket webserver only available at localhost.
   You can use `curl --unix-socket /tmp/nginx-status-server.sock http://localhost/nginx_status` inside the controller container to access it locally, or use the snippet from [nginx-ingress changelog](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0230) to re-enable the http server
 
-## ExternalDNS Service configuration
+### ExternalDNS Service Configuration
 
 Add an [ExternalDNS](https://github.com/kubernetes-incubator/external-dns) annotation to the LoadBalancer service:
 
@@ -288,7 +105,7 @@ controller:
       external-dns.alpha.kubernetes.io/hostname: kubernetes-example.com.
 ```
 
-## AWS L7 ELB with SSL Termination
+### AWS L7 ELB with SSL Termination
 
 Annotate the controller as shown in the [nginx-ingress l7 patch](https://github.com/kubernetes/ingress-nginx/blob/master/deploy/aws/l7/service-l7.yaml):
 
@@ -305,7 +122,7 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '3600'
 ```
 
-## AWS route53-mapper
+### AWS route53-mapper
 
 To configure the LoadBalancer service with the [route53-mapper addon](https://github.com/kubernetes/kops/tree/master/addons/route53-mapper), add the `domainName` annotation and `dns` label:
 
@@ -318,7 +135,7 @@ controller:
       domainName: "kubernetes-example.com"
 ```
 
-## Additional internal load balancer
+### Additional Internal Load Balancer
 
 This setup is useful when you need both external and internal load balancers but don't want to have multiple ingress controllers and multiple ingress objects per application.
 
@@ -333,8 +150,9 @@ If one of them is missing the internal load balancer will not be deployed. Examp
 
 `controller.service.internal.annotations` varies with the cloud service you're using.
 
-Example for AWS
-```
+Example for AWS:
+
+```yaml
 controller:
   service:
     internal:
@@ -345,33 +163,61 @@ controller:
         # Any other annotation can be declared here.
 ```
 
-Example for GCE
-```
+Example for GCE:
+
+```yaml
 controller:
   service:
     internal:
       enabled: true
       annotations:
+        # Create internal LB. More informations: https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing
+        # For GKE versions 1.17 and later
+        networking.gke.io/load-balancer-type: "Internal"
+        # For earlier versions
+        # cloud.google.com/load-balancer-type: "Internal"
+        
+        # Any other annotation can be declared here. 
+```
+
+Example for Azure:
+
+```yaml
+controller:
+  service:
+      annotations:
         # Create internal LB
-        cloud.google.com/load-balancer-type: "Internal"
+        service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+        # Any other annotation can be declared here.
+```
+
+Example for Oracle Cloud Infrastructure:
+
+```yaml
+controller:
+  service:
+      annotations:
+        # Create internal LB
+        service.beta.kubernetes.io/oci-load-balancer-internal: "true"
         # Any other annotation can be declared here.
 ```
 
 An use case for this scenario is having a split-view DNS setup where the public zone CNAME records point to the external balancer URL while the private zone CNAME records point to the internal balancer URL. This way, you only need one ingress kubernetes object.
 
+Optionally you can set `controller.service.loadBalancerIP` if you need a static IP for the resulting `LoadBalancer`.
 
-## Ingress Admission Webhooks
+### Ingress Admission Webhooks
 
 With nginx-ingress-controller version 0.25+, the nginx ingress controller pod exposes an endpoint that will integrate with the `validatingwebhookconfiguration` Kubernetes feature to prevent bad ingress from being added to the cluster.
 **This feature is enabled by default since 0.31.0.**
 
 With nginx-ingress-controller in 0.25.* work only with kubernetes 1.14+, 0.26 fix [this issue](https://github.com/kubernetes/ingress-nginx/pull/4521)
 
-## Helm error when upgrading: spec.clusterIP: Invalid value: ""
+### Helm Error When Upgrading: spec.clusterIP: Invalid value: ""
 
 If you are upgrading this chart from a version between 0.31.0 and 1.2.2 then you may get an error like this:
 
-```
+```console
 Error: UPGRADE FAILED: Service "?????-controller" is invalid: spec.clusterIP: Invalid value: "": field is immutable
 ```
 

--- a/helmfile/upstream/ingress-nginx/ci/daemonset-podannotations-values.yaml
+++ b/helmfile/upstream/ingress-nginx/ci/daemonset-podannotations-values.yaml
@@ -1,0 +1,13 @@
+controller:
+  kind: DaemonSet
+  admissionWebhooks:
+    enabled: false
+  metrics:
+    enabled: true
+  service:
+    type: ClusterIP
+  podAnnotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "10254"
+    prometheus.io/scheme: http
+    prometheus.io/scrape: "true"

--- a/helmfile/upstream/ingress-nginx/ci/deployment-podannotations-values.yaml
+++ b/helmfile/upstream/ingress-nginx/ci/deployment-podannotations-values.yaml
@@ -1,0 +1,12 @@
+controller:
+  admissionWebhooks:
+    enabled: false
+  metrics:
+    enabled: true
+  service:
+    type: ClusterIP
+  podAnnotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "10254"
+    prometheus.io/scheme: http
+    prometheus.io/scrape: "true"

--- a/helmfile/upstream/ingress-nginx/templates/_helpers.tpl
+++ b/helmfile/upstream/ingress-nginx/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Create a default fully qualified controller name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "ingress-nginx.controller.fullname" -}}
-{{- printf "%s-%s" (include "ingress-nginx.fullname" .) "controller" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" (include "ingress-nginx.fullname" .) .Values.controller.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -48,7 +48,7 @@ Users can provide an override for an explicit service they want bound via `.Valu
 
 */}}
 {{- define "ingress-nginx.controller.publishServicePath" -}}
-{{- $defServiceName := printf "%s/%s" .Release.Namespace (include "ingress-nginx.controller.fullname" .) -}}
+{{- $defServiceName := printf "%s/%s" "$(POD_NAMESPACE)" (include "ingress-nginx.controller.fullname" .) -}}
 {{- $servicePath := default $defServiceName .Values.controller.publishService.pathOverride }}
 {{- print $servicePath | trimSuffix "-" -}}
 {{- end -}}
@@ -58,7 +58,7 @@ Create a default fully qualified default backend name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "ingress-nginx.defaultBackend.fullname" -}}
-{{- printf "%s-%s" (include "ingress-nginx.fullname" .) "defaultbackend" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" (include "ingress-nginx.fullname" .) .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -121,4 +121,14 @@ Check the ingress controller version tag is at most three versions behind the la
 {{- if not (semverCompare ">=0.27.0-0" .Values.controller.image.tag) -}}
 {{- fail "Controller container image tag should be 0.27.0 or higher" -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+IngressClass parameters.
+*/}}
+{{- define "ingressClass.parameters" -}}
+  {{- if .Values.controller.ingressClassResource.parameters -}}
+          parameters:
+{{ toYaml .Values.controller.ingressClassResource.parameters | indent 4}}
+  {{ end }}
 {{- end -}}

--- a/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/clusterrole.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/clusterrole.yaml
@@ -22,6 +22,10 @@ rules:
     resources: ['podsecuritypolicies']
     verbs:     ['use']
     resourceNames:
+    {{- with .Values.controller.admissionWebhooks.existingPsp }}
+    - {{ . }}
+    {{- else }}
     - {{ include "ingress-nginx.fullname" . }}-admission
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "ingress-nginx.fullname" . }}-admission
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "ingress-nginx.fullname" . }}-admission-create
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -33,14 +34,19 @@ spec:
       containers:
         - name: create
           {{- with .Values.controller.admissionWebhooks.patch.image }}
-          image: "{{.repository}}{{- if (.digest) -}} @{{.digest}} {{- else -}} :{{ .tag }} {{- end -}}"
+          image: "{{- if .repository -}}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{- end -}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
           {{- end }}
           imagePullPolicy: {{ .Values.controller.admissionWebhooks.patch.image.pullPolicy }}
           args:
             - create
-            - --host={{ include "ingress-nginx.controller.fullname" . }}-admission,{{ include "ingress-nginx.controller.fullname" . }}-admission.{{ .Release.Namespace }}.svc
-            - --namespace={{ .Release.Namespace }}
+            - --host={{ include "ingress-nginx.controller.fullname" . }}-admission,{{ include "ingress-nginx.controller.fullname" . }}-admission.$(POD_NAMESPACE).svc
+            - --namespace=$(POD_NAMESPACE)
             - --secret-name={{ include "ingress-nginx.fullname" . }}-admission
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
       restartPolicy: OnFailure
       serviceAccountName: {{ include "ingress-nginx.fullname" . }}-admission
     {{- if .Values.controller.admissionWebhooks.patch.nodeSelector }}

--- a/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "ingress-nginx.fullname" . }}-admission-patch
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -33,16 +34,21 @@ spec:
       containers:
         - name: patch
           {{- with .Values.controller.admissionWebhooks.patch.image }}
-          image: "{{.repository}}{{- if (.digest) -}} @{{.digest}} {{- else -}} :{{ .tag }} {{- end -}}"
+          image: "{{- if .repository -}}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{- end -}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
           {{- end }}
           imagePullPolicy: {{ .Values.controller.admissionWebhooks.patch.image.pullPolicy }}
           args:
             - patch
             - --webhook-name={{ include "ingress-nginx.fullname" . }}-admission
-            - --namespace={{ .Release.Namespace }}
+            - --namespace=$(POD_NAMESPACE)
             - --patch-mutating=false
             - --secret-name={{ include "ingress-nginx.fullname" . }}-admission
             - --patch-failure-policy={{ .Values.controller.admissionWebhooks.failurePolicy }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
       restartPolicy: OnFailure
       serviceAccountName: {{ include "ingress-nginx.fullname" . }}-admission
     {{- if .Values.controller.admissionWebhooks.patch.nodeSelector }}

--- a/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/psp.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/psp.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled .Values.podSecurityPolicy.enabled -}}
+{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled .Values.podSecurityPolicy.enabled (empty .Values.controller.admissionWebhooks.existingPsp) -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/role.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name:  {{ include "ingress-nginx.fullname" . }}-admission
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "ingress-nginx.fullname" . }}-admission
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -16,5 +17,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "ingress-nginx.fullname" . }}-admission
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ingress-nginx.fullname" . }}-admission
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/helmfile/upstream/ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
@@ -1,18 +1,21 @@
 {{- if .Values.controller.admissionWebhooks.enabled -}}
 # before changing this value, check the required kubernetes version
 # https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#prerequisites
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  {{- if .Values.controller.admissionWebhooks.annotations }}
+  annotations: {{ toYaml .Values.controller.admissionWebhooks.annotations | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: admission-webhook
   name: {{ include "ingress-nginx.fullname" . }}-admission
 webhooks:
   - name: validate.nginx.ingress.kubernetes.io
+    matchPolicy: Equivalent
     rules:
       - apiGroups:
-          - extensions
           - networking.k8s.io
         apiVersions:
           - v1beta1
@@ -21,14 +24,23 @@ webhooks:
           - UPDATE
         resources:
           - ingresses
-    failurePolicy: Fail
+    failurePolicy: {{ .Values.controller.admissionWebhooks.failurePolicy | default "Fail" }}
     sideEffects: None
     admissionReviewVersions:
       - v1
       - v1beta1
     clientConfig:
       service:
-        namespace: {{ .Release.Namespace }}
+        namespace: {{ .Release.Namespace | quote }}
         name: {{ include "ingress-nginx.controller.fullname" . }}-admission
-        path: /extensions/v1beta1/ingresses
+        path: /networking/v1beta1/ingresses
+    {{- if .Values.controller.admissionWebhooks.timeoutSeconds }}
+    timeoutSeconds: {{ .Values.controller.admissionWebhooks.timeoutSeconds }}
+    {{- end }}
+    {{- if .Values.controller.admissionWebhooks.namespaceSelector }}
+    namespaceSelector: {{ toYaml .Values.controller.admissionWebhooks.namespaceSelector | nindent 6 }}
+    {{- end }}
+    {{- if .Values.controller.admissionWebhooks.objectSelector }}
+    objectSelector: {{ toYaml .Values.controller.admissionWebhooks.objectSelector | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/clusterrole.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/clusterrole.yaml
@@ -40,7 +40,6 @@ rules:
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - extensions

--- a/helmfile/upstream/ingress-nginx/templates/clusterrolebinding.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/clusterrolebinding.yaml
@@ -12,5 +12,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "ingress-nginx.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-configmap-addheaders.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-configmap-addheaders.yaml
@@ -6,5 +6,6 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ include "ingress-nginx.fullname" . }}-custom-add-headers
+  namespace: {{ .Release.Namespace }}
 data: {{ toYaml .Values.controller.addHeaders | nindent 2 }}
 {{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-configmap-proxyheaders.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-configmap-proxyheaders.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ include "ingress-nginx.fullname" . }}-custom-proxy-headers
+  namespace: {{ .Release.Namespace }}
 data:
 {{- if .Values.controller.proxySetHeaders }}
 {{ toYaml .Values.controller.proxySetHeaders | indent 2 }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-configmap-tcp.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-configmap-tcp.yaml
@@ -9,5 +9,6 @@ metadata:
   annotations: {{ toYaml .Values.controller.tcp.annotations | nindent 4 }}
 {{- end }}
   name: {{ include "ingress-nginx.fullname" . }}-tcp
+  namespace: {{ .Release.Namespace }}
 data: {{ tpl (toYaml .Values.tcp) . | nindent 2 }}
 {{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-configmap-udp.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-configmap-udp.yaml
@@ -9,5 +9,6 @@ metadata:
   annotations: {{ toYaml .Values.controller.udp.annotations | nindent 4 }}
 {{- end }}
   name: {{ include "ingress-nginx.fullname" . }}-udp
+  namespace: {{ .Release.Namespace }}
 data: {{ tpl (toYaml .Values.udp) . | nindent 2 }}
 {{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-configmap.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-configmap.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations: {{ toYaml .Values.controller.configAnnotations | nindent 4 }}
 {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 data:
 {{- if .Values.controller.addHeaders }}
   add-headers: {{ .Release.Namespace }}/{{ include "ingress-nginx.fullname" . }}-custom-add-headers
@@ -15,6 +16,10 @@ data:
 {{- if or .Values.controller.proxySetHeaders .Values.controller.headers }}
   proxy-set-headers: {{ .Release.Namespace }}/{{ include "ingress-nginx.fullname" . }}-custom-proxy-headers
 {{- end }}
-{{- if .Values.controller.config }}
-  {{ toYaml .Values.controller.config | nindent 2 }}
+{{- if .Values.dhParam }}
+  ssl-dh-param: {{ printf "%s/%s" .Release.Namespace (include "ingress-nginx.controller.fullname" .) }}
 {{- end }}
+{{- range $key, $value := .Values.controller.config }}
+    {{ $key | nindent 2 }}: {{ $value | quote }}
+{{- end }}
+

--- a/helmfile/upstream/ingress-nginx/templates/controller-daemonset.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-daemonset.yaml
@@ -6,7 +6,11 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.controller.annotations }}
   annotations: {{ toYaml .Values.controller.annotations | nindent 4 }}
   {{- end }}
@@ -23,7 +27,10 @@ spec:
   template:
     metadata:
     {{- if .Values.controller.podAnnotations }}
-      annotations: {{ toYaml .Values.controller.podAnnotations | nindent 8 }}
+      annotations:
+      {{- range $key, $value := .Values.controller.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
     {{- end }}
       labels:
         {{- include "ingress-nginx.selectorLabels" . | nindent 8 }}
@@ -56,9 +63,9 @@ spec:
     {{- end }}
     {{- end }}
       containers:
-        - name: controller
+        - name: {{ .Values.controller.containerName }}
           {{- with .Values.controller.image }}
-          image: "{{.repository}}{{- if (.digest) -}} @{{.digest}} {{- else -}} :{{ .tag }} {{- end -}}"
+          image: "{{- if .repository -}}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{- end -}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
           {{- end }}
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         {{- if .Values.controller.lifecycle }}
@@ -89,9 +96,12 @@ spec:
           {{- end }}
           {{- if .Values.controller.admissionWebhooks.enabled }}
             - --validating-webhook=:{{ .Values.controller.admissionWebhooks.port }}
-            - --validating-webhook-certificate=/usr/local/certificates/cert
-            - --validating-webhook-key=/usr/local/certificates/key
+            - --validating-webhook-certificate={{ .Values.controller.admissionWebhooks.certificate }}
+            - --validating-webhook-key={{ .Values.controller.admissionWebhooks.key }}
           {{- end }}
+          {{- if .Values.controller.maxmindMirror }}
+            - --maxmind-mirror={{ .Values.controller.maxmindMirror }}
+          {{- end}}
           {{- if .Values.controller.maxmindLicenseKey }}
             - --maxmind-license-key={{ .Values.controller.maxmindLicenseKey }}
           {{- end }}
@@ -99,10 +109,11 @@ spec:
             - --health-check-path={{ .Values.controller.healthCheckPath }}
           {{- end }}
           {{- range $key, $value := .Values.controller.extraArgs }}
-            {{- if $value }}
-            - --{{ $key }}={{ $value }}
-            {{- else }}
+            {{- /* Accept keys without values or with false as value */}}
+            {{- if eq ($value | quote | len) 2 }}
             - --{{ $key }}
+            {{- else }}
+            - --{{ $key }}={{ $value }}
             {{- end }}
           {{- end }}
           securityContext:
@@ -129,26 +140,11 @@ spec:
           {{- if .Values.controller.extraEnvs }}
             {{- toYaml .Values.controller.extraEnvs | nindent 12 }}
           {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: {{ .Values.controller.livenessProbe.port }}
-              scheme: HTTP
-            initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.controller.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.controller.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.controller.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.controller.livenessProbe.failureThreshold }}
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: {{ .Values.controller.readinessProbe.port }}
-              scheme: HTTP
-            initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.controller.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
+          {{- if .Values.controller.startupProbe }}
+          startupProbe: {{ toYaml .Values.controller.startupProbe | nindent 12 }}
+          {{- end }}
+          livenessProbe: {{ toYaml .Values.controller.livenessProbe | nindent 12 }}
+          readinessProbe: {{ toYaml .Values.controller.readinessProbe | nindent 12 }}
           ports:
           {{- range $key, $value := .Values.controller.containerPort }}
             - name: {{ $key }}
@@ -220,6 +216,9 @@ spec:
     {{- end }}
     {{- if .Values.controller.affinity }}
       affinity: {{ toYaml .Values.controller.affinity | nindent 8 }}
+    {{- end }}
+    {{- if .Values.controller.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml .Values.controller.topologySpreadConstraints | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ template "ingress-nginx.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-deployment.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-deployment.yaml
@@ -6,7 +6,11 @@ metadata:
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- if .Values.controller.annotations }}
   annotations: {{ toYaml .Values.controller.annotations | nindent 4 }}
   {{- end }}
@@ -27,7 +31,10 @@ spec:
   template:
     metadata:
     {{- if .Values.controller.podAnnotations }}
-      annotations: {{ toYaml .Values.controller.podAnnotations | nindent 8 }}
+      annotations:
+      {{- range $key, $value := .Values.controller.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
     {{- end }}
       labels:
         {{- include "ingress-nginx.selectorLabels" . | nindent 8 }}
@@ -60,9 +67,9 @@ spec:
     {{- end }}
     {{- end }}
       containers:
-        - name: controller
+        - name: {{ .Values.controller.containerName }}
           {{- with .Values.controller.image }}
-          image: "{{.repository}}{{- if (.digest) -}} @{{.digest}} {{- else -}} :{{ .tag }} {{- end -}}"
+          image: "{{- if .repository -}}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{- end -}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
           {{- end }}
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         {{- if .Values.controller.lifecycle }}
@@ -71,30 +78,30 @@ spec:
           args:
             - /nginx-ingress-controller
           {{- if .Values.defaultBackend.enabled }}
-            - --default-backend-service={{ .Release.Namespace }}/{{ include "ingress-nginx.defaultBackend.fullname" . }}
+            - --default-backend-service=$(POD_NAMESPACE)/{{ include "ingress-nginx.defaultBackend.fullname" . }}
           {{- end }}
           {{- if .Values.controller.publishService.enabled }}
             - --publish-service={{ template "ingress-nginx.controller.publishServicePath" . }}
           {{- end }}
             - --election-id={{ .Values.controller.electionID }}
             - --ingress-class={{ .Values.controller.ingressClass }}
-            - --configmap={{ .Release.Namespace }}/{{ include "ingress-nginx.controller.fullname" . }}
+            - --configmap=$(POD_NAMESPACE)/{{ include "ingress-nginx.controller.fullname" . }}
           {{- if .Values.tcp }}
-            - --tcp-services-configmap={{ .Release.Namespace }}/{{ include "ingress-nginx.fullname" . }}-tcp
+            - --tcp-services-configmap=$(POD_NAMESPACE)/{{ include "ingress-nginx.fullname" . }}-tcp
           {{- end }}
           {{- if .Values.udp }}
-            - --udp-services-configmap={{ .Release.Namespace }}/{{ include "ingress-nginx.fullname" . }}-udp
+            - --udp-services-configmap=$(POD_NAMESPACE)/{{ include "ingress-nginx.fullname" . }}-udp
           {{- end }}
           {{- if .Values.controller.scope.enabled }}
-            - --watch-namespace={{ default .Release.Namespace .Values.controller.scope.namespace }}
+            - --watch-namespace={{ default "$(POD_NAMESPACE)" .Values.controller.scope.namespace }}
           {{- end }}
           {{- if and .Values.controller.reportNodeInternalIp .Values.controller.hostNetwork }}
             - --report-node-internal-ip-address={{ .Values.controller.reportNodeInternalIp }}
           {{- end }}
           {{- if .Values.controller.admissionWebhooks.enabled }}
             - --validating-webhook=:{{ .Values.controller.admissionWebhooks.port }}
-            - --validating-webhook-certificate=/usr/local/certificates/cert
-            - --validating-webhook-key=/usr/local/certificates/key
+            - --validating-webhook-certificate={{ .Values.controller.admissionWebhooks.certificate }}
+            - --validating-webhook-key={{ .Values.controller.admissionWebhooks.key }}
           {{- end }}
           {{- if .Values.controller.maxmindLicenseKey }}
             - --maxmind-license-key={{ .Values.controller.maxmindLicenseKey }}
@@ -103,10 +110,11 @@ spec:
             - --health-check-path={{ .Values.controller.healthCheckPath }}
           {{- end }}
           {{- range $key, $value := .Values.controller.extraArgs }}
-            {{- if $value }}
-            - --{{ $key }}={{ $value }}
-            {{- else }}
+            {{- /* Accept keys without values or with false as value */}}
+            {{- if eq ($value | quote | len) 2 }}
             - --{{ $key }}
+            {{- else }}
+            - --{{ $key }}={{ $value }}
             {{- end }}
           {{- end }}
           securityContext:
@@ -132,27 +140,12 @@ spec:
           {{- end }}
           {{- if .Values.controller.extraEnvs }}
             {{- toYaml .Values.controller.extraEnvs | nindent 12 }}
+          {{- end }}          
+          {{- if .Values.controller.startupProbe }}
+          startupProbe: {{ toYaml .Values.controller.startupProbe | nindent 12 }}
           {{- end }}
-          livenessProbe:
-            httpGet:
-              path: {{ .Values.controller.healthCheckPath }}
-              port: {{ .Values.controller.livenessProbe.port }}
-              scheme: HTTP
-            initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.controller.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.controller.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.controller.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.controller.livenessProbe.failureThreshold }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.controller.healthCheckPath }}
-              port: {{ .Values.controller.readinessProbe.port }}
-              scheme: HTTP
-            initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.controller.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
+          livenessProbe: {{ toYaml .Values.controller.livenessProbe | nindent 12 }}
+          readinessProbe: {{ toYaml .Values.controller.readinessProbe | nindent 12 }}
           ports:
           {{- range $key, $value := .Values.controller.containerPort }}
             - name: {{ $key }}
@@ -224,6 +217,9 @@ spec:
     {{- end }}
     {{- if .Values.controller.affinity }}
       affinity: {{ toYaml .Values.controller.affinity | nindent 8 }}
+    {{- end }}
+    {{- if .Values.controller.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml .Values.controller.topologySpreadConstraints | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ template "ingress-nginx.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-hpa.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-hpa.yaml
@@ -1,11 +1,18 @@
 {{- if and .Values.controller.autoscaling.enabled (or (eq .Values.controller.kind "Deployment") (eq .Values.controller.kind "Both")) -}}
+{{- if not .Values.controller.keda.enabled }}
+
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
+  annotations:
+  {{- with .Values.controller.autoscaling.annotations }}
+  {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ include "ingress-nginx.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -14,14 +21,6 @@ spec:
   minReplicas: {{ .Values.controller.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
   metrics:
-  {{- with .Values.controller.autoscaling.targetCPUUtilizationPercentage }}
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ . }}
-  {{- end }}
   {{- with .Values.controller.autoscaling.targetMemoryUtilizationPercentage }}
   - type: Resource 
     resource: 
@@ -30,7 +29,17 @@ spec:
         type: Utilization
         averageUtilization: {{ . }}
   {{- end }}
+  {{- with .Values.controller.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
   {{- with .Values.controller.autoscalingTemplate }}
 {{- toYaml . | nindent 2 }}
   {{- end }}
 {{- end }}
+{{- end }}
+

--- a/helmfile/upstream/ingress-nginx/templates/controller-ingressclass.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-ingressclass.yaml
@@ -1,0 +1,23 @@
+{{- if and (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) (.Values.controller.ingressClassResource.enabled) -}}
+{{- if and (semverCompare "=1.18-0" .Capabilities.KubeVersion.GitVersion)  }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: networking.k8s.io/v1
+{{- end }}
+kind: IngressClass
+metadata:
+  labels:
+    {{- include "ingress-nginx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+    {{- with .Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ .Values.controller.ingressClass }}
+{{- if .Values.controller.ingressClassResource.default }}
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+{{- end }}
+spec:
+  controller: k8s.io/ingress-nginx
+  {{ template "ingressClass.parameters" . }}
+{{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-keda.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-keda.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.controller.keda.enabled (or (eq .Values.controller.kind "Deployment") (eq .Values.controller.kind "Both")) -}}
+# https://keda.sh/docs/
+
+apiVersion: {{ .Values.controller.keda.apiVersion }}
+kind: ScaledObject
+metadata:
+  labels:
+    {{- include "ingress-nginx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+  name: {{ include "ingress-nginx.controller.fullname" . }}
+  {{- if .Values.controller.keda.scaledObject.annotations }}
+  annotations: {{ toYaml .Values.controller.keda.scaledObject.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+{{- if eq .Values.controller.keda.apiVersion "keda.k8s.io/v1alpha1" }}
+    deploymentName: {{ include "ingress-nginx.controller.fullname" . }}
+{{- else if eq .Values.controller.keda.apiVersion "keda.sh/v1alpha1" }}
+    name: {{ include "ingress-nginx.controller.fullname" . }}
+{{- end }}
+  pollingInterval: {{ .Values.controller.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.controller.keda.cooldownPeriod }}
+  minReplicaCount: {{ .Values.controller.keda.minReplicas }}
+  maxReplicaCount: {{ .Values.controller.keda.maxReplicas }}
+  triggers:
+{{- with .Values.controller.keda.triggers }}
+{{ toYaml . | indent 2 }}
+{{ end }}
+  advanced:
+    restoreToOriginalReplicaCount: {{ .Values.controller.keda.restoreToOriginalReplicaCount }}
+{{- if .Values.controller.keda.behavior }}
+    horizontalPodAutoscalerConfig:
+      behavior:
+{{ with .Values.controller.keda.behavior -}}
+{{ toYaml . | indent 8 }}
+{{ end }}
+
+{{- end }}
+{{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-poddisruptionbudget.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if or (and .Values.controller.autoscaling.enabled (gt (.Values.controller.autoscaling.minReplicas | int) 1)) (gt (.Values.controller.replicaCount | int) 1) -}}
+{{- if or (and .Values.controller.autoscaling.enabled (gt (.Values.controller.autoscaling.minReplicas | int) 1)) (and (not .Values.controller.autoscaling.enabled) (gt (.Values.controller.replicaCount | int) 1)) }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -6,6 +6,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ include "ingress-nginx.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/helmfile/upstream/ingress-nginx/templates/controller-prometheusrules.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-prometheusrules.yaml
@@ -4,7 +4,7 @@ kind: PrometheusRule
 metadata:
   name: {{ include "ingress-nginx.controller.fullname" . }}
 {{- if .Values.controller.metrics.prometheusRule.namespace }}
-  namespace: {{ .Values.controller.metrics.prometheusRule.namespace }}
+  namespace: {{ .Values.controller.metrics.prometheusRule.namespace | quote }}
 {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-psp.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podSecurityPolicy.enabled -}}
+{{- if and .Values.podSecurityPolicy.enabled (empty .Values.controller.existingPsp) -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -20,7 +20,7 @@ spec:
   # Allow core volume types.
   volumes:
     - 'configMap'
-    #- 'emptyDir'
+    - 'emptyDir'
     #- 'projected'
     - 'secret'
     #- 'downwardAPI'

--- a/helmfile/upstream/ingress-nginx/templates/controller-role.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-role.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ include "ingress-nginx.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - ""
@@ -31,7 +32,6 @@ rules:
     verbs:
       - get
       - list
-      - update
       - watch
   - apiGroups:
       - extensions
@@ -75,14 +75,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - endpoints
-    verbs:
-      - create
-      - get
-      - update
-  - apiGroups:
-      - ""
-    resources:
       - events
     verbs:
       - create
@@ -91,6 +83,10 @@ rules:
   - apiGroups:      [{{ template "podSecurityPolicy.apiGroup" . }}]
     resources:      ['podsecuritypolicies']
     verbs:          ['use']
+    {{- with .Values.controller.existingPsp }}
+    resourceNames:  [{{ . }}]
+    {{- else }}
     resourceNames:  [{{ include "ingress-nginx.fullname" . }}]
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-rolebinding.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-rolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ include "ingress-nginx.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13,5 +14,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "ingress-nginx.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-service-internal.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-service-internal.yaml
@@ -13,8 +13,18 @@ metadata:
     {{- toYaml .Values.controller.service.labels | nindent 4 }}
   {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}-internal
+  namespace: {{ .Release.Namespace }}
 spec:
   type: "{{ .Values.controller.service.type }}"
+{{- if .Values.controller.service.internal.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.controller.service.internal.loadBalancerIP }}
+{{- end }}
+{{- if .Values.controller.service.internal.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.controller.service.internal.loadBalancerSourceRanges | nindent 4 }}
+{{- end }}
+{{- if .Values.controller.service.internal.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.controller.service.internal.externalTrafficPolicy }}
+{{- end }}
   ports:
   {{- $setNodePorts := (or (eq .Values.controller.service.type "NodePort") (eq .Values.controller.service.type "LoadBalancer")) }}
   {{- if .Values.controller.service.enableHttp }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-service-metrics.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-service-metrics.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- toYaml .Values.controller.metrics.service.labels | nindent 4 }}
   {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.controller.metrics.service.type }}
 {{- if .Values.controller.metrics.service.clusterIP }}
@@ -26,10 +27,17 @@ spec:
 {{- if .Values.controller.metrics.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{ toYaml .Values.controller.metrics.service.loadBalancerSourceRanges | nindent 4 }}
 {{- end }}
+{{- if .Values.controller.metrics.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.controller.metrics.service.externalTrafficPolicy }}
+{{- end }}
   ports:
     - name: metrics
       port: {{ .Values.controller.metrics.service.servicePort }}
       targetPort: metrics
+    {{- $setNodePorts := (or (eq .Values.controller.metrics.service.type "NodePort") (eq .Values.controller.metrics.service.type "LoadBalancer")) }}
+    {{- if (and $setNodePorts (not (empty .Values.controller.metrics.service.nodePort))) }}
+      nodePort: {{ .Values.controller.metrics.service.nodePort }}
+    {{- end }}
   selector:
     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: controller

--- a/helmfile/upstream/ingress-nginx/templates/controller-service-webhook.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-service-webhook.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ include "ingress-nginx.controller.fullname" . }}-admission
+  namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.controller.admissionWebhooks.service.type }}
 {{- if .Values.controller.admissionWebhooks.service.clusterIP }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-service.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-service.yaml
@@ -2,9 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.controller.service.annotations }}
-  annotations: {{ toYaml .Values.controller.service.annotations | nindent 4 }}
-{{- end }}
+  annotations:
+  {{- range $key, $value := .Values.controller.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
@@ -12,6 +13,7 @@ metadata:
     {{- toYaml .Values.controller.service.labels | nindent 4 }}
   {{- end }}
   name: {{ include "ingress-nginx.controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.controller.service.type }}
 {{- if .Values.controller.service.clusterIP }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-serviceaccount.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-serviceaccount.yaml
@@ -6,4 +6,6 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
   name: {{ template "ingress-nginx.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-servicemonitor.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-servicemonitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "ingress-nginx.controller.fullname" . }}
 {{- if .Values.controller.metrics.serviceMonitor.namespace }}
-  namespace: {{ .Values.controller.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.controller.metrics.serviceMonitor.namespace | quote }}
 {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
@@ -19,12 +19,24 @@ spec:
     {{- if .Values.controller.metrics.serviceMonitor.honorLabels }}
       honorLabels: true
     {{- end }}
+    {{- if .Values.controller.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml .Values.controller.metrics.serviceMonitor.metricRelabelings | nindent 8 }}
+    {{- end }}
+{{- if .Values.controller.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.controller.metrics.serviceMonitor.jobLabel | quote }}
+{{- end }}
 {{- if .Values.controller.metrics.serviceMonitor.namespaceSelector }}
   namespaceSelector: {{ toYaml .Values.controller.metrics.serviceMonitor.namespaceSelector | nindent 4 }}
 {{ else }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
+{{- end }}
+{{- if .Values.controller.metrics.serviceMonitor.targetLabels }}
+  targetLabels:
+  {{- range .Values.controller.metrics.serviceMonitor.targetLabels }}
+    - {{ . }}
+  {{- end }}
 {{- end }}
   selector:
     matchLabels:

--- a/helmfile/upstream/ingress-nginx/templates/default-backend-deployment.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/default-backend-deployment.yaml
@@ -6,12 +6,15 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
   name: {{ include "ingress-nginx.defaultBackend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
       {{- include "ingress-nginx.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: default-backend
+{{- if not .Values.defaultBackend.autoscaling.enabled }}
   replicas: {{ .Values.defaultBackend.replicaCount }}
+{{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:
@@ -37,21 +40,28 @@ spec:
       containers:
         - name: {{ template "ingress-nginx.name" . }}-default-backend
           {{- with .Values.defaultBackend.image }}
-          image: "{{.repository}}{{- if (.digest) -}} @{{.digest}} {{- else -}} :{{ .tag }} {{- end -}}"
+          image: "{{- if .repository -}}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{- end -}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
           {{- end }}
           imagePullPolicy: {{ .Values.defaultBackend.image.pullPolicy }}
         {{- if .Values.defaultBackend.extraArgs }}
           args:
           {{- range $key, $value := .Values.defaultBackend.extraArgs }}
-            {{- if $value }}
-            - --{{ $key }}={{ $value }}
-            {{- else }}
+            {{- /* Accept keys without values or with false as value */}}
+            {{- if eq ($value | quote | len) 2 }}
             - --{{ $key }}
+            {{- else }}
+            - --{{ $key }}={{ $value }}
             {{- end }}
           {{- end }}
         {{- end }}
           securityContext:
+            capabilities:
+              drop:
+              - ALL
             runAsUser: {{ .Values.defaultBackend.image.runAsUser }}
+            runAsNonRoot: {{ .Values.defaultBackend.image.runAsNonRoot }}
+            allowPrivilegeEscalation: {{ .Values.defaultBackend.image.allowPrivilegeEscalation }}
+            readOnlyRootFilesystem: {{ .Values.defaultBackend.image.readOnlyRootFilesystem}}
         {{- if .Values.defaultBackend.extraEnvs }}
           env: {{ toYaml .Values.defaultBackend.extraEnvs | nindent 12 }}
         {{- end }}
@@ -79,6 +89,9 @@ spec:
             - name: http
               containerPort: {{ .Values.defaultBackend.port }}
               protocol: TCP
+        {{- if .Values.defaultBackend.extraVolumeMounts }}
+          volumeMounts: {{- toYaml .Values.defaultBackend.extraVolumeMounts | nindent 12 }}
+        {{- end }}
         {{- if .Values.defaultBackend.resources }}
           resources: {{ toYaml .Values.defaultBackend.resources | nindent 12 }}
         {{- end }}
@@ -93,4 +106,7 @@ spec:
       affinity: {{ toYaml .Values.defaultBackend.affinity | nindent 8 }}
     {{- end }}
       terminationGracePeriodSeconds: 60
+    {{- if .Values.defaultBackend.extraVolumes }}
+      volumes: {{ toYaml .Values.defaultBackend.extraVolumes | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/default-backend-hpa.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/default-backend-hpa.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.defaultBackend.enabled .Values.defaultBackend.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    {{- include "ingress-nginx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: default-backend
+  name: {{ template "ingress-nginx.defaultBackend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "ingress-nginx.defaultBackend.fullname" . }}
+  minReplicas: {{ .Values.defaultBackend.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.defaultBackend.autoscaling.maxReplicas }}
+  metrics:
+{{- with .Values.defaultBackend.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ . }}
+{{- end }}
+{{- with .Values.defaultBackend.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ . }}
+{{- end }}
+{{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/default-backend-poddisruptionbudget.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/default-backend-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if gt (.Values.defaultBackend.replicaCount | int) 1 -}}
+{{- if or (gt (.Values.defaultBackend.replicaCount | int) 1) (gt (.Values.defaultBackend.autoscaling.minReplicas | int) 1) }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -6,6 +6,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
   name: {{ include "ingress-nginx.defaultBackend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/helmfile/upstream/ingress-nginx/templates/default-backend-psp.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/default-backend-psp.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.podSecurityPolicy.enabled .Values.defaultBackend.enabled -}}
+{{- if and .Values.podSecurityPolicy.enabled .Values.defaultBackend.enabled (empty .Values.defaultBackend.existingPsp) -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/helmfile/upstream/ingress-nginx/templates/default-backend-role.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/default-backend-role.yaml
@@ -6,9 +6,14 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
   name: {{ include "ingress-nginx.fullname" . }}-backend
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:      [{{ template "podSecurityPolicy.apiGroup" . }}]
     resources:      ['podsecuritypolicies']
     verbs:          ['use']
+    {{- with .Values.defaultBackend.existingPsp }}
+    resourceNames:  [{{ . }}]
+    {{- else }}
     resourceNames:  [{{ include "ingress-nginx.fullname" . }}-backend]
+    {{- end }}
 {{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/default-backend-rolebinding.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/default-backend-rolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
   name: {{ include "ingress-nginx.fullname" . }}-backend
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13,5 +14,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "ingress-nginx.defaultBackend.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/default-backend-service.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/default-backend-service.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
   name: {{ include "ingress-nginx.defaultBackend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.defaultBackend.service.type }}
 {{- if .Values.defaultBackend.service.clusterIP }}

--- a/helmfile/upstream/ingress-nginx/templates/default-backend-serviceaccount.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/default-backend-serviceaccount.yaml
@@ -6,4 +6,6 @@ metadata:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: default-backend
   name: {{ template "ingress-nginx.defaultBackend.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+automountServiceAccountToken: {{ .Values.defaultBackend.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/dh-param-secret.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/dh-param-secret.yaml
@@ -1,0 +1,10 @@
+{{- with .Values.dhParam -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ingress-nginx.controller.fullname" $ }}
+  labels:
+    {{- include "ingress-nginx.labels" $ | nindent 4 }}
+data:
+  dhparam.pem: {{ . }}
+{{- end }}

--- a/helmfile/upstream/ingress-nginx/values.yaml
+++ b/helmfile/upstream/ingress-nginx/values.yaml
@@ -1,14 +1,32 @@
 ## nginx configuration
-## Ref: https://github.com/kubernetes/ingress/blob/master/controllers/nginx/configuration.md
+## Ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/index.md
 ##
+
+## Overrides for generated resource names
+# See templates/_helpers.tpl
+# nameOverride:
+# fullnameOverride:
+
 controller:
+  name: controller
   image:
-    repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    tag: "0.33.0"
+    registry: k8s.gcr.io
+    image: ingress-nginx/controller
+    # for backwards compatibility consider setting the full image url via the repository value below
+    # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
+    # repository:
+    tag: "v0.47.0"
+    digest: sha256:a1e4efc107be0bb78f32eaec37bef17d7a0c81bec8066cdf2572508d21351d0b
     pullPolicy: IfNotPresent
     # www-data -> uid 101
     runAsUser: 101
     allowPrivilegeEscalation: true
+
+  # Use an existing PSP instead of creating one
+  existingPsp: ""
+
+  # Configures the controller container name
+  containerName: controller
 
   # Configures the ports the nginx-controller listens on
   containerPort:
@@ -62,6 +80,17 @@ controller:
   ##
   ingressClass: nginx
 
+  # This section refers to the creation of the IngressClass resource
+  # IngressClass resources are supported since k8s >= 1.18
+  ingressClassResource:
+    enabled: false
+    default: false
+
+    # Parameters is a link to a custom resource containing additional
+    # configuration for the controller. This is optional if the controller
+    # does not require extra parameters.
+    parameters: {}
+
   # labels to add to the pod container metadata
   podLabels: {}
   #  key: value
@@ -112,6 +141,10 @@ controller:
     ## Annotations to be added to the udp config configmap
     annotations: {}
 
+  # Maxmind license key to download GeoLite2 Databases
+  # https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases
+  maxmindLicenseKey: ""
+
   ## Additional command line arguments to pass to nginx-ingress-controller
   ## E.g. to specify the default SSL certificate you can use
   ## extraArgs:
@@ -134,6 +167,14 @@ controller:
   ## Annotations to be added to the controller Deployment or DaemonSet
   ##
   annotations: {}
+  #  keel.sh/pollSchedule: "@every 60m"
+
+  ## Labels to be added to the controller Deployment or DaemonSet
+  ##
+  labels: {}
+  #  keel.sh/policy: patch
+  #  keel.sh/trigger: poll
+
 
   # The update strategy to apply to the Deployment or DaemonSet
   ##
@@ -167,10 +208,18 @@ controller:
     #     podAffinityTerm:
     #       labelSelector:
     #         matchExpressions:
-    #         - key: app
+    #         - key: app.kubernetes.io/name
     #           operator: In
     #           values:
     #           - ingress-nginx
+    #         - key: app.kubernetes.io/instance
+    #           operator: In
+    #           values:
+    #           - ingress-nginx
+    #         - key: app.kubernetes.io/component
+    #           operator: In
+    #           values:
+    #           - controller
     #       topologyKey: kubernetes.io/hostname
 
     # # An example of required pod anti-affinity
@@ -178,11 +227,30 @@ controller:
     #   requiredDuringSchedulingIgnoredDuringExecution:
     #   - labelSelector:
     #       matchExpressions:
-    #       - key: app
+    #       - key: app.kubernetes.io/name
     #         operator: In
     #         values:
     #         - ingress-nginx
+    #       - key: app.kubernetes.io/instance
+    #         operator: In
+    #         values:
+    #         - ingress-nginx
+    #       - key: app.kubernetes.io/component
+    #         operator: In
+    #         values:
+    #         - controller
     #     topologyKey: "kubernetes.io/hostname"
+
+  ## Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  ##
+  topologySpreadConstraints: []
+    # - maxSkew: 1
+    #   topologyKey: failure-domain.beta.kubernetes.io/zone
+    #   whenUnsatisfiable: DoNotSchedule
+    #   labelSelector:
+    #     matchLabels:
+    #       app.kubernetes.io/instance: ingress-nginx-internal
 
   ## terminationGracePeriodSeconds
   ## wait up to five minutes for the drain of connections
@@ -192,25 +260,46 @@ controller:
   ## Node labels for controller pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/os: linux
 
   ## Liveness and readiness probe values
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
+  # startupProbe:
+  #   httpGet:
+  #     # should match container.healthCheckPath
+  #     path: "/healthz"
+  #     port: 10254
+  #     scheme: HTTP
+  #   initialDelaySeconds: 5
+  #   periodSeconds: 5
+  #   timeoutSeconds: 2
+  #   successThreshold: 1
+  #   failureThreshold: 5
   livenessProbe:
-    failureThreshold: 3
+    httpGet:
+      # should match container.healthCheckPath
+      path: "/healthz"
+      port: 10254
+      scheme: HTTP
     initialDelaySeconds: 10
     periodSeconds: 10
-    successThreshold: 1
     timeoutSeconds: 1
-    port: 10254
+    successThreshold: 1
+    failureThreshold: 5
   readinessProbe:
-    failureThreshold: 3
+    httpGet:
+      # should match container.healthCheckPath
+      path: "/healthz"
+      port: 10254
+      scheme: HTTP
     initialDelaySeconds: 10
     periodSeconds: 10
-    successThreshold: 1
     timeoutSeconds: 1
-    port: 10254
+    successThreshold: 1
+    failureThreshold: 3
+
 
   # Path of the health check endpoint. All requests received on the port defined by
   # the healthz-port parameter are forwarded internally to this path.
@@ -236,6 +325,7 @@ controller:
       cpu: 100m
       memory: 90Mi
 
+  # Mutually exclusive with keda autoscaling
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -254,10 +344,49 @@ controller:
   #       type: AverageValue
   #       averageValue: 10000m
 
+  # Mutually exclusive with hpa autoscaling
+  keda:
+    apiVersion: "keda.sh/v1alpha1"
+  # apiVersion changes with keda 1.x vs 2.x
+  # 2.x = keda.sh/v1alpha1
+  # 1.x = keda.k8s.io/v1alpha1
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 11
+    pollingInterval: 30
+    cooldownPeriod: 300
+    restoreToOriginalReplicaCount: false
+    scaledObject:
+      annotations: {}
+      # Custom annotations for ScaledObject resource
+      #  annotations:
+      # key: value
+    triggers: []
+ #     - type: prometheus
+ #       metadata:
+ #         serverAddress: http://<prometheus-host>:9090
+ #         metricName: http_requests_total
+ #         threshold: '100'
+ #         query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
+
+    behavior: {}
+ #     scaleDown:
+ #       stabilizationWindowSeconds: 300
+ #       policies:
+ #       - type: Pods
+ #         value: 1
+ #         periodSeconds: 180
+ #     scaleUp:
+ #       stabilizationWindowSeconds: 300
+ #       policies:
+ #       - type: Pods
+ #         value: 2
+ #         periodSeconds: 60
+
   ## Enable mimalloc as a drop-in replacement for malloc.
   ## ref: https://github.com/microsoft/mimalloc
   ##
-  enableMimalloc: false
+  enableMimalloc: true
 
   ## Override NGINX template
   customTemplate:
@@ -324,6 +453,16 @@ controller:
       enabled: false
       annotations: {}
 
+      # loadBalancerIP: ""
+
+      ## Restrict access For LoadBalancer service. Defaults to 0.0.0.0/0.
+      loadBalancerSourceRanges: []
+
+      ## Set external traffic policy to: "Local" to preserve source IP on
+      ## providers supporting it
+      ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
+      # externalTrafficPolicy: ""
+
   extraContainers: []
   ## Additional containers to be added to the controller pod.
   ## See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example.
@@ -365,9 +504,18 @@ controller:
   #   command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
 
   admissionWebhooks:
+    annotations: {}
     enabled: true
     failurePolicy: Fail
+    # timeoutSeconds: 10
     port: 8443
+    certificate: "/usr/local/certificates/cert"
+    key: "/usr/local/certificates/key"
+    namespaceSelector: {}
+    objectSelector: {}
+
+    # Use an existing PSP instead of creating one
+    existingPsp: ""
 
     service:
       annotations: {}
@@ -381,8 +529,12 @@ controller:
     patch:
       enabled: true
       image:
-        repository: docker.io/jettech/kube-webhook-certgen
-        tag: v1.2.2
+        registry: docker.io
+        image: jettech/kube-webhook-certgen
+        # for backwards compatibility consider setting the full image url via the repository value below
+        # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
+        # repository:
+        tag: v1.5.1
         pullPolicy: IfNotPresent
       ## Provide a priority class name to the webhook patching job
       ##
@@ -411,12 +563,16 @@ controller:
 
       # loadBalancerIP: ""
       loadBalancerSourceRanges: []
-      servicePort: 9913
+      servicePort: 10254
       type: ClusterIP
+      # externalTrafficPolicy: ""
+      # nodePort: ""
 
     serviceMonitor:
       enabled: false
       additionalLabels: {}
+      # The label to use to retrieve the job name from.
+      # jobLabel: "app.kubernetes.io/name"
       namespace: ""
       namespaceSelector: {}
       # Default: scrape .Release.Namespace only
@@ -425,6 +581,8 @@ controller:
       #   any: true
       scrapeInterval: 30s
       # honorLabels: true
+      targetLabels: []
+      metricRelabelings: []
 
     prometheusRule:
       enabled: false
@@ -432,28 +590,44 @@ controller:
       # namespace: ""
       rules: []
         # # These are just examples rules, please adapt them to your needs
-        # - alert: TooMany500s
+        # - alert: NGINXConfigFailed
+        #   expr: count(nginx_ingress_controller_config_last_reload_successful == 0) > 0
+        #   for: 1s
+        #   labels:
+        #     severity: critical
+        #   annotations:
+        #     description: bad ingress config - nginx config test failed
+        #     summary: uninstall the latest ingress changes to allow config reloads to resume
+        # - alert: NGINXCertificateExpiry
+        #   expr: (avg(nginx_ingress_controller_ssl_expire_time_seconds) by (host) - time()) < 604800
+        #   for: 1s
+        #   labels:
+        #     severity: critical
+        #   annotations:
+        #     description: ssl certificate(s) will expire in less then a week
+        #     summary: renew expiring certificates to avoid downtime
+        # - alert: NGINXTooMany500s
         #   expr: 100 * ( sum( nginx_ingress_controller_requests{status=~"5.+"} ) / sum(nginx_ingress_controller_requests) ) > 5
         #   for: 1m
         #   labels:
-        #     severity: critical
+        #     severity: warning
         #   annotations:
         #     description: Too many 5XXs
-        #     summary: More than 5% of the all requests did return 5XX, this require your attention
-        # - alert: TooMany400s
+        #     summary: More than 5% of all requests returned 5XX, this requires your attention
+        # - alert: NGINXTooMany400s
         #   expr: 100 * ( sum( nginx_ingress_controller_requests{status=~"4.+"} ) / sum(nginx_ingress_controller_requests) ) > 5
         #   for: 1m
         #   labels:
-        #     severity: critical
+        #     severity: warning
         #   annotations:
         #     description: Too many 4XXs
-        #     summary: More than 5% of the all requests did return 4XX, this require your attention
+        #     summary: More than 5% of all requests returned 4XX, this requires your attention
 
   ## Improve connection draining when ingress controller pod is deleted using a lifecycle hook:
   ## With this new hook, we increased the default terminationGracePeriodSeconds from 30 seconds
   ## to 300, allowing the draining of connections up to five minutes.
   ## If the active connections end before that, the pod will terminate gracefully at that time.
-  ## To efectively take advantage of this feature, the Configmap feature
+  ## To effectively take advantage of this feature, the Configmap feature
   ## worker-shutdown-timeout new value is 240s instead of 10s.
   ##
   lifecycle:
@@ -468,28 +642,36 @@ controller:
 ##
 revisionHistoryLimit: 10
 
-# Maxmind license key to download GeoLite2 Databases
-# https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases
-maxmindLicenseKey: ""
-
 ## Default 404 backend
 ##
 defaultBackend:
   ##
   enabled: false
 
+  name: defaultbackend
   image:
-    repository: k8s.gcr.io/defaultbackend-amd64
+    registry: k8s.gcr.io
+    image: defaultbackend-amd64
+    # for backwards compatibility consider setting the full image url via the repository value below
+    # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
+    # repository:
     tag: "1.5"
     pullPolicy: IfNotPresent
     # nobody user -> uid 65534
     runAsUser: 65534
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+
+  # Use an existing PSP instead of creating one
+  existingPsp: ""
 
   extraArgs: {}
 
   serviceAccount:
     create: true
-    name:
+    name: ""
+    automountServiceAccountToken: true
   ## Additional environment variables to set for defaultBackend pods
   extraEnvs: []
 
@@ -553,6 +735,24 @@ defaultBackend:
   #   cpu: 10m
   #   memory: 20Mi
 
+  extraVolumeMounts: []
+  ## Additional volumeMounts to the default backend container.
+  #  - name: copy-portal-skins
+  #   mountPath: /var/lib/lemonldap-ng/portal/skins
+
+  extraVolumes: []
+  ## Additional volumes to the default backend pod.
+  #  - name: copy-portal-skins
+  #    emptyDir: {}
+
+  autoscaling:
+    annotations: {}
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
+
   service:
     annotations: {}
 
@@ -582,7 +782,8 @@ podSecurityPolicy:
 
 serviceAccount:
   create: true
-  name:
+  name: ""
+  automountServiceAccountToken: true
 
 ## Optional array of imagePullSecrets containing private registry credentials
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -600,3 +801,8 @@ tcp: {}
 ##
 udp: {}
 #  53: "kube-system/kube-dns:53"
+
+# A base64ed Diffie-Hellman parameter
+# This can be generated with: openssl dhparam 4096 2> /dev/null | base64
+# Ref: https://github.com/krmichel/ingress-nginx/blob/master/docs/examples/customization/ssl-dh-param
+dhParam:

--- a/helmfile/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile/values/ingress-nginx.yaml.gotmpl
@@ -1,12 +1,31 @@
 ## nginx configuration
-## Ref: https://github.com/kubernetes/ingress/blob/master/controllers/nginx/configuration.md
+## Ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/index.md
 ##
-controller:
-  image:
-    allowPrivilegeEscalation: true
-    tag: "0.28.0"
-    runAsUser: 101
 
+controller:
+  name: controller
+  image:
+    registry: k8s.gcr.io
+    image: ingress-nginx/controller
+    # for backwards compatibility consider setting the full image url via the repository value below
+    # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
+    # repository:
+    tag: "v0.47.0"
+    digest: sha256:a1e4efc107be0bb78f32eaec37bef17d7a0c81bec8066cdf2572508d21351d0b
+    pullPolicy: IfNotPresent
+    # www-data -> uid 101
+    runAsUser: 101
+    allowPrivilegeEscalation: true
+
+  # Configures the controller container name
+  containerName: controller
+
+  # Configures the ports the nginx-controller listens on
+  containerPort:
+    http: 80
+    https: 443
+
+  # Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
   config:
     disable-ipv6-dns: "true"
     proxy-body-size: "200m"
@@ -18,36 +37,39 @@ controller:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 
-  # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
-  # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
-  # is merged
-  hostNetwork: true
-
   # Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
   # By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller
   # to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
   dnsPolicy: ClusterFirstWithHostNet
 
-  publishService:
-    enabled: false
+  # Bare-metal considerations via the host network https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network
+  # Ingress status was blank because there is no Service exposing the NGINX Ingress controller in a configuration using the host network, the default --publish-service flag used in standard cloud setups does not apply
+  reportNodeInternalIp: false
 
+  # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
+  # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
+  # is merged
+  hostNetwork: true
+
+  ## Use host ports 80 and 443
+  ## Disabled by default
+  ##
   hostPort:
     enabled: {{ .Values.ingressNginx.controller.useHostPort }}
-    http: 80
-    https: 443
+    ports:
+      http: 80
+      https: 443
 
-  metrics:
-    port: 10254
-    # if this port is changed, change healthz-port: in extraArgs: accordingly
-    enabled: true
-
-    serviceMonitor:
-      enabled: true
-
-  resources:    {{- toYaml .Values.ingressNginx.controller.resources | nindent 4 }}
-  nodeSelector: {{- toYaml .Values.ingressNginx.controller.nodeSelector | nindent 4 }}
-  affinity:     {{- toYaml .Values.ingressNginx.controller.affinity | nindent 4 }}
-  tolerations:  {{- toYaml .Values.ingressNginx.controller.tolerations | nindent 4 }}
+  ## Allows customization of the source of the IP address or FQDN to report
+  ## in the ingress status field. By default, it reads the information provided
+  ## by the service. If disable, the status field reports the IP address of the
+  ## node or nodes where an ingress controller pod is running.
+  publishService:
+    enabled: false
+    ## Allows overriding of the publish service to bind to
+    ## Must be <namespace>/<service_name>
+    ##
+    pathOverride: ""
 
   ## DaemonSet or Deployment
   ##
@@ -55,16 +77,43 @@ controller:
 
   # The update strategy to apply to the Deployment or DaemonSet
   ##
-  updateStrategy:
+  updateStrategy: 
     type: RollingUpdate
 
   # minReadySeconds to avoid killing pods before we are ready
   ##
   minReadySeconds: 10
 
+
+  ## Node tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: {{- toYaml .Values.ingressNginx.controller.tolerations | nindent 4 }}
+
+  ## Affinity and anti-affinity
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {{- toYaml .Values.ingressNginx.controller.affinity | nindent 4 }}
+
   ## terminationGracePeriodSeconds
+  ## wait up to five minutes for the drain of connections
   ##
   terminationGracePeriodSeconds: 60
+
+  ## Node labels for controller pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {{- toYaml .Values.ingressNginx.controller.nodeSelector | nindent 4 }}
+
+  replicaCount: 1
+
+  minAvailable: 1
+
+  # Define requests resources to avoid probe issues due to CPU utilization in busy nodes
+  # ref: https://github.com/kubernetes/ingress-nginx/issues/4735#issuecomment-551204903
+  # Ideally, there should be no limits.
+  # https://engineering.indeedblog.com/blog/2019/12/cpu-throttling-regression-fix/
+  resources: {{- toYaml .Values.ingressNginx.controller.resources | nindent 4 }}
 
   service:
     {{ if .Values.externalTrafficPolicy.local }}
@@ -83,37 +132,69 @@ controller:
     enabled: false
     {{ end }}
 
+  metrics:
+    port: 10254
+    # if this port is changed, change healthz-port: in extraArgs: accordingly
+    enabled: true
+
+    serviceMonitor:
+       enabled: true
+
+## Rollback limit
+##
+revisionHistoryLimit: 10
 
 ## Default 404 backend
 ##
 defaultBackend:
-
-  ## If false, controller.defaultBackendService must be provided
   ##
   enabled: true
 
   name: default-backend
   image:
-    repository: k8s.gcr.io/defaultbackend-amd64
+    registry: k8s.gcr.io
+    image: defaultbackend-amd64
+    # for backwards compatibility consider setting the full image url via the repository value below
+    # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
+    # repository:
     tag: "1.5"
     pullPolicy: IfNotPresent
     # nobody user -> uid 65534
     runAsUser: 65534
-
-  extraArgs: {}
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
 
   serviceAccount:
     create: true
-    name:
-  ## Additional environment variables to set for defaultBackend pods
-  extraEnvs: []
+    name: ""
+    automountServiceAccountToken: true
 
   port: 8080
 
-  resources:    {{- toYaml .Values.ingressNginx.defaultBackend.resources | nindent 4  }}
-  nodeSelector: {{- toYaml .Values.ingressNginx.defaultBackend.nodeSelector | nindent 4 }}
-  affinity:     {{- toYaml .Values.ingressNginx.defaultBackend.affinity | nindent 4 }}
-  tolerations:  {{- toYaml .Values.ingressNginx.defaultBackend.tolerations | nindent 4 }}
+  ## Node tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: {{- toYaml .Values.ingressNginx.defaultBackend.tolerations | nindent 4 }}
+
+  affinity: {{- toYaml .Values.ingressNginx.defaultBackend.affinity | nindent 4 }}
+  ## Security Context policies for controller pods
+  ## See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for
+  ## notes on enabling and using sysctls
+  ##
+  podSecurityContext: {}
+
+  ## Node labels for default backend pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector:{{- toYaml .Values.ingressNginx.defaultBackend.nodeSelector | nindent 4 } }
+
+  resources: {{- toYaml .Values.ingressNginx.defaultBackend.resources | nindent 4 }}
+
+## Enable RBAC as per https://github.com/kubernetes/ingress/tree/master/examples/rbac/nginx and https://github.com/kubernetes/ingress/issues/266
+rbac:
+  create: true
+  scope: false
 
 # If true, create & use Pod Security Policy resources
 # https://kubernetes.io/docs/concepts/policy/pod-security-policy/
@@ -122,4 +203,6 @@ podSecurityPolicy:
 
 serviceAccount:
   create: true
-  name:
+  name: ""
+  automountServiceAccountToken: true
+

--- a/helmfile/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile/values/ingress-nginx.yaml.gotmpl
@@ -10,8 +10,8 @@ controller:
     # for backwards compatibility consider setting the full image url via the repository value below
     # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
     # repository:
-    tag: "v0.47.0"
-    digest: sha256:a1e4efc107be0bb78f32eaec37bef17d7a0c81bec8066cdf2572508d21351d0b
+    tag: "v0.48.1"
+    digest: sha256:e9fb216ace49dfa4a5983b183067e97496e7a8b307d2093f4278cd550c303899
     pullPolicy: IfNotPresent
     # www-data -> uid 101
     runAsUser: 101

--- a/helmfile/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile/values/ingress-nginx.yaml.gotmpl
@@ -187,7 +187,7 @@ defaultBackend:
   ## Node labels for default backend pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
-  nodeSelector:{{- toYaml .Values.ingressNginx.defaultBackend.nodeSelector | nindent 4 } }
+  nodeSelector: {{- toYaml .Values.ingressNginx.defaultBackend.nodeSelector | nindent 4 }}
 
   resources: {{- toYaml .Values.ingressNginx.defaultBackend.resources | nindent 4 }}
 

--- a/pipeline/test/services/service-cluster/testPodsReady.sh
+++ b/pipeline/test/services/service-cluster/testPodsReady.sh
@@ -30,7 +30,7 @@ deployments=(
     "kube-system calico-kube-controllers"
     "kube-system coredns"
     "kube-system metrics-server"
-    "ingress-nginx ingress-nginx-defaultbackend"
+    "ingress-nginx ingress-nginx-default-backend"
     "monitoring kube-prometheus-stack-operator"
     "monitoring kube-prometheus-stack-grafana"
     "monitoring kube-prometheus-stack-kube-state-metrics"

--- a/pipeline/test/services/workload-cluster/testPodsReady.sh
+++ b/pipeline/test/services/workload-cluster/testPodsReady.sh
@@ -27,7 +27,7 @@ deployments=(
     "kube-system coredns"
     "kube-system metrics-server"
     "kube-system calico-kube-controllers"
-    "ingress-nginx ingress-nginx-defaultbackend"
+    "ingress-nginx ingress-nginx-default-backend"
     "monitoring kube-prometheus-stack-operator"
     "monitoring kube-prometheus-stack-kube-state-metrics"
 )


### PR DESCRIPTION
**What this PR does / why we need it**: newer version with new features, fixes and some CVEs solved

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #71 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**: downtime is expected during the upgrade check [documentation](https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx#upgrading-with-zero-downtime-in-production) for zero downtime production upgrades

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [x] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [x] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [x] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.
<details>
  <summary>Breaking Changes:</summary>

     * Kubernetes v1.16 or higher is required. Only ValidatingWebhookConfiguration AdmissionReviewVersions v1 is supported.
     * Following the Ingress extensions/v1beta1 deprecation, please use networking.k8s.io/v1beta1 or networking.k8s.io/v1 (Kubernetes v1.19 or higher) for new Ingress definitions
     * The repository https://quay.io/repository/kubernetes-ingress-controller/nginx-ingress-controller is deprecated and read-only for historical purposes.
</details>
<details>
  <summary>New Features:</summary>

     * NGINX 1.20.1
     * alpine 3.13.5
     * Go 1.15.6
     * client-go v0.20.2
     * jettech/kube-webhook-certgen v1.5.0
     * k8s supoorted versions: 1.19, 1.20, 1.21
     * OpenSSL 1.1.1g - CVE-2020-1967
     * OWASP ModSecurity Core Rule Set v3.3.0
     * Update kube-webhook-certgen image to v1.5.1
     * Update datadog tracer to v1.1.3
     * Migrate to klog v2
     * Remove ClusterRole when scope option is enabled
     * Allow volume-type emptyDir in controller podsecuritypolicy
     * OCSP stapling
     * TLSv1.3 is enabled by default
     * Use k8s.gcr.io vanity domain
     * NGINX reloads create Kubernetes events
     * Support Keda Autoscaling in helm chart
     * Add SameSite support for Cookie Affinity https://www.chromium.org/updates/same-site
     * Refactor of mirror feature to remove additional annotations
     * Allow service type ExternalName with different port and targetPort
     * Update default variables_hash_bucket_size value to 256
     * Enable Opentracing for authentication subrequests (auth_request)
     * Helm chart stable/nginx-ingress is now maintained in the ingress-nginx repository
     * Support for custom Maxmind GeoLite2 Databases flag --maxmind-edition-ids
     * New PathType and IngressClass fields. Requires Kubernetes v1.18 or higher
     * Enable configuration of lua plugins using the configuration configmap
     * Fix regression in validating webhook when the ingress controller is installed in Kubernetes v1.18
     * Experimental support for s390x
     * Allow combination of NGINX variables in annotation upstream-hash-by
     * New setting to configure different access logs for http and stream sections: http-access-log-path and stream-access-log-path      options in configMap
     * Configure User-Agent for client-go
     * Switch to gcr.io as container registry
     * Use cloud-build to build container images
     * Publish images using Container Image Promoter
     * New configmap option enable-real-ip to enable realip_module
     * New annotation nginx.ingress.kubernetes.io/limit-burst-multiplier to set value for burst multiplier on rate limit
     * Switch to structured logging
     * Improve HandleAdmission resiliency
     * Support custom redirect URL parameter in external authentication #6294
     * Support local GeoIP database mirror #6685
     * New option to set a shutdown grace period #5855
     * Support for Global/Distributed Rate Limiting [#6673](https://github.com/kubernetes/ingress-nginx/pull/6673
     * Update the Ingress Controller Image to correct OpenSSL CVEs
     * Add support for Jaeger Endpoint #6884
     * Allow Multiple Publish Status Addresses #6856
     * Add support for custom probes
 </details>
<details>
  <summary>New defaults:</summary>
     
     * server-tokens is disabled
     * ssl-session-tickets is disabled
     * use-gzip is disabled
     * upstream-keepalive-requests is now 10000
     * upstream-keepalive-connections is now 320
</details>
<details>
  <summary>Deprecations:</summary>

     * Setting access-log-path is deprecated and will be removed in 0.35.0. Please use http-access-log-path and stream-access-log-path
</details>

[full changelog](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md)

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
