### PR TITLE
apps sc: Added JumpCloud as a IDP

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -22,5 +22,6 @@
 - Added configuration properties for falco-exporter.
 - calico-felix-metrics helm chart to enable calico targets discovery and scraping
   calico felix grafana dashboard to visualize the metrics
+- Added JumpCloud as a IDP using dex.
 
 ### Removed

--- a/config/secrets/sc-secrets.yaml
+++ b/config/secrets/sc-secrets.yaml
@@ -101,6 +101,29 @@ dex:
     #     clientSecret: "" # Azure app secret
     #     #groups: # App needs to have `Directory.Read.All` permission
     #     #  - example-group
+    #
+    # ## https://dexidp.io/docs/connectors/ldap/
+    # -   name: Jumpcloud
+    #     id: ldap
+    #     type: ldap
+    #     config:
+    #         host: ldap.jumpcloud.com:636
+    #         bindDN: uid=<LDAP_BINDING_USER>,ou=Users,o=<YOUR_ORG_ID>,dc=jumpcloud,dc=com
+    #         bindPW: <LDAP_BINDING_USER_PASSWORD>
+    #         usernamePrompt: exmaple@email.com
+    #         userSearch:
+    #             baseDN: ou=Users,o=<YOUR_ORG_ID>,dc=jumpcloud,dc=com
+    #             filter: (objectClass=inetOrgPerson)
+    #             idAttr: uid
+    #             username: mail
+    #             emailAttr: mail
+    #             nameAttr: cn
+    #         groupSearch:
+    #             baseDN: ou=Users,o=<YOUR_ORG_ID>,dc=jumpcloud,dc=com
+    #             filter: (objectClass=groupOfNames)
+    #             userAttr: DN
+    #             groupAttr: member
+    #             nameAttr: cn
   additionalStaticClients: []
     #  - id: example-app
     #    secret: ZXhhbXBsZS1hcHAtc2VjcmV0


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding JumpCloud as IDP

**Which issue this PR fixes**:
fixes #561

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

There is a document describing how to create a bind user and other users in Jumpcloud: [JumpCloud Dex](https://docs.google.com/document/d/1fRJUMmdgBl2_QFwtld81951dx1wctN4W5H_1W1g223A/edit#). 
Please also take a look at it.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
