### PR TITLE
apps: added relabling for rook/cert servicemonitor

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -50,6 +50,7 @@
 - Fixed rendering of new prometheus alert rule to allow it to be admitted by the operator
 - Fixed rendering of s3-exporter to be idempotent
 - Fixed bug where init'ing a config path a second time without the `CK8S_FLAVOR` variable set would fail.
+- Fixed relabeling for rook-ceph and cert servicemonitor.
 
 ### Added
 

--- a/helmfile/charts/prometheus-servicemonitor/templates/cert-monitor.yaml
+++ b/helmfile/charts/prometheus-servicemonitor/templates/cert-monitor.yaml
@@ -14,4 +14,6 @@ spec:
       app.kubernetes.io/instance: {{ .Values.certMonitor.target.instance }}
   endpoints:
   - targetPort: {{ .Values.certMonitor.port }}
+    relabelings:
+    {{- toYaml .Values.certMonitor.relabelings | nindent 6 }}
 {{- end }}

--- a/helmfile/charts/prometheus-servicemonitor/values.yaml
+++ b/helmfile/charts/prometheus-servicemonitor/values.yaml
@@ -10,6 +10,7 @@ certMonitor:
     name: "cert-manager"
     instance: "cert-manager"
   port: 9402
+  relabelings: []
 
 rookMonitor:
   enabled: false

--- a/helmfile/values/sc-servicemonitor.yaml.gotmpl
+++ b/helmfile/values/sc-servicemonitor.yaml.gotmpl
@@ -4,6 +4,12 @@ defaultRules:
 
 rookMonitor:
   enabled: {{ .Values.monitoring.rook.enabled }}
+  relabelings:
+  - targetLabel: cluster
+    replacement: service_cluster
 
 certMonitor:
   enabled: true
+  relabelings:
+  - targetLabel: cluster
+    replacement: service_cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

The relabelings for the cert-manager and rook service monitors are not correct

**Which issue this PR fixes**: 
fixes #721

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
Notice in second image the addition of cluster: service_cluster

Before:
![monitor1](https://user-images.githubusercontent.com/12862587/148966017-f11a9f23-8e77-44cd-98ec-4ae81ad3bc57.png)

After:
![monitor2](https://user-images.githubusercontent.com/12862587/148966030-05302f67-ede9-46a1-ada6-e4994ca4ebf2.png)


**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
