### PR TITLE
apps: fix minor issues with predict linear alerts

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 - Use `master` tag for the grafana-label-enforcer as the previous sha used no longer exist.
 - The opensearch SLM job now uses `/_cat/snapshots` to make it work better when there are a large amount of snapshots available.
+- predictlinear alerts
 - Calico-accountant is now being scheduled on master nodes.
 
 ### Added

--- a/helmfile/charts/prometheus-alerts/templates/alerts/predict-linear.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/alerts/predict-linear.yaml
@@ -35,35 +35,35 @@ spec:
         severity: warning
     - alert: PersistentVolume{{.Values.predictLinearLimit}}PercentInThreeDays
       annotations:
-        message: The PersistentVolume claimed by {{`{{ $labels.persistentvolumeclaim }}`}} in Namespace {{`{{ $labels.namespace }}`}} is full in three days.
+        message: The PersistentVolume claimed by {{`{{ $labels.persistentvolumeclaim }}`}} in Namespace {{`{{ $labels.namespace }}`}} will go over {{.Values.predictLinearLimit}} in three days.
       expr: predict_linear(kubelet_volume_stats_available_bytes[24h], 3*24*60*60) <= (kubelet_volume_stats_capacity_bytes*(1-{{ .Values.predictLinearLimit }}/100))
       for: 5m
       labels:
         severity: warning
     - alert: Memory{{.Values.predictLinearLimit}}PercentInThreeDays
       annotations:
-        message: Memory usage in Cluster {{`{{ $labels.cluster }}`}} Instance {{`{{ $labels.instance }}`}} is predicted to go over {{.Values.predictLinearLimit}} percent within the next 3 days at current use rate.
+        message: Memory usage in Cluster {{`{{ $labels.cluster }}`}} Instance {{`{{ $labels.instance }}`}} is predicted to go over {{.Values.predictLinearLimit}}% within the next 3 days at current use rate.
       expr: predict_linear(node_memory_MemAvailable_bytes[24h], 3*24*60*60) <= (node_memory_MemTotal_bytes*(1-{{ .Values.predictLinearLimit }}/100))
       for: 5m
       labels:
         severity: warning
     - alert: CPU{{.Values.predictLinearLimit}}PercentOnAverage
       annotations:
-        message: CPU usage has been over {{.Values.predictLinearLimit}} percent on average over the span of 24h in a Instance {{`{{ $labels.instance }}`}} of a Cluster {{`{{ $labels.cluster }}`}}.
+        message: CPU usage has been over {{.Values.predictLinearLimit}}% on average over the span of 24h in a Instance {{`{{ $labels.instance }}`}} of a Cluster {{`{{ $labels.cluster }}`}}.
       expr: 1 - (avg by (instance, cluster) (rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[24h]))) >= {{ .Values.predictLinearLimit }}/100
       for: 5m
       labels:
         severity: warning
     - alert: CPURequest{{.Values.predictLinearLimit}}Percent
       annotations:
-        message: CPU requests has been over {{.Values.predictLinearLimit}} percent in a Instance {{`{{ $labels.instance }}`}} of a Cluster {{`{{ $labels.cluster }}`}}.
+        message: CPU requests has been over {{.Values.predictLinearLimit}}% on node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}}.
       expr: sum by (node, cluster) (kube_pod_container_resource_requests{cluster=~".*", namespace=~".*", resource="cpu"} and on (pod, namespace, cluster) kube_pod_status_phase{phase="Running", cluster=~".*", namespace=~".*"} == 1 ) / sum by (node, cluster) (kube_node_status_allocatable{cluster=~".*", resource="cpu"}) >= {{ .Values.predictLinearLimit }}/100
       for: 5m
       labels:
         severity: warning
     - alert: MemoryRequest{{.Values.predictLinearLimit}}Percent
       annotations:
-        message: Memory request has been over {{.Values.predictLinearLimit}} percent in a Instance {{`{{ $labels.instance }}`}} of a Cluster {{`{{ $labels.cluster }}`}}.
+        message: Memory request has been over {{.Values.predictLinearLimit}}% on node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}}.
       expr: sum by (node, cluster)(kube_pod_container_resource_requests{cluster=~".*", namespace=~".*", resource="memory"} and on (pod, namespace, cluster) kube_pod_status_phase{phase="Running", cluster=~".*", namespace=~".*"} == 1) / sum by (node, cluster)(kube_node_status_allocatable{cluster=~".*", resource="memory"}) >= {{ .Values.predictLinearLimit }}/100
       for: 5m
       labels:


### PR DESCRIPTION
**What this PR does / why we need it**: to fix some issue with the predict linear alerts

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #884 

**Add a screenshot or an example to illustrate the proposed solution:**
![MemoryRequest36Percent](https://user-images.githubusercontent.com/77267293/159735731-149692d4-b0fb-45af-9dbf-c0a61cb88235.png)
![Memory36PercentInThreeDays](https://user-images.githubusercontent.com/77267293/159735845-ea5fa79d-bdee-423d-acfc-f9cde5908b89.png)
![CPURequest36Percent](https://user-images.githubusercontent.com/77267293/159735763-84261f93-25f7-490f-992b-3a00617d0a56.png)
![CPU36PercentOnAverage](https://user-images.githubusercontent.com/77267293/159735780-3d021181-661c-4d70-bb7a-cd5f261fb6ef.png)

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
