### PR TITLE
apps sc: Add allowlisting for thanos-receiver endpoint

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -22,5 +22,6 @@
 - Made thanos storegateway persistence size configurable
 - New 'Welcoming' Opensearch dashboard / home page.
 - New 'Welcoming' Grafana dashboard / home page.
+- Add allowlisting for kubeapi-metrics (wc) and thanos-receiver (sc) endpoints
 
 ### Removed

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -785,14 +785,19 @@ alerts:
     apiUrl: https://api.eu.opsgenie.com
 
 externalTrafficPolicy:
+  # Whitelisting requires externalTrafficPolicy.local to be true
+  # local: true
+
+  # Comma separated list of CIDRs, e.g. 172.16.0.0/24,172.24.0.0/24
   whitelistRange:
+    # global: 0.0.0.0/0
     dex: false
     harbor: false
     opensearch: false
     opensearchDashboards: false
     userGrafana: false
     opsGrafana: false
-    prometheusWc: false
+    thanosReceiver: false
 
 s3Exporter:
   # Also requries objectStorage.type=s3

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -182,9 +182,20 @@ fluentd:
     tolerations: []
     affinity: {}
     nodeSelector: {}
+
+externalTrafficPolicy:
+  # Whitelisting requires externalTrafficPolicy.local to be true
+  # local: true
+
+  # Comma separated list of CIDRs, e.g. 172.16.0.0/24,172.24.0.0/24
+  whitelistRange:
+    # global: 0.0.0.0/0
+    kubeapiMetrics: false
+
 velero:
   includedNamespaces:
     - alertmanager
+
 prometheusBlackboxExporter:
   targets:
     gatekeeper: true

--- a/helmfile/values/kubeapi-metrics.yaml.gotmpl
+++ b/helmfile/values/kubeapi-metrics.yaml.gotmpl
@@ -3,6 +3,7 @@ ingress:
   clusterDomain: "{{ .Values.global.baseDomain }}"
   username: "kubeapiuser"
   password: "{{ .Values.kubeapiMetricsPassword }}"
-  ## TODO: ingress whitelist
-  #extraAnnotations:
-  #  nginx.ingress.kubernetes.io/whitelist-source-range: ...
+  {{ if and .Values.externalTrafficPolicy.local .Values.externalTrafficPolicy.whitelistRange.kubeapiMetrics }}
+  extraAnnotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.externalTrafficPolicy.whitelistRange.kubeapiMetrics }}
+  {{ end }}

--- a/helmfile/values/thanos/receiver.yaml.gotmpl
+++ b/helmfile/values/thanos/receiver.yaml.gotmpl
@@ -57,6 +57,9 @@ receive:
       nginx.ingress.kubernetes.io/auth-secret: thanos-ingress-secret-basic-auth
       nginx.ingress.kubernetes.io/auth-type: basic
       nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
+      {{ if and .Values.externalTrafficPolicy.local .Values.externalTrafficPolicy.whitelistRange.thanosReceiver }}
+      nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.externalTrafficPolicy.whitelistRange.thanosReceiver }}
+      {{ end }}
 
 receiveDistributor:
   resources: {{- toYaml .Values.thanos.receiveDistributor.resources | nindent 4 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add allowlisting for thanos-receiver endpoint, the rest can already be set.

**Which issue this PR fixes**:
Fixes #840 

**Special notes for reviewer**:
Do we want to update anything else about how we configure allowlisting, renaming the setting, convert it into a yaml sequence, prepare so ops endpoints and/or public endpoints can set common ranges?

<!--**Add a screenshot or an example to illustrate the proposed solution:**-->

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
