### PR TITLE
apps: Add missing value for prometheus-servicemonitor

### DIFF
--- a/helmfile/charts/prometheus-servicemonitor/values.yaml
+++ b/helmfile/charts/prometheus-servicemonitor/values.yaml
@@ -1,3 +1,6 @@
+defaultRules:
+  labels: {}
+
 certMonitor:
   enabled: true
   name: "cert-monitor"

--- a/helmfile/values/sc-servicemonitor.yaml.gotmpl
+++ b/helmfile/values/sc-servicemonitor.yaml.gotmpl
@@ -1,3 +1,7 @@
+defaultRules:
+  labels:
+    cluster: service
+
 rookMonitor:
   enabled: {{ .Values.monitoring.rook.enabled }}
 

--- a/helmfile/values/wc-servicemonitor.yaml.gotmpl
+++ b/helmfile/values/wc-servicemonitor.yaml.gotmpl
@@ -1,3 +1,7 @@
+defaultRules:
+  labels:
+    cluster: workload
+
 rookMonitor:
   enabled: {{ .Values.monitoring.rook.enabled }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Needed to render the prometheus-servicemonitor chart with rook monitor enabled, occurs after the split of alerts/servicemonitors.

**Special notes for reviewer**:
I don't really know if the labels are used or if they should have a different value, but with this they will have the same as they would have had before the split.

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
