### PR TITLE
apps sc: Configuration max body for elasticsearch

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -11,4 +11,6 @@
 
 ### Added
 
+- Added the ability to configure elasticsearch ingress body size from sc config.
+
 ### Removed

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -422,6 +422,8 @@ elasticsearch:
       scrapeTimeout: 30s
     resources: {}
     tolerations: []
+  ingress:
+    maxbodysize: 8m
 
 fluentd:
   enabled: true

--- a/helmfile/values/opendistro-es.yaml.gotmpl
+++ b/helmfile/values/opendistro-es.yaml.gotmpl
@@ -343,7 +343,7 @@ elasticsearch:
       annotations:
         nginx.ingress.kubernetes.io/backend-protocol: HTTP
         cert-manager.io/cluster-issuer: {{ .Values.global.issuer }}
-        nginx.ingress.kubernetes.io/proxy-body-size: 8m
+        nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.elasticsearch.ingress.maxbodysize }}
         {{ if and .Values.externalTrafficPolicy.local .Values.externalTrafficPolicy.whitelistRange.elasticsearch }}
         nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.externalTrafficPolicy.whitelistRange.elasticsearch }}
         {{ end }}

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -398,6 +398,8 @@ elasticsearch:
     #     cpu: 100m
     #     memory: 128Mi
     tolerations: []
+  ingress:
+    maxbodysize: 8m
 fluentd:
   enabled: true
   forwarder:


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr allows to configure elasticsearch ingress max body size via `elasticsearch.ingress.maxBodySize`.

**Which issue this PR fixes**: 
fixes #514

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [x] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
