### PR TITLE
Enable fluentd metrics 

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,13 @@
+# Release notes
+
+# Updated
+
+### Changed
+
+### Fixed
+
+### Added
+
+- Added fluentd metrics
+
+### Removed

--- a/helmfile/values/fluentd-configmap.yaml.gotmpl
+++ b/helmfile/values/fluentd-configmap.yaml.gotmpl
@@ -1,6 +1,34 @@
 aggregator:
   configMaps:
     fluentd.conf: |
+      # Prometheus Exporter Plugin
+      # input plugin that exports metrics
+      <source>
+        @id prometheus
+        @type prometheus
+      </source>
+
+      # input plugin that collects metrics from MonitorAgent
+      <source>
+        @id prometheus_monitor
+        @type prometheus_monitor
+        <labels>
+          host ${hostname}
+        </labels>
+      </source>
+
+      # input plugin that collects metrics for output plugin
+      <source>
+        @id prometheus_output_monitor
+        @type prometheus_output_monitor
+        <labels>
+          host ${hostname}
+        </labels>
+      </source>
+
+      # Don't include prometheus_tail_monitor since this will cause number of metrics to increase indefinitely
+      # https://github.com/fluent/fluent-plugin-prometheus/issues/20
+
       # TCP input to receive logs from the forwarders
       <source>
         @type forward
@@ -75,6 +103,34 @@ aggregator:
 forwarder:
   configMaps:
     fluentd.conf: |
+      # Prometheus Exporter Plugin
+      # input plugin that exports metrics
+      <source>
+        @id prometheus
+        @type prometheus
+      </source>
+
+      # input plugin that collects metrics from MonitorAgent
+      <source>
+        @id prometheus_monitor
+        @type prometheus_monitor
+        <labels>
+          host ${hostname}
+        </labels>
+      </source>
+
+      # input plugin that collects metrics for output plugin
+      <source>
+        @id prometheus_output_monitor
+        @type prometheus_output_monitor
+        <labels>
+          host ${hostname}
+        </labels>
+      </source>
+
+      # Don't include prometheus_tail_monitor since this will cause number of metrics to increase indefinitely
+      # https://github.com/fluent/fluent-plugin-prometheus/issues/20
+
       # Throw the healthcheck to the standard output instead of forwarding it
       <match fluentd.healthcheck>
         @type stdout

--- a/helmfile/values/fluentd-sc.yaml.gotmpl
+++ b/helmfile/values/fluentd-sc.yaml.gotmpl
@@ -52,3 +52,8 @@ forwarder:
       value: "{{ .Values.fluentd.forwarder.chunkLimitSizeBytes }}"
     - name: OUTPUT_BUFFER_QUEUE_LIMIT
       value: "{{ .Values.fluentd.forwarder.queueLimitSizeBytes }}"
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true

--- a/helmfile/values/fluentd-user.yaml.gotmpl
+++ b/helmfile/values/fluentd-user.yaml.gotmpl
@@ -18,6 +18,7 @@ configMaps:
     systemConf: false
     containersInputConf: false
     outputConf: false
+    monitoringConf: false
 
 secret:
 - name: OUTPUT_PASSWORD
@@ -32,6 +33,18 @@ env:
   STUCK_THRESHOLD_SECONDS: 1200
   OUTPUT_PORT: 443
 
+serviceMonitor:
+  enabled: true
+
+prometheusRule:
+  enabled: true
+
+service:
+  ports:
+  - name: metrics
+    type: ClusterIP
+    port: 24231
+
 extraConfigMaps:
   system.conf: |-
     <system>
@@ -40,6 +53,35 @@ extraConfigMaps:
         format json
       </log>
     </system>
+
+  10-monitoring.conf: |-
+    # Prometheus Exporter Plugin
+    # input plugin that exports metrics
+    <source>
+      @id prometheus
+      @type prometheus
+    </source>
+
+    # input plugin that collects metrics from MonitorAgent
+    <source>
+      @id prometheus_monitor
+      @type prometheus_monitor
+      <labels>
+        host ${hostname}
+      </labels>
+    </source>
+
+    # input plugin that collects metrics for output plugin
+    <source>
+      @id prometheus_output_monitor
+      @type prometheus_output_monitor
+      <labels>
+        host ${hostname}
+      </labels>
+    </source>
+
+    # Don't include prometheus_tail_monitor since this will cause number of metrics to increase indefinitely
+    # https://github.com/fluent/fluent-plugin-prometheus/issues/20
 
   containers.input.conf: |-
     #This config is taken from a default config that we have disabled

--- a/helmfile/values/fluentd-wc.yaml.gotmpl
+++ b/helmfile/values/fluentd-wc.yaml.gotmpl
@@ -27,6 +27,18 @@ env:
   STUCK_THRESHOLD_SECONDS: 1200
   OUTPUT_PORT: 443
 
+serviceMonitor:
+  enabled: true
+
+prometheusRule:
+  enabled: true
+
+service:
+  ports:
+  - name: metrics
+    type: ClusterIP
+    port: 24231
+
 # Default args include "-q" which sets loglevel to warning.
 fluentdArgs: "--no-supervisor -q"
 configMaps:
@@ -34,6 +46,7 @@ configMaps:
     systemConf: false
     containersInputConf: false
     outputConf: false
+    monitoringConf: false
 
 extraConfigMaps:
   system.conf: |-
@@ -43,6 +56,35 @@ extraConfigMaps:
         format json
       </log>
     </system>
+
+  10-monitoring.conf: |-
+    # Prometheus Exporter Plugin
+    # input plugin that exports metrics
+    <source>
+      @id prometheus
+      @type prometheus
+    </source>
+
+    # input plugin that collects metrics from MonitorAgent
+    <source>
+      @id prometheus_monitor
+      @type prometheus_monitor
+      <labels>
+        host ${hostname}
+      </labels>
+    </source>
+
+    # input plugin that collects metrics for output plugin
+    <source>
+      @id prometheus_output_monitor
+      @type prometheus_output_monitor
+      <labels>
+        host ${hostname}
+      </labels>
+    </source>
+
+    # Don't include prometheus_tail_monitor since this will cause number of metrics to increase indefinitely
+    # https://github.com/fluent/fluent-plugin-prometheus/issues/20
 
   10-kube-audit.conf: |-
     <source>


### PR DESCRIPTION
**What this PR does / why we need it**:

Since we want to have merics for the buffer in fluentd to earlier indicate some issues with elasticsearch or s3 I enabled the output metrics and prometheus rules for wc fluentd.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*:
fixes #638

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

The input metrics are not enabled (the ones that creates [this issue ](https://github.com/elastisys/compliantkubernetes-apps/issues/246))

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
