### PR TITLE
apps sc: migrate-openid.sh fix

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -8,6 +8,7 @@
 - Lowered default falco resource requests
 
 ### Fixed
+- migration/v0.16.x-v0.17.x/migrate-openid.sh fix
 
 ### Added
 

--- a/migration/v0.16.x-v0.17.x/migrate-openid.sh
+++ b/migration/v0.16.x-v0.17.x/migrate-openid.sh
@@ -10,8 +10,8 @@ set -euo pipefail
 "${here}/../../bin/ck8s" ops kubectl sc delete pod -n elastic-system -l role=master
 
 # Wait for master pod to be ready before updating the config
-"${here}/../../bin/ck8s" ops kubectl sc wait --for=condition=ready pod  -n elastic-system opendistro-es-master-0
-sleep 10
+"${here}/../../bin/ck8s" ops kubectl sc wait --for=condition=Ready pod -n elastic-system opendistro-es-master-0
+sleep 20
 # Make the script executable
 "${here}/../../bin/ck8s" ops kubectl sc -n elastic-system exec opendistro-es-master-0 -- chmod +x ./plugins/opendistro_security/tools/securityadmin.sh
 # Run the script to update the configuration


### PR DESCRIPTION
**What this PR does / why we need it**:
The migrate-openid.sh have stopped working somehow. Have done small corrections to make it work.

**Which issue this PR fixes**:
fixes #556 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).