### PR TITLE
apps sc: expose max seconds for curl and verbose curl for slm job

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -12,6 +12,8 @@
  - Added new panel to backup dashboard to reflect partial, failed and successful velero backups
  - Alertmanager group-by parameters was removed and replaced by the special value `...`
      See https://github.com/prometheus/alertmanager/blob/ec83f71/docs/configuration.md#route for more information
+ - Exposed opensearch-slm-job max request seconds for curl.
+ - Made opensearch-slm-job more verbose when using curl.
 
 ### Fixed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -638,6 +638,7 @@ opensearch:
     min: 7
     max: 14
     ageSeconds: 864000
+    maxRequestSeconds: 1200
     backupSchedule: 0 */2 * * *
     backupStartingDeadlineSeconds: 600
     backupActiveDeadlineSeconds: 600

--- a/helmfile/charts/opensearch/slm/templates/cronjob.yaml
+++ b/helmfile/charts/opensearch/slm/templates/cronjob.yaml
@@ -50,6 +50,8 @@ spec:
                   value: {{ .Values.snapshots.max | quote }}
                 - name: MAX_AGE_SECONDS
                   value: {{ .Values.snapshots.maxAgeSeconds | quote }}
+                - name: REQUEST_TIMEOUT_SECONDS
+                  value: {{ .Values.snapshots.maxRequestSeconds | quote }}
           volumes:
             - name: scripts
               configMap:

--- a/helmfile/charts/opensearch/slm/values.yaml
+++ b/helmfile/charts/opensearch/slm/values.yaml
@@ -11,8 +11,8 @@ opensearch:
   userSecret: opensearch-snapshotter-user
   clusterEndpoint: opensearch-cluster-master:9200
 
-startingDeadlineSeconds: 300
-activeDeadlineSeconds: 600
+startingDeadlineSeconds: 600
+activeDeadlineSeconds: 2700
 
 schedule: "@daily"
 snapshotRepository: s3
@@ -20,6 +20,7 @@ snapshots:
   min: 7
   max: 14
   maxAgeSeconds: 864000 # = 60 * 60 * 24 * 10 = 10 days
+  maxRequestSeconds: 1200
 
 restartPolicy: OnFailure
 

--- a/helmfile/values/opensearch/slm.yaml.gotmpl
+++ b/helmfile/values/opensearch/slm.yaml.gotmpl
@@ -17,5 +17,6 @@ snapshots:
   min: {{ .Values.opensearch.snapshot.min }}
   max: {{ .Values.opensearch.snapshot.max }}
   maxAgeSeconds: {{ .Values.opensearch.snapshot.ageSeconds | quote }}
+  maxRequestSeconds: {{ .Values.opensearch.snapshot.maxRequestSeconds | quote }}
 
 resources: {{- toYaml .Values.opensearch.snapshot.retentionResources | nindent 2 }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Have noticed that slm jobs crashes because of error 28 which is curls error code for timeout. As such i exposed the max seconds for requests for curl. Also changed --silent to --no-progress-meter to make the curl request more verbose. 

From curl man:
```
--no-progress-meter

Option to switch off the progress meter output without muting or 
otherwise affecting warning and informational messages like --silent does.
```

```
Error code 28

Operation timeout. The specified time-out period was reached according to the conditions.

```

```
kubectl describe pod -n elastic-system elasticsearch-slm-manual-x9kpc
Name:         elasticsearch-slm-manual-x9kpc
Namespace:    elastic-system
...
Status:       Succeeded
IP:           10.233.115.12
IPs:
  IP:           10.233.115.12
Controlled By:  Job/elasticsearch-slm-manual
Containers:
  run:
    ...
    State:          Terminated
      Reason:       Completed
      Exit Code:    0
      Started:      Fri, 28 Jan 2022 08:37:23 +0100
      Finished:     Fri, 28 Jan 2022 08:40:57 +0100
    Last State:     Terminated
      Reason:       Error
      Exit Code:    28
      Started:      Fri, 28 Jan 2022 08:25:55 +0100
      Finished:     Fri, 28 Jan 2022 08:37:21 +0100
    Ready:          False
    Restart Count:  1
    ...
Events:
  Type    Reason     Age                  From               Message
  ----    ------     ----                 ----               -------
  Normal  Scheduled  20m                  default-scheduler  Successfully assigned elastic-system/elasticsearch-slm-manual-x9kpc to pwelt-sc-cluster-k8s-node-b-xlarge-1
  Normal  Pulled     8m34s (x2 over 20m)  kubelet            Container image "elastisys/curl-jq:ubuntu" already present on machine
  Normal  Created    8m33s (x2 over 20m)  kubelet            Created container run
  Normal  Started    8m33s (x2 over 20m)  kubelet            Started container run
```



**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
