### PR TITLE
apps: fluentd can now create and write to .orphaned indexes

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -14,7 +14,12 @@
      See https://github.com/prometheus/alertmanager/blob/ec83f71/docs/configuration.md#route for more information
  - Exposed opensearch-slm-job max request seconds for curl.
  - Made opensearch-slm-job more verbose when using curl.
+<<<<<<< HEAD
  - Update kubeapi-metrics ingress api version to `networking.k8s.io/v1`.
+=======
+ - Fluentd can now properly handle and write orphaned documents to Opensearch when using the index per namespace feature.
+  The orphaned documents will be written to `.orphaned-...` indices, which a user does not have access to read from.
+>>>>>>> apps: fluentd can now create and write to .orphaned indexes
 
 ### Fixed
 

--- a/helmfile/values/opensearch/configurer.yaml.gotmpl
+++ b/helmfile/values/opensearch/configurer.yaml.gotmpl
@@ -83,8 +83,9 @@ config:
         index_permissions:
         {{- if .Values.opensearch.indexPerNamespace }}
         - index_patterns:
-          # Only allow indices not starting with "."
+          # Only allow indices not starting with ".", except ".orphaned-"
           - '/^[^.].*/'
+          - ".orphaned-*"
           allowed_actions:
           - "indices:admin/create"
           - "index"
@@ -110,6 +111,7 @@ config:
         - index_patterns:
           {{- if .Values.opensearch.indexPerNamespace }}
           - '/^[^.].*/'
+          - ".orphaned-*"
           {{- else }}
           - "kubernetes-*"
           - "other-*"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows fluentd to create and write to .orphaned indexes
**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #746 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
