### PR TITLE
apps sc: apply dex kibana fix

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Fixed
 
+- added kibana restart to make dex kibana work on a fresh cluster automatically
+
 ### Added
 
 ### Removed

--- a/scripts/deploy-sc.sh
+++ b/scripts/deploy-sc.sh
@@ -40,3 +40,9 @@ else
 fi
 
 echo "Deploy sc completed!" >&2
+
+isSSOenabled=$(yq r -e "${config[config_file_sc]}" elasticsearch.sso.enabled)
+
+if [[ ${isSSOenabled} == "true" ]]; then
+../bin/ck8s ops kubectl sc delete pod -n elastic-system -l role=kibana &> /dev/null
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
As of now, authentication by dex in Kibana doesn't work without restarting Kibana on a completely fresh cluster. This adds a restart of the Kibana pod in the deploy-sc script.

**Which issue this PR fixes**: 
fixes #523 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).