### PR TITLE
Add resource requests

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -31,6 +31,9 @@
 - Added JumpCloud as a IDP using dex.
 - Setting chunk limit size and queue limit size for fluentd from sc-config file
 - Added options to configure the liveness and readiness probe settings for fluentd forwarder.
+- resource requests for apps [#551](https://github.com/elastisys/compliantkubernetes-apps/pull/551)
+  !! This will cause disruptions/downtime in the cluster as many of the pods will restart to apply the new resource limits/requests. !!
+  !! Check your cluster available resources before applying the new requests. The pods will remain in a pending state if not enough resources are available. !!
 
 ### Removed
 

--- a/config/config/flavors/dev-sc.yaml
+++ b/config/config/flavors/dev-sc.yaml
@@ -34,7 +34,7 @@ elasticsearch:
     javaOpts: -Xms1536m -Xmx1536m
     resources:
       requests:
-        memory: 3072Mi
+        memory: 2Gi
         cpu: 300m
       limits:
         memory: 3072Mi

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -1,3 +1,5 @@
+## Adjust the containers resources requests and limits based on your cluster size and usage.
+
 global:
   ## Compliantkubernetes-apps version.
   ## Use version number if you are exactly at a release tag.
@@ -53,10 +55,10 @@ user:
     resources:
       limits:
         cpu: 100m
-        memory: 128Mi
+        memory: 160Mi
       requests:
-        cpu: 100m
-        memory: 128Mi
+        cpu: 50m
+        memory: 80Mi
     tolerations: []
     affinity: {}
     nodeSelector: {}
@@ -68,6 +70,14 @@ user:
       scopes: profile email openid
       allowedDomains:
         - example.com
+    sidecar:
+      resources:
+        requests:
+          cpu: 5m
+          memory: 80Mi
+        limits:
+          cpu: 10m
+          memory: 100Mi
   # Todo remove dependencie on alertmanager from service cluster
   alertmanager:
     enabled: false
@@ -89,13 +99,19 @@ harbor:
       size: 5Gi
     resources:
       requests:
-        memory: 16Mi
+        cpu: 2m
+        memory: 25Mi
+      limits:
         cpu: 5m
+        memory: 50Mi
   core:
     resources:
       requests:
-        memory: 64Mi
+        cpu: 5m
+        memory: 50Mi
+      limits:
         cpu: 10m
+        memory: 100Mi
   database:
     persistentVolumeClaim:
       size: 1Gi
@@ -108,20 +124,29 @@ harbor:
       size: 1Gi
     resources:
       requests:
-        memory: 64Mi
-        cpu: 10m
+        cpu: 2m
+        memory: 25Mi
+      limits:
+        cpu: 5m
+        memory: 50Mi
   registry:
     persistentVolumeClaim:
       size: 5Gi
     resources:
       requests:
-        memory: 64Mi
-        cpu: 10m
+        cpu: 2m
+        memory: 25Mi
+      limits:
+        cpu: 5m
+        memory: 50Mi
     controller:
       resources:
         requests:
-          memory: 16Mi
-          cpu: 1m
+          cpu: 2m
+          memory: 20Mi
+        limits:
+          cpu: 5m
+          memory: 40Mi
   redis:
     persistentVolumeClaim:
       size: 1Gi
@@ -132,28 +157,37 @@ harbor:
   notary:
     resources:
       requests:
-        memory: 16Mi
+        cpu: 2m
+        memory: 15Mi
+      limits:
         cpu: 5m
+        memory: 20Mi
   notarySigner:
     resources:
       requests:
-        memory: 16Mi
+        cpu: 2m
+        memory: 10Mi
+      limits:
         cpu: 5m
+        memory: 20Mi
   portal:
     resources:
       requests:
-        memory: 16Mi
+        cpu: 2m
+        memory: 5Mi
+      limits:
         cpu: 5m
+        memory: 10Mi
   trivy:
     persistentVolumeClaim:
       size: 5Gi
     resources:
       requests:
-        cpu: 200m
-        memory: 512Mi
+        cpu: 10m
+        memory: 263Mi
       limits:
-        cpu: "1"
-        memory: 1024Mi
+        cpu: 20m
+        memory: 512Mi
   persistence:
     # Valid options are "filesystem" (persistent volume), "swift", or "objectStorage" (matching global config)
     type: set-me
@@ -168,13 +202,48 @@ harbor:
   backup:
     enabled: true
 
+prometheusBlackboxExporter:
+  resources:
+    requests:
+      cpu: 5m
+      memory: 25Mi
+    limits:
+      cpu: 10m
+      memory: 50Mi
+prometheusOperator:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 100Mi
+    limits:
+      cpu: 100m
+      memory: 200Mi
+
+prometheusNodeExporter:
+  resources:
+    requests:
+      cpu: 5m
+      memory: 25Mi
+    limits:
+      cpu: 10m
+      memory: 50Mi
+
+kubeStateMetrics:
+  resources:
+    requests:
+      cpu: 5m
+      memory: 25Mi
+    limits:
+      cpu: 10m
+      memory: 50Mi
+
 prometheus:
   storage:
     enabled: false
     size: 5Gi
   retention:
     size: 4GiB
-    age:  3d
+    age: 3d
     alertmanager: 72h
   resources:
     requests:
@@ -199,18 +268,23 @@ prometheus:
       size: 5Gi
     retention:
       size: 4GiB
-      age:  3d
+      age: 3d
     tolerations: []
     affinity: {}
     nodeSelector: {}
+  alertmanagerSpec:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
   grafana:
     resources:
       requests:
-        cpu: 100m
-        memory: 128Mi
+        cpu: 50m
+        memory: 60Mi
       limits:
         cpu: 100m
-        memory: 128Mi
+        memory: 160Mi
     tolerations: []
     affinity: {}
     nodeSelector: {}
@@ -224,16 +298,24 @@ prometheus:
       # scopes: "openid profile email groups"
       # allowedDomains: []
 
+    sidecar:
+      resources:
+        requests:
+          cpu: 5m
+          memory: 80Mi
+        limits:
+          cpu: 10m
+          memory: 100Mi
 dex:
   additionalKubeloginRedirects: []
   enableStaticLogin: true
   resources:
     limits:
-      cpu: 100m
+      cpu: 10m
       memory: 50Mi
     requests:
-      cpu: 100m
-      memory: 50Mi
+      cpu: 5m
+      memory: 25Mi
   tolerations: []
   affinity: {}
   nodeSelector: {}
@@ -249,7 +331,10 @@ dex:
 
 kibana:
   # Note sso is enabled via `elasticsearch.sso.enabled`
-  resources: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 286Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -355,8 +440,8 @@ elasticsearch:
         cpu: 100m
         memory: 128Mi
       requests:
-        cpu: 10m
-        memory: 32Mi
+        cpu: 50m
+        memory: 64Mi
     affinity: {}
     nodeSelector: {}
     tolerations: []
@@ -424,7 +509,13 @@ elasticsearch:
     serviceMonitor:
       interval: 30s
       scrapeTimeout: 30s
-    resources: {}
+    resources:
+      requests:
+        cpu: 15m
+        memory: 30Mi
+      limits:
+        cpu: 30m
+        memory: 60Mi
     tolerations: []
   ingress:
     maxbodysize: 8m
@@ -435,10 +526,10 @@ fluentd:
     resources:
       limits:
         cpu: 500m
-        memory: 200Mi
+        memory: 572Mi
       requests:
-        cpu: 100m
-        memory: 200Mi
+        cpu: 200m
+        memory: 300Mi
     tolerations: []
     affinity: {}
     nodeSelector: {}
@@ -481,10 +572,10 @@ influxDB:
   createdb: true
   resources:
     requests:
-      memory: 4Gi
+      memory: 2Gi
       cpu: 0.5
     limits:
-      memory: 4Gi
+      memory: 6Gi
       cpu: 2
   persistence:
     size: 10Gi
@@ -531,6 +622,23 @@ influxDB:
         cpu: 250m
         memory: 300Mi
 
+  sidecar:
+    nodeexporter:
+      resources:
+        requests:
+          cpu: 5m
+          memory: 15Mi
+        limits:
+          cpu: 10m
+          memory: 30Mi
+    cronjob:
+      resources:
+        requests:
+          cpu: 5m
+          memory: 50Mi
+        limits:
+          cpu: 10m
+          memory: 100Mi
 alerts:
   alertTo: "null"
   opsGenieHeartbeat:
@@ -570,7 +678,13 @@ nfsProvisioner:
 
 ingressNginx:
   controller:
-    resources: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 263Mi
+      limits:
+        cpu: 200m
+        memory: 512Mi
     tolerations: []
     affinity: {}
     nodeSelector: {}
@@ -585,7 +699,13 @@ ingressNginx:
     additionalConfig: {}
 
   defaultBackend:
-    resources: {}
+    resources:
+      requests:
+        cpu: 5m
+        memory: 10Mi
+      limits:
+        cpu: 10m
+        memory: 20Mi
     tolerations: []
     affinity: {}
     nodeSelector: {}
@@ -596,19 +716,19 @@ velero:
   nodeSelector: {}
   resources:
     limits:
-      cpu: 200m
+      cpu: 100m
       memory: 200Mi
     requests:
-      cpu: 100m
+      cpu: 50m
       memory: 100Mi
   restic:
     tolerations: []
     resources:
       limits:
-        cpu: 200m
+        cpu: 100m
         memory: 200Mi
       requests:
-        cpu: 100m
+        cpu: 50m
         memory: 100Mi
 
 issuers:
@@ -621,19 +741,37 @@ issuers:
   extraIssuers: []
 
 certmanager:
-  resources: {}
+  resources:
+    requests:
+      cpu: 25m
+      memory: 100Mi
+    limits:
+      cpu: 50m
+      memory: 200Mi
   nodeSelector: {}
   tolerations: {}
   affinity: {}
 
   webhook:
-    resources: {}
+    resources:
+      requests:
+        cpu: 25m
+        memory: 25Mi
+      limits:
+        cpu: 50m
+        memory: 50Mi
     nodeSelector: {}
     tolerations: {}
     affinity: {}
 
   cainjector:
-    resources: {}
+    resources:
+      requests:
+        cpu: 25m
+        memory: 100Mi
+      limits:
+        cpu: 50m
+        memory: 200Mi
     nodeSelector: {}
     tolerations: {}
     affinity: {}
@@ -641,6 +779,13 @@ certmanager:
 ## Configuration for metric-server
 metricsServer:
   enabled: true
+  resources:
+    requests:
+      cpu: 10m
+      memory: 25Mi
+    limits:
+      cpu: 20m
+      memory: 50Mi
 
 calicoAccountant:
   enabled: true
@@ -667,27 +812,35 @@ s3Exporter:
 
 starboard:
   # Note: The developers of starboard explicitly recommend against setting your own resources
-  resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+    requests:
+      cpu: 5m
+      memory: 50Mi
+    limits:
+      cpu: 10m
+      memory: 128Mi
   tolerations: []
   affinity: {}
 
 vulnerabilityExporter:
-  resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 50m
-  #   memory: 64Mi
+  resources:
+    requests:
+      cpu: 20m
+      memory: 15Mi
+    limits:
+      cpu: 40m
+      memory: 30Mi
   tolerations: []
   affinity: {}
 
+  curlcronjob:
+    resources:
+      requests:
+        cpu: 20m
+        memory: 64Mi
+      limits:
+        cpu: 40m
+        memory: 128Mi
 monitoring:
   rook:
     enabled: false

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -144,10 +144,10 @@ falco:
   resources:
     limits:
       cpu: 200m
-      memory: 300Mi
+      memory: 1024Mi
     requests:
       cpu: 100m
-      memory: 100Mi
+      memory: 512Mi
 
   ## Run on master nodes.
   tolerations:
@@ -179,13 +179,18 @@ falco:
     nodeSelector: {}
 
   falcoExporter:
-    resources: {}
+    resources:
+      requests:
+        cpu: 5m
+        memory: 15Mi
+      limits:
+        cpu: 5m
+        memory: 15Mi
     tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
     affinity: {}
     nodeSelector: {}
-
 ## Elasticsearch cluster topolgy.
 ## Used in prometheus alerts.
 elasticsearch:
@@ -198,6 +203,33 @@ elasticsearch:
 
 ## Prometheus configuration.
 ## Prometheus collects metrics and pushes it to InfluxDB.
+prometheusOperator:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 100Mi
+    limits:
+      cpu: 100m
+      memory: 200Mi
+
+prometheusNodeExporter:
+  resources:
+    requests:
+      cpu: 5m
+      memory: 25Mi
+    limits:
+      cpu: 10m
+      memory: 50Mi
+
+kubeStateMetrics:
+  resources:
+    requests:
+      cpu: 5m
+      memory: 25Mi
+    limits:
+      cpu: 10m
+      memory: 50Mi
+
 prometheus:
   remoteWrite:
     ## User used when authentication against InfluxDB.
@@ -211,7 +243,7 @@ prometheus:
   ## When prometheus should start to remove metrics from local storage.
   retention:
     size: 4GiB
-    age:  3d
+    age: 3d
 
   resources:
     requests:
@@ -259,9 +291,9 @@ opa:
 fluentd:
   ## Tolerate master nodes.
   tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    value: ""
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      value: ""
 
   ## Only run on master nodes.
   nodeSelector:
@@ -269,11 +301,11 @@ fluentd:
 
   resources:
     limits:
-      cpu: 200m
-      memory: 500Mi
+      cpu: 500m
+      memory: 572Mi
     requests:
       cpu: 200m
-      memory: 500Mi
+      memory: 300Mi
 
   affinity: {}
 
@@ -287,11 +319,11 @@ fluentd:
   user:
     resources:
       limits:
-        cpu: 200m
-        memory: 500Mi
+        cpu: 500m
+        memory: 572Mi
       requests:
         cpu: 200m
-        memory: 500Mi
+        memory: 300Mi
 
     tolerations: []
     affinity: {}
@@ -310,7 +342,13 @@ externalTrafficPolicy:
 ## Nginx ingress controller configuration
 ingressNginx:
   controller:
-    resources: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 263Mi
+      limits:
+        cpu: 200m
+        memory: 512Mi
     tolerations: []
     affinity: {}
     nodeSelector: {}
@@ -340,7 +378,13 @@ ingressNginx:
     additionalConfig: {}
 
   defaultBackend:
-    resources: {}
+    resources:
+      requests:
+        cpu: 5m
+        memory: 10Mi
+      limits:
+        cpu: 10m
+        memory: 20Mi
     tolerations: []
     affinity: {}
     nodeSelector: {}
@@ -353,20 +397,20 @@ velero:
   nodeSelector: {}
   resources:
     limits:
-      cpu: 200m
+      cpu: 100m
       memory: 200Mi
     requests:
-      cpu: 100m
+      cpu: 50m
       memory: 100Mi
 
   restic:
     tolerations: []
     resources:
       limits:
-        cpu: 200m
+        cpu: 100m
         memory: 200Mi
       requests:
-        cpu: 100m
+        cpu: 50m
         memory: 100Mi
 
 ## Configuration for cert-manager issuers.
@@ -396,19 +440,37 @@ issuers:
 
 ## Configration for cert-manager and it's components.
 certmanager:
-  resources: {}
+  resources:
+    requests:
+      cpu: 25m
+      memory: 100Mi
+    limits:
+      cpu: 50m
+      memory: 200Mi
   nodeSelector: {}
   tolerations: {}
   affinity: {}
 
   webhook:
-    resources: {}
+    resources:
+      requests:
+        cpu: 25m
+        memory: 25Mi
+      limits:
+        cpu: 50m
+        memory: 50Mi
     nodeSelector: {}
     tolerations: {}
     affinity: {}
 
   cainjector:
-    resources: {}
+    resources:
+      requests:
+        cpu: 15m
+        memory: 100Mi
+      limits:
+        cpu: 50m
+        memory: 200Mi
     nodeSelector: {}
     tolerations: {}
     affinity: {}
@@ -416,6 +478,13 @@ certmanager:
 ## Configuration for metric-server
 metricsServer:
   enabled: true
+  resources:
+    requests:
+      cpu: 10m
+      memory: 25Mi
+    limits:
+      cpu: 20m
+      memory: 50Mi
 
 calicoAccountant:
   enabled: true
@@ -429,27 +498,35 @@ clusterAdmin:
 
 starboard:
   # Note: The developers of starboard explicitly recommend against setting your own resources
-  resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+    requests:
+      cpu: 5m
+      memory: 50Mi
+    limits:
+      cpu: 10m
+      memory: 128Mi
   tolerations: []
   affinity: {}
 
 vulnerabilityExporter:
-  resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 50m
-  #   memory: 64Mi
+  resources:
+    requests:
+      cpu: 20m
+      memory: 15Mi
+    limits:
+      cpu: 40m
+      memory: 30Mi
   tolerations: []
   affinity: {}
 
+  curlcronjob:
+    resources:
+      requests:
+        cpu: 20m
+        memory: 64Mi
+      limits:
+        cpu: 40m
+        memory: 128Mi
 monitoring:
   rook:
     enabled: false

--- a/helmfile/charts/vulnerability-exporter/templates/deployment.yaml
+++ b/helmfile/charts/vulnerability-exporter/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
             mountPath: /scripts
           - name: cronfiles
             mountPath: /etc/cron.d/
+        resources: {{- .Values.curlcronjob.resources | toYaml | nindent 10 }}
       - name: influxdb-node-exporter
         image: prom/node-exporter:v1.0.1
         args: ["--collector.textfile.directory=/textfile-collector", "--no-collector.arp", "--no-collector.bcache", "--no-collector.bonding", "--no-collector.conntrack", "--no-collector.cpu", "--no-collector.cpufreq", "--no-collector.diskstats", "--no-collector.edac", "--no-collector.entropy", "--no-collector.filefd", "--no-collector.filesystem", "--no-collector.hwmon", "--no-collector.infiniband", "--no-collector.ipvs", "--no-collector.loadavg", "--no-collector.mdadm", "--no-collector.meminfo", "--no-collector.netclass", "--no-collector.netdev", "--no-collector.nfs", "--no-collector.nfsd", "--no-collector.netstat", "--no-collector.pressure", "--no-collector.stat", "--no-collector.sockstat", "--no-collector.timex", "--no-collector.vmstat", "--no-collector.xfs", "--no-collector.zfs"]
@@ -35,6 +36,7 @@ spec:
         volumeMounts:
           - name: textfile-collector-dir
             mountPath: /textfile-collector
+        resources: {{- .Values.resources | toYaml | nindent 10 }}
       volumes:
       - name: textfile-collector-dir
         emptyDir: {}

--- a/helmfile/values/blackbox.yaml.gotmpl
+++ b/helmfile/values/blackbox.yaml.gotmpl
@@ -1,4 +1,5 @@
 prometheus-blackbox-exporter:
+  resources: {{- toYaml .Values.prometheusBlackboxExporter.resources | nindent 4 }}
   secretConfig: true
   config:
     # See https://github.com/prometheus/blackbox_exporter/blob/master/CONFIGURATION.md

--- a/helmfile/values/grafana-user.yaml.gotmpl
+++ b/helmfile/values/grafana-user.yaml.gotmpl
@@ -44,6 +44,7 @@ sidecar:
   datasources:
     enabled: false
     defaultDatasourceEnabled: false
+  resources: {{- toYaml .Values.prometheus.grafana.sidecar.resources | nindent 6 }}
 
 datasources:
   datasources.yaml:

--- a/helmfile/values/influxdb.yaml.gotmpl
+++ b/helmfile/values/influxdb.yaml.gotmpl
@@ -135,6 +135,7 @@ extraContainers:
     volumeMounts:
       - name: textfile-collector-dir
         mountPath: /textfile-collector
+    resources: {{- toYaml .Values.influxDB.sidecar.nodeexporter.resources | nindent 6 }}
   - name: influxdb-cronjob
     image: bambash/docker-cron
     volumeMounts:
@@ -148,6 +149,7 @@ extraContainers:
         mountPath: /etc/cron.d/
       - name: config-volume
         mountPath: /etc/config
+    resources: {{- toYaml .Values.influxDB.sidecar.cronjob.resources | nindent 6 }}
 
 volumes:
   - name: textfile-collector-dir

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -5,6 +5,7 @@ global:
 kube-state-metrics:
   podSecurityPolicy:
     enabled: true
+  resources: {{- toYaml .Values.kubeStateMetrics.resources | nindent 4  }}
 
 kubeApiServer:
   serviceMonitor:
@@ -135,6 +136,7 @@ alertmanager:
     ## [0-9]+(ms|s|m|h) (milliseconds seconds minutes hours).
     ##
     retention: {{ .Values.prometheus.retention.alertmanager }}
+    resources: {{- toYaml .Values.prometheus.alertmanagerSpec.resources | nindent 6 }}
 
 kubeControllerManager:
   enabled: false
@@ -192,6 +194,7 @@ grafana:
     datasources:
       enabled: true
       defaultDatasourceEnabled: false
+    resources: {{- toYaml .Values.prometheus.grafana.sidecar.resources | nindent 6 }}
 
   additionalDataSources:
   - name: prometheus-wc-reader
@@ -243,7 +246,7 @@ grafana:
 
 prometheusOperator:
   createCustomResource: false
-
+  resources: {{- toYaml .Values.prometheusOperator.resources | nindent 4  }}
   serviceMonitor:
     relabelings:
     - targetLabel: cluster
@@ -342,6 +345,9 @@ nodeExporter:
     relabelings:
     - targetLabel: cluster
       replacement: service_cluster
+
+prometheus-node-exporter:
+  resources: {{- toYaml .Values.prometheusNodeExporter.resources | nindent 4 }}
 
 kubeStateMetrics:
   serviceMonitor:

--- a/helmfile/values/kube-prometheus-stack-wc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-wc.yaml.gotmpl
@@ -16,10 +16,15 @@ kubeScheduler:
 
 prometheusOperator:
   createCustomResource: false
+  resources: {{- toYaml .Values.prometheusOperator.resources | nindent 4 }}
 
 kube-state-metrics:
   podSecurityPolicy:
     enabled: true
+  resources: {{- toYaml .Values.kubeStateMetrics.resources | nindent 4 }}
+
+prometheus-node-exporter:
+  resources: {{- toYaml .Values.prometheusNodeExporter.resources | nindent 4 }}
 
 kubeApiServer:
   serviceMonitor:

--- a/helmfile/values/metrics-server.yaml.gotmpl
+++ b/helmfile/values/metrics-server.yaml.gotmpl
@@ -5,3 +5,6 @@ rbac:
 args:
   - "--kubelet-insecure-tls"
   - "--kubelet-preferred-address-types=InternalIP"
+
+resources:
+{{- toYaml .Values.metricsServer.resources | nindent 2 }}

--- a/helmfile/values/vulnerability-exporter.yaml.gotmpl
+++ b/helmfile/values/vulnerability-exporter.yaml.gotmpl
@@ -1,8 +1,10 @@
-resources:
-{{- toYaml .Values.vulnerabilityExporter.resources | nindent 2 }}
+resources: {{- toYaml .Values.vulnerabilityExporter.resources | nindent 2 }}
 
 tolerations:
 {{- toYaml .Values.vulnerabilityExporter.tolerations | nindent 2 }}
 
 affinity:
 {{- toYaml .Values.vulnerabilityExporter.affinity | nindent 2 }}
+
+curlcronjob:
+  resources: {{- toYaml .Values.vulnerabilityExporter.curlcronjob.resources | nindent 4 }}

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -47,10 +47,10 @@ user:
     resources:
       limits:
         cpu: 100m
-        memory: 128Mi
+        memory: 160Mi
       requests:
-        cpu: 100m
-        memory: 128Mi
+        cpu: 50m
+        memory: 80Mi
     tolerations: []
     affinity: {}
     nodeSelector: {}
@@ -62,6 +62,14 @@ user:
       scopes: "profile email openid"
       allowedDomains:
         - example.com
+    sidecar:
+      resources:
+        requests:
+          cpu: 5m
+          memory: 80Mi
+        limits:
+          cpu: 10m
+          memory: 100Mi
   # Todo remove dependencie on alertmanager from service cluster
   alertmanager:
     enabled: false
@@ -83,13 +91,19 @@ harbor:
       size: 5Gi
     resources:
       requests:
-        memory: 16Mi
+        cpu: 2m
+        memory: 25Mi
+      limits:
         cpu: 5m
+        memory: 50Mi
   core:
     resources:
       requests:
-        memory: 64Mi
+        cpu: 5m
+        memory: 50Mi
+      limits:
         cpu: 10m
+        memory: 100Mi
   database:
     persistentVolumeClaim:
       size: 1Gi
@@ -102,20 +116,29 @@ harbor:
       size: 1Gi
     resources:
       requests:
-        memory: 64Mi
-        cpu: 10m
+        cpu: 2m
+        memory: 25Mi
+      limits:
+        cpu: 5m
+        memory: 50Mi
   registry:
     persistentVolumeClaim:
       size: 5Gi
     resources:
       requests:
-        memory: 64Mi
-        cpu: 10m
+        cpu: 2m
+        memory: 25Mi
+      limits:
+        cpu: 5m
+        memory: 50Mi
     controller:
       resources:
         requests:
-          memory: 16Mi
-          cpu: 1m
+          cpu: 2m
+          memory: 20Mi
+        limits:
+          cpu: 5m
+          memory: 40Mi
   redis:
     persistentVolumeClaim:
       size: 1Gi
@@ -126,28 +149,37 @@ harbor:
   notary:
     resources:
       requests:
-        memory: 16Mi
+        cpu: 2m
+        memory: 15Mi
+      limits:
         cpu: 5m
+        memory: 20Mi
   notarySigner:
     resources:
       requests:
-        memory: 16Mi
+        cpu: 2m
+        memory: 10Mi
+      limits:
         cpu: 5m
+        memory: 20Mi
   portal:
     resources:
       requests:
-        memory: 16Mi
+        cpu: 2m
+        memory: 5Mi
+      limits:
         cpu: 5m
+        memory: 10Mi
   trivy:
     persistentVolumeClaim:
       size: 5Gi
     resources:
       requests:
-        cpu: 200m
-        memory: 512Mi
+        cpu: 10m
+        memory: 263Mi
       limits:
-        cpu: "1"
-        memory: 1024Mi
+        cpu: 20m
+        memory: 512Mi
   persistence:
     # Valid options are "filesystem" (persistent volume), "swift", or "objectStorage" (matching global config)
     type: objectStorage
@@ -159,6 +191,42 @@ harbor:
     scope: openid,email,profile,offline_access,groups
   backup:
     enabled: true
+
+prometheusBlackboxExporter:
+  resources:
+    requests:
+      cpu: 5m
+      memory: 25Mi
+    limits:
+      cpu: 10m
+      memory: 50Mi
+prometheusOperator:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 100Mi
+    limits:
+      cpu: 100m
+      memory: 200Mi
+
+prometheusNodeExporter:
+  resources:
+    requests:
+      cpu: 5m
+      memory: 25Mi
+    limits:
+      cpu: 10m
+      memory: 50Mi
+
+kubeStateMetrics:
+  resources:
+    requests:
+      cpu: 5m
+      memory: 25Mi
+    limits:
+      cpu: 10m
+      memory: 50Mi
+
 prometheus:
   storage:
     enabled: false
@@ -192,29 +260,42 @@ prometheus:
     tolerations: []
     affinity: {}
     nodeSelector: {}
+  alertmanagerSpec:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
   grafana:
     resources:
       requests:
-        cpu: 100m
-        memory: 128Mi
+        cpu: 50m
+        memory: 60Mi
       limits:
         cpu: 100m
-        memory: 128Mi
+        memory: 160Mi
     tolerations: []
     affinity: {}
     nodeSelector: {}
     oidc:
       enabled: false
+    sidecar:
+      resources:
+        requests:
+          cpu: 5m
+          memory: 80Mi
+        limits:
+          cpu: 10m
+          memory: 100Mi
 dex:
   additionalKubeloginRedirects: []
   enableStaticLogin: true
   resources:
     limits:
-      cpu: 100m
+      cpu: 10m
       memory: 50Mi
     requests:
-      cpu: 100m
-      memory: 50Mi
+      cpu: 5m
+      memory: 25Mi
   tolerations: []
   affinity: {}
   nodeSelector: {}
@@ -222,7 +303,10 @@ dex:
     groupSupport: false
 kibana:
   # Note sso is enabled via `elasticsearch.sso.enabled`
-  resources: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 286Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -326,8 +410,8 @@ elasticsearch:
         cpu: 100m
         memory: 128Mi
       requests:
-        cpu: 10m
-        memory: 32Mi
+        cpu: 50m
+        memory: 64Mi
     affinity: {}
     nodeSelector: {}
     tolerations: []
@@ -395,13 +479,13 @@ elasticsearch:
     serviceMonitor:
       interval: 30s
       scrapeTimeout: 30s
-    resources: {}
-    #   requests:
-    #     cpu: 100m
-    #     memory: 128Mi
-    #   limits:
-    #     cpu: 100m
-    #     memory: 128Mi
+    resources:
+      requests:
+        cpu: 15m
+        memory: 30Mi
+      limits:
+        cpu: 30m
+        memory: 60Mi
     tolerations: []
   ingress:
     maxbodysize: 8m
@@ -411,10 +495,10 @@ fluentd:
     resources:
       limits:
         cpu: 500m
-        memory: 200Mi
+        memory: 572Mi
       requests:
-        cpu: 100m
-        memory: 200Mi
+        cpu: 200m
+        memory: 300Mi
     tolerations: []
     affinity: {}
     nodeSelector: {}
@@ -502,6 +586,24 @@ influxDB:
       limits:
         cpu: 250m
         memory: 300Mi
+
+  sidecar:
+    nodeexporter:
+      resources:
+        requests:
+          cpu: 5m
+          memory: 15Mi
+        limits:
+          cpu: 10m
+          memory: 30Mi
+    cronjob:
+      resources:
+        requests:
+          cpu: 5m
+          memory: 50Mi
+        limits:
+          cpu: 10m
+          memory: 100Mi
 alerts:
   alertTo: "null"
   opsGenieHeartbeat:
@@ -538,7 +640,13 @@ nfsProvisioner:
   nodeSelector: {}
 ingressNginx:
   controller:
-    resources: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 263Mi
+      limits:
+        cpu: 200m
+        memory: 512Mi
     tolerations: []
     affinity: {}
     nodeSelector: {}
@@ -552,7 +660,13 @@ ingressNginx:
     # Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
     additionalConfig: {}
   defaultBackend:
-    resources: {}
+    resources:
+      requests:
+        cpu: 5m
+        memory: 10Mi
+      limits:
+        cpu: 10m
+        memory: 20Mi
     tolerations: []
     affinity: {}
     nodeSelector: {}
@@ -562,19 +676,19 @@ velero:
   nodeSelector: {}
   resources:
     limits:
-      cpu: 200m
+      cpu: 100m
       memory: 200Mi
     requests:
-      cpu: 100m
+      cpu: 50m
       memory: 100Mi
   restic:
     tolerations: []
     resources:
       limits:
-        cpu: 200m
+        cpu: 100m
         memory: 200Mi
       requests:
-        cpu: 100m
+        cpu: 50m
         memory: 100Mi
 issuers:
   letsencrypt:
@@ -585,22 +699,47 @@ issuers:
       email: letsencrypt@elastisys.com
   extraIssuers: []
 certmanager:
-  resources: {}
+  resources:
+    requests:
+      cpu: 25m
+      memory: 100Mi
+    limits:
+      cpu: 50m
+      memory: 200Mi
   nodeSelector: {}
   tolerations: {}
   affinity: {}
   webhook:
-    resources: {}
+    resources:
+      requests:
+        cpu: 25m
+        memory: 25Mi
+      limits:
+        cpu: 50m
+        memory: 50Mi
     nodeSelector: {}
     tolerations: {}
     affinity: {}
   cainjector:
-    resources: {}
+    resources:
+      requests:
+        cpu: 25m
+        memory: 100Mi
+      limits:
+        cpu: 50m
+        memory: 200Mi
     nodeSelector: {}
     tolerations: {}
     affinity: {}
 metricsServer:
   enabled: true
+  resources:
+    requests:
+      cpu: 10m
+      memory: 25Mi
+    limits:
+      cpu: 20m
+      memory: 50Mi
 calicoAccountant:
   enabled: true
 calicoFelixMetrics:
@@ -621,13 +760,33 @@ s3Exporter:
   affinity: {}
   nodeSelector: {}
 starboard:
-  resources: {}
+  resources:
+    requests:
+      cpu: 5m
+      memory: 50Mi
+    limits:
+      cpu: 10m
+      memory: 128Mi
   tolerations: []
   affinity: {}
 vulnerabilityExporter:
-  resources: {}
+  resources:
+    requests:
+      cpu: 20m
+      memory: 15Mi
+    limits:
+      cpu: 40m
+      memory: 30Mi
   tolerations: []
   affinity: {}
+  curlcronjob:
+    resources:
+      requests:
+        cpu: 20m
+        memory: 64Mi
+      limits:
+        cpu: 40m
+        memory: 128Mi
 monitoring:
   rook:
     enabled: true

--- a/pipeline/config/exoscale/wc-config.yaml
+++ b/pipeline/config/exoscale/wc-config.yaml
@@ -130,10 +130,10 @@ falco:
   resources:
     limits:
       cpu: 200m
-      memory: 300Mi
+      memory: 1024Mi
     requests:
       cpu: 100m
-      memory: 100Mi
+      memory: 512Mi
   ## Run on master nodes.
   tolerations:
     - key: node-role.kubernetes.io/master
@@ -159,7 +159,13 @@ falco:
     affinity: {}
     nodeSelector: {}
   falcoExporter:
-    resources: {}
+    resources:
+      requests:
+        cpu: 5m
+        memory: 15Mi
+      limits:
+        cpu: 5m
+        memory: 15Mi
     tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
@@ -176,6 +182,33 @@ elasticsearch:
     count: 1
 ## Prometheus configuration.
 ## Prometheus collects metrics and pushes it to InfluxDB.
+prometheusOperator:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 100Mi
+    limits:
+      cpu: 100m
+      memory: 200Mi
+
+prometheusNodeExporter:
+  resources:
+    requests:
+      cpu: 5m
+      memory: 25Mi
+    limits:
+      cpu: 10m
+      memory: 50Mi
+
+kubeStateMetrics:
+  resources:
+    requests:
+      cpu: 5m
+      memory: 25Mi
+    limits:
+      cpu: 10m
+      memory: 50Mi
+
 prometheus:
   remoteWrite:
     ## User used when authentication against InfluxDB.
@@ -235,11 +268,11 @@ fluentd:
     node-role.kubernetes.io/master: ""
   resources:
     limits:
-      cpu: 200m
-      memory: 500Mi
+      cpu: 500m
+      memory: 572Mi
     requests:
       cpu: 200m
-      memory: 500Mi
+      memory: 300Mi
   affinity: {}
   ## Extra fluentd config to mount.
   extraConfigMaps: {}
@@ -250,11 +283,11 @@ fluentd:
   user:
     resources:
       limits:
-        cpu: 200m
-        memory: 500Mi
+        cpu: 500m
+        memory: 572Mi
       requests:
         cpu: 200m
-        memory: 500Mi
+        memory: 300Mi
     tolerations: []
     affinity: {}
     nodeSelector: {}
@@ -269,7 +302,13 @@ externalTrafficPolicy:
 ## Nginx ingress controller configuration
 ingressNginx:
   controller:
-    resources: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 263Mi
+      limits:
+        cpu: 200m
+        memory: 512Mi
     tolerations: []
     affinity: {}
     nodeSelector: {}
@@ -292,7 +331,13 @@ ingressNginx:
     ## ref: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
     additionalConfig: {}
   defaultBackend:
-    resources: {}
+    resources:
+      requests:
+        cpu: 5m
+        memory: 10Mi
+      limits:
+        cpu: 10m
+        memory: 20Mi
     tolerations: []
     affinity: {}
     nodeSelector: {}
@@ -304,19 +349,19 @@ velero:
   nodeSelector: {}
   resources:
     limits:
-      cpu: 200m
+      cpu: 100m
       memory: 200Mi
     requests:
-      cpu: 100m
+      cpu: 50m
       memory: 100Mi
   restic:
     tolerations: []
     resources:
       limits:
-        cpu: 200m
+        cpu: 100m
         memory: 200Mi
       requests:
-        cpu: 100m
+        cpu: 50m
         memory: 100Mi
 ## Configuration for cert-manager issuers.
 issuers:
@@ -336,22 +381,47 @@ issuers:
   #     selfSigned: {}
 ## Configration for cert-manager and it's components.
 certmanager:
-  resources: {}
+  resources:
+    requests:
+      cpu: 25m
+      memory: 100Mi
+    limits:
+      cpu: 50m
+      memory: 200Mi
   nodeSelector: {}
   tolerations: {}
   affinity: {}
   webhook:
-    resources: {}
+    resources:
+      requests:
+        cpu: 25m
+        memory: 25Mi
+      limits:
+        cpu: 50m
+        memory: 50Mi
     nodeSelector: {}
     tolerations: {}
     affinity: {}
   cainjector:
-    resources: {}
+    resources:
+      requests:
+        cpu: 15m
+        memory: 100Mi
+      limits:
+        cpu: 50m
+        memory: 200Mi
     nodeSelector: {}
     tolerations: {}
     affinity: {}
 metricsServer:
   enabled: true
+  resources:
+    requests:
+      cpu: 10m
+      memory: 25Mi
+    limits:
+      cpu: 20m
+      memory: 50Mi
 calicoAccountant:
   enabled: true
 calicoFelixMetrics:
@@ -360,13 +430,33 @@ clusterAdmin:
   users: []
   groups: []
 starboard:
-  resources: {}
+  resources:
+    requests:
+      cpu: 5m
+      memory: 50Mi
+    limits:
+      cpu: 10m
+      memory: 128Mi
   tolerations: []
   affinity: {}
 vulnerabilityExporter:
-  resources: {}
+  resources:
+    requests:
+      cpu: 20m
+      memory: 15Mi
+    limits:
+      cpu: 40m
+      memory: 30Mi
   tolerations: []
   affinity: {}
+  curlcronjob:
+    resources:
+      requests:
+        cpu: 20m
+        memory: 64Mi
+      limits:
+        cpu: 40m
+        memory: 128Mi
 monitoring:
   rook:
     enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**: added resources requests for apps

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #580 and #545 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
- the values for the resource requests and limits are based on what I observed on 3 prod cluster;
- the remaining containers without resource requests are rook-ceph (I will fix them from the kubespray repo);
- I didn't find a solution for adding resource requests to kube-proxy, kube-apiserver, kube-scheduler and kube-controller. The manifests from kubernetes do not contain this fields and cannot be added or costumized via kubeadm.
- sc:
![sc_cluster_size](https://user-images.githubusercontent.com/77267293/134131918-e3bd73ba-d90a-495a-a0ad-9f06e9e94c85.png)

- wc:
![wc_cluster_resources](https://user-images.githubusercontent.com/77267293/134131925-ed2cfd4a-981d-4b2f-a421-accea19df988.png)




**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [x] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [x] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
