### PR TITLE
apps wc: allow users to view PVs

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -14,5 +14,6 @@
 ### Added
 
 - Added the ability to configure elasticsearch ingress body size from sc config.
+- Added RBAC to allow users to view PVs.
 
 ### Removed

--- a/helmfile/charts/user-rbac/templates/clusterroles/user-view.yaml
+++ b/helmfile/charts/user-rbac/templates/clusterroles/user-view.yaml
@@ -4,5 +4,5 @@ metadata:
   name: user-view
 rules:
 - apiGroups: [""]
-  resources: ["nodes","namespaces"]
+  resources: ["nodes","namespaces","persistentvolumes"]
   verbs: ["get", "watch", "list"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow users to get/list PVs.

**Which issue this PR fixes**: 
fixes #521

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

Before Apply:
```
$ kubectl auth can-i get persistentvolumes --as=admin@example.com
Warning: resource 'persistentvolumes' is not namespace scoped
no
```
```
$ kubectl get pv --as=admin@example.com
Error from server (Forbidden): persistentvolumes is forbidden: User "admin@example.com" cannot list resource "persistentvolumes" in API group "" at the cluster scope
```

After Apply:
```
$ kubectl auth can-i get persistentvolumes --as=admin@example.com
Warning: resource 'persistentvolumes' is not namespace scoped
yes
```
```
$ kubectl get pv --as=admin@example.com
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM             STORAGECLASS      REASON   AGE
pvc-7e28627c-86e5-4e72-aae1-1b26507d12f6   1Gi        RWO            Delete           Bound    default/rbd-pvc   rook-ceph-block            69m
```
**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [x] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
