### PR TITLE
Fixed flavor issue with init script

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release notes
 
 * This release introduces a new feature called "index per namespace".
-  Enabling it makes fluentd log to indices in elasticsearch based on the namespace from which the container log originates.
+    Enabling it makes fluentd log to indices in elasticsearch based on the namespace from which the container log originates.
 * Check out the [upgrade guide](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration/v0.18.x-v0.19.x/upgrade-apps.md) for a complete set of instructions needed to upgrade.
+* CK8S_FLAVOR is now mandatory on init
 
 # Updated
 
@@ -41,6 +42,7 @@
 - moved the elasticsearch alerts from the prometheus-elasticsearch-exporter chart to the prometheus-alerts chart [#685](https://github.com/elastisys/compliantkubernetes-apps/pull/685)
 - Changed the User Alertmanager namespace (alertmanager) to an operator namespace from an user namespace
 - Moved the User Alertmanager RBAC to `user-alertmanager` chart
+- Made CK8S_FLAVOR mandatory on init
 
 ### Fixed
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -47,6 +47,7 @@
 - Grafana dashboards by keeping more metrics from the kubeApiServer [#681](https://github.com/elastisys/compliantkubernetes-apps/pull/681)
 - Fixed rendering of new prometheus alert rule to allow it to be admitted by the operator
 - Fixed rendering of s3-exporter to be idempotent
+- Fixed bug where init'ing a config path a second time without the `CK8S_FLAVOR` variable set would fail.
 
 ### Added
 

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -34,7 +34,7 @@ else
     export CK8S_ENVIRONMENT_NAME="${environment_name}"
 fi
 if [ -z "${flavor:-}" ]; then
-    export CK8S_FLAVOR="${CK8S_FLAVOR:-dev}"
+    : "${CK8S_FLAVOR:?Missing CK8S_FLAVOR}"
 elif [ -v CK8S_FLAVOR ] && [ -n "${CK8S_FLAVOR}" ] && [ "${CK8S_FLAVOR}" != "${flavor}" ]; then
     log_error "ERROR: Environment flavor mismatch, '${flavor}' in config and '${CK8S_FLAVOR}' in env"
     exit 1

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -35,8 +35,8 @@ else
 fi
 if [ -z "${flavor:-}" ]; then
     export CK8S_FLAVOR="${CK8S_FLAVOR:-dev}"
-elif [ -v CK8S_FLAVOR ] && [ "${CK8S_FLAVOR}" != "${flavor}" ]; then
-    log_error "ERROR: Environment name mismatch, '${flavor}' in config and '${CK8S_FLAVOR}' in env"
+elif [ -v CK8S_FLAVOR ] && [ -n "${CK8S_FLAVOR}" ] && [ "${CK8S_FLAVOR}" != "${flavor}" ]; then
+    log_error "ERROR: Environment flavor mismatch, '${flavor}' in config and '${CK8S_FLAVOR}' in env"
     exit 1
 else
     export CK8S_FLAVOR="${flavor}"

--- a/pipeline/init.bats
+++ b/pipeline/init.bats
@@ -12,6 +12,7 @@ setup() {
 
     export CK8S_CONFIG_PATH="${ck8s_config_path_tmp}"
     export CK8S_ENVIRONMENT_NAME=test
+    export CK8S_FLAVOR=dev
     export CK8S_PGP_FP=529D964DE0BBD900C4A395DA09986C297F8B7757
     export CK8S_CLOUD_PROVIDER=aws
 }
@@ -30,6 +31,12 @@ teardown() {
     CK8S_ENVIRONMENT_NAME="" run ck8s init
     assert_failure
     assert_output --partial "Missing CK8S_ENVIRONMENT_NAME"
+}
+
+@test "ck8s init requires CK8S_FLAVOR" {
+    CK8S_FLAVOR="" run ck8s init
+    assert_failure
+    assert_output --partial "Missing CK8S_FLAVOR"
 }
 
 @test "ck8s init requires valid CK8S_PGP_FP or valid CK8S_PGP_UID" {


### PR DESCRIPTION
**What this PR does / why we need it**:

When initing a config path the second time without the `CK8S_FLAVOR` variable set it fails. This fixes that.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #727

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
