### PR TITLE
apps sc: add retention for security-auditlog

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -9,6 +9,7 @@
 - Patched Falco rules for  `write_etc_common` , `Launch Package Management Process in Container` , `falco_privileged_images` & `falco_sensitive_mount_containers`. Will be removed if upstream Falco Chart accepts these.
 - Improved error handling for applying manifests in wc deploy script
 - `kube-prometheus-stack-alertmanager` is configured to have 2 replicas to increase stability and make it highly available.
+- Add pattern `security-auditlog-*` to default retention for Curator
 
 ### Fixed
 

--- a/config/config/flavors/dev/sc-config.yaml
+++ b/config/config/flavors/dev/sc-config.yaml
@@ -43,6 +43,9 @@ opensearch:
       - pattern: authlog-*
         sizeGB: 1
         ageDays: 30
+      - pattern: security-auditlog-*
+        sizeGB: 1
+        ageDays: 7
   snapshot:
     enabled: false
     backupSchedule: 0 */12 * * * # run twice/day

--- a/config/config/flavors/prod/sc-config.yaml
+++ b/config/config/flavors/prod/sc-config.yaml
@@ -60,6 +60,9 @@ opensearch:
       - pattern: authlog-*
         sizeGB: 5
         ageDays: 30
+      - pattern: security-auditlog-*
+        sizeGB: 1
+        ageDays: 14
     resources:
       requests:
         cpu: 10m

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -672,6 +672,9 @@ opensearch:
       - pattern: authlog-*
         sizeGB: 1
         ageDays: 30
+      - pattern: security-auditlog-*
+        sizeGB: 1
+        ageDays: 30
     startingDeadlineSeconds: 600
     activeDeadlineSeconds: 2700
     resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the _default_ retention for curator.

**Which issue this PR fixes**:
fixes #26 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
