### PR TITLE
all: update 0.17-0.18 migration guide and script

### DIFF
--- a/migration/v0.17.x-v0.18.x/upgrade-apps.md
+++ b/migration/v0.17.x-v0.18.x/upgrade-apps.md
@@ -29,6 +29,8 @@
     bin/ck8s init
     ```
 
+1. If you had requests (but not limits) enabled for harbor, you may have to adjust them in your override config to make sure that they are lower than the new limits.
+
 1. Upgrade applications:
 
     ```bash
@@ -48,7 +50,7 @@
    do
      echo "Removing the hostPort for: $i"
      INDEX=$(bin/ck8s ops kubectl sc get ds -n ingress-nginx ingress-nginx-controller -o json | jq --arg i $i '.spec.template.spec.containers[].ports | map(.hostPort == '$i') | index(true)')
-     bin/ck8s ops kubectl sc patch ds -n ingress-nginx ingress-nginx-controller --type='json' -p="[{'op': 'remove', 'path': '/spec/template/spec/containers/0/ports/$INDEX/hostPort'}]"
+     bin/ck8s ops kubectl sc patch ds -n ingress-nginx ingress-nginx-controller --type='json' -p="\"[{'op': 'remove', 'path': '/spec/template/spec/containers/0/ports/$INDEX/hostPort'}]\""
    done < ports.txt
    ```
 


### PR DESCRIPTION
**What this PR does / why we need it**: QA: A few minor fixes I noticed were necessary while doing the migration steps.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
