### PR TITLE
apps sc: predict linear rules

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -21,6 +21,7 @@
 - Added fluentd metrics
 - Enabled automatic compaction (cleanup) of pos_files for fluentd
 - Added and enabled by default an option for Grafana Viewers to temporarily edit dashboards and panels without saving.
+- New Prometheus rules have been added to forewarn against when memory and disk (PVC and host disk) capacity overloads
 
 ### Removed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -232,6 +232,8 @@ prometheus:
         limits:
           cpu: 10m
           memory: 100Mi
+  ## the percentage of use the resources are set to hit in 3 days
+  predictLinearLimit: 66
 
 dex:
   subdomain: dex

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -113,6 +113,8 @@ prometheus:
   ## Additional prometheus scrape config.
   ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
   additionalScrapeConfigs: []
+  ## the percentage of use the resources are set to hit in 3 days
+  predictLinearLimit: 66
 
 ## Open policy agent configuration
 opa:

--- a/helmfile/charts/prometheus-alerts/templates/rules/node-exporter.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/rules/node-exporter.yaml
@@ -24,12 +24,12 @@ spec:
       annotations:
         description: Filesystem on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available space left and is filling up.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-nodefilesystemspacefillingup
-        summary: Filesystem is predicted to run out of space within the next 24 hours.
+        summary: Filesystem is predicted to run out of space within the next 3 days.
       expr: |-
         (
-          node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 40
+          (node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100) < (100-{{ .Values.predictLinearLimit }})
         and
-          predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!=""}[6h], 24*60*60) < 0
+          predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!=""}[6h], 3*24*60*60) <= (node_filesystem_size_bytes*(1-{{ .Values.predictLinearLimit }}/100))
         and
           node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
         )

--- a/helmfile/charts/prometheus-alerts/templates/rules/predict-linear.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/rules/predict-linear.yaml
@@ -1,0 +1,55 @@
+{{- if and .Values.defaultRules.create .Values.defaultRules.rules.predictLinear}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-alerts.fullname" .) "predict-linear" | trunc 63 | trimSuffix "-" }}
+  labels:
+    app: {{ template "prometheus-alerts.name" . }}
+{{ include "prometheus-alerts.labels" . | indent 4 }}
+{{- if .Values.defaultRules.labels }}
+{{ toYaml .Values.defaultRules.labels | indent 4 }}
+{{- end }}
+{{- if .Values.defaultRules.annotations }}
+  annotations:
+{{ toYaml .Values.defaultRules.annotations | indent 4 }}
+{{- end }}
+spec:
+  groups:
+  - name: predict-linear
+    rules:
+    - alert: PersistentVolume{{.Values.predictLinearLimit}}ProcentInThreeDays
+      annotations:
+        message: The PersistentVolume claimed by {{`{{ $labels.persistentvolumeclaim }}`}} in Namespace {{`{{ $labels.namespace }}`}} is full in three days.
+      expr: predict_linear(kubelet_volume_stats_available_bytes[24h], 3*24*60*60) <= (kubelet_volume_stats_capacity_bytes*(1-{{ .Values.predictLinearLimit }}/100))
+      for: 5m
+      labels:
+        severity: warning
+    - alert: Memory{{.Values.predictLinearLimit}}ProcentInThreeDays
+      annotations:
+        message: Memory usage in Cluster {{`{{ $labels.cluster }}`}} Instance {{`{{ $labels.instance }}`}} is predicted to go over {{.Values.predictLinearLimit}} percent within the next 3 days at current use rate.
+      expr: predict_linear(node_memory_MemAvailable_bytes[24h], 3*24*60*60) <= (node_memory_MemTotal_bytes*(1-{{ .Values.predictLinearLimit }}/100))
+      for: 5m
+      labels:
+        severity: warning
+    - alert: CPU{{.Values.predictLinearLimit}}ProcentOnAverige
+      annotations:
+        message: CPU usage has been over {{.Values.predictLinearLimit}} percent on average over the span of 24h in a Instance {{`{{ $labels.instance }}`}} of a Cluster {{`{{ $labels.cluster }}`}}.
+      expr: 1 - (avg by (instance, cluster) (rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[24h]))) >= {{ .Values.predictLinearLimit }}/100
+      for: 5m
+      labels:
+        severity: warning
+    - alert: CPURequest{{.Values.predictLinearLimit}}rocent
+      annotations:
+        message: CPU requests has been over {{.Values.predictLinearLimit}} percent in a Instance {{`{{ $labels.instance }}`}} of a Cluster {{`{{ $labels.cluster }}`}}.
+      expr: sum by (node, cluster) (kube_pod_container_resource_requests{cluster=~".*", namespace=~".*", resource="cpu"} and on (pod, namespace, cluster) kube_pod_status_phase{phase="Running", cluster=~".*", namespace=~".*"} == 1 ) / sum by (node, cluster) (kube_node_status_allocatable{cluster=~".*", resource="cpu"}) >= {{ .Values.predictLinearLimit }}/100
+      for: 5m
+      labels:
+        severity: warning
+    - alert: MemoryRequest{{.Values.predictLinearLimit}}Procent
+      annotations:
+        message: Memory request has been over {{.Values.predictLinearLimit}} percent in a Instance {{`{{ $labels.instance }}`}} of a Cluster {{`{{ $labels.cluster }}`}}.
+      expr: sum by (node, cluster)(kube_pod_container_resource_requests{cluster=~".*", namespace=~".*", resource="memory"} and on (pod, namespace, cluster) kube_pod_status_phase{phase="Running", cluster=~".*", namespace=~".*"} == 1) / sum by (node, cluster)(kube_node_status_allocatable{cluster=~".*", resource="memory"}) >= {{ .Values.predictLinearLimit }}/100
+      for: 5m
+      labels:
+        severity: warning
+{{- end }}

--- a/helmfile/charts/prometheus-alerts/values.yaml
+++ b/helmfile/charts/prometheus-alerts/values.yaml
@@ -34,6 +34,7 @@ defaultRules:
     kubernetesSystem: true
     kubeScheduler: false
     network: true
+    node: true
     nodeExporter: true
     prometheus: true
     time: true
@@ -43,3 +44,4 @@ defaultRules:
     certMonitor: true
     falcoAlerts: true
     rookMonitor: true
+    predictLinear: true

--- a/helmfile/values/prometheus-alerts-sc.yaml.gotmpl
+++ b/helmfile/values/prometheus-alerts-sc.yaml.gotmpl
@@ -6,6 +6,8 @@ defaultRules:
   rules:
     rookMonitor: {{ .Values.monitoring.rook.enabled }}
 
+predictLinearLimit: {{ .Values.prometheus.predictLinearLimit }}
+
 rookMonitor:
   enabled: {{ .Values.monitoring.rook.enabled }}
   relabelings:

--- a/helmfile/values/prometheus-alerts-wc.yaml.gotmpl
+++ b/helmfile/values/prometheus-alerts-wc.yaml.gotmpl
@@ -18,6 +18,8 @@ defaultRules:
     certMonitor: false
     rookMonitor: false
 
+predictLinearLimit: {{ .Values.prometheus.predictLinearLimit }}
+
 rookMonitor:
   # The monitor sits in WC, no need to add it here in SC.
   enabled: false

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -55,3 +55,5 @@ alerts:
 s3Exporter:
   interval: 120s
   scrapeTimeout: 30s
+prometheus:
+  predictLinearLimit: 66

--- a/pipeline/config/exoscale/wc-config.yaml
+++ b/pipeline/config/exoscale/wc-config.yaml
@@ -16,3 +16,5 @@ user:
   adminUsers:
     - user-admin@example.com
   adminGroups: []
+prometheus:
+  predictLinearLimit: 66


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to improve our capacity management posture. While the Kubernetes status dashboards help, it would be great to improve scalability by avoiding more daily checks and getting P2 (requires attention within 24 hours) alert. Therefore, new rules have been added to forewarn against when memory and disk (PVC and host disk) capacity is predicted to hit 66% in 3 days. CPU alert triggers when the CPU usage has been over eighty percent on average over the span of 24h.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #625

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
The CPU rule couldn't be written based on predict_linear as it doesn't work as memory and storage do.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
