### PR TITLE
apps-wc: adding-new-repo-safeguard-default

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,12 @@
+### Release notes
+
+### Updated
+
+### Changed
+- Added the repo - "quay.io/jetstack/cert-manager-acmesolver" in allowrepo safeguard by default.
+
+### Fixed
+
+### Added
+
+### Removed

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -104,10 +104,7 @@ opa:
     URL:
       - set-me
       - harbor.example.com
-      ## Uncomment this if you want to add an OPA exception for cert-manager-acmesolver.
-      ## This should be added only as an exception, e.g: if you cannot rely on a harbor instance managed by users.
-      ## Otherwise set the correct repository for this image in the certmanager section.
-      # - quay.io/jetstack/cert-manager-acmesolver
+      - quay.io/jetstack/cert-manager-acmesolver
 
   ## Enable rule that requires pods to be targeted
   ## by at least one network policy.


### PR DESCRIPTION
**What this PR does / why we need it**: Adding this new repo - `quay.io/jetstack/cert-manager-acmesolver`  in safeguard else creation of certificate will be blocked . 

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [X] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
