### PR TITLE
apps sc: curator ignore all exceptions

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - Added the repo - "quay.io/jetstack/cert-manager-acmesolver" in allowrepo safeguard by default.
 - Backup operator namespaces can for example be added as veloro parameters to be able to back them up. 'alertmanager' is added as default in the workload cluster.
+- Set 'continue_if_exception' in curator as to not fail when a snapshot is in progress and it is trying to remove some indices.
 
 ### Fixed
 - Use `master` tag for the grafana-label-enforcer as the previous sha used no longer exist.

--- a/helmfile/charts/opensearch/curator/templates/configmap.yaml
+++ b/helmfile/charts/opensearch/curator/templates/configmap.yaml
@@ -17,6 +17,7 @@ data:
           continue_if_exception: False
           ignore_empty_list: True
           allow_ilm_indices: True
+          continue_if_exception: True
         filters:
         - filtertype: pattern
           kind: regex
@@ -38,6 +39,7 @@ data:
           continue_if_exception: False
           ignore_empty_list: True
           allow_ilm_indices: True
+          continue_if_exception: True
         filters:
         - filtertype: pattern
           kind: regex


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes curator always complete sucessfully.
This means that there won't be any failed curator jobs.
We have alerts in this repository that warns about high disk usage, and eluding such an alert back to curator failing isn't that hard.  

**Which issue this PR fixes**:
fixes #750 

**Special notes for reviewer**:
Works as expected

```
$ k -n opensearch-system logs -f ct-tbb2n
...
2022-03-15 15:21:57,060 INFO      Trying Action ID: 8, "delete_indices": Delete authlog-* indices that are older than 1 days
2022-03-15 15:21:57,746 INFO      Deleting 29 selected indices: ['authlog-default-2022.03.01-000037', 'authlog-default-2022.02.17-000025', 'authlog-default-2022.03.12-000048', 'authlog-default-2022.02.22-000030', 'authlog-default-2022.03.14-000050', 'authlog-default-2022.02.15-000023', 'authlog-default-2022.03.03-000039', 'authlog-default-2022.02.26-000034', 'authlog-default-2022.03.11-000047', 'authlog-default-2022.03.02-000038', 'authlog-default-2022.02.28-000036', 'authlog-default-2022.03.09-000045', 'authlog-default-2022.02.23-000031', 'authlog-default-2022.02.16-000024', 'authlog-default-2022.03.05-000041', 'authlog-default-2022.03.13-000049', 'authlog-default-2022.02.21-000029', 'authlog-default-2022.02.25-000033', 'authlog-default-2022.02.14-000022', 'authlog-default-2022.02.20-000028', 'authlog-default-2022.02.27-000035', 'authlog-default-2022.03.07-000043', 'authlog-default-2022.02.19-000027', 'authlog-default-2022.02.24-000032', 'authlog-default-2022.03.10-000046', 'authlog-default-2022.02.18-000026', 'authlog-default-2022.03.04-000040', 'authlog-default-2022.03.08-000044', 'authlog-default-2022.03.06-000042']
2022-03-15 15:21:57,747 INFO      ---deleting index authlog-default-2022.03.01-000037
2022-03-15 15:21:57,747 INFO      ---deleting index authlog-default-2022.02.17-000025
2022-03-15 15:21:57,747 INFO      ---deleting index authlog-default-2022.03.12-000048
2022-03-15 15:21:57,747 INFO      ---deleting index authlog-default-2022.02.22-000030
2022-03-15 15:21:57,747 INFO      ---deleting index authlog-default-2022.03.14-000050
2022-03-15 15:21:57,747 INFO      ---deleting index authlog-default-2022.02.15-000023
2022-03-15 15:21:57,747 INFO      ---deleting index authlog-default-2022.03.03-000039
2022-03-15 15:21:57,838 INFO      ---deleting index authlog-default-2022.02.26-000034
2022-03-15 15:21:57,838 INFO      ---deleting index authlog-default-2022.03.11-000047
2022-03-15 15:21:57,838 INFO      ---deleting index authlog-default-2022.03.02-000038
2022-03-15 15:21:57,838 INFO      ---deleting index authlog-default-2022.02.28-000036
2022-03-15 15:21:57,838 INFO      ---deleting index authlog-default-2022.03.09-000045
2022-03-15 15:21:57,838 INFO      ---deleting index authlog-default-2022.02.23-000031
2022-03-15 15:21:57,838 INFO      ---deleting index authlog-default-2022.02.16-000024
2022-03-15 15:21:57,838 INFO      ---deleting index authlog-default-2022.03.05-000041
2022-03-15 15:21:57,838 INFO      ---deleting index authlog-default-2022.03.13-000049
2022-03-15 15:21:57,838 INFO      ---deleting index authlog-default-2022.02.21-000029
2022-03-15 15:21:57,838 INFO      ---deleting index authlog-default-2022.02.25-000033
2022-03-15 15:21:57,838 INFO      ---deleting index authlog-default-2022.02.14-000022
2022-03-15 15:21:57,838 INFO      ---deleting index authlog-default-2022.02.20-000028
2022-03-15 15:21:57,838 INFO      ---deleting index authlog-default-2022.02.27-000035
2022-03-15 15:21:57,838 INFO      ---deleting index authlog-default-2022.03.07-000043
2022-03-15 15:21:57,838 INFO      ---deleting index authlog-default-2022.02.19-000027
2022-03-15 15:21:57,839 INFO      ---deleting index authlog-default-2022.02.24-000032
2022-03-15 15:21:57,839 INFO      ---deleting index authlog-default-2022.03.10-000046
2022-03-15 15:21:57,839 INFO      ---deleting index authlog-default-2022.02.18-000026
2022-03-15 15:21:57,839 INFO      ---deleting index authlog-default-2022.03.04-000040
2022-03-15 15:21:57,839 INFO      ---deleting index authlog-default-2022.03.08-000044
2022-03-15 15:21:57,839 INFO      ---deleting index authlog-default-2022.03.06-000042
2022-03-15 15:21:57,854 ERROR     Failed to complete action: delete_indices.  <class 'curator.exceptions.FailedExecution'>: Exception encountered.  Rerun with loglevel DEBUG and/or check Elasticsearch logs for more information. Exception: RequestError(400, 'snapshot_in_progress_exception', 'Cannot delete indices that are being snapshotted: [[authlog-default-2022.03.10-000046/IdUWlhJCSbec3xyOpUxVaA], [authlog-default-2022.02.21-000029/nk8YF04oQRqCb45uY9JTuA], [authlog-default-2022.02.14-000022/vBBX1NaQSx6D3zKb_KEM6g], [authlog-default-2022.02.23-000031/jvtGCARmQC6EXMzRqSHysQ], [authlog-default-2022.02.22-000030/2RjHmPJITgq_QbsdLKAZ8w], [authlog-default-2022.02.20-000028/O9ZnICiFQC6xuVSX8rWVhw], [authlog-default-2022.03.03-000039/czkvWQCrSH24gilSNwRrXw], [authlog-default-2022.02.28-000036/uFNCFVdpSfyW6c-W7Lhi6A], [authlog-default-2022.03.12-000048/3_J1JSczSn2junE43OuU2A], [authlog-default-2022.02.25-000033/Y2xYzvtMQaaTKK88huicjQ], [authlog-default-2022.03.11-000047/mEmICRC2S5SZ9tFY6tL16w], [authlog-default-2022.03.14-000050/nDRvVnkBR8O9WVZguhHGGg], [authlog-default-2022.03.07-000043/Hrxdw2xHSh6fod-hTlmV7g], [authlog-default-2022.03.05-000041/ixxmxojiQy-52icCVnxTHQ], [authlog-default-2022.03.13-000049/0txo7bxbRSS_35nbSLY3zQ], [authlog-default-2022.02.16-000024/gyh-2xnARte_lamcxHFavw], [authlog-default-2022.02.19-000027/pERZAssBQNach3xdBIVqCA], [authlog-default-2022.02.24-000032/oH04V7gIQb-P-m0QmckjJA], [authlog-default-2022.03.06-000042/ICpRgJkHSwmbLp6AxnRXQw], [authlog-default-2022.03.04-000040/v6R3zfD4Rz6qAtrqvKL--A], [authlog-default-2022.02.15-000023/ZznYz4ShRQ2Hx0XdP8P7kw], [authlog-default-2022.02.17-000025/1YdNNZu9SfOUrfV_DCge0g], [authlog-default-2022.02.18-000026/a-GoPUJNRT26PUW_MQ8MXQ], [authlog-default-2022.03.08-000044/S9C3hbpjRL--_qsXyR3_5w], [authlog-default-2022.03.09-000045/eH8RC6g0S5-icOnrOS3wmQ], [authlog-default-2022.02.26-000034/m2qZq9x3TSOgTEDonualCg], [authlog-default-2022.02.27-000035/W9CF4zpfS4SvyamdxzMlZw], [authlog-default-2022.03.01-000037/0rxO1hEYS1CEIwpsLpceZg], [authlog-default-2022.03.02-000038/eXMPwvi6Sw2-apEK9OgSJQ]]. Try again after snapshot finishes or cancel the currently running snapshot.')
2022-03-15 15:21:57,854 INFO      Continuing execution with next action because "continue_if_exception" is set to True for action delete_indices
2022-03-15 15:21:57,854 INFO      Action ID: 8, "delete_indices" completed.
2022-03-15 15:21:57,854 INFO      Job completed.
```

```
❯ k -n opensearch-system get pods
NAME                                                 READY   STATUS      RESTARTS   AGE
ct-tbb2n                                             0/1     Completed   0          69s
```

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
