### PR TITLE
apps sc: group_by in alertmanager made configurable

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -8,6 +8,7 @@
 - Lowered default falco resource requests
 - The timeout of the prometheus-elasticsearch-exporter is set to be 5s lower than the one of the service monitor
 - fluentd replaced the time_key value from time to requestReceivedTimestamp for kube-audit log pattern [#571](https://github.com/elastisys/compliantkubernetes-apps/pull/571)
+- group_by in alertmanager changed to be configurable
 
 ### Fixed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -74,7 +74,10 @@ user:
     namespace: monitoring
     ingress:
       enabled: false
-
+    group_by:
+    - cluster
+    - alertname
+    - severity
 harbor:
   enabled: true
   # The tolerations, affinity, and nodeSelector are applied to all harbor pods.

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -29,7 +29,7 @@ alertmanager:
   config:
     # See https://prometheus.io/docs/alerting/configuration/
     route:
-      group_by: [cluster, alertname, severity]
+      group_by: '{{ toYaml .Values.user.alertmanager.group_by | nindent 4}}'
       # default receiver
       receiver: '{{ .Values.alerts.alertTo }}'
       routes:

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -68,6 +68,10 @@ user:
     namespace: monitoring
     ingress:
       enabled: false
+    group_by:
+    - cluster
+    - alertname
+    - severity
 harbor:
   enabled: true
   # The tolerations, affinity, and nodeSelector are applied to all harbor pods.


### PR DESCRIPTION
**What this PR does / why we need it**:
At the moment we have hardcoded values for the group_by config in alertmanager. This makes it configurable values in sc-config.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #540 

**Special notes for reviewer**:
This issue is on re-evaluation. No hurry to review it.

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [x] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).