### PR TITLE
apps sc: fixed warning for velero backup location

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fixed disabling retention cronjob for influxdb by allowing to create required resources
 - Fixed harbor backup job run as non-root
 - fixed "Uptime and status", "ElasticSearch" and "Kubernetes cluster status" grafana dashboards
+- Fixed warning from velero that the default backup location "default" was missing.
 
 ### Added
 

--- a/helmfile/values/velero.yaml.gotmpl
+++ b/helmfile/values/velero.yaml.gotmpl
@@ -35,7 +35,7 @@ configuration:
     {{- if eq .Values.objectStorage.type "s3" }}
     # Cloud provider where backups should be stored. Usually should
     # match `configuration.provider`. Required.
-    name: aws
+    name: default
     # Bucket to store backups in. Required.
     bucket: {{ .Values.objectStorage.buckets.velero }}
     # Prefix within bucket under which to store backups. Optional.
@@ -49,7 +49,7 @@ configuration:
     {{- else if eq .Values.objectStorage.type "gcs" }}
     # Cloud provider where backups should be stored. Usually should
     # match `configuration.provider`. Required.
-    name: gcs
+    name: default
     # Bucket to store backups in. Required.
     bucket: {{ .Values.objectStorage.buckets.velero }}
     # Prefix within bucket under which to store backups. Optional.
@@ -91,9 +91,9 @@ schedules:
     schedule: "0 0 * * *" #once per day
     template:
       {{- if eq .Values.objectStorage.type "s3" }}
-      storageLocation: aws
+      storageLocation: default
       {{- else if eq .Values.objectStorage.type "gcs" }}
-      storageLocation: gcs
+      storageLocation: default
       {{- end }}
       labelSelector:
         matchLabels:

--- a/migration/v0.17.x-v0.18.x/remove-velero-backupstoragelocation.sh
+++ b/migration/v0.17.x-v0.18.x/remove-velero-backupstoragelocation.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+here="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
+OBJECT_STORAGE_TYPE_SC=$(yq r "${CK8S_CONFIG_PATH}/sc-config.yaml" objectStorage.type)
+if [[ ${OBJECT_STORAGE_TYPE_SC} == "s3" ]]; then
+  STORAGE_TYPE_SC="aws"
+elif [[ ${OBJECT_STORAGE_TYPE_SC} == "gcs" ]]; then
+  STORAGE_TYPE_SC="gcs"
+else
+  echo "Skipped deletion of backupstoragelocation because the type was set to ${OBJECT_STORAGE_TYPE_SC}"
+  exit 0
+fi
+"${here}/../../bin/ck8s" ops kubectl sc delete backupstoragelocation -n velero $STORAGE_TYPE_SC
+OBJECT_STORAGE_TYPE_WC=$(yq r "${CK8S_CONFIG_PATH}/wc-config.yaml" objectStorage.type)
+if [[ ${OBJECT_STORAGE_TYPE_WC} == "s3" ]]; then
+  STORAGE_TYPE_WC="aws"
+elif [[ ${OBJECT_STORAGE_TYPE_WC} == "gcs" ]]; then
+  STORAGE_TYPE_WC="gcs"
+else
+  echo "Skipped deletion of backupstoragelocation because the type was set to ${OBJECT_STORAGE_TYPE_WC}"
+  exit 0
+fi
+"${here}/../../bin/ck8s" ops kubectl wc delete backupstoragelocation -n velero $STORAGE_TYPE_WC

--- a/migration/v0.17.x-v0.18.x/upgrade-apps.md
+++ b/migration/v0.17.x-v0.18.x/upgrade-apps.md
@@ -1,0 +1,11 @@
+# Upgrade v0.17.x to v0.18.0
+
+1. Upgrade applications:
+
+    ```bash
+    bin/ck8s apply {sc|wc}
+    ```
+
+1. Run migration script: `./migration/v0.17.x-v0.18.x/remove-velero-backupstoragelocation.sh`
+
+    This script removes the unused `backupstoragelocation` "aws/gcs". It has been switched to "defualt"


### PR DESCRIPTION
**What this PR does / why we need it**:

Removed warning from velero which said that `The specified default backup location named \"default\" was not found`. 

**Which issue this PR fixes**: 
fixes #519

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

Should be investigated if it can be reverted once velero v1.6 is used. 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [x] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
