### PR TITLE
apps-sc: Enable dex kubernetes persistence

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
  - Exposed sc-log-retention's resource requests.
+ - Persist Dex state in Kubernetes.
 
 ### Fixed
 

--- a/helmfile/values/dex.yaml.gotmpl
+++ b/helmfile/values/dex.yaml.gotmpl
@@ -27,7 +27,9 @@ volumes:
 
 config:
   storage:
-    type: memory
+    type: kubernetes
+    config:
+      inCluster: true
   issuer: https://{{ .Values.dex.subdomain }}.{{ .Values.global.baseDomain }}
   connectors:
   {{- toYaml .Values.dex.connectors | nindent 4 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
See #680 

**Which issue this PR fixes**:
fixes #680 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

Test (the same test at Cristian did in the issue):
```
# Before using in memory storage
❯ diff -y before-keys.json after-keys.json 
{								{
  "keys": [							 "keys": [
    {								   {
      "use": "sig",						     "use": "sig",
      "kty": "RSA",						     "kty": "RSA",
      "kid": "6a33a10b93067988e6b320399c17e645f765fb87",      |	     "kid": "485d638a1309f9fa670ec5095a342253a5c7f739",
      "alg": "RS256",						     "alg": "RS256",
      "n": "19lpWXTZdw37C2c5wtNrdwPwcpk1vIZJeoBxKEEcvpsQ2fiWL |	     "n": "yC9CDsranNlnVyK6qQN67nMN_kGyIf5kcdBDonoxPKpinjTOD
      "e": "AQAB"						     "e": "AQAB"
    }								   }
  ]								 ]
}								}

# After using kubernetes storage
❯ diff -y dex-after-crds/before-keys.json dex-after-crds/after-keys.json 
{								{
  "keys": [							 "keys": [
    {								   {
      "use": "sig",						     "use": "sig",
      "kty": "RSA",						     "kty": "RSA",
      "kid": "4d72b0687cd051ac1899fdabbef3b8bfa690173f",	     "kid": "4d72b0687cd051ac1899fdabbef3b8bfa690173f",
      "alg": "RS256",						     "alg": "RS256",
      "n": "v2k8Is2V836LHRE_BntIKkFI8zt0JmiV1ePtapHKkNy0haVFz	     "n": "v2k8Is2V836LHRE_BntIKkFI8zt0JmiV1ePtapHKkNy0haVFz
      "e": "AQAB"						     "e": "AQAB"
    }								   }
  ]								 ]
}	
```

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
