### PR TITLE
apps sc: added backup retention in config

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -43,6 +43,7 @@
 - Changed the User Alertmanager namespace (alertmanager) to an operator namespace from an user namespace
 - Moved the User Alertmanager RBAC to `user-alertmanager` chart
 - Made CK8S_FLAVOR mandatory on init
+- Exposed harbor's backup retention period as config.
 
 ### Fixed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -163,6 +163,7 @@ harbor:
     scope: openid,email,profile,offline_access,groups
   backup:
     enabled: true
+    retentionDays: 7
 
 
 

--- a/helmfile/values/harbor-backup.yaml.gotmpl
+++ b/helmfile/values/harbor-backup.yaml.gotmpl
@@ -2,6 +2,7 @@
 {{ fail "\nERROR: Harbor backup requires s3 or gcs object storage, see Values.objectStorage.type" }}
 {{ end }}
 dbPassword: {{ .Values.harbor.databasePassword }}
+retentionDays: {{ .Values.harbor.backup.retentionDays }}
 {{ if eq .Values.objectStorage.type "s3" -}}
 s3:
   enabled: true

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -13,6 +13,7 @@ harbor:
     adminGroupName: not-used
   backup:
     enabled: true
+    retentionDays: 7
 elasticsearch:
   masterNode:
     storageSize: 1Gi


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR exposes Harbor's backup retention period through Config. 

**Which issue this PR fixes** : fixes #698 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
