### PR TITLE
apps sc: reworked harbor restore script

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed influxdb-du-monitor to only select influxdb and not backup pods
 - Added dex/dex as a need for opendistro-es to make kibana available out-the-box at cluster initiation if dex is enabled
 - Fixed disabling retention cronjob for influxdb by allowing to create required resources
+- Fixed harbor backup job run as non-root
 
 ### Added
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -9,6 +9,7 @@
 - The timeout of the prometheus-elasticsearch-exporter is set to be 5s lower than the one of the service monitor
 - fluentd replaced the time_key value from time to requestReceivedTimestamp for kube-audit log pattern [#571](https://github.com/elastisys/compliantkubernetes-apps/pull/571)
 - group_by in alertmanager changed to be configurable
+- Reworked harbor restore script into a k8s job and updated the documentation.
 
 ### Fixed
 

--- a/helmfile/charts/harbor-backup/templates/harbor-backup-job.yaml
+++ b/helmfile/charts/harbor-backup/templates/harbor-backup-job.yaml
@@ -13,6 +13,10 @@ spec:
             release: {{ .Release.Name }}
         spec:
           restartPolicy: OnFailure
+          securityContext:
+           runAsUser: 1000
+           runAsGroup: 1000
+           fsGroup: 1000
           containers:
             - name: run
               image: elastisys/backup-postgres:1.1.0

--- a/scripts/restore/README.md
+++ b/scripts/restore/README.md
@@ -1,30 +1,64 @@
 ### Restore Harbor
-With the script `restore-harbor.sh` you can restore the database in Harbor from a backup in S3.
+With the k8s job you can restore the database in Harbor from a backup in S3.
+The steps should be preformed from the `compliantkubernetes-apps` root directory.
+*Note this k8s job does not include restore from gcs.*
 
-Before restoring the database, make sure that Harbor is installed. It can be installed normally.
+Before restoring the database, make sure that Harbor is installed.
+It can be installed normally.
 
-In order to run the restore script you need the aws client and the postgres client installed:
-```bash
-curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-unzip awscli-bundle.zip
-sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
-sudo apt install postgresql-client-10
-sudo apt install postgresql-client-common
-```
-Set these variables for the restore-script:
+#### Env variables
+Set these variables for the restore job:
 ```bash
 export CK8S_CONFIG_PATH=<your config path>
 export S3_BUCKET=$(yq read "${CK8S_CONFIG_PATH}/sc-config.yaml" objectStorage.buckets.harbor)
 export S3_REGION_ENDPOINT=$(yq read "${CK8S_CONFIG_PATH}/sc-config.yaml" objectStorage.s3.regionEndpoint)
-export AWS_ACCESS_KEY_ID=$(sops -d "${CK8S_CONFIG_PATH}/secrets.yaml" | yq read - objectStorage.s3.accessKey)
-export AWS_SECRET_ACCESS_KEY=$(sops -d "${CK8S_CONFIG_PATH}/secrets.yaml" | yq read - objectStorage.s3.secretKey)
 ```
-While restoring we need to stop all harbor pods except for the database. Then restart them after the restoration.
-Run these commands to stop the pods, restore the database, and restart the pods:
+
+##### Optional env variables
+
+The job will restore the latest backup.
+`$SPECIFIC_BACKUP` can be used to specify which backup.
+To get a list of available backups use:
+```
+aws s3 ls ${S3_BUCKET}"/backups" --recursive --endpoint-url=${S3_REGION_ENDPOINT}
+```
+Then set:
 ```bash
+export SPECIFIC_BACKUP=<backups/xxxxxxxxxx.sql.gz> # Optional
+```
+
+#### Restore
+
+Setup the necessary job.yaml and configmap:
+
+```bash
+envsubst > tmp-job.yaml < scripts/restore/restore-harbor-job.yaml
+./bin/ck8s ops kubectl sc create configmap -n harbor restore-harbor --from-file=scripts/restore/restore-harbor.sh
+```
+
+While restoring we need to stop all harbor pods except for the database.
+
+```
 ./bin/ck8s ops kubectl sc scale deployment --replicas 0 -n harbor --all
-./bin/ck8s ops kubectl sc port-forward -n harbor harbor-harbor-database-0 5432:5432 &
-PORT_FORWARD_PID=$!
-./restore-harbor.sh
-kill $PORT_FORWARD_PID
+```
+
+Create the job and wait until it has completed:
+
+```
+./bin/ck8s ops kubectl sc apply -n harbor -f tmp-job.yaml
+./bin/ck8s ops kubectl sc wait --for=condition=complete job -n harbor restore-harbor-job --timeout=-1s
+```
+
+Restore the pods:
+
+```
 ./bin/ck8s ops kubectl sc scale deployment --replicas 1 -n harbor --all
+```
+
+Clean up:
+
+```
+./bin/ck8s ops kubectl sc delete -n harbor -f tmp-job.yaml
+./bin/ck8s ops kubectl sc delete configmap -n harbor restore-harbor
+rm -v tmp-job.yaml
+```

--- a/scripts/restore/restore-harbor-job.yaml
+++ b/scripts/restore/restore-harbor-job.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+ name: restore-harbor-job
+spec:
+ template:
+   metadata:
+     name: restore-harbor
+   spec:
+     volumes:
+      - name: scripts
+        configMap:
+          name: restore-harbor
+      - name: backup
+        emptyDir: {}
+     securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+     restartPolicy: Never
+     containers:
+     - name: run
+       image: elastisys/backup-postgres:1.1.0
+       command: ['/bin/bash', '/scripts/restore-harbor.sh']
+       env:
+         - name: AWS_ACCESS_KEY_ID
+           valueFrom:
+             secretKeyRef:
+               name: harbor-backup-secret
+               key: aws-access-key-id
+         - name: AWS_SECRET_ACCESS_KEY
+           valueFrom:
+             secretKeyRef:
+               name: harbor-backup-secret
+               key: aws-secret-access-key
+         - name: S3_BUCKET
+           value: ${S3_BUCKET}
+         - name: S3_REGION_ENDPOINT
+           value: ${S3_REGION_ENDPOINT}
+         - name: SPECIFIC_BACKUP
+           value: ${SPECIFIC_BACKUP}
+         - name: PGPASSWORD
+           valueFrom:
+             secretKeyRef:
+               name: harbor-backup-secret
+               key: db-password
+       volumeMounts:
+         - name: scripts
+           mountPath: /scripts
+         - name: backup
+           mountPath: /backup

--- a/scripts/restore/restore-harbor.sh
+++ b/scripts/restore/restore-harbor.sh
@@ -1,18 +1,15 @@
 #!/bin/bash
 # Check https://compliantkubernetes.io/operator-manual/disaster-recovery/ for instructions
-# Restores latest backup from S3_BUCKET. $1 can be used to specify backup
-# To get a list of available backups use:
-# aws s3 ls ${S3_BUCKET}"/backups" --recursive --endpoint-url=$S3_REGION_ENDPOINT
 set -e
 
-HOSTNAME=localhost
+HOSTNAME=harbor-harbor-database
 backup_dir=backups
 
 s3_download() {
     : "${S3_BUCKET:?Missing S3_BUCKET}"
     : "${S3_REGION_ENDPOINT:?Missing S3_REGION_ENDPOINT}"
-    if [[ -n "$1" ]]; then
-        backup_key=$1
+    if [[ -n "$SPECIFIC_BACKUP" ]]; then
+        backup_key=$SPECIFIC_BACKUP
     else
         backup_key=$(aws s3 ls "${S3_BUCKET}/backups" \
           --recursive \
@@ -76,7 +73,7 @@ cleanup_local_files(){
   rmdir ${backup_dir}
 }
 
-s3_download "$1"
+s3_download
 extract_backup
 wait_for_db_ready
 clean_database_data


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR converts the harbor backup script into a k8s job. This reduces the need to have aws cli and postgres installed locally. Also the documentation on how to restore a backup has been updated, including from specific backups.

It also include a fix for harbor backup job, ensuring it run as a non-root user. 

**Which issue this PR fixes** : 
fixes #386

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

Tried on safespring with no specific backup and specific backup set. Both worked.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
