### PR TITLE
apps sc: Fix rendering of s3-exporter to be idempotent

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -23,6 +23,7 @@
 - Grafana dashboards by keeping more metrics from the kubeApiServer [#681](https://github.com/elastisys/compliantkubernetes-apps/pull/681)
 
 - Fixed rendering of new prometheus alert rule to allow it to be admitted by the operator
+- Fixed rendering of s3-exporter to be idempotent
 
 ### Added
 

--- a/helmfile/values/s3-exporter.yaml.gotmpl
+++ b/helmfile/values/s3-exporter.yaml.gotmpl
@@ -3,7 +3,7 @@ s3:
   regionEndpoint: {{ .Values.objectStorage.s3.regionEndpoint | quote }}
   accessKey: {{ .Values.objectStorage.s3.accessKey | quote }}
   secretKey: {{ .Values.objectStorage.s3.secretKey | quote }}
-  buckets: {{ values .Values.objectStorage.buckets | toYaml | nindent 2 }}
+  buckets: {{ values .Values.objectStorage.buckets | sortAlpha | toYaml | nindent 2 }}
   forcePathStyle: {{ .Values.objectStorage.s3.forcePathStyle }}
 
 serviceMonitor:


### PR DESCRIPTION
**What this PR does / why we need it**:
Just a small fix to sort the results of the values function to make it consistent whenever s3-exporter is reapplied.

**Which issue this PR fixes**:

**Public facing documentation PR**:

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config**

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
