### PR TITLE
apps sc: move user grafana groups path under oidc

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -33,6 +33,7 @@
  - Exposed options for starboard-operator to control the number of jobs it generates and to allow for it to be disabled.
  - Added the new OPA policy - disallowed the latest image tag.
  - Moved `user.alertmanager.group_by` to `prometheus.alertmanagerSpec.groupBy` in `sc-config.yaml`
+ - Moved `user.grafana.userGroups` to `user.grafana.oidc.userGroups` in `sc-config.yaml`
 
 ### Fixed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -65,12 +65,12 @@ user:
     tolerations: []
     affinity: {}
     nodeSelector: {}
-    userGroups:
-      grafanaAdmin: grafana_admin   # maps to grafana role admin
-      grafanaEditor: grafana_editor # maps to grafana role editor
-      grafanaViewer: grafana_viewer # maps to grafana role viewer
     oidc:
       scopes: profile email openid
+      userGroups:
+        grafanaAdmin: grafana_admin   # maps to grafana role admin
+        grafanaEditor: grafana_editor # maps to grafana role editor
+        grafanaViewer: grafana_viewer # maps to grafana role viewer
       allowedDomains:
         - set-me
         - example.com

--- a/helmfile/values/grafana-user.yaml.gotmpl
+++ b/helmfile/values/grafana-user.yaml.gotmpl
@@ -139,7 +139,7 @@ grafana.ini:
     allowed_domains: {{ join " " .Values.user.grafana.oidc.allowedDomains }}
     allow_sign_up: true
     tls_skip_verify_insecure: {{ not .Values.global.verifyTls }}
-    role_attribute_path: contains(groups[*], '{{ .Values.user.grafana.userGroups.grafanaAdmin }}') && 'Admin' || contains(groups[*], '{{ .Values.user.grafana.userGroups.grafanaEditor }}') && 'Editor' || contains(groups[*], '{{ .Values.user.grafana.userGroups.grafanaViewer }}') && 'Viewer'
+    role_attribute_path: contains(groups[*], '{{ .Values.user.grafana.oidc.userGroups.grafanaAdmin }}') && 'Admin' || contains(groups[*], '{{ .Values.user.grafana.oidc.userGroups.grafanaEditor }}') && 'Editor' || contains(groups[*], '{{ .Values.user.grafana.oidc.userGroups.grafanaViewer }}') && 'Viewer'
   users:
     viewers_can_edit: {{ .Values.user.grafana.viewersCanEdit }}
 

--- a/migration/v0.19.x-v0.20.x/move-usergroups-user-grafana.sh
+++ b/migration/v0.19.x-v0.20.x/move-usergroups-user-grafana.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
+sc_config="${CK8S_CONFIG_PATH}/sc-config.yaml"
+
+move_value_to() {
+    value=$(yq r "${sc_config}" "$1")
+
+    if [[ -z "${value}" ]]; then
+        echo "$1 missing from sc-config, skipping."
+    else
+        yq w -i "${sc_config}" "$2" "${value}"
+    fi
+}
+
+delete_value() {
+    value=$(yq r "${sc_config}" "$1")
+
+    if [[ -z "${value}" ]]; then
+        echo "$1 missing from sc-config, skipping."
+    else
+        yq d -i "${sc_config}" "$1"
+    fi
+}
+
+if [[ ! -f "${sc_config}" ]]; then
+    echo "Sc-config does not exist, skipping."
+    exit 0
+fi
+
+move_value_to 'user.grafana.userGroups.grafanaAdmin' 'user.grafana.oidc.userGroups.grafanaAdmin'
+move_value_to 'user.grafana.userGroups.grafanaEditor' 'user.grafana.oidc.userGroups.grafanaEditor'
+move_value_to 'user.grafana.userGroups.grafanaViewer' 'user.grafana.oidc.userGroups.grafanaViewer'
+delete_value 'user.grafana.userGroups'

--- a/migration/v0.19.x-v0.20.x/upgrade-apps.md
+++ b/migration/v0.19.x-v0.20.x/upgrade-apps.md
@@ -6,9 +6,11 @@
 
 1. Run the migration script: `move_log_retention_days.sh`
 
-2. Run the migration script: `move-alertmanager-groupby.sh`
+1. Run the migration script: `move-alertmanager-groupby.sh`
 
-3. Update apps configuration:
+1. Run the migration script: `move-usergroups-user-grafana.sh`
+
+1. Update apps configuration:
 
     This will take a backup into `backups/` before modifying any files.
 
@@ -16,7 +18,7 @@
     bin/ck8s init
     ```
 
-4. Remove conflicting starboard secret:
+1. Remove conflicting starboard secret:
 
    This was managed by starboard-operator and from now on it is managed by helm.
 
@@ -24,13 +26,13 @@
    bin/ck8s ops kubectl {sc|wc} -n monitoring delete secret starboard
    ```
 
-5. Update starboard-operator custom resource definitions:
+1. Update starboard-operator custom resource definitions:
 
    ```bash
    bin/ck8s ops kubectl {sc|wc} apply -f helmfile/upstream/starboard-operator/crds
    ```
 
-6. Upgrade applications:
+1. Upgrade applications:
 
     ```bash
     bin/ck8s apply {sc|wc}


### PR DESCRIPTION
**What this PR does / why we need it**:

Move the userGroups for user grafana under oidc path. To unify the config with ops grafana.

**Which issue this PR fixes**: fixes #846

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [x] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
