### PR TITLE
apps sc: cat snapshots in slm job

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Fixed
 - Use `master` tag for the grafana-label-enforcer as the previous sha used no longer exist.
 
+### Fixed
+- The opensearch SLM job now uses `/_cat/snapshots` to make it work better when there are a large amount of snapshots available.
+
 ### Added
 
 ### Removed

--- a/helmfile/charts/opensearch/slm/scripts/slm-retention.bash
+++ b/helmfile/charts/opensearch/slm/scripts/slm-retention.bash
@@ -31,23 +31,19 @@ OPENSEARCH_URL="http://${OPENSEARCH_ENDPOINT}"
 # Snapshots returned from this function should be succeeded, or depending on how it was created, partial.
 # https://opensearch.org/docs/latest/opensearch/snapshot-restore
 function get_snapshots {
-    local url="${OPENSEARCH_URL}/_snapshot/${SNAPSHOT_REPOSITORY}/_all"
+    local url="${OPENSEARCH_URL}/_cat/snapshots/${SNAPSHOT_REPOSITORY}"
     curl "${url}" -f -X GET --max-time "${REQUEST_TIMEOUT_SECONDS}" --no-progress-meter \
-        --basic --user "${OPENSEARCH_USERNAME}:${OPENSEARCH_PASSWORD}" \
-        | jq '.snapshots | sort_by(.start_time_in_millis)'
-    echo ""
+        --basic --user "${OPENSEARCH_USERNAME}:${OPENSEARCH_PASSWORD}"
 }
 
 function get_snapshot_age {
     local snapshots=$1
     local idx=$2
-    local snapshot_start_date
     local snapshot_start_date_seconds
     local now_seconds
     local age_seconds
 
-    snapshot_start_date=$(echo "${snapshots}" | jq -r ".[${idx}].start_time")
-    snapshot_start_date_seconds=$(date --date="${snapshot_start_date}" +%s)
+    snapshot_start_date_seconds=$(echo "${snapshots}" | sed "${idx}q;d" | awk '{ print $3 }')
     now_seconds=$(date +%s)
     age_seconds=$((now_seconds - snapshot_start_date_seconds))
     echo "${age_seconds}"
@@ -72,14 +68,14 @@ function check_snapshot_count {
 
 function check_old_snapshots {
     local snapshots=$1
-    if [ "$(get_snapshot_age "${snapshots}" 0)" -le "${MAX_AGE_SECONDS}" ]; then
+    if [ "$(get_snapshot_age "${snapshots}" 1)" -le "${MAX_AGE_SECONDS}" ]; then
         echo "No old snapshots"
         return 1
     fi
 }
 
 function remove_old_snapshots {
-    local idx=0
+    local idx=1
     local snapshots
     local snapshot_count
     local snapshots_to_delete=""
@@ -87,17 +83,21 @@ function remove_old_snapshots {
     echo "Checking for old snapshots."
 
     snapshots=$(get_snapshots)
-    snapshot_count=$(echo "${snapshots}" | jq length)
+    if [[ -z ${snapshots} ]]; then
+        snapshot_count=0
+    else
+        snapshot_count=$(echo "${snapshots}" | wc -l)
+    fi
 
     check_snapshot_count "${snapshot_count}" || return 0
     check_old_snapshots  "${snapshots}"      || return 0
 
-    while [ $((snapshot_count - idx )) -gt "${MIN_SNAPSHOTS}" ]; do
+    while [ $((snapshot_count - idx )) -ge "${MIN_SNAPSHOTS}" ]; do
         local age_seconds
         age_seconds=$(get_snapshot_age "${snapshots}" "${idx}")
         if [ "${age_seconds}" -gt "${MAX_AGE_SECONDS}" ]; then
             local snapshot_name
-            snapshot_name=$(echo "${snapshots}" | jq -r ".[${idx}].snapshot")
+            snapshot_name=$(echo "${snapshots}" | sed "${idx}q;d" | awk '{ print $1 }')
             echo "Snapshot ${snapshot_name} is ${age_seconds} s old, max ${MAX_AGE_SECONDS} s"
             snapshots_to_delete="${snapshots_to_delete}${snapshot_name},"
         fi
@@ -109,7 +109,7 @@ function remove_old_snapshots {
 }
 
 function remove_excess_snapshots {
-    local idx=0
+    local idx=1
     local snapshots
     local snapshot_count
     local snapshots_to_delete=""
@@ -117,15 +117,19 @@ function remove_excess_snapshots {
     echo "Checking number of snapshots."
 
     snapshots=$(get_snapshots)
-    snapshot_count=$(echo "${snapshots}" | jq length)
+    if [[ -z ${snapshots} ]]; then
+        snapshot_count=0
+    else
+        snapshot_count=$(echo "${snapshots}" | wc -l)
+    fi
     echo "Number of snapshots: $snapshot_count"
 
     check_snapshot_count "${snapshot_count}" || return 0
 
-    while [ $((snapshot_count - idx )) -gt "${MAX_SNAPSHOTS}" ]; do
+    while [ $((snapshot_count - idx )) -ge "${MAX_SNAPSHOTS}" ]; do
         local snapshot_name
-        snapshot_name=$(echo "${snapshots}" | jq -r ".[${idx}].snapshot")
-        echo "Too many snapshots: $((snapshot_count - idx )), max ${MAX_SNAPSHOTS}"
+        snapshot_name=$(echo "${snapshots}" | sed "${idx}q;d" | awk '{ print $1 }')
+        echo "Too many snapshots: $snapshot_count, max ${MAX_SNAPSHOTS}"
         snapshots_to_delete="${snapshots_to_delete}${snapshot_name},"
         idx=$((idx + 1))
     done


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
fixes #868 

**Special notes for reviewer**:
Test with the following setup
```
MIN_SNAPSHOTS=1
MAX_SNAPSHOTS=2
MAX_AGE_SECONDS=1000

# And the following snapshots
snapshot-20220310_125821z SUCCESS 1646917101 12:58:21 1646917254 13:00:54 2.5m 120 120 0 120
snapshot-20220311_000002z SUCCESS 1646956802 00:00:02 1646957106 00:05:06   5m 123 123 0 123
snapshot-20220311_064510z SUCCESS 1646981110 06:45:10 1646981276 06:47:56 2.7m 120 120 0 120
```

Output:
```
❯ ./slm-retention.bash # with the removal skipped
SLM retention procedure started
Removing snapshots older than 1000 seconds but keeping at least 1 snapshots and at most 2 snapshots.
Checking for old snapshots.
Snapshot snapshot-20220310_125821z is 65462 s old, max 1000 s
Snapshot snapshot-20220311_000002z is 25761 s old, max 1000 s
Deleting snapshots: snapshot-20220310_125821z,snapshot-20220311_000002z,

Checking number of snapshots.
Number of snapshots: 3
Too many snapshots: 3, max 2
Deleting snapshots: snapshot-20220310_125821z,

SLM retention procedure done.

```

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
