### PR TITLE
apps: restic and opt-out velero backups wc

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -45,6 +45,9 @@
   !! This will cause disruptions/downtime in the cluster as many of the pods will restart to apply the new resource limits/requests. !!
   !! Check your cluster available resources before applying the new requests. The pods will remain in a pending state if not enough resources are available. !!
 - Increased Velero request limits.
+- Velero restic backup is now default
+- Velero backups everything in user namespaces, opt out by using label compliantkubernetes.io/nobackup: velero
+- Added configuration for Velero daily backup schedule in config files
 
 ### Removed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -714,6 +714,7 @@ velero:
   enabled: true
   tolerations: []
   nodeSelector: {}
+  schedule: 0 0 * * * #once per day
   resources:
     limits:
       cpu: 500m

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -395,6 +395,7 @@ velero:
   enabled: true
   tolerations: []
   nodeSelector: {}
+  schedule: 0 0 * * * #once per day
   resources:
     limits:
       cpu: 500m

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -52,14 +52,11 @@ releases:
   installed: {{ .Values.velero.enabled }}
   missingFileHandler: Error
   values:
-  - values/velero.yaml.gotmpl
-  - configuration:
-      backupStorageLocation:
 {{ if eq .Environment.Name "service_cluster" }}
-        prefix: service-cluster
+  - values/velero-sc.yaml.gotmpl
 {{ end }}
 {{ if eq .Environment.Name "workload_cluster" }}
-        prefix: workload-cluster
+  - values/velero-wc.yaml.gotmpl
 {{ end }}
 
 - name: node-local-dns

--- a/helmfile/values/grafana-user.yaml.gotmpl
+++ b/helmfile/values/grafana-user.yaml.gotmpl
@@ -96,9 +96,6 @@ labels:
 podLabels:
   velero: backup
 
-podAnnotations:
-  backup.velero.io/backup-volumes: storage
-
 resources: {{- toYaml .Values.user.grafana.resources | nindent 2 }}
 nodeSelector: {{- toYaml .Values.user.grafana.nodeSelector | nindent 2 }}
 affinity: {{- toYaml .Values.user.grafana.affinity | nindent 2  }}

--- a/helmfile/values/velero-sc.yaml.gotmpl
+++ b/helmfile/values/velero-sc.yaml.gotmpl
@@ -1,0 +1,106 @@
+{{ if not (or (eq .Values.objectStorage.type "s3") (eq .Values.objectStorage.type "gcs") ) }}
+{{ fail "\nERROR: Velero requires s3 or gcs object storage, see Values.objectStorage.type" }}
+{{ end }}
+resources:    {{- toYaml .Values.velero.resources | nindent 2  }}
+tolerations:  {{- toYaml .Values.velero.tolerations | nindent 2  }}
+nodeSelector: {{- toYaml .Values.velero.nodeSelector | nindent 2  }}
+
+initContainers:
+  {{- if eq .Values.objectStorage.type "s3" }}
+  - name: velero-plugin-for-aws
+    image: velero/velero-plugin-for-aws:v1.0.0
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+      - mountPath: /target
+        name: plugins
+  {{- else if eq .Values.objectStorage.type "gcs" }}
+  - name: velero-plugin-for-gcs
+    image: velero/velero-plugin-for-gcp:v1.1.0
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+      - mountPath: /target
+        name: plugins
+  {{- end }}
+
+configuration:
+  # Cloud provider being used (e.g. aws, azure, gcp).
+  {{- if eq .Values.objectStorage.type "s3" }}
+  provider: aws
+  {{- else if eq .Values.objectStorage.type "gcs" }}
+  provider: gcp
+  {{- end }}
+
+  defaultVolumesToRestic: true
+
+  # https://velero.io/docs/v1.0.0/api-types/backupstoragelocation/
+  backupStorageLocation:
+    {{- if eq .Values.objectStorage.type "s3" }}
+    # Cloud provider where backups should be stored. Usually should
+    # match `configuration.provider`. Required.
+    name: default
+    # Bucket to store backups in. Required.
+    bucket: {{ .Values.objectStorage.buckets.velero }}
+    # Prefix within bucket under which to store backups. Optional.
+    prefix: service-cluster
+    # Additional provider-specific configuration. See link above
+    # for details of required/optional fields for your provider.
+    config:
+      region: {{ .Values.objectStorage.s3.region }}
+      s3ForcePathStyle: "true"
+      s3Url: {{ .Values.objectStorage.s3.regionEndpoint }}
+    {{- else if eq .Values.objectStorage.type "gcs" }}
+    # Cloud provider where backups should be stored. Usually should
+    # match `configuration.provider`. Required.
+    name: default
+    # Bucket to store backups in. Required.
+    bucket: {{ .Values.objectStorage.buckets.velero }}
+    # Prefix within bucket under which to store backups. Optional.
+    prefix: service-cluster
+    # Additional provider-specific configuration. See link above
+    # for details of required/optional fields for your provider.
+    {{- end }}
+
+  # Parameters for the `default` VolumeSnapshotLocation. See
+  # https://velero.io/docs/v1.0.0/api-types/volumesnapshotlocation/
+  volumeSnapshotLocation:
+    config:
+      {{- if eq .Values.objectStorage.type "s3" }}
+      region: {{ .Values.objectStorage.s3.region }}
+      {{- else if eq .Values.objectStorage.type "gcs" }}
+      project: {{ .Values.objectStorage.gcs.project }}
+      {{- end }}
+
+credentials:
+  # Create secret with credentials
+  secretContents:
+    cloud: |
+    {{- if eq .Values.objectStorage.type "s3" }}
+      [default]
+      aws_access_key_id: {{ .Values.objectStorage.s3.accessKey }}
+      aws_secret_access_key: {{ .Values.objectStorage.s3.secretKey }}
+    {{- else if eq .Values.objectStorage.type "gcs" }}
+      {{ .Values.objectStorage.gcs.keyfileData | nindent 6 }}
+    {{- end }}
+
+deployRestic: true
+
+restic:
+  resources:   {{- toYaml .Values.velero.restic.resources | nindent 4  }}
+  tolerations: {{- toYaml .Values.velero.restic.tolerations | nindent 4  }}
+
+schedules:
+  daily-backup:
+    schedule: {{ .Values.velero.schedule }}
+    template:
+      storageLocation: default
+      labelSelector:
+        matchLabels:
+          velero: backup
+      ttl: 720h0m0s
+
+metrics:
+  enabled: true
+  scrapeInterval: 30s
+
+  serviceMonitor:
+    enabled: true

--- a/helmfile/values/velero-wc.yaml.gotmpl
+++ b/helmfile/values/velero-wc.yaml.gotmpl
@@ -30,6 +30,8 @@ configuration:
   provider: gcp
   {{- end }}
 
+  defaultVolumesToRestic: true
+
   # https://velero.io/docs/v1.0.0/api-types/backupstoragelocation/
   backupStorageLocation:
     {{- if eq .Values.objectStorage.type "s3" }}
@@ -39,7 +41,7 @@ configuration:
     # Bucket to store backups in. Required.
     bucket: {{ .Values.objectStorage.buckets.velero }}
     # Prefix within bucket under which to store backups. Optional.
-    #prefix: will be set outside of values file.
+    prefix: workload-cluster
     # Additional provider-specific configuration. See link above
     # for details of required/optional fields for your provider.
     config:
@@ -53,7 +55,7 @@ configuration:
     # Bucket to store backups in. Required.
     bucket: {{ .Values.objectStorage.buckets.velero }}
     # Prefix within bucket under which to store backups. Optional.
-    #prefix: will be set outside of values file.
+    prefix: workload-cluster
     # Additional provider-specific configuration. See link above
     # for details of required/optional fields for your provider.
     {{- end }}
@@ -88,17 +90,16 @@ restic:
 
 schedules:
   daily-backup:
-    schedule: "0 0 * * *" #once per day
+    schedule: {{ .Values.velero.schedule }}
     template:
-      {{- if eq .Values.objectStorage.type "s3" }}
       storageLocation: default
-      {{- else if eq .Values.objectStorage.type "gcs" }}
-      storageLocation: default
-      {{- end }}
-      labelSelector:
-        matchLabels:
-          velero: backup
+      includedNamespaces:
+      {{ .Values.user.namespaces | toYaml | nindent 8 }}
       ttl: 720h0m0s
+      labelSelector:
+        matchExpressions:
+        - key: compliantkubernetes.io/nobackup
+          operator: DoesNotExist
 
 metrics:
   enabled: true

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -674,6 +674,7 @@ velero:
   enabled: true
   tolerations: []
   nodeSelector: {}
+  schedule: 0 0 * * * #once per day
   resources:
     limits:
       cpu: 500m

--- a/pipeline/config/exoscale/wc-config.yaml
+++ b/pipeline/config/exoscale/wc-config.yaml
@@ -347,6 +347,7 @@ velero:
   enabled: true
   tolerations: []
   nodeSelector: {}
+  schedule: 0 0 * * * #once per day
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
**What this PR does / why we need it**:

All user namespaces are now backed up by default. It is possible to opt-out using the label `nobackup: velero`. 

Also restic volume backup is now on by default.

**Which issue this PR fixes**:
fixes #608

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

See [#183](https://github.com/elastisys/compliantkubernetes/pull/183) for compliantkubernetes.io update

Images showing that velero did a daily backup on the user namespaces and that the pods with the label `nobackup: velero` was skipped.

Pod included
![Screenshot from 2021-10-05 15-43-13](https://user-images.githubusercontent.com/12862587/136035078-e97aff2a-841b-4411-ae93-8ca414c9b7f8.png)

Pod excluded
![Screenshot from 2021-10-05 15-42-50](https://user-images.githubusercontent.com/12862587/136035096-c7e8bf58-2f07-4404-ac07-804b76c01991.png)

Backup describe
![Screenshot from 2021-10-05 14-44-16](https://user-images.githubusercontent.com/12862587/136034569-b35e6094-fda2-4e4a-b81a-1fc193d61641.png)

Backup described with details about pods
![Screenshot from 2021-10-05 14-45-20](https://user-images.githubusercontent.com/12862587/136034588-e79cf32f-df2e-41dd-ab32-85075ab9ac6b.png)

Backup described with details about restic
![Screenshot from 2021-10-05 14-45-34](https://user-images.githubusercontent.com/12862587/136034600-23618b7f-e7fc-41a5-9b82-b489644e551c.png)

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
