### PR TITLE
apps WC : New OPA policy disallow latest image tag

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -31,6 +31,8 @@
  - Upgrade velero helm chart to `v2.27.3`, which also upgrades velero to `v1.7.1`.
  - Upgrade prometheus-elasticsearch-exporter helm chart to v4.11.0 and prometheus-elasticsearch-exporter itself to v1.3.0
  - Exposed options for starboard-operator to control the number of jobs it generates and to allow for it to be disabled.
+ - Added the new OPA policy - disallowed the latest image tag.
+
 
 ### Fixed
 

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -135,6 +135,13 @@ opa:
     enabled: true
     enforcement: deny
 
+  ## It will not allow any image with the latest tag
+  disallowedTags:
+    enabled: true
+    enforcement: dryrun
+    tags:
+     - latest
+
 ## Configuration for fluentd.
 ## Fluentd ships logs to OpenSearch using the endpoint 'opensearch.subdomain' set in common-config.yaml.
 ## Consists of two different deployments, one for running on master nodes

--- a/helmfile/charts/gatekeeper-constraints/templates/disallow-tag/constraint.yaml
+++ b/helmfile/charts/gatekeeper-constraints/templates/disallow-tag/constraint.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.disallowedTags.enable -}}
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sDisallowedTags
+metadata:
+  name: container-image-must-not-have-disallowed-tags
+spec:
+  enforcementAction: {{ .Values.disallowedTags.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod", "ReplicationController"]
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "StatefulSet", "DaemonSet", "ReplicaSet"]
+      - apiGroups: ["extensions"]
+        kinds: ["Deployment", "StatefulSet", "DaemonSet", "ReplicaSet"]
+      - apiGroups: ["batch"]
+        kinds: ["Job", "CronJob"]
+    namespaceSelector:
+      matchExpressions:
+      - key: owner
+        operator: NotIn
+        values:
+        - operator
+  parameters:
+    tags: {{- toYaml .Values.imageDisallowedTags | nindent 6}}
+{{- end }}

--- a/helmfile/charts/gatekeeper-constraints/values.yaml
+++ b/helmfile/charts/gatekeeper-constraints/values.yaml
@@ -7,5 +7,11 @@ requireNetworkpolicies:
 requireResourceRequests:
     enable: true
     enforcementAction: dryrun
+disallowedTags:
+    enable: true
+    enforcementAction: dryrun
 
 imageRegistryURL: registry.example.com
+
+imageDisallowedTags:
+  - latest

--- a/helmfile/charts/gatekeeper-templates/policies/disallow-tag.rego
+++ b/helmfile/charts/gatekeeper-templates/policies/disallow-tag.rego
@@ -1,0 +1,93 @@
+package k8sdisallowedtags
+
+# For regular containers
+violation[{"msg": msg}] {
+
+    container := get_containers[_]
+
+    tags := [forbid | tag = input.parameters.tags[_] ; forbid = endswith(container.image, concat(":", ["", tag]))]
+    any(tags)
+    msg := sprintf("container <%v> uses a disallowed tag <%v>; disallowed tags are %v", [container.name, container.image, input.parameters.tags])
+}
+
+violation[{"msg": msg}] {
+
+    container := get_containers[_]
+
+    tag := [contains(container.image, ":")]
+    not all(tag)
+    msg := sprintf("container <%v> didn't specify an image tag <%v>", [container.name, container.image])
+}
+
+# Get containers for "Pods"
+get_containers = res {
+    input.review.object.kind == "Pod"
+    res := input.review.object.spec.containers
+}
+
+# Get containers for resources that use pod templates.
+get_containers = res {
+    kinds := [
+        "Deployment",
+        "StatefulSet",
+        "DaemonSet",
+        "ReplicaSet",
+        "Job",
+        "ReplicationController"
+    ]
+    input.review.object.kind == kinds[_]
+
+    res := input.review.object.spec.template.spec.containers
+}
+
+# Get containers for "CronJobs"
+get_containers = res {
+    input.review.object.kind == "CronJob"
+    res := input.review.object.spec.jobTemplate.spec.template.spec.containers
+}
+
+# For init containers
+violation[{"msg": msg}] {
+
+    container := get_init_containers[_]
+
+    tags := [forbid | tag = input.parameters.tags[_] ; forbid = endswith(container.image, concat(":", ["", tag]))]
+    any(tags)
+    msg := sprintf("container <%v> uses a disallowed tag <%v>; disallowed tags are %v", [container.name, container.image, input.parameters.tags])
+}
+
+violation[{"msg": msg}] {
+
+    container := get_init_containers[_]
+
+    tag := [contains(container.image, ":")]
+    not all(tag)
+    msg := sprintf("container <%v> didn't specify an image tag <%v>", [container.name, container.image])
+}
+
+# Get init containers for "Pods"
+get_init_containers = res {
+    input.review.object.kind == "Pod"
+    res := input.review.object.spec.initContainers
+}
+
+# Get init containers for resources that use pod templates.
+get_init_containers = res {
+    kinds := [
+        "Deployment",
+        "StatefulSet",
+        "DaemonSet",
+        "ReplicaSet",
+        "Job",
+        "ReplicationController"
+    ]
+    input.review.object.kind == kinds[_]
+
+    res := input.review.object.spec.template.spec.initContainers
+}
+
+# Get init containers for "CronJobs"
+get_init_containers = res {
+    input.review.object.kind == "CronJob"
+    res := input.review.object.spec.jobTemplate.spec.template.spec.initContainers
+}

--- a/helmfile/charts/gatekeeper-templates/policies/tests/disallow-tag.rego
+++ b/helmfile/charts/gatekeeper-templates/policies/tests/disallow-tag.rego
@@ -1,0 +1,543 @@
+package test.k8sdisallowedtags
+
+import data.k8sdisallowedtags
+
+#
+# Help functions
+#
+generate_pod(tags, containers) = obj {
+    obj := {
+        "parameters": {
+            "tags": tags
+        },
+        "review": {
+            "object": {
+                "kind": "Pod",
+                "spec": {
+                    "containers": containers
+                }
+            }
+        }
+    }
+}
+
+generate_pod_with_initContainer(tags, containers, initContainers) = obj {
+    obj := {
+        "parameters": {
+            "tags": tags
+        },
+        "review": {
+            "object": {
+                "kind": "Pod",
+                "spec": {
+                    "containers": containers,
+                    "initContainers": initContainers
+                }
+            }
+        }
+    }
+}
+
+generate_resource_controller(tags, kind, containers) = obj {
+    obj := {
+        "parameters": {
+            "tags": tags
+        },
+        "review": {
+            "object": {
+                "kind": kind,
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": containers
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+generate_resource_controller_with_initContainer(tags, kind, containers, initContainers) = obj {
+    obj := {
+        "parameters": {
+            "tags": tags
+        },
+        "review": {
+            "object": {
+                "kind": kind,
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": containers,
+                            "initContainers": initContainers
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+generate_cronJob(tags, containers) = obj {
+    obj := {
+        "parameters": {
+            "tags": tags
+        },
+        "review": {
+            "object": {
+                "kind": "CronJob",
+                "spec": {
+                    "jobTemplate": {
+                        "spec": {
+                            "template": {
+                                "spec": {
+                                    "containers": containers
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+generate_cronJob_with_initContainer(tags, containers, initContainers) = obj {
+    obj := {
+        "parameters": {
+            "tags": tags
+        },
+        "review": {
+            "object": {
+                "kind": "CronJob",
+                "spec": {
+                    "jobTemplate": {
+                        "spec": {
+                            "template": {
+                                "spec": {
+                                    "containers": containers,
+                                    "initContainers": initContainers
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#
+# Tests
+#
+test_pod_bad_tag_deny {
+    count(k8sdisallowedtags.violation) == 1 with input as generate_pod(
+        [
+            "latest",
+        ],
+        [
+            {
+                "name": "test",
+                "image": "nginx:latest"
+            }
+        ]
+    )
+}
+
+test_pod_good_tag_allow {
+    count(k8sdisallowedtags.violation) == 0 with input as generate_pod(
+        [
+            "latest"
+        ],
+        [
+            {
+                "name": "test",
+                "image": "nginx:1.21.6"
+            }
+        ]
+    )
+}
+
+test_pod_bad_tag_initContainer_deny {
+    count(k8sdisallowedtags.violation) == 1 with input as generate_pod_with_initContainer(
+        [
+            "latest"
+        ],
+        [
+            {
+                "name": "container",
+                "image": "harbor.example.com/test/nginx:1.21.6"
+            }
+        ],
+        [
+            {
+                "name": "initContainer",
+                "image": "nginx:latest"
+            }
+        ]
+    )
+}
+
+test_pod_good_initContainer_allow {
+    count(k8sdisallowedtags.violation) == 0 with input as generate_pod_with_initContainer(
+        [
+            "latest"
+        ],
+        [
+            {
+                "name": "container",
+                "image": "harbor.example.com/test/nginx:1.21.6"
+            }
+        ],
+        [
+            {
+                "name": "initContainer",
+                "image": "other.secure-registry.com/test/nginx:1.21.6"
+            }
+        ]
+    )
+}
+
+test_pod_multiple_containers_deny {
+    count(k8sdisallowedtags.violation) == 2 with input as generate_pod(
+        [
+            "latest"
+        ],
+        [
+            {
+                "name": "allow1",
+                "image": "harbor.example.com/test/nginx:1.21.6"
+            },
+            {
+                "name": "allow2",
+                "image": "other.secure-registry.com/ubuntu:1.21.6"
+            },
+            {
+                "name": "deny1",
+                "image": "harbor.bad.com/test/nginx:latest"
+            },
+            {
+                "name": "deny2",
+                "image": "nginx:latest"
+            }
+        ]
+    )
+}
+
+test_pod_multiple_containers_and_initContainers_deny {
+    count(k8sdisallowedtags.violation) == 3 with input as generate_pod_with_initContainer(
+        [
+            "latest"
+        ],
+        [
+            {
+                "name": "allow1",
+                "image": "harbor.example.com/test/nginx:1.21.6"
+            },
+            {
+                "name": "allow2",
+                "image": "other.secure-registry.com/ubuntu:1.21.6"
+            },
+            {
+                "name": "deny1",
+                "image": "harbor.bad.com/test/nginx:latest"
+            },
+            {
+                "name": "deny2",
+                "image": "nginx:latest"
+            }
+        ],
+        [
+            {
+                "name": "allow",
+                "image": "harbor.example.com/test/ubuntu:18.04"
+            },
+            {
+                "name": "deny",
+                "image": "harbor.bad.com/test/ubuntu:latest"
+            }
+        ],
+    )
+}
+
+kinds := [
+    "Deployment",
+    "StatefulSet",
+    "DaemonSet",
+    "ReplicaSet",
+    "Job",
+    "ReplicationController"
+]
+
+test_resource_controller_bad_tag_deny {
+    res = [test | test = count(k8sdisallowedtags.violation) == 1 with input as generate_resource_controller(
+        [
+            "latest"
+        ],
+        kinds[_],
+        [
+            {
+                "name": "test",
+                "image": "nginx:latest"
+            }
+        ]
+    )]
+    all(res)
+}
+
+test_resource_controller_good_tag_allow {
+    res = [test | test = count(k8sdisallowedtags.violation) == 0 with input as generate_resource_controller(
+        [
+            "latest"
+        ],
+        kinds[_],
+        [
+            {
+                "name": "test",
+                "image": "harbor.example.com/test/nginx:1.21.6"
+            }
+        ]
+    )]
+    all(res)
+}
+
+test_resource_controller_bad_initContainer_deny {
+    res = [test | test = count(k8sdisallowedtags.violation) == 1 with input as generate_resource_controller_with_initContainer(
+        [
+            "latest"
+        ],
+        kinds[_],
+        [
+            {
+                "name": "container",
+                "image": "harbor.example.com/test/nginx:1.21.6"
+            }
+        ],
+        [
+            {
+                "name": "initContainer",
+                "image": "nginx:latest"
+            }
+        ]
+    )]
+    all(res)
+}
+
+test_resource_controller_good_initContainer_allow {
+    res = [test | test = count(k8sdisallowedtags.violation) == 0 with input as generate_resource_controller_with_initContainer(
+        [
+            "latest"
+        ],
+        kinds[_],
+        [
+            {
+                "name": "container",
+                "image": "harbor.example.com/test/nginx:1.21.6"
+            }
+        ],
+        [
+            {
+                "name": "initContainer",
+                "image": "other.secure-registry.com/test/nginx:1.21.6"
+            }
+        ]
+    )]
+    all(res)
+}
+
+test_resource_controller_multiple_containers_deny {
+    res = [test | test = count(k8sdisallowedtags.violation) == 2 with input as generate_resource_controller(
+        [
+            "latest"
+        ],
+        kinds[_],
+        [
+            {
+                "name": "allow1",
+                "image": "harbor.example.com/test/nginx:1.21.6"
+            },
+            {
+                "name": "allow2",
+                "image": "other.secure-registry.com/ubuntu:18.04"
+            },
+            {
+                "name": "deny1",
+                "image": "harbor.bad.com/test/nginx:latest"
+            },
+            {
+                "name": "deny2",
+                "image": "nginx:latest"
+            }
+        ]
+    )]
+    all(res)
+}
+
+test_resource_controller_multiple_containers_and_initContainers_deny {
+    res = [test | test = count(k8sdisallowedtags.violation) == 3 with input as generate_resource_controller_with_initContainer(
+        [
+            "latest"
+        ],
+        kinds[_],
+        [
+            {
+                "name": "allow1",
+                "image": "harbor.example.com/test/nginx:1.21.6"
+            },
+            {
+                "name": "allow2",
+                "image": "other.secure-registry.com/ubuntu:1.21.6"
+            },
+            {
+                "name": "deny1",
+                "image": "harbor.bad.com/test/nginx:latest"
+            },
+            {
+                "name": "deny2",
+                "image": "nginx:latest"
+            }
+        ],
+        [
+            {
+                "name": "allow",
+                "image": "harbor.example.com/test/ubuntu:1.21.6"
+            },
+            {
+                "name": "deny",
+                "image": "harbor.bad.com/test/ubuntu:latest"
+            }
+        ],
+    )]
+    all(res)
+}
+
+test_cronJob_bad_tag_deny {
+    count(k8sdisallowedtags.violation) == 1 with input as generate_cronJob(
+        [
+            "latest"
+        ],
+        [
+            {
+                "name": "test",
+                "image": "nginx:latest"
+            }
+        ]
+    )
+}
+
+test_cronJob_good_tag_allow {
+    count(k8sdisallowedtags.violation) == 0 with input as generate_cronJob(
+        [
+            "latest"
+        ],
+        [
+            {
+                "name": "test",
+                "image": "harbor.example.com/test/nginx:1.21.6"
+            }
+        ]
+    )
+}
+
+test_cronJob_bad_initContainer_deny {
+    count(k8sdisallowedtags.violation) == 1 with input as generate_cronJob_with_initContainer(
+        [
+            "latest"
+        ],
+        [
+            {
+                "name": "container",
+                "image": "harbor.example.com/test/nginx:1.21.6"
+            }
+        ],
+        [
+            {
+                "name": "initContainer",
+                "image": "nginx:latest"
+            }
+        ]
+    )
+}
+
+test_cronJob_good_initContainer_allow {
+    count(k8sdisallowedtags.violation) == 0 with input as generate_cronJob_with_initContainer(
+        [
+            "latest"
+        ],
+        [
+            {
+                "name": "container",
+                "image": "harbor.example.com/test/nginx:1.21.6"
+            }
+        ],
+        [
+            {
+                "name": "initContainer",
+                "image": "other.secure-registry.com/test/nginx:1.21.6"
+            }
+        ]
+    )
+}
+
+test_cronJob_multiple_containers_deny {
+    count(k8sdisallowedtags.violation) == 2 with input as generate_cronJob(
+        [
+            "latest"
+        ],
+        [
+            {
+                "name": "allow1",
+                "image": "harbor.example.com/test/nginx:1.21.6"
+            },
+            {
+                "name": "allow2",
+                "image": "other.secure-registry.com/ubuntu:18.04"
+            },
+            {
+                "name": "deny1",
+                "image": "harbor.bad.com/test/nginx:latest"
+            },
+            {
+                "name": "deny2",
+                "image": "nginx:latest"
+            }
+        ]
+    )
+}
+
+test_cronJob_multiple_containers_and_initContainers_deny {
+    count(k8sdisallowedtags.violation) == 3 with input as generate_cronJob_with_initContainer(
+        [
+            "latest"
+        ],
+        [
+            {
+                "name": "allow1",
+                "image": "harbor.example.com/test/nginx:1.21.6"
+            },
+            {
+                "name": "allow2",
+                "image": "other.secure-registry.com/ubuntu:18.04"
+            },
+            {
+                "name": "deny1",
+                "image": "harbor.bad.com/test/nginx:latest"
+            },
+            {
+                "name": "deny2",
+                "image": "nginx:latest"
+            }
+        ],
+        [
+            {
+                "name": "allow",
+                "image": "harbor.example.com/test/ubuntu:18.04"
+            },
+            {
+                "name": "deny",
+                "image": "harbor.bad.com/test/ubuntu:latest"
+            }
+        ],
+    )
+}

--- a/helmfile/charts/gatekeeper-templates/templates/disallow-tag/template.yaml
+++ b/helmfile/charts/gatekeeper-templates/templates/disallow-tag/template.yaml
@@ -1,0 +1,20 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sdisallowedtags
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sDisallowedTags
+      validation:
+        openAPIV3Schema:
+          properties:
+            tags:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ .Files.Get "policies/disallow-tag.rego"  | indent 8 }}

--- a/helmfile/values/gatekeeper-constraints.yaml.gotmpl
+++ b/helmfile/values/gatekeeper-constraints.yaml.gotmpl
@@ -7,5 +7,9 @@ requireNetworkpolicies:
 requireResourceRequests:
     enable: {{ .Values.opa.resourceRequests.enabled }}
     enforcementAction: {{ .Values.opa.resourceRequests.enforcement }}
+disallowedTags:
+    enable: {{ .Values.opa.disallowedTags.enabled }}
+    enforcementAction: {{ .Values.opa.disallowedTags.enforcement }}
 
 imageRegistryURL: {{- toYaml .Values.opa.imageRegistry.URL | nindent 2}}
+imageDisallowedTags: {{- toYaml .Values.opa.disallowedTags.tags | nindent 2}}


### PR DESCRIPTION
**What this PR does / why we need it**: New OPA policy - Disallow latest image tag . 

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

I have upgraded the charts and not sure if the migrations steps is needed or not . Please review and suggest that too . 

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
