### PR TITLE
apps sc: fix sc log retention script to not silently fail

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -23,6 +23,7 @@
 - predictlinear alerts
 - Calico-accountant is now being scheduled on master nodes.
 - it is now possible to set tolerations and affinity for vulnerability-exporter
+- SC log retention no longer fails silently after removing one day of logs.
 
 ### Added
 - the possibility to add falco custom rules for each environment

--- a/helmfile/charts/sc-logs-retention/scripts/logs-retention.sh
+++ b/helmfile/charts/sc-logs-retention/scripts/logs-retention.sh
@@ -57,7 +57,8 @@ else
         aws s3 rm --recursive "${BACKUP_URI}" --endpoint-url="${S3_REGION_ENDPOINT}"
         # Wait 5 seconds to see if new files have been created while the deletion was done
         sleep 5
-        NR_OF_FILES=$(aws s3 ls "${BACKUP_URI}" --endpoint-url="${S3_REGION_ENDPOINT}" | wc -l)
+        # "aws s3 ls" will return an error if the path is empty, so the echo is needed to not exit the script
+        NR_OF_FILES=$(aws s3 ls "${BACKUP_URI}" --endpoint-url="${S3_REGION_ENDPOINT}" | wc -l) || echo "No more files in ${BACKUP_URI}"
       done
 
     elif [[ ${GCS_BACKUP} == "true" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #933 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**
Screenshot first shows what happens without the fix (clears one day of logs, then gives an error) and then with the fix (clears all old logs and does not give an error)

![sc-log-retention-fix](https://user-images.githubusercontent.com/58632240/162930911-ac87f24d-83c5-4b0f-a37f-38ff961dfd63.png)


**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [x] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
