### PR TITLE
Add custom falco rules

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -19,5 +19,6 @@
 - Calico-accountant is now being scheduled on master nodes.
 
 ### Added
+- the possibility to add falco custom rules for each environment
 
 ### Removed

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -27,6 +27,9 @@ user:
 ## Falco configuration.
 falco:
   enabled: true
+  ## additional falco rules
+  ## ref: https://falco.org/docs/rules/
+  customRules: {}
   resources:
     limits:
       cpu: 200m

--- a/helmfile/values/falco.yaml.gotmpl
+++ b/helmfile/values/falco.yaml.gotmpl
@@ -22,6 +22,9 @@ podSecurityPolicy:
   create: true
 
 customRules:
+  {{- if .Values.falco.customRules }}
+    {{ toYaml .Values.falco.customRules | nindent 2}}
+  {{- end }}
   ssh-trafic.yaml: |-
     - rule: Inbound SSH Connection
       desc: Detect Inbound SSH Connection


### PR DESCRIPTION
**What this PR does / why we need it**: to ad the possibility to add falco custom rules for each env

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #889

**Add a screenshot or an example to illustrate the proposed solution:**
![falco-custom-rules](https://user-images.githubusercontent.com/77267293/160832019-d566c92e-8a27-4ea7-a7a7-2c6754f8989a.png)
![falco-rules-loaded](https://user-images.githubusercontent.com/77267293/160832030-ed9d0bc7-45c1-42ec-8339-5be2f1b7d473.png)

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
