### PR TITLE
apps wc: fix path to extra-user-view manifest in deploy script

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -7,6 +7,7 @@
 - Set S3 region in OpenSearch config
 - Bump kubectl version to v1.22.6
 - Patched Falco rules for  `write_etc_common` , `Launch Package Management Process in Container` , `falco_privileged_images` & `falco_sensitive_mount_containers`. Will be removed if upstream Falco Chart accepts these.
+- Improved error handling for applying manifests in wc deploy script
 
 ### Fixed
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Issue where users couldn't do `POST` or `DELETE` requests to alertmanager via service proxy
+- Fixed deploy script with correct path to `extra-user-view` manifest.
 
 ### Added
 

--- a/scripts/deploy-wc.sh
+++ b/scripts/deploy-wc.sh
@@ -31,7 +31,7 @@ kubectl create -f "${SCRIPTS_PATH}/../manifests/examples/fluentd/fluentd-extra-c
     2>/dev/null || echo "fluentd-extra-config configmap already in place. Ignoring."
 kubectl create -f "${SCRIPTS_PATH}/../manifests/examples/fluentd/fluentd-extra-plugins.yaml" \
     2>/dev/null || echo "fluentd-extra-plugins configmap already in place. Ignoring." >&2
-kubectl create -f "${SCRIPTS_PATH}/../helmfile/charts/manifests/user-rbac/clusterrolebindings/extra-user-view.yaml" \
+kubectl create -f "${SCRIPTS_PATH}/../manifests/user-rbac/clusterrolebindings/extra-user-view.yaml" \
     2>/dev/null || echo "extra-user-view ClusterRoleBinding already in place. Ignoring." >&2
 
 echo "Installing helm charts" >&2

--- a/scripts/deploy-wc.sh
+++ b/scripts/deploy-wc.sh
@@ -27,12 +27,26 @@ kubectl -n fluentd create secret generic opensearch \
 # Add example resources.
 # We use `create` here instead of `apply` to avoid overwriting any changes the
 # user may have done.
-kubectl create -f "${SCRIPTS_PATH}/../manifests/examples/fluentd/fluentd-extra-config.yaml" \
-    2>/dev/null || echo "fluentd-extra-config configmap already in place. Ignoring."
-kubectl create -f "${SCRIPTS_PATH}/../manifests/examples/fluentd/fluentd-extra-plugins.yaml" \
-    2>/dev/null || echo "fluentd-extra-plugins configmap already in place. Ignoring." >&2
-kubectl create -f "${SCRIPTS_PATH}/../manifests/user-rbac/clusterrolebindings/extra-user-view.yaml" \
-    2>/dev/null || echo "extra-user-view ClusterRoleBinding already in place. Ignoring." >&2
+if [ "$(kubectl get configmap fluentd-extra-config -n fluentd)" ] ; then
+  echo "fluentd-extra-config ConfigMap already in place. Ignoring."
+else
+  echo "Creating fluentd-extra-config ConfigMap"
+  kubectl create -f "${SCRIPTS_PATH}/../manifests/examples/fluentd/fluentd-extra-config.yaml"
+fi
+
+if [ "$(kubectl get configmap fluentd-extra-plugins -n fluentd)" ] ; then
+  echo "fluentd-extra-plugins ConfigMap already in place. Ignoring."
+else
+  echo "Creating fluentd-extra-plugins ConfigMap"
+  kubectl create -f "${SCRIPTS_PATH}/../manifests/examples/fluentd/fluentd-extra-plugins.yaml"
+fi
+
+if [ "$(kubectl get clusterrolebinding extra-user-view)" ] ; then
+  echo "extra-user-view ClusterRoleBinding already in place. Ignoring."
+else
+  echo "Creating extra-user-view ClusterRoleBinding"
+  kubectl create -f "${SCRIPTS_PATH}/../manifests/user-rbac/clusterrolebindings/extra-user-view.yaml"
+fi
 
 echo "Installing helm charts" >&2
 cd "${SCRIPTS_PATH}/../helmfile"


### PR DESCRIPTION
**What this PR does / why we need it**: Fixing a path. We should probably put this in the next patch release for v0.21.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
