### PR TITLE
Allow curator to delete all but for system indices

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -15,6 +15,7 @@
 - made the [CISO grafana dashboards](https://elastisys.io/compliantkubernetes/ciso-guide/) visible to the end-users
 - indices.query.bool.max_clause_count is now configurable.
 - Patched Falco rules for  `k8s_containers` , `postgres_running_wal_e` & `user_known_contact_k8s_api_server_activities`. Will be removed if upstream Falco Chart accepts these.
+- Curator can now delete all but for system indices.
 - Added the user-permissions available pre-defined alerting roles for opensearch.
 - PrometheusBlackboxExporter targets with customized propes added for internal service health-checking.
 - The dex chart has been upgraded from version 0.6.3 to 0.8.1. Dex has changed to have two replicas to increase the stability of OpenSearch's authentication. A dex ServiceMonitor has also been enabled

--- a/helmfile/values/opensearch/configurer.yaml.gotmpl
+++ b/helmfile/values/opensearch/configurer.yaml.gotmpl
@@ -109,15 +109,8 @@ config:
           allowed_actions:
           - "indices_monitor"
         - index_patterns:
-          {{- if .Values.opensearch.indexPerNamespace }}
           - '/^[^.].*/'
           - ".orphaned-*"
-          {{- else }}
-          - "kubernetes-*"
-          - "other-*"
-          - "kubeaudit-*"
-          - "authlog-*"
-          {{- end }}
           allowed_actions:
           - "indices:admin/delete"
     - role_name: kubernetes_log_reader


### PR DESCRIPTION
**What this PR does / why we need it**:
This elevates the privileges for curator as to be able to delete all but for `.` indices even when the index per namespace feature is disabled.
I deem this as fine as we don't create any indices manually that might cause curator to accidentally delete it.

One of the main reasons for this change is to be able to remove security-auditlog indices.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
