### PR TITLE
apps sc & wc: Add missing value and correct chart dependency

### DIFF
--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -752,6 +752,7 @@ certmanager:
   nodeSelector: {}
   tolerations: {}
   affinity: {}
+  extraArgs: []
 
   webhook:
     resources:

--- a/helmfile/00-psp_rbac_np.yaml
+++ b/helmfile/00-psp_rbac_np.yaml
@@ -59,15 +59,4 @@ releases:
   values:
   - values/workload-cluster-psp-rbac.yaml.gotmpl
 
-# Workload cluster NetworkPolicy
-- name: workload-cluster-np
-  namespace: kube-system
-  labels:
-    app: workload-cluster-np
-  chart: ./charts/networkpolicy
-  version: 0.1.0
-  missingFileHandler: Error
-  values:
-  - values/workload-cluster-networkpolicy.yaml.gotmpl
-
 {{ end }}

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -541,4 +541,18 @@ releases:
   missingFileHandler: Error
   values:
   - values/kubeapi-metrics.yaml.gotmpl
+
+# Workload cluster NetworkPolicy
+- name: workload-cluster-np
+  namespace: kube-system
+  labels:
+    app: workload-cluster-np
+  chart: ./charts/networkpolicy
+  version: 0.1.0
+  missingFileHandler: Error
+  needs:
+  - kube-system/user-rbac
+  values:
+  - values/workload-cluster-networkpolicy.yaml.gotmpl
+
 {{ end }}

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -710,6 +710,7 @@ certmanager:
   nodeSelector: {}
   tolerations: {}
   affinity: {}
+  extraArgs: []
   webhook:
     resources:
       requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
Bug fix for #593. Sets missing config option to render chart, and set dependency on networkpolicy chart to run after the namespaces it operates on gets created.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #629 and fixes #630.

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.
Is done.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
