### PR TITLE
apps: Increased Velero and Restic limits

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -43,6 +43,7 @@
 - resource requests for apps [#551](https://github.com/elastisys/compliantkubernetes-apps/pull/551)
   !! This will cause disruptions/downtime in the cluster as many of the pods will restart to apply the new resource limits/requests. !!
   !! Check your cluster available resources before applying the new requests. The pods will remain in a pending state if not enough resources are available. !!
+- Increased Velero request limits.
 
 ### Removed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -716,8 +716,8 @@ velero:
   nodeSelector: {}
   resources:
     limits:
-      cpu: 100m
-      memory: 200Mi
+      cpu: 500m
+      memory: 500Mi
     requests:
       cpu: 50m
       memory: 100Mi
@@ -725,8 +725,8 @@ velero:
     tolerations: []
     resources:
       limits:
-        cpu: 100m
-        memory: 200Mi
+        cpu: 500m
+        memory: 500Mi
       requests:
         cpu: 50m
         memory: 100Mi

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -397,8 +397,8 @@ velero:
   nodeSelector: {}
   resources:
     limits:
-      cpu: 100m
-      memory: 200Mi
+      cpu: 500m
+      memory: 500Mi
     requests:
       cpu: 50m
       memory: 100Mi
@@ -407,8 +407,8 @@ velero:
     tolerations: []
     resources:
       limits:
-        cpu: 100m
-        memory: 200Mi
+        cpu: 500m
+        memory: 500Mi
       requests:
         cpu: 50m
         memory: 100Mi

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -676,8 +676,8 @@ velero:
   nodeSelector: {}
   resources:
     limits:
-      cpu: 100m
-      memory: 200Mi
+      cpu: 500m
+      memory: 500Mi
     requests:
       cpu: 50m
       memory: 100Mi
@@ -685,8 +685,8 @@ velero:
     tolerations: []
     resources:
       limits:
-        cpu: 100m
-        memory: 200Mi
+        cpu: 500m
+        memory: 500Mi
       requests:
         cpu: 50m
         memory: 100Mi

--- a/pipeline/config/exoscale/wc-config.yaml
+++ b/pipeline/config/exoscale/wc-config.yaml
@@ -349,8 +349,8 @@ velero:
   nodeSelector: {}
   resources:
     limits:
-      cpu: 100m
-      memory: 200Mi
+      cpu: 500m
+      memory: 500Mi
     requests:
       cpu: 50m
       memory: 100Mi
@@ -358,8 +358,8 @@ velero:
     tolerations: []
     resources:
       limits:
-        cpu: 100m
-        memory: 200Mi
+        cpu: 500m
+        memory: 500Mi
       requests:
         cpu: 50m
         memory: 100Mi


### PR DESCRIPTION
**What this PR does / why we need it**:

We noticed during migration from rook to cinder using Velero that it required a higher limit to succeed.

**Which issue this PR fixes**: 
fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
