### PR TITLE
apps: remove nfs config from kube-prometheus-stack

### DIFF
--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -357,17 +357,6 @@ prometheus:
               storage: {{ .Values.prometheus.storage.size }}
     {{- end }}
 
-    {{ if .Values.storageClasses.nfs.enabled  }}
-    additionalScrapeConfigs:
-    - job_name: 'node-exporter'
-      scrape_interval: 30s
-      metrics_path: /metrics
-      scheme: http
-      static_configs:
-      - targets:
-        - '{{ .Values.nfsProvisioner.server }}:9100'
-    {{ end }}
-
   serviceMonitor:
     relabelings:
     - targetLabel: cluster

--- a/helmfile/values/kube-prometheus-stack-wc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-wc.yaml.gotmpl
@@ -126,15 +126,6 @@ prometheus:
     {{- end }}
 
     additionalScrapeConfigs:
-    {{ if .Values.storageClasses.nfs.enabled }}
-    - job_name: 'node-exporter'
-      scrape_interval: 30s
-      metrics_path: /metrics
-      scheme: http
-      static_configs:
-      - targets:
-        - '{{ .Values.nfsProvisioner.server }}:9100'
-    {{ end }}
 
     {{ if .Values.user.alertmanager.enabled }}
     - job_name: 'alertmanager/alertmanager-operated'


### PR DESCRIPTION
**What this PR does / why we need it**: Since the `storageClasses.nfs` and `nfsProvisioner` values were removed from the config in PR https://github.com/elastisys/compliantkubernetes-apps/pull/879, this prevents the `kube-prometheus-stack` chart from trying to use these now non-existent values.

**Which issue this PR fixes**:

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [X] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
