### PR TITLE
apps: upgrade prometheus-elastic-search exporter

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -28,7 +28,7 @@
   The orphaned documents will be written to `.orphaned-...` indices, which a user does not have access to read from.
  - Add `ingressClassName` in ingresses where that configuration option is available.
  - Upgrade velero helm chart to `v2.27.3`, which also upgrades velero to `v1.7.1`.
-
+ - Upgrade prometheus-elasticsearch-exporter helm chart to v4.11.0 and prometheus-elasticsearch-exporter itself to v1.3.0
 ### Fixed
 
 ### Added

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -458,7 +458,7 @@ releases:
     app: prometheus-elasticsearch-exporter
     group: opensearch
   chart: ./upstream/prometheus-elasticsearch-exporter
-  version: 4.0.1
+  version: 4.11.0
   installed: true
   missingFileHandler: Error
   needs:

--- a/helmfile/upstream/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/helmfile/upstream/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v1
-appVersion: 1.1.0
 description: Elasticsearch stats exporter for Prometheus
-home: https://github.com/justwatchcom/elasticsearch_exporter
-keywords:
-- metrics
-- elasticsearch
-- monitoring
-kubeVersion: '>=1.10.0-0'
-maintainers:
-- email: sven.mueller@commercetools.com
-  name: svenmueller
-- email: carlos@carlosbecker.com
-  name: caarlos0
-- email: cedric@desaintmartin.fr
-  name: desaintmartin
 name: prometheus-elasticsearch-exporter
+version: 4.11.0
+kubeVersion: ">=1.10.0-0"
+appVersion: 1.3.0
+home: https://github.com/prometheus-community/elasticsearch_exporter
 sources:
-- https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-elasticsearch-exporter
-version: 4.0.1
+  - https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-elasticsearch-exporter
+keywords:
+  - metrics
+  - elasticsearch
+  - monitoring
+maintainers:
+  - name: svenmueller
+    email: sven.mueller@commercetools.com
+  - name: caarlos0
+    email: carlos@carlosbecker.com
+  - name: desaintmartin
+    email: cedric@desaintmartin.fr

--- a/helmfile/upstream/prometheus-elasticsearch-exporter/README.md
+++ b/helmfile/upstream/prometheus-elasticsearch-exporter/README.md
@@ -2,7 +2,7 @@
 
 Prometheus exporter for various metrics about ElasticSearch, written in Go.
 
-Learn more: <https://github.com/justwatchcom/elasticsearch_exporter>
+Learn more: <https://github.com/prometheus-community/elasticsearch_exporter>
 
 This chart creates an Elasticsearch-Exporter deployment on a [Kubernetes](http://kubernetes.io)
 cluster using the [Helm](https://helm.sh) package manager.

--- a/helmfile/upstream/prometheus-elasticsearch-exporter/ci/pod-security-policies.yaml
+++ b/helmfile/upstream/prometheus-elasticsearch-exporter/ci/pod-security-policies.yaml
@@ -1,0 +1,5 @@
+---
+# Enable podSecurityPolicies
+
+podSecurityPolicies:
+  enabled: true

--- a/helmfile/upstream/prometheus-elasticsearch-exporter/templates/_helpers.tpl
+++ b/helmfile/upstream/prometheus-elasticsearch-exporter/templates/_helpers.tpl
@@ -31,3 +31,13 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Return the appropriate apiVersion for rbac.
+*/}}
+{{- define "rbac.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+{{- print "rbac.authorization.k8s.io/v1" -}}
+{{- else -}}
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/helmfile/upstream/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/helmfile/upstream/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
     app: {{ template "elasticsearch-exporter.name" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.deployment.annotations }}
+  annotations:
+{{- toYaml .Values.deployment.annotations | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -23,6 +27,9 @@ spec:
       labels:
         app: {{ template "elasticsearch-exporter.name" . }}
         release: "{{ .Release.Name }}"
+        {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+        {{- end }}
       {{- if .Values.podAnnotations }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
@@ -46,19 +53,23 @@ spec:
         runAsNonRoot: true
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
+{{- with .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml . | indent 8 }}
+{{- end }}
       containers:
         - name: exporter
           env:
-            {{- range $key, $value := .Values.env }}
-            - name: {{ $key }}
-              value: "{{ $value }}"
-            {{- end }}
             {{- range $key, $value := .Values.extraEnvSecrets }}
             - name: {{ $key }}
               valueFrom:
                 secretKeyRef:
                   name: {{ required "Must specify secret!" $value.secret }}
                   key: {{ required "Must specify key!" $value.key }}
+            {{- end }}
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
             {{- end }}
           {{- if .Values.envFromSecret }}
           envFrom:
@@ -75,7 +86,7 @@ spec:
                     "--log.level={{ . }}",
                     {{- end }}
                     {{- if .Values.es.uri }}
-                    "--es.uri={{ .Values.es.uri }}",
+                    "--es.uri={{ tpl .Values.es.uri . }}",
                     {{- end }}
                     {{- if .Values.es.all }}
                     "--es.all",
@@ -85,6 +96,9 @@ spec:
                     {{- end }}
                     {{- if .Values.es.indices_settings }}
                     "--es.indices_settings",
+                    {{- end }}
+                    {{- if .Values.es.indices_mappings }}
+                    "--es.indices_mappings",
                     {{- end }}
                     {{- if .Values.es.shards }}
                     "--es.shards",
@@ -105,6 +119,9 @@ spec:
                     "--es.client-cert={{ .Values.es.ssl.client.pemPath }}",
                     "--es.client-private-key={{ .Values.es.ssl.client.keyPath }}",
                     {{- end }}
+                    {{- end }}
+                    {{- range .Values.extraArgs }}
+                    {{ . | quote }},
                     {{- end }}
                     "--web.listen-address=:{{ .Values.service.httpPort }}",
                     "--web.telemetry-path={{ .Values.web.path }}"]
@@ -161,6 +178,9 @@ spec:
               subPath: {{ .subPath }}
               {{- end }}
             {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
 {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
@@ -183,4 +203,7 @@ spec:
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}

--- a/helmfile/upstream/prometheus-elasticsearch-exporter/templates/role.yaml
+++ b/helmfile/upstream/prometheus-elasticsearch-exporter/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicies.enabled -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ template "elasticsearch-exporter.fullname" . }}

--- a/helmfile/upstream/prometheus-elasticsearch-exporter/templates/rolebinding.yaml
+++ b/helmfile/upstream/prometheus-elasticsearch-exporter/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podSecurityPolicies.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ template "rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "elasticsearch-exporter.fullname" . }}

--- a/helmfile/upstream/prometheus-elasticsearch-exporter/templates/serviceaccount.yaml
+++ b/helmfile/upstream/prometheus-elasticsearch-exporter/templates/serviceaccount.yaml
@@ -8,4 +8,9 @@ metadata:
     app: {{ template "elasticsearch-exporter.name" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/helmfile/upstream/prometheus-elasticsearch-exporter/values.yaml
+++ b/helmfile/upstream/prometheus-elasticsearch-exporter/values.yaml
@@ -7,8 +7,8 @@ replicaCount: 1
 restartPolicy: Always
 
 image:
-  repository: justwatch/elasticsearch_exporter
-  tag: 1.1.0
+  repository: quay.io/prometheuscommunity/elasticsearch-exporter
+  tag: v1.3.0
   pullPolicy: IfNotPresent
   pullSecret: ""
 
@@ -19,6 +19,18 @@ image:
 securityContext:
   enabled: true  # Should be set to false when running on OpenShift
   runAsUser: 1000
+
+# Custom DNS configuration to be added to prometheus-elasticsearch-exporter pods
+dnsConfig: {}
+# nameservers:
+#   - 1.2.3.4
+# searches:
+#   - ns1.svc.cluster-domain.example
+#   - my.dns.search.suffix
+# options:
+#   - name: ndots
+#     value: "2"
+#   - name: edns0
 
 log:
   format: logfmt
@@ -40,6 +52,8 @@ tolerations: []
 
 podAnnotations: {}
 
+podLabels: {}
+
 affinity: {}
 
 service:
@@ -50,12 +64,22 @@ service:
   annotations: {}
   labels: {}
 
+deployment:
+  annotations: {}
+
 ## Extra environment variables that will be passed into the exporter pod
 ## example:
 ## env:
 ##   KEY_1: value1
 ##   KEY_2: value2
 env: {}
+
+
+## Extra arguments to pass to the container's executable
+## example:
+# extraArgs:
+#   - --es.indices_mappings
+extraArgs: []
 
 ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
 ## This can be useful for auth tokens, etc
@@ -77,6 +101,24 @@ secretMounts: []
 #    secretName: elastic-certs
 #    path: /ssl
 
+# A list of additional Volume to add to the deployment
+# this is useful if the volume you need is not a secret (csi volume etc.)
+extraVolumes: []
+#  - name: csi-volume
+#    csi:
+#      driver: secrets-store.csi.k8s.io
+#      readOnly: true
+#      volumeAttributes:
+#        secretProviderClass: my-spc
+
+#  A list of additional VolumeMounts to add to the deployment
+#  this is useful for mounting any other needed resource into
+#  the elasticsearch-exporter pod
+extraVolumeMounts: []
+#  - name: csi-volume
+#    mountPath: /csi/volume
+#    readOnly: true
+
 es:
   ## Address (host and port) of the Elasticsearch node we should connect to.
   ## This could be a local node (localhost:9200, for instance), or the address
@@ -97,6 +139,10 @@ es:
   ## If true, query settings stats for all indices in the cluster.
   ##
   indices_settings: true
+
+  ## If true, query mapping stats for all indices in the cluster.
+  ##
+  indices_mappings: true
 
   ## If true, query stats for shards in the cluster.
   ##
@@ -215,6 +261,8 @@ prometheusRule:
 serviceAccount:
   create: false
   name: default
+  automountServiceAccountToken: true
+  annotations: {}
 
 # Creates a PodSecurityPolicy and the role/rolebinding
 # allowing the serviceaccount to use it

--- a/helmfile/values/prometheus-elasticsearch-exporter.yaml.gotmpl
+++ b/helmfile/values/prometheus-elasticsearch-exporter.yaml.gotmpl
@@ -8,6 +8,7 @@ es:
   shards: true
   snapshots: true
   cluster_settings: false
+  indices_mappings: false
   {{- if or (contains "m" .Values.opensearch.exporter.serviceMonitor.scrapeTimeout) (contains "h" .Values.opensearch.exporter.serviceMonitor.scrapeTimeout) }}
   {{- fail "scrapeTimeout must only be given in seconds" }}
   {{ else }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR upgrades prometheus-elasticsearch-exporter to v4.11.0 
**Which issue this PR fixes** : fixes #826 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [x] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
