### PR TITLE
apps: Expose velero's backup retention

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -63,6 +63,7 @@
 - resources requests and limits for falco-exporter, kubeStateMetrics and prometheusNodeExporter [#739](https://github.com/elastisys/compliantkubernetes-apps/pull/739)
 - increased resource requests and limits for falco-exporter, kubeStateMetrics and prometheusNodeExporter [#739](https://github.com/elastisys/compliantkubernetes-apps/pull/739)
 - increased the influxDB pvc size [#739](https://github.com/elastisys/compliantkubernetes-apps/pull/739)
+- Exposed velero's backup timetolive for both sc and wc.
 
 ### Fixed
 

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -241,6 +241,7 @@ velero:
   tolerations: []
   nodeSelector: {}
   schedule: 0 0 * * * # once per day
+  retentionPeriod: 720h0m0s
   resources:
     limits:
       cpu: 500m

--- a/helmfile/values/velero-sc.yaml.gotmpl
+++ b/helmfile/values/velero-sc.yaml.gotmpl
@@ -96,7 +96,7 @@ schedules:
       labelSelector:
         matchLabels:
           velero: backup
-      ttl: 720h0m0s
+      ttl: {{ .Values.velero.retentionPeriod }}
 
 metrics:
   enabled: true

--- a/helmfile/values/velero-wc.yaml.gotmpl
+++ b/helmfile/values/velero-wc.yaml.gotmpl
@@ -95,7 +95,7 @@ schedules:
       storageLocation: default
       includedNamespaces:
       {{ .Values.user.namespaces | toYaml | nindent 8 }}
-      ttl: 720h0m0s
+      ttl: {{ .Values.velero.retentionPeriod }}
       labelSelector:
         matchExpressions:
         - key: compliantkubernetes.io/nobackup


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR expose velero's backup retention as config 
**Which issue this PR fixes** : fixes #697

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
