### PR TITLE
apps-wc: Self service userAdmin creation

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added the user-permissions available pre-defined alerting roles for opensearch.
 - PrometheusBlackboxExporter targets with customized propes added for internal service health-checking.
 - The dex chart has been upgraded from version 0.6.3 to 0.8.1. Dex has changed to have two replicas to increase the stability of OpenSearch's authentication. A dex ServiceMonitor has also been enabled
+- Self service: User admins are now allowed to add new users to the clusterrole user-view. Clusterrole and Clusterrolebinding has been added accordingly.
 
 ### Fixed
 - Use `master` tag for the grafana-label-enforcer as the previous sha used no longer exist.

--- a/helmfile/charts/user-rbac/templates/clusterrolebindings/user-admin-cluster-wide-delegation.yaml
+++ b/helmfile/charts/user-rbac/templates/clusterrolebindings/user-admin-cluster-wide-delegation.yaml
@@ -1,0 +1,20 @@
+# Managed by compliantkubernetes-apps
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: user-admin-cluster-wide-delegation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: user-admin-cluster-wide-delegation
+subjects:
+{{- range $user := .Values.users }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ $user }}
+{{- end }}
+{{- range $group := $.Values.groups }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: {{ $group }}
+{{- end }}

--- a/helmfile/charts/user-rbac/templates/clusterroles/user-admin-cluster-wide-delegation.yaml
+++ b/helmfile/charts/user-rbac/templates/clusterroles/user-admin-cluster-wide-delegation.yaml
@@ -1,0 +1,18 @@
+# Managed by compliantkubernetes-apps
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: user-admin-cluster-wide-delegation
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  resourceNames:
+  - extra-user-view
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch

--- a/manifests/user-rbac/clusterrolebindings/extra-user-view.yaml
+++ b/manifests/user-rbac/clusterrolebindings/extra-user-view.yaml
@@ -1,0 +1,9 @@
+# Created, but not updated by compliantkubernetes-apps
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: extra-user-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: user-view

--- a/scripts/deploy-wc.sh
+++ b/scripts/deploy-wc.sh
@@ -31,6 +31,8 @@ kubectl create -f "${SCRIPTS_PATH}/../manifests/examples/fluentd/fluentd-extra-c
     2>/dev/null || echo "fluentd-extra-config configmap already in place. Ignoring."
 kubectl create -f "${SCRIPTS_PATH}/../manifests/examples/fluentd/fluentd-extra-plugins.yaml" \
     2>/dev/null || echo "fluentd-extra-plugins configmap already in place. Ignoring." >&2
+kubectl create -f "${SCRIPTS_PATH}/../helmfile/charts/manifests/user-rbac/clusterrolebindings/extra-user-view.yaml" \
+    2>/dev/null || echo "extra-user-view ClusterRoleBinding already in place. Ignoring." >&2
 
 echo "Installing helm charts" >&2
 cd "${SCRIPTS_PATH}/../helmfile"


### PR DESCRIPTION
**What this PR does / why we need it**: Self service userAdmin creation based on issue - https://github.com/elastisys/compliantkubernetes-apps/issues/738

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #738

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [X] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
