### PR TITLE
bin: added support for kubecolor

### DIFF
--- a/bin/ck8s
+++ b/bin/ck8s
@@ -21,6 +21,7 @@ usage() {
     # TODO: We might want to make this command less visible once we have proper
     #       support for OIDC logins.
     echo "  ops kubectl <wc|sc>                               run kubectl as cluster admin" 1>&2
+    echo "  ops kubecolor <wc|sc>                             run kubecolor as cluster admin" 1>&2
     echo "  ops helm <wc|sc>                                  run helm as cluster admin" 1>&2
     # TODO: We might want to make this command less visible once we feel
     #       confident that the apply command and migrations are good enough
@@ -89,6 +90,11 @@ case "${1}" in
                 [[ "${3}" =~ ^(wc|sc)$ ]] || usage
                 shift 2
                 "${here}/ops.bash" kubectl "${@}"
+            ;;
+            kubecolor)
+                [[ "${3}" =~ ^(wc|sc)$ ]] || usage
+                shift 2
+                "${here}/ops.bash" kubecolor "${@}"
             ;;
             helm)
                 [[ "${3}" =~ ^(wc|sc)$ ]] || usage

--- a/bin/ops.bash
+++ b/bin/ops.bash
@@ -11,9 +11,21 @@ source "${here}/common.bash"
 
 usage() {
     echo "Usage: kubectl <wc|sc> ..." >&2
+    echo "       kubecolor <wc|sc> ..." >&2
     echo "       helm <wc|sc> ..." >&2
     echo "       helmfile <wc|sc> ..." >&2
     exit 1
+}
+
+# Run arbitrary kubecolor commands as cluster admin.
+ops_kubecolor() {
+    case "${1}" in
+        sc) kubeconfig="${secrets[kube_config_sc]}" ;;
+        wc) kubeconfig="${secrets[kube_config_wc]}" ;;
+        *) usage ;;
+    esac
+    shift
+    with_kubeconfig "${kubeconfig}" kubecolor "${@}"
 }
 
 # Run arbitrary kubectl commands as cluster admin.
@@ -66,6 +78,10 @@ case "${1}" in
     kubectl)
         shift
         ops_kubectl "${@}"
+    ;;
+    kubecolor)
+        shift
+        ops_kubecolor "${@}"
     ;;
     helm)
         shift


### PR DESCRIPTION
**What this PR does / why we need it**:
I wanted kubecolor to work with ck8s ops and using an alias is not enough as bash does not expand aliases. 

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
