### PR TITLE
pipeline fixing

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -171,20 +171,10 @@ jobs:
 
     - name: Wait for OpenSearch to be ready
       if: steps.install-apps.outcome == 'success' && matrix.cluster == 'wc'
+      run: ./apps/pipeline/opensearch.bash
       continue-on-error: true
       shell: bash
-      run: |
-        retries=60
-        while [ ${retries} -gt 0 ]; do
-          result="$(curl --connect-timeout 20 --max-time 60 -ksIL -o /dev/null -w "%{http_code}" https://opensearch.ops.pipeline-exoscale.elastisys.se)"
-          echo "Waiting for OpenSearch to be ready. Got status ${result}"
-          [[ "${result}" == "401" ]] && break
-          sleep 10
-          retries=$((retries-1))
-        done
-        ./apps/bin/ck8s ops kubectl wc -n fluentd rollout restart daemonset fluentd-fluentd-elasticsearch
-        ./apps/bin/ck8s ops kubectl wc -n kube-system rollout restart daemonset fluentd-system-fluentd-elasticsearch
-        # There seem to be no point in waiting for the pods here, as the tests already do this.
+      id: opensearch
 
     - name: Test apps
       if: always() && (steps.install-apps.outcome != 'cancelled' && steps.install-apps.outcome != 'skipped' && steps.install-apps.outcome != 'failure')

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,6 @@
+### Release notes
+
+### Fixed
+
+- `prometheus-blackbox-exporter's` internal thanos servicemonitor changed name to avoid name collisions.
+- dex `topologySpreadConstraints` matchLabel was changed from `app: dex` to `app.kubernetes.io/name: dex` to increase stability of replica placements.

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -315,7 +315,7 @@ dex:
   topologySpreadConstraints:
     - labelSelector:
         matchLabels:
-          app: dex
+          app.kubernetes.io/name: dex
       maxSkew: 1
       topologyKey: kubernetes.io/hostname
       whenUnsatisfiable: DoNotSchedule

--- a/helmfile/values/prometheus-blackbox-exporter-sc.yaml.gotmpl
+++ b/helmfile/values/prometheus-blackbox-exporter-sc.yaml.gotmpl
@@ -56,7 +56,7 @@ serviceMonitor:
       module: http_2xx
     {{- end }}
     {{- if .Values.prometheusBlackboxExporter.targets.thanosReceiver }}
-    - name: thanos-receiver
+    - name: thanos-internal-receiver
       url: thanos-receiver-receive.thanos.svc.cluster.local:10902/-/ready
       interval: 60s
       scrapeTimeout: 30s

--- a/pipeline/opensearch.bash
+++ b/pipeline/opensearch.bash
@@ -1,0 +1,13 @@
+set -eu
+
+retries=60
+ while [ ${retries} -gt 0 ]; do
+   result="$(curl --connect-timeout 20 --max-time 60 -ksIL -o /dev/null -w "%{http_code}" https://opensearch.ops.pipeline-exoscale.elastisys.se || true)"
+   echo "Waiting for OpenSearch to be ready. Got status ${result}"
+   [[ "${result}" == "401" ]] && break
+   sleep 10
+   retries=$((retries-1))
+ done
+./apps/bin/ck8s ops kubectl wc -n fluentd rollout restart daemonset fluentd-fluentd-elasticsearch
+./apps/bin/ck8s ops kubectl wc -n kube-system rollout restart daemonset fluentd-system-fluentd-elasticsearch
+# There seem to be no point in waiting for the pods here, as the tests already do this.


### PR DESCRIPTION
**What this PR does / why we need it**:
Our pipeline crashes every now and again and I gave it a try to figure out what's up!

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #913

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
This branch was first created to work with https://github.com/elastisys/compliantkubernetes-apps/issues/913 interactively. It has now turned into a regular branch as solutions to the problems our pipeline was having has been found.

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [x] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
