### PR TITLE
config: moved custom acme example to wc config

### DIFF
--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -315,10 +315,7 @@ certmanager:
   tolerations: {}
   affinity: {}
 
-  ## when using cert-manager with HTTP01 challenge and a custom image registry the below parameter should be added in the extraArgs
-  ## !! this works only with public repositories !! see https://github.com/jetstack/cert-manager/issues/2429
-  ## update the image tag based on the version used in the helm chart
-  ## - --acme-http01-solver-image=<harbor_server_name>/<proxy_project_name>/jetstack/cert-manager-acmesolver:v1.4.0
+  ## if you need use cert-manager with HTTP01 challenge and a custom image registry in wc, please update the wc-config.yaml with the correct extraArgs
   extraArgs: []
 
   webhook:

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -142,6 +142,13 @@ opa:
     tags:
      - latest
 
+## certmanager:
+  ## when using cert-manager with HTTP01 challenge and a custom image registry the below parameter should be added in the extraArgs
+  ## !! this works only with public repositories !! see https://github.com/jetstack/cert-manager/issues/2429
+  ## update the image tag based on the version used in the helm chart
+  ## - --acme-http01-solver-image=<harbor_server_name>/<proxy_project_name>/jetstack/cert-manager-acmesolver:v1.4.0
+  ## extraArgs: []
+
 ## Configuration for fluentd.
 ## Fluentd ships logs to OpenSearch using the endpoint 'opensearch.subdomain' set in common-config.yaml.
 ## Consists of two different deployments, one for running on master nodes


### PR DESCRIPTION
**What this PR does / why we need it**: to avoid any mistakes and setup the custom registry for cert-manager acme image for both sc and wc, I moved the example from common-config.yaml to wc-config.yaml

**Special notes for reviewer**: let me know if you have a better idea on how to do this

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
