### PR TITLE
apps sc: apply dex kibana fix

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Fixed influxdb-du-monitor to only select influxdb and not backup pods
+- Added dex/dex as a need for opendistro-es to make kibana available out-the-box at cluster initiation if dex is enabled
 
 ### Added
 

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -383,6 +383,8 @@ releases:
   chart: ./elastisys/opendistro-es
   version: 1.12.1
   missingFileHandler: Error
+  needs:
+  - dex/dex
   values:
   - values/opendistro-es.yaml.gotmpl
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As of now, authentication by dex in Kibana doesn't work without restarting Kibana on a completely fresh cluster. This makes opendistro-es be installed when dex is ready.

**Which issue this PR fixes**: 
fixes #523 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).