### PR TITLE
apps: enforce opa policies in prod flavor

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -65,6 +65,7 @@
 - increased the influxDB pvc size [#739](https://github.com/elastisys/compliantkubernetes-apps/pull/739)
 - Exposed velero's backup timetolive for both sc and wc.
 - disabled internal database for InfluxDB
+- OPA policies are now enforced (deny) for the prod flavor.
 
 ### Fixed
 

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -114,7 +114,7 @@ opa:
   ## "enforcement" can assume either "dryrun" or "deny".
   imageRegistry:
     enabled: true
-    enforcement: dryrun
+    enforcement: deny
     URL:
       - set-me
       - harbor.example.com
@@ -127,12 +127,12 @@ opa:
   ## by at least one network policy.
   networkPolicies:
     enabled: true
-    enforcement: dryrun
+    enforcement: deny
 
   ## Enable rule that requires pods to have resource requests.
   resourceRequests:
     enabled: true
-    enforcement: dryrun
+    enforcement: deny
 
 ## Configuration for fluentd.
 ## Fluentd ships logs to OpenSearch using the endpoint 'opensearch.subdomain' set in common-config.yaml.


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the blocking issue has been resolved, we should now enforce (deny) opa policies for the prod flavor.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: 
fixes #19


**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
