### PR TITLE
apps: fluentd ignore own logs and set type of keys

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -16,6 +16,9 @@
 - Fixed deploy script with correct path to `extra-user-view` manifest.
 - Fixed issue when `keys` in config had `'.'` in its name and was being moved from `sc/wc` to `common` configs.
 - Fixed broken index per namespace feature for logging. The version of `elasticsearch_dynamic` plugin in Fluentd no longer supports OpenSearch. Now the OpenSearch output plugin is used for the feature thanks to the usage of placeholders.
+- Fixed conflicting type `ts` in opensearch, where multiple services log `ts` as different types.
+- Fixed conflicting type `@timestamp`, should always be `date` in opensearch.
+- Fluentd no longer tails its own container log. Fixes the issue when Fluentd failed to push to OpenSearch and started filling up its logs with `\`. Because recursive logging of its own errors to OpenSearch which kept failing and for each fail adding more `\`.
 
 ### Added
 

--- a/helmfile/charts/opensearch/configurer/files/index-templates/kubernetes.template.json
+++ b/helmfile/charts/opensearch/configurer/files/index-templates/kubernetes.template.json
@@ -7,6 +7,16 @@
       "index.refresh_interval": "10s",
       "plugins.index_state_management.rollover_alias": "kubernetes",
       "mapping.total_fields.limit": "1000"
+    },
+    "mappings" : {
+      "properties" : {
+        "@timestamp" : {
+          "type" : "date"
+        },
+        "ts" : {
+          "type" : "text"
+        }
+      }
     }
   }
 }

--- a/helmfile/values/fluentd-configmap.yaml.gotmpl
+++ b/helmfile/values/fluentd-configmap.yaml.gotmpl
@@ -183,6 +183,7 @@ forwarder:
         @id fluentd-containers.log
         @type tail
         path /var/log/containers/*.log
+        exclude_path ["/var/log/containers/fluentd*"]
         pos_file /var/log/containers.log.pos
         pos_file_compaction_interval 72h
         tag raw.kubernetes.*

--- a/helmfile/values/fluentd-user.yaml.gotmpl
+++ b/helmfile/values/fluentd-user.yaml.gotmpl
@@ -96,6 +96,7 @@ extraConfigMaps:
       @id fluentd-containers.log
       @type tail
       path /var/log/containers/*.log
+      exclude_path ["/var/log/containers/fluentd*"]
       pos_file /var/log/containers.log.pos
       pos_file_compaction_interval 72h
       tag raw.kubernetes.*

--- a/helmfile/values/fluentd-wc.yaml.gotmpl
+++ b/helmfile/values/fluentd-wc.yaml.gotmpl
@@ -139,6 +139,7 @@ extraConfigMaps:
       @id fluentd-containers.log
       @type tail
       path /var/log/containers/*.log
+      exclude_path ["/var/log/containers/fluentd*"]
       pos_file /var/log/containers.log.pos
       pos_file_compaction_interval 72h
       tag raw.kubernetes.*


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed issue when fluentd start adding `\` to a log after failing to push to opensearch.
Also fixed two mapping issues. 

**Which issue this PR fixes**: fixes #544 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

![image](https://user-images.githubusercontent.com/12862587/168544254-09654697-9a18-4b4e-8775-8de18fefd0f2.png)

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
