### PR TITLE
apps sc: Add and enable Viewers can edit in Grafana

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Added fluentd metrics
 - Enabled automatic compaction (cleanup) of pos_files for fluentd
+- Added and enabled by default an option for Grafana Viewers to temporarily edit dashboards and panels without saving.
 
 ### Removed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -33,6 +33,7 @@ user:
       allowedDomains:
         - set-me
         - example.com
+    viewersCanEdit: true
     sidecar:
       resources:
         requests:
@@ -221,6 +222,7 @@ prometheus:
       #   grafanaViewer: grafana_viewer # maps to grafana role viewer
       # scopes: "openid profile email groups"
       # allowedDomains: []
+    viewersCanEdit: true
 
     sidecar:
       resources:

--- a/helmfile/values/grafana-user.yaml.gotmpl
+++ b/helmfile/values/grafana-user.yaml.gotmpl
@@ -87,6 +87,8 @@ grafana.ini:
     allow_sign_up: true
     tls_skip_verify_insecure: {{ not .Values.global.verifyTls }}
     role_attribute_path: contains(groups[*], '{{ .Values.user.grafana.userGroups.grafanaAdmin }}') && 'Admin' || contains(groups[*], '{{ .Values.user.grafana.userGroups.grafanaEditor }}') && 'Editor' || contains(groups[*], '{{ .Values.user.grafana.userGroups.grafanaViewer }}') && 'Viewer'
+  users:
+    viewers_can_edit: {{ .Values.user.grafana.viewersCanEdit }}
 
 # Velero backup
 

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -234,6 +234,8 @@ grafana:
       tls_skip_verify_insecure: {{ not .Values.global.verifyTls }}
       role_attribute_path: contains(groups[*], '{{ .Values.prometheus.grafana.oidc.userGroups.grafanaAdmin }}') && 'Admin' || contains(groups[*], '{{ .Values.prometheus.grafana.oidc.userGroups.grafanaEditor }}') && 'Editor' || contains(groups[*], '{{ .Values.prometheus.grafana.oidc.userGroups.grafanaViewer }}') && 'Viewer'
       {{- end }}
+    users:
+      viewers_can_edit: {{ .Values.prometheus.grafana.viewersCanEdit }}
 
   serviceMonitor:
     relabelings:


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds and enables the option for Grafana Viewers to temporarily edit dashboards and panels without saving.

**Which issue this PR fixes**: 
Fixes #687

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config**:
Picked up by init.
<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
