### PR TITLE
apps sc: Make deadline configurable for the SLM job

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -16,5 +16,6 @@
 - Added the ability to configure elasticsearch ingress body size from sc config.
 - Added RBAC to allow users to view PVs.
 - Added group support for user RBAC.
+- Added option `elasticsearch.snapshot.retentionActiveDeadlineSeconds` to control the deadline for the SLM job.
 
 ### Removed

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -387,6 +387,7 @@ elasticsearch:
     ageSeconds: 864000
     retentionSchedule: '@daily'
     backupSchedule: 0 */2 * * *
+    retentionActiveDeadlineSeconds: 1800
   extraRoles: []
   # - role_name: log_reader
   #   definition:

--- a/helmfile/values/elasticsearch-slm.yaml.gotmpl
+++ b/helmfile/values/elasticsearch-slm.yaml.gotmpl
@@ -10,6 +10,8 @@ schedule: {{ .Values.elasticsearch.snapshot.retentionSchedule | quote }}
 
 snapshotRepository: {{ .Values.elasticsearch.snapshotRepository }}
 
+activeDeadlineSeconds: {{ .Values.elasticsearch.snapshot.retentionActiveDeadlineSeconds }}
+
 resources:
   limits:
     cpu: 100m

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -357,6 +357,7 @@ elasticsearch:
     ageSeconds: 864000
     retentionSchedule: 0 1 * * * # 1am
     backupSchedule: 0 */12 * * * # run twice/day
+    retentionActiveDeadlineSeconds: 1800
   extraRoles: []
   # - role_name: log_reader
   #   definition:


### PR DESCRIPTION
**What this PR does / why we need it**:
Taking snapshots in elasticsearch takes longer than the default configured deadline of 10 minutes.
This results in false-postive failed SLM retention jobs, which is annoying.
This PR makes the deadline for the SLM configurable via `elasticsearch.snapshot.retentionActiveDeadlineSeconds` option.


```
❯ curl -u admin:`sops -d secrets.yaml | yq r - elasticsearch.adminPassword` https://elastic.`yq r wc-config.yaml global.opsDomain`/_cat/snapshots/elastic-snapshots/?v
id                         status start_epoch start_time end_epoch  end_time duration indices successful_shards failed_shards total_shards
snapshot-20210801_120004z SUCCESS 1627819205  12:00:05   1627820374 12:19:34    19.4m     206               206             0          206
```
**Which issue this PR fixes**:

**Special notes for reviewer**:
I'm not a super fan of the name of the configuration option, but it did not feel worth it to me to separate the backup job and slm variables atm.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
I have updated the pipeline configuration.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
