### PR TITLE
config: increased thanos resources

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -35,6 +35,7 @@
  - Moved `user.alertmanager.group_by` to `prometheus.alertmanagerSpec.groupBy` in `sc-config.yaml`
  - Moved `user.grafana.userGroups` to `user.grafana.oidc.userGroups` in `sc-config.yaml`
  - kubeconfig.bash have been edited to work with the new 'secret' structure.
+ - memory limit for thanos receiveDistributor and pvc size for thanos receiver
 
 ### Fixed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -334,7 +334,7 @@ thanos:
         memory: 200Mi
       limits:
         cpu: 500m
-        memory: 200Mi
+        memory: 300Mi
 
   ruler:
     # Enables the ruler component
@@ -352,7 +352,7 @@ thanos:
   receiver:
     persistence:
       enabled: true
-      size: 8Gi
+      size: 50Gi
 
     # Sets the mode of operation for the receiver component
     # dual-mode: Multiple instances of the receiver. For redundancy


### PR DESCRIPTION
**What this PR does / why we need it**: 
1. I noticed that thanos receiver needs a bigger volume
2. during a recovery process thanos-receiver-receive-distributor needed more memory, so I increased the limit

**Add a screenshot or an example to illustrate the proposed solution:**
![image](https://user-images.githubusercontent.com/77267293/156524811-f281be1d-cf9f-4123-81d0-2298a567dd83.png)

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
