### PR TITLE
apps sc: prometheus-elasticsearch-exporter timeout fix

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - ingress-nginx increased the value for client-body-buffer-size from 16K to 256k
 - Lowered default falco resource requests
+- The timeout of the prometheus-elasticsearch-exporter is set to be 5s lower than the one of the service monitor
 
 ### Fixed
 

--- a/helmfile/values/prometheus-elasticsearch-exporter.yaml.gotmpl
+++ b/helmfile/values/prometheus-elasticsearch-exporter.yaml.gotmpl
@@ -8,7 +8,11 @@ es:
   shards: true
   snapshots: true
   cluster_settings: false
-  timeout: 30s
+  {{- if or (contains "m" .Values.elasticsearch.exporter.serviceMonitor.scrapeTimeout) (contains "h" .Values.elasticsearch.exporter.serviceMonitor.scrapeTimeout) }}
+  {{- fail "scrapeTimeout must only be given in seconds" }}
+  {{ else }}
+  timeout: {{ .Values.elasticsearch.exporter.serviceMonitor.scrapeTimeout | trimSuffix "s" | atoi | add -5 }}s
+  {{- end }}
   sslSkipVerify: true
 
 # Load credentials from secret, used in uri below


### PR DESCRIPTION
**What this PR does / why we need it**:
When changing the scrape timeout for prometheus-elasticsearch-exporter, the timeout is currently only changed in the service monitor and not in the exporter itself. These timeouts need to be synched. This is fixed by setting the timeout of the exporter to be 5s lower than the service monitor programmatically.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #511 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [x] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).