### PR TITLE
apps sc: OpenSearch bugfixes

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -74,6 +74,8 @@
 - Fixed relabeling for rook-ceph and cert servicemonitor.
 - Fluentd will now properly detect changes in container logs.
 - The `init` script will now properly generate secrets for new configuration options.
+- Fixed an issue preventing OpenSearch to run without snapshots enabled
+- Fixed a permission issue preventing OpenSearch init container to run sysctl
 
 ### Added
 

--- a/helmfile/values/opensearch/common.yaml.gotmpl
+++ b/helmfile/values/opensearch/common.yaml.gotmpl
@@ -71,6 +71,7 @@ config:
               ".opendistro-asynchronous-search-response*",
             ]
 
+    {{ if .Values.opensearch.snapshot.enabled -}}
     # Object storage configuration
     {{ if eq .Values.objectStorage.type "s3" -}}
     s3:
@@ -80,6 +81,7 @@ config:
           path_style_access: true
     {{ else if eq .Values.objectStorage.type "gcs" -}}
     # TODO: Add config for GCS if any.
+    {{- end }}
     {{- end }}
 
 # To prevent the demo certs from generating: https://github.com/opensearch-project/helm-charts/issues/154
@@ -99,6 +101,7 @@ extraInitContainers:
       - vm.max_map_count=262144
     securityContext:
       privileged: true
+      runAsUser: 0
 
 secretMounts:
   - secretName: opensearch-admin-cert

--- a/migration/v0.18.x-v0.19.x/upgrade-apps.md
+++ b/migration/v0.18.x-v0.19.x/upgrade-apps.md
@@ -34,6 +34,7 @@
 
     By default it will configure OpenSearch using the subdomain `opensearch` on `ops.${DOMAIN}`, OpenSearch Dashboards using the subdomain `opensearch` on `${DOMAIN}`, and the snapshot repository using the bucket `${ENVIRONMENT_NAME}-opensearch`.
     **These must be prepared for the migration.**
+    The bucket is not needed if snapshots are disabled.
 
 1. Update apps configuration:
 
@@ -56,7 +57,7 @@
 
 1. Migrate from ODFE to OpenSearch:
 
-    This will set up a fresh OpenSearch cluster and migrate the data from ODFE via snapshots.
+    This will set up a fresh OpenSearch cluster and migrate the data from ODFE via snapshots if enabled.
     **Note** that this will *not* carry over security settings.
     Any user, role, or rolemapping that has been manually created must be either be added into the configuration manifests or later manually added when the data migration is complete.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Some fixes for OpenSearch:
- Enable the OpenSearch migration script to run on dev clusters that don't use snapshots.
- Enable OpenSearch to actually run without snapshots enabled.
- Give the init container permission to actually use sysctl (thanks busybox for making that error silent :sweat_smile:).

**Special notes for reviewer**:
Indentation is off, but I didn't want to spend too much time fixing it as I would have to rewrite big chunks of it.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
