### PR TITLE
pipeline: enabled thanos ns in wc

### DIFF
--- a/pipeline/config/exoscale/common-config.yaml
+++ b/pipeline/config/exoscale/common-config.yaml
@@ -31,3 +31,5 @@ clusterAdmin:
 monitoring:
   rook:
     enabled: true
+thanos:
+  enabled: true

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -58,5 +58,3 @@ s3Exporter:
   scrapeTimeout: 30s
 prometheus:
   predictLinearLimit: 66
-thanos:
-  enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**: enabled thanos in the common config, as we need it for both sc and wc

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
