### PR TITLE
apps: enabled PSP in some helm charts

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -18,6 +18,7 @@
 - grafana-user.yaml.gotmpl:
   1. grafana-user.yaml.gotmpl to load only the ConfiMaps that have the value of "1" fron "labelKey" [#587](https://github.com/elastisys/compliantkubernetes-apps/pull/587)
   2. added prometheus-sc as a datasource to user-grafana
+- enabled podSecurityPolicy in falco, fluentd, cert-manager, prometheus-elasticsearch-exporter helm charts
 
 ### Fixed
 

--- a/helmfile/values/cert-manager.yaml.gotmpl
+++ b/helmfile/values/cert-manager.yaml.gotmpl
@@ -16,3 +16,7 @@ cainjector:
   tolerations:  {{- toYaml .Values.certmanager.cainjector.tolerations | nindent 4 }}
 
 installCRDs: true
+
+global:
+  podSecurityPolicy:
+    enabled: true

--- a/helmfile/values/falco.yaml.gotmpl
+++ b/helmfile/values/falco.yaml.gotmpl
@@ -30,6 +30,9 @@ nodeSelector: {{- toYaml .Values.falco.nodeSelector | nindent 2  }}
 affinity: {{- toYaml .Values.falco.affinity | nindent 2  }}
 tolerations: {{- toYaml .Values.falco.tolerations | nindent 2  }}
 
+podSecurityPolicy:
+  create: true
+
 customRules:
   ssh-trafic.yaml: |-
     - rule: Inbound SSH Connection

--- a/helmfile/values/falcosidekick.yaml.gotmpl
+++ b/helmfile/values/falcosidekick.yaml.gotmpl
@@ -19,3 +19,6 @@ resources:    {{- toYaml .Values.falco.falcoSidekick.resources | nindent 2  }}
 nodeSelector: {{- toYaml .Values.falco.falcoSidekick.nodeSelector | nindent 2  }}
 affinity:     {{- toYaml .Values.falco.falcoSidekick.affinity | nindent 2  }}
 tolerations:  {{- toYaml .Values.falco.falcoSidekick.tolerations | nindent 2  }}
+
+podSecurityPolicy:
+  create: true

--- a/helmfile/values/fluentd-user.yaml.gotmpl
+++ b/helmfile/values/fluentd-user.yaml.gotmpl
@@ -24,6 +24,9 @@ secret:
   secret_name: elasticsearch
   secret_key: password
 
+podSecurityPolicy:
+  enabled: true
+
 env:
   LIVENESS_THRESHOLD_SECONDS: 900
   STUCK_THRESHOLD_SECONDS: 1200

--- a/helmfile/values/fluentd-wc.yaml.gotmpl
+++ b/helmfile/values/fluentd-wc.yaml.gotmpl
@@ -19,6 +19,9 @@ secret:
   secret_name: elasticsearch
   secret_key: password
 
+podSecurityPolicy:
+  enabled: true
+
 env:
   LIVENESS_THRESHOLD_SECONDS: 900
   STUCK_THRESHOLD_SECONDS: 1200

--- a/helmfile/values/prometheus-elasticsearch-exporter.yaml.gotmpl
+++ b/helmfile/values/prometheus-elasticsearch-exporter.yaml.gotmpl
@@ -62,3 +62,6 @@ prometheusRule:
 resources: {{- toYaml .Values.elasticsearch.exporter.resources | nindent 2 }}
 
 tolerations: {{- toYaml .Values.elasticsearch.exporter.tolerations | nindent 2 }}
+
+podSecurityPolicies:
+  enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**: the pods for fluentd and falco weren't created due to the missing psp

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #610 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
