### PR TITLE
apps: fluentd for kube-audit fixed the time key

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -7,6 +7,7 @@
 - ingress-nginx increased the value for client-body-buffer-size from 16K to 256k
 - Lowered default falco resource requests
 - The timeout of the prometheus-elasticsearch-exporter is set to be 5s lower than the one of the service monitor
+- fluentd replaced the time_key value from time to requestReceivedTimestamp for kube-audit log pattern [#571](https://github.com/elastisys/compliantkubernetes-apps/pull/571)
 
 ### Fixed
 

--- a/helmfile/values/fluentd-configmap.yaml.gotmpl
+++ b/helmfile/values/fluentd-configmap.yaml.gotmpl
@@ -105,7 +105,7 @@ forwarder:
           @type multi_format
           <pattern>
             format json
-            time_key time
+            time_key requestReceivedTimestamp
             time_format %Y-%m-%dT%H:%M:%S.%NZ
           </pattern>
         </parse>

--- a/helmfile/values/fluentd-wc.yaml.gotmpl
+++ b/helmfile/values/fluentd-wc.yaml.gotmpl
@@ -53,7 +53,7 @@ extraConfigMaps:
         @type multi_format
         <pattern>
           format json
-          time_key time
+          time_key requestReceivedTimestamp
           time_format %Y-%m-%dT%H:%M:%S.%NZ
         </pattern>
       </parse>


### PR DESCRIPTION
**What this PR does / why we need it**: to fix the kube-audit time key

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes 188 from ck8s-apps 

**Special notes for reviewer**:
Previously we were using time for the kube-audit time_key. This key is not available in the kube-audit logs so the current time was used.
I replaced with requestReceivedTimestamp - Time the request reached the apiserver.
The full list of events can be viewed here: [kube-apiserver Audit Configuration](https://kubernetes.io/docs/reference/config-api/apiserver-audit.v1/)

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
