### PR TITLE
apps sc: expose sc-log-retention jobs resource requests

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,13 @@
+# Release notes
+
+# Updated
+
+### Changed
+
+ - Exposed sc-log-retention's resource requests.
+
+### Fixed
+
+### Added
+
+### Removed

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -709,10 +709,16 @@ fluentd:
     tolerations: []
     affinity: {}
     nodeSelector: {}
+  scLogsRetention:
+    days: 7
+    resources:
+      requests:
+        cpu: 200m
+        memory: 50Mi
+      limits:
+        cpu: 300m
+        memory: 100Mi
 
-# Log retention for service cluster logs stored in object storage.
-logRetention:
-  days: 7
 influxDB:
   enabled: true
   subdomain: influxdb

--- a/helmfile/values/sc-logs-retention.yaml.gotmpl
+++ b/helmfile/values/sc-logs-retention.yaml.gotmpl
@@ -3,11 +3,11 @@
 {{ end }}
 resources:
   requests:
-    cpu: 100m
-    memory: 50Mi
+    cpu: {{ .Values.fluentd.scLogsRetention.resources.requests.cpu }}
+    memory: {{ .Values.fluentd.scLogsRetention.resources.requests.memory }}
   limits:
-    memory: 100Mi
-    cpu: 200m
+    memory: {{ .Values.fluentd.scLogsRetention.resources.limits.memory }}
+    cpu: {{ .Values.fluentd.scLogsRetention.resources.limits.cpu }}
 
 {{ if eq .Values.objectStorage.type "s3" -}}
 s3:
@@ -15,7 +15,7 @@ s3:
   region: {{ .Values.objectStorage.s3.region | quote }}
   regionEndpoint: {{ .Values.objectStorage.s3.regionEndpoint | quote }}
   bucket: {{ .Values.objectStorage.buckets.scFluentd | quote }}
-  retentionDays: {{ .Values.logRetention.days }}
+  retentionDays: {{ .Values.fluentd.scLogsRetention.days }}
   accessKey: {{ .Values.objectStorage.s3.accessKey | quote }}
   secretKey: {{ .Values.objectStorage.s3.secretKey | quote }}
 

--- a/migration/v0.19.x-v0.20.x/move_log_retention_days.sh
+++ b/migration/v0.19.x-v0.20.x/move_log_retention_days.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
+sc_config="${CK8S_CONFIG_PATH}/sc-config.yaml"
+
+move_value_to() {
+    value=$(yq r "${sc_config}" "$1")
+
+    if [[ -z "${value}" ]]; then
+        echo "$1 missing from sc-config, skipping."
+    else
+        yq w -i "${sc_config}" "$2" "${value}"
+
+    fi
+}
+
+delete_value() {
+    value=$(yq r "${sc_config}" "$1")
+
+    if [[ -z "${value}" ]]; then
+        echo "$1 missing from sc-config, skipping."
+    else
+        yq d -i "${sc_config}" "$1"
+    fi
+}
+
+if [[ ! -f "${sc_config}" ]]; then
+    echo "Sc-config does not exist, skipping."
+    exit 0
+fi
+
+move_value_to 'logRetention.days' 'fluentd.scLogsRetention.days'
+delete_value 'logRetention'

--- a/migration/v0.19.x-v0.20.x/upgrade-apps.md
+++ b/migration/v0.19.x-v0.20.x/upgrade-apps.md
@@ -1,0 +1,21 @@
+# Upgrade v0.19.x to v0.20.0
+
+## Prerequisites
+
+## Steps
+
+1. Run the migration script: `move_log_retention_days.sh`
+
+2. Update apps configuration:
+
+    This will take a backup into `backups/` before modifying any files.
+
+    ```bash
+    bin/ck8s init
+    ```
+
+3. Upgrade applications:
+
+    ```bash
+    bin/ck8s apply {sc|wc}
+    ```


### PR DESCRIPTION
**What this PR does / why we need it**:

Exposed the sc-log-retention resource requests. As i have noticed that sc-logs-retention job is throttled.  
![sc-logs-re](https://user-images.githubusercontent.com/12862587/151148231-3b1095de-5ba1-4265-b685-37d885bb9787.png)

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [X] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
