### PR TITLE
apps sc: Added buffer configuration for fluentd

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -23,5 +23,6 @@
 - calico-felix-metrics helm chart to enable calico targets discovery and scraping
   calico felix grafana dashboard to visualize the metrics
 - Added JumpCloud as a IDP using dex.
+- Setting chunk limit size and queue limit size for fluentd from sc-config file
 
 ### Removed

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -442,6 +442,8 @@ fluentd:
     # Set to 'false' when using AWS S3,
     # and 'true' when using any other S3 provider.
     useRegionEndpoint: set-me
+    chunkLimitSizeBytes: 2048
+    queueLimitSizeBytes: 4096
   aggregator:
     resources:
       limits:

--- a/helmfile/values/fluentd-sc.yaml.gotmpl
+++ b/helmfile/values/fluentd-sc.yaml.gotmpl
@@ -39,6 +39,6 @@ forwarder:
     pspEnabled: true
   extraEnv:
     - name: OUTPUT_BUFFER_CHUNK_LIMIT
-      value: "2048"
+      value: "{{ .Values.fluentd.forwarder.chunkLimitSizeBytes }}"
     - name: OUTPUT_BUFFER_QUEUE_LIMIT
-      value: "4096"
+      value: "{{ .Values.fluentd.forwarder.queueLimitSizeBytes }}"

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -415,6 +415,8 @@ fluentd:
     affinity: {}
     nodeSelector: {}
     useRegionEndpoint: true
+    chunkLimitSizeBytes: 2048
+    queueLimitSizeBytes: 4096
   aggregator:
     resources:
       limits:


### PR DESCRIPTION
**What this PR does / why we need it**:

This allow us to set the `chunk_limit_size` and `queue_limit_length` from the `sc-config`.  Set these to a reasonable size for the clusters so that fluentd does not complain about `record is larger than buffer chunk limit size`.

**Which issue this PR fixes**: 
fixes #586

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

This does not fix the problem of crash-loop. That is a separat issue.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
