### PR TITLE
apps wc: added configuration for falco-exporter

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -18,5 +18,6 @@
 - Added RBAC to allow users to view PVs.
 - Added group support for user RBAC.
 - Added option `elasticsearch.snapshot.retentionActiveDeadlineSeconds` to control the deadline for the SLM job.
+- Added configuration properties for falco-exporter.
 
 ### Removed

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -178,6 +178,14 @@ falco:
     affinity: {}
     nodeSelector: {}
 
+  falcoExporter:
+    resources: {}
+    tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+    affinity: {}
+    nodeSelector: {}
+
 ## Elasticsearch cluster topolgy.
 ## Used in prometheus alerts.
 elasticsearch:

--- a/helmfile/values/falco-exporter.yaml.gotmpl
+++ b/helmfile/values/falco-exporter.yaml.gotmpl
@@ -1,3 +1,12 @@
+image:
+  tag: 0.3.0
+  pullPolicy: IfNotPresent
+
+resources: {{- toYaml .Values.falco.falcoExporter.resources | nindent 2  }}
+nodeSelector: {{- toYaml .Values.falco.falcoExporter.nodeSelector | nindent 2  }}
+affinity: {{- toYaml .Values.falco.falcoExporter.affinity | nindent 2  }}
+tolerations: {{- toYaml .Values.falco.falcoExporter.tolerations | nindent 2  }}
+
 podSecurityPolicy:
   # Specifies whether a PSP, Role and RoleBinding should be created
   create: true

--- a/pipeline/config/exoscale/wc-config.yaml
+++ b/pipeline/config/exoscale/wc-config.yaml
@@ -158,6 +158,13 @@ falco:
     tolerations: []
     affinity: {}
     nodeSelector: {}
+  falcoExporter:
+    resources: {}
+    tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+    affinity: {}
+    nodeSelector: {}
 ## Elasticsearch cluster topolgy.
 ## Used in prometheus alerts.
 elasticsearch:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds configuration properties for falco-exporter from wc-config.yaml.

**Which issue this PR fixes**: 
fixes #218

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
Added in my wc-config.yaml
```
...
  falcoExporter:
    resources:
      limits:
        cpu: 20m
        memory: 50Mi
      requests:
        cpu: 10m
        memory: 25Mi
...
```

```
$ ./bin/ck8s ops helmfile wc -l app=falco-exporter diff
...
            resources:
-             {}
+             limits:
+               cpu: 100m
+               memory: 128Mi
+             requests:
+               cpu: 100m
+               memory: 128Mi
...
```
**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [x] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
