### PR TITLE
apps wc: fixed gatekeeper log fails to be indexed

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -41,6 +41,8 @@
 
 ### Fixed
 
+- Opensearch unable to parse `"source":{}` when gatekeeper starts up. The log including `"source":{}` from gatekeeper is excluded for now.
+
 ### Added
 - Added Prometheus alerts for the 'backup status' and 'daily checks' dashboards. Also, 's3BucketPercentLimit' and 's3BucketSizeQuotaGB' parameters to set what limits the s3 rule including will alert off.
 - RBAC for admin user so that they now can list pods cluster wide and run the `kubectl top`.

--- a/helmfile/values/fluentd-user.yaml.gotmpl
+++ b/helmfile/values/fluentd-user.yaml.gotmpl
@@ -190,6 +190,14 @@ extraConfigMaps:
       </parse>
     </filter>
 
+    <filter kubernetes.var.log.containers.gatekeeper-controller-manager-**>
+      @type grep
+      <exclude>
+        key $.source
+        pattern {}
+      </exclude>
+    </filter>
+
     <filter **>
       @type record_transformer
       <record>


### PR DESCRIPTION
**What this PR does / why we need it**:

When gatekeeper-controller-manager starts up it prints the line below. Which includes `"source":{}`
```bash
{"level":"info","ts":1646635981.7427528,"logger":"controller","msg":"Starting EventSource","controller":"cert-rotator","source":{}}
```
Later `source` is a string. This messes with opensearch when it should index source.

This time it had set `source` as `text` which gives an error when gatekeeper started up.
```
'failed to parse field [source] of type [text] in document with id 'C9MfVH8Bb86XbYgaCkxr'. Preview of field's value: '{}''\"
```

I decided to exclude the log lines with `"source":{}` from getekeeper to opensearch. To remove this error. 

**Which issue this PR fixes**: fixes #811

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [x] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
