### PR TITLE
tests: Fix OpenSearch client tests

### DIFF
--- a/pipeline/test/services/service-cluster/testPodsReady.sh
+++ b/pipeline/test/services/service-cluster/testPodsReady.sh
@@ -15,7 +15,7 @@ enable_velero=$(yq r -e "${CONFIG_FILE}" 'velero.enabled')
 enable_local_pv_provisioner=$(yq r -e "${CONFIG_FILE}" 'storageClasses.local.enabled')
 enable_nfs_provisioner=$(yq r -e "${CONFIG_FILE}" 'storageClasses.nfs.enabled')
 enable_os_data_sts=$(yq r -e "${CONFIG_FILE}" 'opensearch.dataNode.dedicatedPods')
-enable_os_client_deploy=$(yq r -e "${CONFIG_FILE}" 'opensearch.clientNode.dedicatedPods')
+enable_os_client_sts=$(yq r -e "${CONFIG_FILE}" 'opensearch.clientNode.dedicatedPods')
 
 echo
 echo
@@ -38,9 +38,6 @@ deployments=(
     "opensearch-system prometheus-elasticsearch-exporter"
     "opensearch-system opensearch-dashboards"
 )
-if "${enable_os_client_deploy}"; then
-    deployments+=("opensearch-system opensearch-client")
-fi
 if "${enable_nfs_provisioner}"; then
     deployments+=("kube-system nfs-subdir-external-provisioner")
 fi
@@ -117,6 +114,9 @@ statefulsets=(
 )
 if "${enable_os_data_sts}"; then
     statefulsets+=("opensearch-system opensearch-data")
+fi
+if "${enable_os_client_sts}"; then
+    statefulsets+=("opensearch-system opensearch-client")
 fi
 if "${enable_harbor}"; then
     statefulsets+=(


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix OpenSearch client tests
Missed that it was deployed as a StatefulSet rather than Deployment.

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
