### PR TITLE
apps sc: group_by in alertmanager made configurable fix

### DIFF
--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -29,7 +29,7 @@ alertmanager:
   config:
     # See https://prometheus.io/docs/alerting/configuration/
     route:
-      group_by: '{{ toYaml .Values.user.alertmanager.group_by | nindent 4}}'
+      group_by: {{ .Values.user.alertmanager.group_by }}
       # default receiver
       receiver: '{{ .Values.alerts.alertTo }}'
       routes:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix of https://github.com/elastisys/compliantkubernetes-apps/pull/578

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #540

**Special notes for reviewer**:
Needed to fix the pipeline

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).