### PR TITLE
Nginx client body buffer size

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,3 +1,13 @@
 # Updated
 
 * Updated influxdb chart to 4.8.13
+
+### Changed
+
+- ingress-nginx increased the value for client-body-buffer-size from 16K to 256k
+
+### Fixed
+
+### Added
+
+### Removed

--- a/helmfile/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile/values/ingress-nginx.yaml.gotmpl
@@ -10,6 +10,7 @@ controller:
   config:
     disable-ipv6-dns: "true"
     proxy-body-size: "200m"
+    client-body-buffer-size: "256k"
     {{ if and .Values.externalTrafficPolicy.local .Values.externalTrafficPolicy.whitelistRange.global }}
     whitelist-source-range: {{ .Values.externalTrafficPolicy.whitelistRange.global }}
     {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**: to decrease the number of warnings generated by nginx for elastic and influxdb hosts when request body is larger than the buffer

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #537 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
client_body_buffer_size default value is 16K (buffer size is equal to two memory pages.) on a 64-bit platform. In case the request body is larger than the buffer, the whole body or only its part is written to a temporary file and a warning message is logged.

Increasing it from 64k to 256k seems to solve the issue on an dev cluster with low load.
**Caution**: settings this value to high may generate memory pressure if there are many simultaneous uploads.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [x] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
