### PR TITLE
apps sc: move alertmanager group by

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -32,7 +32,7 @@
  - Upgrade prometheus-elasticsearch-exporter helm chart to v4.11.0 and prometheus-elasticsearch-exporter itself to v1.3.0
  - Exposed options for starboard-operator to control the number of jobs it generates and to allow for it to be disabled.
  - Added the new OPA policy - disallowed the latest image tag.
-
+ - Moved `user.alertmanager.group_by` to `prometheus.alertmanagerSpec.groupBy` in `sc-config.yaml`
 
 ### Fixed
 

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -100,6 +100,7 @@ user:
   alertmanager:
     enabled: false
 
+    ## Todo remove dependencies on alertmanager from service cluster
     ## Create basic-auth protected ingress to alertmanager
     ingress:
       enabled: false

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -83,10 +83,6 @@ user:
         limits:
           cpu: 10m
           memory: 100Mi
-  # Todo remove dependencie on alertmanager from service cluster
-  alertmanager:
-    group_by:
-      - '...'
 harbor:
   enabled: true
   subdomain: harbor
@@ -235,7 +231,10 @@ prometheus:
     affinity: {}
     nodeSelector: {}
 
+  # Todo remove dependencie on alertmanager from service cluster
   alertmanagerSpec:
+    groupBy:
+      - '...'
     resources:
       requests:
         cpu: 10m

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -43,7 +43,7 @@ alertmanager:
   config:
     # See https://prometheus.io/docs/alerting/configuration/
     route:
-      group_by: {{ toYaml .Values.user.alertmanager.group_by | nindent 8 }}
+      group_by: {{ toYaml .Values.prometheus.alertmanagerSpec.groupBy | nindent 8 }}
       # default receiver
       receiver: '{{ .Values.alerts.alertTo }}'
       routes:

--- a/migration/v0.19.x-v0.20.x/move-alertmanager-groupby.sh
+++ b/migration/v0.19.x-v0.20.x/move-alertmanager-groupby.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
+sc_config="${CK8S_CONFIG_PATH}/sc-config.yaml"
+
+move_value_to() {
+    value=$(yq r "${sc_config}" "$1")
+
+    if [[ -z "${value}" ]]; then
+        echo "$1 missing from sc-config, skipping."
+    else
+        if [[ $value = '[]' ]]; then
+            yq w -i "${sc_config}" "$2" "${value}"
+        else
+            for row in ${value}; do
+                eval row="${row}"
+                if [[ $row = '-' ]]; then
+                    continue
+                fi
+                yq w -i --style=single "${sc_config}" "$2[+]" "${row}"
+            done
+        fi
+    fi
+}
+
+delete_value() {
+    value=$(yq r "${sc_config}" "$1")
+
+    if [[ -z "${value}" ]]; then
+        echo "$1 missing from sc-config, skipping."
+    else
+        yq d -i "${sc_config}" "$1"
+    fi
+}
+
+if [[ ! -f "${sc_config}" ]]; then
+    echo "Sc-config does not exist, skipping."
+    exit 0
+fi
+
+move_value_to 'user.alertmanager.group_by' 'prometheus.alertmanagerSpec.groupBy'
+delete_value 'user.alertmanager'

--- a/migration/v0.19.x-v0.20.x/upgrade-apps.md
+++ b/migration/v0.19.x-v0.20.x/upgrade-apps.md
@@ -6,7 +6,9 @@
 
 1. Run the migration script: `move_log_retention_days.sh`
 
-2. Update apps configuration:
+2. Run the migration script: `move-alertmanager-groupby.sh`
+
+3. Update apps configuration:
 
     This will take a backup into `backups/` before modifying any files.
 
@@ -14,7 +16,7 @@
     bin/ck8s init
     ```
 
-3. Remove conflicting starboard secret:
+4. Remove conflicting starboard secret:
 
    This was managed by starboard-operator and from now on it is managed by helm.
 
@@ -22,13 +24,13 @@
    bin/ck8s ops kubectl {sc|wc} -n monitoring delete secret starboard
    ```
 
-4. Update starboard-operator custom resource definitions:
+5. Update starboard-operator custom resource definitions:
 
    ```bash
    bin/ck8s ops kubectl {sc|wc} apply -f helmfile/upstream/starboard-operator/crds
    ```
 
-5. Upgrade applications:
+6. Upgrade applications:
 
     ```bash
     bin/ck8s apply {sc|wc}


### PR DESCRIPTION
**What this PR does / why we need it**:

Moved alertmanager from user to prometheus

**Which issue this PR fixes**: fixes #755

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [x] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
