### PR TITLE
apps sc: disabled internal database on influxdb

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -64,6 +64,7 @@
 - increased resource requests and limits for falco-exporter, kubeStateMetrics and prometheusNodeExporter [#739](https://github.com/elastisys/compliantkubernetes-apps/pull/739)
 - increased the influxDB pvc size [#739](https://github.com/elastisys/compliantkubernetes-apps/pull/739)
 - Exposed velero's backup timetolive for both sc and wc.
+- disabled internal database for InfluxDB
 
 ### Fixed
 

--- a/helmfile/values/influxdb.yaml.gotmpl
+++ b/helmfile/values/influxdb.yaml.gotmpl
@@ -88,6 +88,8 @@ env:
       key: INFLUXDB_SCWRITER_PWD
 
 config:
+  monitor:
+    store-enabled: false
   data:
     index-version: tsi1
   http:

--- a/migration/v0.18.x-v0.19.x/upgrade-apps.md
+++ b/migration/v0.18.x-v0.19.x/upgrade-apps.md
@@ -92,3 +92,9 @@
 1. Clean up after ODFE:
 
     Run script `opensearch-migration-clean.sh`, this will delete deprecated parameters for ODFE in `secrets.yaml`, `sc-config.yaml` and `wc-config.yaml`.
+
+1. You will need to restart the influxdb pod in order for it to load the new configmap:
+
+   ```bash
+   bin/ck8s ops kubectl sc delete po influxdb-0 -n influxdb-prometheus
+   ```


### PR DESCRIPTION
**What this PR does / why we need it**: to disable internal database on influxsb

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #743 

**Special notes for reviewer**: i didn't find a  "nicer" way to reload the config on influx

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [x] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
