### PR TITLE
apps-wc: Upstream a patch to falco rules

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added persistence to alertmanager.
 - made the [CISO grafana dashboards](https://elastisys.io/compliantkubernetes/ciso-guide/) visible to the end-users
 - indices.query.bool.max_clause_count is now configurable.
+- Patched Falco rules for  `k8s_containers` , `postgres_running_wal_e` & `user_known_contact_k8s_api_server_activities`. Will be removed if upstream Falco Chart accepts these.
 
 ### Fixed
 - Use `master` tag for the grafana-label-enforcer as the previous sha used no longer exist.

--- a/helmfile/values/falco.yaml.gotmpl
+++ b/helmfile/values/falco.yaml.gotmpl
@@ -49,7 +49,12 @@ customRules:
       condition: >
         (container.image.repository in (gcr.io/google_containers/hyperkube-amd64,
         gcr.io/google_containers/kube2sky, sysdig/agent, sysdig/falco,
-        sysdig/sysdig, falcosecurity/falco, quay.io/fluentd_elasticsearch/fluentd) or (k8s.ns.name = "kube-system"))
+        sysdig/sysdig, falcosecurity/falco, quay.io/fluentd_elasticsearch/fluentd,
+        velero/velero, quay.io/jetstack/cert-manager-cainjector, weaveworks/kured,
+        ingress-controller/controller, quay.io/prometheus-operator/prometheus-operator,
+        k8s.gcr.io/ingress-nginx/kube-webhook-certgen, quay.io/spotahome/redis-operator,
+        registry.opensource.zalan.do/acid/postgres-operator, registry.opensource.zalan.do/acid/postgres-operator-ui,
+        rabbitmqoperator/cluster-operator) or (k8s.ns.name = "kube-system"))
     - list: falco_privileged_images
       items: [
         docker.io/sysdig/agent, docker.io/sysdig/falco, docker.io/sysdig/sysdig,
@@ -57,6 +62,11 @@ customRules:
         docker.io/rook/toolbox, docker.io/cloudnativelabs/kube-router, docker.io/mesosphere/mesos-slave,
         docker.io/docker/ucp-agent, sematext_images, k8s.gcr.io/kube-proxy, calico/node,falcosecurity/falco, k8s.gcr.io/k8s-dns-node-cache
     ]
+    - macro: postgres_running_wal_e
+      condition: (proc.pname=postgres and proc.cmdline startswith "sh -c envdir \"/run/etc/wal-e.d/env\" wal-g wal-push")
+    - macro: user_known_contact_k8s_api_server_activities
+      condition: >
+        (container.image.repository in (elastisys/curl-jq))
     - list: falco_sensitive_mount_images
       items: [
         docker.io/sysdig/agent, docker.io/sysdig/falco, docker.io/sysdig/sysdig,falcosecurity/falco,


### PR DESCRIPTION
**What this PR does / why we need it**: Based on the issue - https://github.com/elastisys/compliantkubernetes-apps/issues/896, Upstream a patch to falco rules

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

As discussed with @cristiklein , This PR against the https://github.com/elastisys/compliantkubernetes-apps still exists to gain the speed , and remove those values if and when Falco upstream accepts your changes ( refer - https://github.com/falcosecurity/charts/pull/319 )

So , please continuing approving this current PR here too . 

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
