### PR TITLE
apps sc: Make fluentd liveness probe configurable

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -31,6 +31,7 @@
 - Added JumpCloud as a IDP using dex.
 - Setting chunk limit size and queue limit size for fluentd from sc-config file
 - Added options to set the liveness probe for fluentd forwarder.
+- Added options to set the liveness and readiness probe for fluentd forwarder.
 
 ### Removed
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -10,6 +10,7 @@
 - fluentd replaced the time_key value from time to requestReceivedTimestamp for kube-audit log pattern [#571](https://github.com/elastisys/compliantkubernetes-apps/pull/571)
 - group_by in alertmanager changed to be configurable
 - Reworked harbor restore script into a k8s job and updated the documentation.
+- Increased slm timeout from 30 to 45 min.
 
 ### Fixed
 
@@ -29,6 +30,7 @@
   calico felix grafana dashboard to visualize the metrics
 - Added JumpCloud as a IDP using dex.
 - Setting chunk limit size and queue limit size for fluentd from sc-config file
+- Added options to set the liveness probe for fluentd forwarder.
 
 ### Removed
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -30,8 +30,7 @@
   calico felix grafana dashboard to visualize the metrics
 - Added JumpCloud as a IDP using dex.
 - Setting chunk limit size and queue limit size for fluentd from sc-config file
-- Added options to set the liveness probe for fluentd forwarder.
-- Added options to set the liveness and readiness probe for fluentd forwarder.
+- Added options to configure the liveness and readiness probe settings for fluentd forwarder.
 
 ### Removed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -447,6 +447,11 @@ fluentd:
       periodSeconds: 10
       timeoutSeconds: 5
       failureThreshold: 6
+    readinessProbe:
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
     # Set to 'false' when using AWS S3,
     # and 'true' when using any other S3 provider.
     useRegionEndpoint: set-me

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -390,7 +390,7 @@ elasticsearch:
     ageSeconds: 864000
     retentionSchedule: '@daily'
     backupSchedule: 0 */2 * * *
-    retentionActiveDeadlineSeconds: 1800
+    retentionActiveDeadlineSeconds: 2700
   extraRoles: []
   # - role_name: log_reader
   #   definition:
@@ -442,6 +442,11 @@ fluentd:
     tolerations: []
     affinity: {}
     nodeSelector: {}
+    livenessProbe:
+      initialDelaySeconds: 60
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
     # Set to 'false' when using AWS S3,
     # and 'true' when using any other S3 provider.
     useRegionEndpoint: set-me

--- a/helmfile/values/fluentd-sc.yaml.gotmpl
+++ b/helmfile/values/fluentd-sc.yaml.gotmpl
@@ -35,6 +35,11 @@ forwarder:
   nodeSelector: {{- toYaml .Values.fluentd.forwarder.nodeSelector | nindent 4  }}
   affinity:     {{- toYaml .Values.fluentd.forwarder.affinity | nindent 4  }}
   tolerations:  {{- toYaml .Values.fluentd.forwarder.tolerations | nindent 4  }}
+  livenessProbe:
+    initialDelaySeconds: {{ .Values.fluentd.forwarder.livenessProbe.initialDelaySeconds  }}
+    periodSeconds: {{ .Values.fluentd.forwarder.livenessProbe.periodSeconds  }}
+    timeoutSeconds: {{ .Values.fluentd.forwarder.livenessProbe.timeoutSeconds  }}
+    failureThreshold: {{ .Values.fluentd.forwarder.livenessProbe.failureThreshold  }}
   rbac:
     pspEnabled: true
   extraEnv:

--- a/helmfile/values/fluentd-sc.yaml.gotmpl
+++ b/helmfile/values/fluentd-sc.yaml.gotmpl
@@ -40,6 +40,11 @@ forwarder:
     periodSeconds: {{ .Values.fluentd.forwarder.livenessProbe.periodSeconds  }}
     timeoutSeconds: {{ .Values.fluentd.forwarder.livenessProbe.timeoutSeconds  }}
     failureThreshold: {{ .Values.fluentd.forwarder.livenessProbe.failureThreshold  }}
+  readinessProbe:
+    initialDelaySeconds: {{ .Values.fluentd.forwarder.readinessProbe.initialDelaySeconds  }}
+    periodSeconds: {{ .Values.fluentd.forwarder.readinessProbe.periodSeconds  }}
+    timeoutSeconds: {{ .Values.fluentd.forwarder.readinessProbe.timeoutSeconds  }}
+    failureThreshold: {{ .Values.fluentd.forwarder.readinessProbe.failureThreshold  }}
   rbac:
     pspEnabled: true
   extraEnv:

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -423,6 +423,11 @@ fluentd:
       periodSeconds: 10
       timeoutSeconds: 5
       failureThreshold: 6
+    readinessProbe:
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
     useRegionEndpoint: true
     chunkLimitSizeBytes: 2048
     queueLimitSizeBytes: 4096

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -361,7 +361,7 @@ elasticsearch:
     ageSeconds: 864000
     retentionSchedule: 0 1 * * * # 1am
     backupSchedule: 0 */12 * * * # run twice/day
-    retentionActiveDeadlineSeconds: 1800
+    retentionActiveDeadlineSeconds: 2700
   extraRoles: []
   # - role_name: log_reader
   #   definition:
@@ -418,6 +418,11 @@ fluentd:
     tolerations: []
     affinity: {}
     nodeSelector: {}
+    livenessProbe:
+      initialDelaySeconds: 60
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
     useRegionEndpoint: true
     chunkLimitSizeBytes: 2048
     queueLimitSizeBytes: 4096


### PR DESCRIPTION
**What this PR does / why we need it**:
Fluentd sometimes stalls which makes the liveness probe believe it is dead with its default configured timeouts. Leading to alerts and situations where it has to be manually restarted.
This PR makes the timeouts configurable under the `fluentd.forwarder.livenessProbe` which allows this to be tuned.

This PR also includes an increased deadline for the SLM job, as some do take long enough to be failed. 

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
For now the liveness probe is only set to the default values, as I have no understanding of how long these can take.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
The pipeline config is updated.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
