### PR TITLE
apps wc: add condition to enable falcosidekick alertmanager

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -19,6 +19,7 @@
 - PrometheusBlackboxExporter targets with customized propes added for internal service health-checking.
 - The dex chart has been upgraded from version 0.6.3 to 0.8.1. Dex has changed to have two replicas to increase the stability of OpenSearch's authentication. A dex ServiceMonitor has also been enabled
 - Self service: User admins are now allowed to add new users to the clusterrole user-view. Clusterrole and Clusterrolebinding has been added accordingly.
+- Enabled falcosidekick alertmanager if user alertmanager is also enabled
 
 ### Fixed
 - Use `master` tag for the grafana-label-enforcer as the previous sha used no longer exist.

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -51,7 +51,7 @@ falco:
     ## supported: 'alertmanager', 'slack'.
     type: alertmanager
     priority: notice
-    hostPort: http://kube-prometheus-stack-alertmanager.monitoring:9093
+    hostPort: http://alertmanager-operated.alertmanager:9093
 
   falcoSidekick:
     resources:

--- a/helmfile/values/falco.yaml.gotmpl
+++ b/helmfile/values/falco.yaml.gotmpl
@@ -93,7 +93,7 @@ falcosidekick:
       minimumpriority: {{ .Values.falco.alerts.priority }}
       messageformat: "Falco Alert : rule *{{`{{ .Rule }}`}}*"
     {{ end }}
-    {{ if eq .Values.falco.alerts.type "alertmanager" }}
+    {{ if and (eq .Values.falco.alerts.type "alertmanager") .Values.user.alertmanager.enabled }}
     alertmanager:
       hostport: {{ .Values.falco.alerts.hostPort }}
       minimumpriority: {{ .Values.falco.alerts.priority }}


### PR DESCRIPTION
**What this PR does / why we need it**: to enabled falcosidekick alertmanager only if user alertmanager is enabled

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #745 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
