### PR TITLE
apps sc: user master tag in grafana label enforcer

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -7,6 +7,7 @@
 - Backup operator namespaces can for example be added as veloro parameters to be able to back them up. 'alertmanager' is added as default in the workload cluster.
 
 ### Fixed
+- Use `master` tag for the grafana-label-enforcer as the previous sha used no longer exist.
 
 ### Added
 

--- a/helmfile/charts/grafana-label-enforcer/templates/deployment.yaml
+++ b/helmfile/charts/grafana-label-enforcer/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         runAsUser: 1000
       containers:
       - name: prom-label-enforcer
-        image: quay.io/prometheuscommunity/prom-label-proxy@sha256:574bc3be1e514767530d555097e2ff01a774b2c9a04b9327810619cb9cbee721
+        image: quay.io/prometheuscommunity/prom-label-proxy:master
         imagePullPolicy: IfNotPresent
         resources: {{- toYaml .Values.resources | nindent 10 }}
         args:


### PR DESCRIPTION
**What this PR does / why we need it**:

```
❯ sudo docker pull quay.io/prometheuscommunity/prom-label-proxy@sha256:574bc3be1e514767530d555097e2ff01a774b2c9a04b9327810619cb9cbee721
Error response from daemon: manifest for quay.io/prometheuscommunity/prom-label-proxy@sha256:574bc3be1e514767530d555097e2ff01a774b2c9a04b9327810619cb9cbee721 not found: manifest unknown: manifest unknown
```

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
