### PR TITLE
apps wc: Change default namespace for user alertmanager

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -44,6 +44,7 @@
 - enable hostNetwork and set the dnsPolicy to ClusterFirstWithHostNet only if hostPort is enabled [#535](https://github.com/elastisys/compliantkubernetes-apps/pull/535)
   > **_Note:_** The upgrade will fail while disabling the hostNetwork when LoadBalancer type service is used, this is due removing some privileges from the PSP. See the migration steps for more details.
 - Prometheus alert and servicemonitor was separated
+- Default user alertmanager namespace changed from monitoring to alertmanager.
 
 ### Fixed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -82,7 +82,7 @@ user:
   # Todo remove dependencie on alertmanager from service cluster
   alertmanager:
     enabled: false
-    namespace: monitoring
+    namespace: alertmanager
     ingress:
       enabled: false
     group_by:

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -131,7 +131,8 @@ user:
     enabled: false
 
     ## Namespace in which to install alertmanager
-    namespace: monitoring
+    # Ensure that the namespace is included in the namespaces list above.
+    namespace: alertmanager
 
     ## Create basic-auth protected ingress to alertmanager
     ingress:

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -448,7 +448,7 @@ releases:
     - values/falco-exporter.yaml.gotmpl
 
 - name: user-alertmanager
-  namespace: {{ .Values.user.alertmanager.namespace | default "monitoring" }}
+  namespace: {{ .Values.user.alertmanager.namespace | default "alertmanager" }}
   labels:
     app: user-alertmanager
   chart: ./charts/examples/user-alertmanager

--- a/helmfile/charts/user-rbac/templates/namespaces.yaml
+++ b/helmfile/charts/user-rbac/templates/namespaces.yaml
@@ -1,3 +1,9 @@
+{{- if .Values.alertmanager.enabled }}
+{{- if not (has .Values.alertmanager.namespace .Values.namespaces) }}
+{{- fail "The namespace for alertmanager must be listed under namespaces when enabled" }}
+{{- end }}
+{{- end }}
+
 {{- if .Values.createNamespaces }}
 {{- range $namespace := .Values.namespaces }}
 apiVersion: v1

--- a/helmfile/charts/user-rbac/values.yaml
+++ b/helmfile/charts/user-rbac/values.yaml
@@ -5,4 +5,4 @@ createNamespaces: true
 enableFalcoViewer: false
 alertmanager:
   enabled: false
-  namespace: monitoring
+  namespace: alertmanager

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -74,7 +74,7 @@ user:
   # Todo remove dependencie on alertmanager from service cluster
   alertmanager:
     enabled: false
-    namespace: monitoring
+    namespace: alertmanager
     ingress:
       enabled: false
     group_by:

--- a/pipeline/config/exoscale/wc-config.yaml
+++ b/pipeline/config/exoscale/wc-config.yaml
@@ -106,6 +106,7 @@ user:
   createNamespaces: true
   ## List of user namespaces to create.
   namespaces:
+    - alertmanager
     - demo1
     - demo2
     - demo3
@@ -120,7 +121,8 @@ user:
   alertmanager:
     enabled: false
     ## Namespace in which to install alertmanager
-    namespace: monitoring
+    # Ensure that the namespace is included in the namespaces list above.
+    namespace: alertmanager
     ## Create basic-auth protected ingress to alertmanager
     ingress:
       enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:
This changes the default namespace for user alertmanager to not put it into the system namespace monitoring.
Also added a check for `user-rbac` to check that the namespace used for alertmanager is listed.

**Which issue this PR fixes** 
fixes #524 

**Public facing documentation PR** *(if applicable)*
Already says to put it in the alertmanager namespace.
<!-- https://github.com/elastisys/compliantkubernetes/pull/ --> 

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
Is done.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
