### PR TITLE
secret structure for kubeconfig.bash

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -28,12 +28,16 @@
  - Fluentd can now properly handle and write orphaned documents to Opensearch when using the index per namespace feature.
   The orphaned documents will be written to `.orphaned-...` indices, which a user does not have access to read from.
  - Add `ingressClassName` in ingresses where that configuration option is available.
+<<<<<<< HEAD
  - Upgrade velero helm chart to `v2.27.3`, which also upgrades velero to `v1.7.1`.
  - Upgrade prometheus-elasticsearch-exporter helm chart to v4.11.0 and prometheus-elasticsearch-exporter itself to v1.3.0
  - Exposed options for starboard-operator to control the number of jobs it generates and to allow for it to be disabled.
  - Added the new OPA policy - disallowed the latest image tag.
  - Moved `user.alertmanager.group_by` to `prometheus.alertmanagerSpec.groupBy` in `sc-config.yaml`
  - Moved `user.grafana.userGroups` to `user.grafana.oidc.userGroups` in `sc-config.yaml`
+=======
+ - kubeconfig.bash have been edited to work with the new 'secret' structure.
+>>>>>>> secret structure for kubeconfig.bash
 
 ### Fixed
 

--- a/bin/kubeconfig.bash
+++ b/bin/kubeconfig.bash
@@ -16,7 +16,7 @@ case "${1}" in
         config_load wc
         cluster_config="${config[config_file_wc]}"
         kubeconfig="${secrets[kube_config_wc]}"
-        user_kubeconfig=${CK8S_CONFIG_PATH}/user/kubeconfig.yaml
+        user_kubeconfig=${CK8S_CONFIG_PATH}/user/secret/kubeconfig.yaml
     ;;
     admin)
         case "${2}" in


### PR DESCRIPTION
**What this PR does / why we need it**:
This is changed to have https://github.com/elastisys/ck8s-ops/pull/835 work. Check it out to read the details.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
