### PR TITLE
apps sc: Add off-site backup replication using rclone sync

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -75,6 +75,7 @@
 - Added pwgen and htpasswd as requirements
 - Added the blackbox installation in the wc cluster based on ADR to monitor the uptime of internal services as well in wc .
 - Added option to enable index per namespace feature in fluentd and elasticsearch
+- Added optional off-site backup replication between two providers or regions using rclone sync
 
 ### Removed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -10,6 +10,42 @@ objectStorage:
     opensearch: ${CK8S_ENVIRONMENT_NAME}-opensearch
     scFluentd: ${CK8S_ENVIRONMENT_NAME}-sc-logs
 
+  ## Off-site backup replication between two providers or regions using rclone sync
+  sync:
+    enabled: false
+    # dryrun: false
+
+    ## Options are 's3'
+    type: none
+    # s3:
+    #   region: set-me
+    #   regionEndpoint: set-me
+    #   # Generally false when using AWS and Exoscale and true for other providers.
+    #   forcePathStyle: set-me
+    #   # v2Auth: false
+
+    ## Sync all buckets under 'objectStorage.buckets'
+    ## These will be appended to 'buckets' using the same name from source as destination, and the default schedule.
+    syncDefaultBuckets: false
+
+    ## Default schedule for sync jobs
+    defaultSchedule: 0 5 * * *
+
+    ## Buckets to sync.
+    buckets: []
+      # - source: source-bucket
+      #   # destination: destination-bucket # if unset it will be the same as 'source'
+      #   # schedule: 0 5 * * *             # if unset it will be the same as 'defaultSchedule'
+
+    ## Sync job resources
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+      limits:
+        cpu: 300m
+        memory: 300Mi
+
 user:
   grafana:
     enabled: true

--- a/config/secrets/sc-secrets.yaml
+++ b/config/secrets/sc-secrets.yaml
@@ -5,6 +5,12 @@ objectStorage: {}
   # s3:
   #   accessKey: "set-me"
   #   secretKey: "set-me"
+  #
+  # # If backup sync is enabled
+  # sync:
+  #   s3:
+  #     accessKey: "set-me"
+  #     secretKey: "set-me"
 grafana:
   password: somelongsecret
   clientSecret: somelongsecret

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -559,6 +559,17 @@ releases:
   values:
   - values/opendistro-es.yaml.gotmpl
 
+- name: rclone-sync
+  namespace: kube-system
+  labels:
+    app: rclone-sync
+  chart: ./charts/rclone-sync
+  version: 0.1.0
+  installed: {{ .Values.objectStorage.sync.enabled }}
+  missingFileHandler: Error
+  values:
+  - values/rclone-sync.yaml.gotmpl
+
 # End of system services releases
 {{ end }}
 

--- a/helmfile/charts/grafana-ops/dashboards/backup-dashboard.json
+++ b/helmfile/charts/grafana-ops/dashboards/backup-dashboard.json
@@ -326,6 +326,207 @@
             "timeShift": null,
             "title": "Time since last successful OpenSearch snapshot ",
             "type": "stat"
+        },
+        {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 14
+            },
+            "id": 10,
+            "panels": [],
+            "title": "Backup rclone sync",
+            "type": "row"
+        },
+        {
+            "datasource": "${datasource}",
+            "description": "",
+            "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 15
+            },
+            "id": 16,
+            "options": {
+                "content": "# Off-site backup replication is <<rclone-sync-state>>",
+                "mode": "markdown"
+            },
+            "pluginVersion": "8.2.7",
+            "type": "text"
+        },
+        {
+            "datasource": "${datasource}",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "options": {
+                                "0": {
+                                    "color": "dark-yellow",
+                                    "index": 1,
+                                    "text": "suspended"
+                                },
+                                "1": {
+                                    "index": 0,
+                                    "text": "active"
+                                }
+                            },
+                            "type": "value"
+                        },
+                        {
+                            "options": {
+                                "match": "nan",
+                                "result": {
+                                    "color": "dark-red",
+                                    "index": 2,
+                                    "text": "unknown"
+                                }
+                            },
+                            "type": "special"
+                        },
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "color": "text",
+                                    "index": 3,
+                                    "text": "missing"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "dark-green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 3,
+                "w": 24,
+                "x": 0,
+                "y": 17
+            },
+            "id": 12,
+            "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "last"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "8.2.7",
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "sum by (bucket) (label_replace(kube_cronjob_spec_suspend{cronjob=~\"rclone-sync-.*\"} == bool 0, \"bucket\", \"$1\", \"cronjob\", \"rclone-sync-(.*)\"))",
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "{{bucket}}",
+                    "refId": "A"
+                }
+            ],
+            "title": "Status of backup rclone sync cronjobs",
+            "type": "stat"
+        },
+        {
+            "datasource": "${datasource}",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "decimals": 1,
+                    "mappings": [
+                        {
+                            "options": {
+                                "match": "null",
+                                "result": {
+                                    "color": "text",
+                                    "index": 0,
+                                    "text": "missing"
+                                }
+                            },
+                            "type": "special"
+                        }
+                    ],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "dark-green",
+                                "value": null
+                            },
+                            {
+                                "color": "dark-yellow",
+                                "value": 86400
+                            },
+                            {
+                                "color": "dark-red",
+                                "value": 172800
+                            }
+                        ]
+                    },
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 20
+            },
+            "id": 14,
+            "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "last"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "8.2.7",
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "min by (bucket) ((time()-label_replace(kube_job_status_completion_time{job_name=~\"rclone-sync-.*\"}, \"bucket\", \"$1\", \"job_name\", \"rclone-sync-(.*?)-(manual|[0-9-])*(manual|[0-9-])*\")))",
+                    "interval": "",
+                    "legendFormat": "{{bucket}}",
+                    "refId": "A"
+                }
+            ],
+            "title": "Time since last successful backup rclone sync jobs",
+            "type": "stat"
         }
     ],
     "refresh": "30s",

--- a/helmfile/charts/grafana-ops/templates/configmap-dashboards.yaml
+++ b/helmfile/charts/grafana-ops/templates/configmap-dashboards.yaml
@@ -15,7 +15,13 @@ items:
       {{ $.Values.labelKey }}: "ops"
       {{- end }}
   data:
+    {{- if eq $key "backup" }}
+    {{- $sync := (empty $value.sync) | ternary "**disabled**" (printf "**enabled** for bucket(s) %s" (join ", " (sortAlpha $value.sync))) }}
+    {{ $key }}.json: |-
+      {{- regexReplaceAll "<<rclone-sync-state>>" ($.Files.Get (printf "dashboards/%s-dashboard.json" $key)) $sync | nindent 6 }}
+    {{- else }}
     {{ $key }}.json: |-
       {{- regexReplaceAll "<<kibanaURL>>" ($.Files.Get (printf "dashboards/%s-dashboard.json" $key)) ($value.logEndpoint | toString) | nindent 6 }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/helmfile/charts/grafana-ops/values.yaml
+++ b/helmfile/charts/grafana-ops/values.yaml
@@ -16,6 +16,7 @@ dashboards:
   backup:
     enabled: true
     user_visible: false
+    sync: []
   elasticsearch:
     enabled: true
     user_visible: false

--- a/helmfile/charts/rclone-sync/Chart.yaml
+++ b/helmfile/charts/rclone-sync/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: rclone-sync
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/helmfile/charts/rclone-sync/Dockerfile
+++ b/helmfile/charts/rclone-sync/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:latest as download
+
+# Install dependencies
+RUN apt-get update && apt-get install -y curl unzip
+
+# Install rclone
+RUN curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip && \
+    unzip rclone-current-linux-amd64.zip && \
+    cd rclone-*-linux-amd64 && \
+    install rclone /usr/bin/rclone
+
+FROM ubuntu:latest as final
+
+
+# Install root certificates
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y ca-certificates && \
+    apt-get clean -y
+
+# Copy in rclone
+COPY --from=download /usr/bin/rclone /usr/bin/rclone
+
+# Create rclone user
+RUN adduser --system --uid 10000 rclone
+
+# Run as rclone user
+USER 10000
+
+ENTRYPOINT ["rclone"]
+CMD ["--version"]

--- a/helmfile/charts/rclone-sync/files/rclone.conf
+++ b/helmfile/charts/rclone-sync/files/rclone.conf
@@ -1,0 +1,21 @@
+[{{ .Values.config.source.name }}]
+type = {{ .Values.config.source.type }}
+{{- if eq .Values.config.source.type "s3" }}
+access_key_id = {{ .Values.config.source.s3.accessKey }}
+secret_access_key = {{ .Values.config.source.s3.secretKey }}
+region = {{ .Values.config.source.s3.region }}
+endpoint = {{ .Values.config.source.s3.regionEndpoint }}
+force_path_style = {{ .Values.config.source.s3.forcePathStyle }}
+v2_auth = {{ .Values.config.source.s3.v2Auth }}
+{{- end }}
+
+[{{ .Values.config.destination.name }}]
+type = {{ .Values.config.destination.type }}
+{{- if eq .Values.config.destination.type "s3" }}
+access_key_id = {{ .Values.config.destination.s3.accessKey }}
+secret_access_key = {{ .Values.config.destination.s3.secretKey }}
+region = {{ .Values.config.destination.s3.region }}
+endpoint = {{ .Values.config.destination.s3.regionEndpoint }}
+force_path_style = {{ .Values.config.destination.s3.forcePathStyle }}
+v2_auth = {{.Values.config.destination.s3.v2Auth }}
+{{- end }}

--- a/helmfile/charts/rclone-sync/templates/cronjob.yaml
+++ b/helmfile/charts/rclone-sync/templates/cronjob.yaml
@@ -1,0 +1,48 @@
+{{- range .Values.buckets }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $.Chart.Name }}-{{ .source }}
+  labels:
+    app: {{ $.Chart.Name }}-{{ .source }}
+spec:
+  {{- if hasKey . "schedule" }}
+  schedule: {{ .schedule }}
+  {{- else }}
+  schedule: {{ $.Values.defaultSchedule }}
+  {{- end }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: {{ $.Chart.Name }}-{{ .source }}
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: {{ $.Chart.Name }}
+              image: {{ $.Values.image.repository }}:{{ $.Values.image.tag }}
+              args:
+                - sync
+                - {{ $.Values.config.source.name }}:{{ .source }}
+                {{- if hasKey . "destination" }}
+                - {{ $.Values.config.destination.name }}:{{ .destination }}
+                {{- else }}
+                - {{ $.Values.config.destination.name }}:{{ .source }}
+                {{- end }}
+                - --log-level
+                - DEBUG
+                {{- if $.Values.config.dryrun }}
+                - --dry-run
+                {{- end }}
+              resources: {{ toYaml $.Values.resources | nindent 16 }}
+              volumeMounts:
+                - name: {{ $.Chart.Name }}-config
+                  mountPath: /home/rclone/.config/rclone/
+          volumes:
+            - name: {{ $.Chart.Name }}-config
+              secret:
+                secretName: {{ $.Chart.Name }}-config
+{{- end }}

--- a/helmfile/charts/rclone-sync/templates/rclone-config.yaml
+++ b/helmfile/charts/rclone-sync/templates/rclone-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Chart.Name }}-config
+type: Opaque
+data:
+  rclone.conf: {{ tpl (.Files.Get "files/rclone.conf") . | b64enc }}

--- a/helmfile/charts/rclone-sync/values.yaml
+++ b/helmfile/charts/rclone-sync/values.yaml
@@ -1,0 +1,43 @@
+image:
+  repository: elastisys/rclone-sync
+  tag: 1.3.0
+
+config:
+  dryrun: false
+
+  source:
+    name: provider-region-a
+    type: s3
+    s3:
+      region: region
+      regionendpoint: s3.region.provider.net
+      accessKey: access-key
+      secretKey: secret-key
+      forcePathStyle: true
+      v2Auth: false
+
+  destination:
+    name: provider-region-b
+    type: s3
+    s3:
+      region: region
+      regionEndpoint: s3.region.provider.net
+      accessKey: access-key
+      secretKey: secret-key
+      forcePathStyle: true
+      v2Auth: false
+
+defaultSchedule: 0 5 * * *
+
+buckets:
+  - source: bucket
+    destination: other-bucket
+    schedule: 0 5 * * *
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 100Mi
+  limits:
+    cpu: 300m
+    memory: 300Mi

--- a/helmfile/values/grafana-ops.yaml.gotmpl
+++ b/helmfile/values/grafana-ops.yaml.gotmpl
@@ -11,6 +11,12 @@ dashboards:
   backup:
     enabled: true
     user_visible: false
+    {{- if .Values.objectStorage.sync.enabled }}
+    sync:
+      {{- range .Values.objectStorage.sync.buckets }}
+      - {{ .source }}
+      {{- end }}
+    {{- end }}
   elasticsearch:
     enabled: true
     user_visible: true

--- a/helmfile/values/rclone-sync.yaml.gotmpl
+++ b/helmfile/values/rclone-sync.yaml.gotmpl
@@ -1,0 +1,56 @@
+{{- if or (ne .Values.objectStorage.type "s3") (ne .Values.objectStorage.sync.type "s3") }}
+{{- fail "rclone-sync is (for now) only supported using s3 on both ends" }}
+{{- end }}
+
+{{- if not (or .Values.objectStorage.sync.syncDefaultBuckets .Values.objectStorage.sync.buckets) }}
+{{- fail "rclone-sync configured without buckets to sync" }}
+{{- end }}
+
+config:
+{{- if hasKey .Values.objectStorage.sync "dryrun" }}
+  dryrun: {{ .Values.objectStorage.sync.dryrun }}
+{{- end }}
+
+  source:
+    name: default
+    type: {{ .Values.objectStorage.type }}
+  {{- if eq .Values.objectStorage.type "s3" }}
+    s3:
+      accessKey: {{ .Values.objectStorage.s3.accessKey }}
+      secretKey: {{ .Values.objectStorage.s3.secretKey }}
+      region: {{ .Values.objectStorage.s3.region }}
+      regionEndpoint: {{ .Values.objectStorage.s3.regionEndpoint }}
+      forcePathStyle: {{ .Values.objectStorage.s3.forcePathStyle }}
+    {{- if hasKey .Values.objectStorage.s3 "v2Auth" }}
+      v2Auth: {{ .Values.objectStorage.s3.v2Auth }}
+    {{- end }}
+  {{- end }}
+
+  destination:
+    name: backup
+    type: {{ .Values.objectStorage.sync.type }}
+  {{- if eq .Values.objectStorage.sync.type "s3" }}
+    s3:
+      accessKey: {{ .Values.objectStorage.sync.s3.accessKey }}
+      secretKey: {{ .Values.objectStorage.sync.s3.secretKey }}
+      region: {{ .Values.objectStorage.sync.s3.region }}
+      regionEndpoint: {{ .Values.objectStorage.sync.s3.regionEndpoint }}
+      forcePathStyle: {{ .Values.objectStorage.sync.s3.forcePathStyle }}
+    {{- if hasKey .Values.objectStorage.sync.s3 "v2Auth" }}
+      v2Auth: {{ .Values.objectStorage.sync.s3.v2Auth }}
+    {{- end }}
+  {{- end }}
+
+defaultSchedule: {{ .Values.objectStorage.sync.defaultSchedule }}
+
+buckets:
+{{- if .Values.objectStorage.sync.syncDefaultBuckets }}
+{{- range (values .Values.objectStorage.buckets | sortAlpha) }}
+  - source: {{ . }}
+{{- end }}
+{{- end }}
+{{- if .Values.objectStorage.sync.buckets }}
+{{- toYaml .Values.objectStorage.sync.buckets | nindent 2 }}
+{{- end }}
+
+resources: {{- toYaml .Values.objectStorage.sync.resources | nindent 2 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Upstreams the work done on enabling off-site backup replication using rclone sync.
Includes additional section in the "Backup status" dashboard to show the
state of it and successful sync jobs.

**Which issue this PR fixes**:
fixes #318 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
Pictures of dashboard additions, note that the text has been changed to "Off-site backup replication is..." instead to make it a bit clearer.

Enabled, with one suspended cronjob:
![enabled](https://user-images.githubusercontent.com/58822152/148957719-58764a9b-30b2-4277-8d5c-3ecd1385fedb.png)

Disabled, with all cronjobs and jobs removed:
![disabled](https://user-images.githubusercontent.com/58822152/148957746-df2c582b-0f02-482e-85d5-de3d14acb6cc.png)

The state of the cronjobs and jobs are extracting the bucket name using a regex, and it has been tested to work with a suffix containing `manual`.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
