### PR TITLE
apps: Updated fluentd filter to match cri logformat

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -4,6 +4,8 @@
         By default, an ingressClass called `nginx` will be available in the cluster.
         Ingress-nginx will still handle ingresses that do not specify an `ingressClassName`, however users are strongly encouraged to update their Ingress Objects and specify `spec.ingressClassName: nginx`.
     - The entire changelog can be found [here](https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md).
+- Added a new config `global.containerRuntime` (default set to `containerd`).
+  - Supported runtimes are `containerd` and `docker`
 
 ### Updated
  - Upgraded nginx-ingress helm chart to `v4.0.17`, which upgrade nginx-ingress to `v1.1.1`.
@@ -42,6 +44,7 @@
 ### Added
 - Added Prometheus alerts for the 'backup status' and 'daily checks' dashboards. Also, 's3BucketPercentLimit' and 's3BucketSizeQuotaGB' parameters to set what limits the s3 rule including will alert off.
 - RBAC for admin user so that they now can list pods cluster wide and run the `kubectl top`.
+- Added containerd support for fluentd.
 
 - fluentd alerts for sc [#812](https://github.com/elastisys/compliantkubernetes-apps/pull/812)
 - fluentd grafana dashboard [#812](https://github.com/elastisys/compliantkubernetes-apps/pull/812)

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -49,6 +49,10 @@ global:
   ## IP of the cluster DNS in kubernetes
   clusterDns: 10.233.0.3
 
+  ## Container runtime.
+  ## Supported values are 'docker', 'containerd'
+  containerRuntime: containerd
+
 ## Configuration of storageclasses.
 storageClasses:
   # Name of the default storageclass.

--- a/helmfile/values/fluentd-configmap.yaml.gotmpl
+++ b/helmfile/values/fluentd-configmap.yaml.gotmpl
@@ -197,7 +197,7 @@ forwarder:
             time_format %Y-%m-%dT%H:%M:%S.%NZ
           </pattern>
           <pattern>
-            format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
+            format /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$/
             time_format %Y-%m-%dT%H:%M:%S.%N%:z
           </pattern>
         </parse>
@@ -215,6 +215,7 @@ forwarder:
         max_lines 1000
       </match>
 
+      {{- if eq .Values.global.containerRuntime "docker" }}
       # Concatenate multi-line logs
       <filter **>
         @id filter_concat
@@ -223,6 +224,27 @@ forwarder:
         multiline_end_regexp /\n$/
         separator ""
       </filter>
+      {{- else if eq .Values.global.containerRuntime "containerd" }}
+      # Concatenate multi-line logs
+      <filter **>
+        @id filter_concat
+        @type concat
+        key message
+        use_first_timestamp true
+        partial_key logtag
+        partial_value P
+        separator ""
+        # TODO: When we have updated this plugin to v2.5.0 change to this instead
+        # @id filter_concat
+        # @type concat
+        # key message
+        # use_partial_cri_logtag true
+        # partial_cri_logtag_key logtag
+        # partial_cri_stream_key stream
+      </filter>
+      {{- else }}
+        {{ fail "Misconfigured `global.containerRuntime`. Supported container runtimes are 'containerd' and 'docker'" }}
+      {{- end }}
 
       # Enriches records with Kubernetes metadata
       <filter kubernetes.**>

--- a/helmfile/values/fluentd-user.yaml.gotmpl
+++ b/helmfile/values/fluentd-user.yaml.gotmpl
@@ -102,7 +102,7 @@ extraConfigMaps:
           time_format %Y-%m-%dT%H:%M:%S.%NZ
         </pattern>
         <pattern>
-          format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
+          format /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$/
           time_format %Y-%m-%dT%H:%M:%S.%N%:z
         </pattern>
       </parse>
@@ -122,7 +122,6 @@ extraConfigMaps:
       </parse>
     </source>
 
-
     # Detect exceptions in the log output and forward them as one log entry.
     <match raw.kubernetes.**>
       @id raw.kubernetes
@@ -135,6 +134,7 @@ extraConfigMaps:
       max_lines 1000
     </match>
 
+    {{- if eq .Values.global.containerRuntime "docker" }}
     # Concatenate multi-line logs
     <filter **>
       @id filter_concat
@@ -143,6 +143,27 @@ extraConfigMaps:
       multiline_end_regexp /\n$/
       separator ""
     </filter>
+    {{- else if eq .Values.global.containerRuntime "containerd" }}
+    # Concatenate multi-line logs
+    <filter **>
+      @id filter_concat
+      @type concat
+      key message
+      use_first_timestamp true
+      partial_key logtag
+      partial_value P
+      separator ""
+      # TODO: When we have updated this plugin to v2.5.0 change to this instead
+      # @id filter_concat
+      # @type concat
+      # key message
+      # use_partial_cri_logtag true
+      # partial_cri_logtag_key logtag
+      # partial_cri_stream_key stream
+    </filter>
+    {{- else }}
+      {{ fail "Misconfigured `global.containerRuntime`. Supported container runtimes are 'containerd' and 'docker'" }}
+    {{- end }}
 
     # Enriches records with Kubernetes metadata
     <filter kubernetes.**>

--- a/helmfile/values/fluentd-wc.yaml.gotmpl
+++ b/helmfile/values/fluentd-wc.yaml.gotmpl
@@ -145,7 +145,7 @@ extraConfigMaps:
           time_format %Y-%m-%dT%H:%M:%S.%NZ
         </pattern>
         <pattern>
-          format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
+          format /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$/
           time_format %Y-%m-%dT%H:%M:%S.%N%:z
         </pattern>
       </parse>
@@ -163,6 +163,7 @@ extraConfigMaps:
       max_lines 1000
     </match>
 
+    {{- if eq .Values.global.containerRuntime "docker" }}
     # Concatenate multi-line logs
     <filter **>
       @id filter_concat
@@ -171,6 +172,27 @@ extraConfigMaps:
       multiline_end_regexp /\n$/
       separator ""
     </filter>
+    {{- else if eq .Values.global.containerRuntime "containerd" }}
+    # Concatenate multi-line logs
+    <filter **>
+      @id filter_concat
+      @type concat
+      key message
+      use_first_timestamp true
+      partial_key logtag
+      partial_value P
+      separator ""
+      # TODO: When we have updated this plugin to v2.5.0 change to this instead
+      # @id filter_concat
+      # @type concat
+      # key message
+      # use_partial_cri_logtag true
+      # partial_cri_logtag_key logtag
+      # partial_cri_stream_key stream
+    </filter>
+    {{- else }}
+      {{ fail "Misconfigured `global.containerRuntime`. Supported container runtimes are 'containerd' and 'docker'" }}
+    {{- end }}
 
     # Enriches records with Kubernetes metadata
     <filter kubernetes.**>

--- a/migration/v0.19.x-v0.20.x/upgrade-apps.md
+++ b/migration/v0.19.x-v0.20.x/upgrade-apps.md
@@ -18,6 +18,10 @@
     bin/ck8s init
     ```
 
+1. If your cluster are using docker as container runtime, set `global.containerRuntime` in `common-config.yaml` to `docker`
+
+    > To see which container runtime your nodes are running you can run `kubectl get container -owide` and check the `CONTAINER-RUNTIME` column.
+
 1. Remove conflicting starboard secret:
 
    This was managed by starboard-operator and from now on it is managed by helm.


### PR DESCRIPTION
**What this PR does / why we need it**:

To support kubespray 2.18 where containerd cri is default we want containerd support

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #815 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
