### PR TITLE
apps: fix index per namespace opensearch

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -15,6 +15,7 @@
 - Issue where users couldn't do `POST` or `DELETE` requests to alertmanager via service proxy
 - Fixed deploy script with correct path to `extra-user-view` manifest.
 - Fixed issue when `keys` in config had `'.'` in its name and was being moved from `sc/wc` to `common` configs.
+- Fixed broken index per namespace feature for logging. The version of `elasticsearch_dynamic` plugin in Fluentd no longer supports OpenSearch. Now the OpenSearch output plugin is used for the feature thanks to the usage of placeholders.
 
 ### Added
 

--- a/helmfile/values/fluentd-user.yaml.gotmpl
+++ b/helmfile/values/fluentd-user.yaml.gotmpl
@@ -294,11 +294,7 @@ extraConfigMaps:
     </match>
     <match kubernetes.**>
       @id elasticsearch_kubernetes
-      {{- if .Values.opensearch.indexPerNamespace }}
-      @type elasticsearch_dynamic
-      {{- else }}
       @type "#{ENV['OUTPUT_TYPE']}"
-      {{- end }}
       @log_level "#{ENV['OUTPUT_LOG_LEVEL']}"
       include_tag_key "#{ENV['OUTPUT_INCLUDE_TAG_KEY']}"
       hosts "#{ENV['OUTPUT_HOSTS']}"
@@ -319,13 +315,17 @@ extraConfigMaps:
       include_timestamp true # defaults to false
       {{- if .Values.opensearch.indexPerNamespace }}
       logstash_format true
-      logstash_prefix ${record['kubernetes']['namespace_name']}
+      logstash_prefix ${$.kubernetes.namespace_name}
       {{- else }}
       index_name kubernetes
       {{- end }}
       default_opensearch_version 1
 
+      {{- if .Values.opensearch.indexPerNamespace }}
+      <buffer tag, $.kubernetes.namespace_name>
+      {{- else }}
       <buffer>
+      {{- end }}
         @type "#{ENV['OUTPUT_BUFFER_TYPE']}"
         path /var/log/fluentd-buffers/kubernetes.kubernetes.system.buffer
         flush_mode "#{ENV['OUTPUT_BUFFER_FLUSH_MODE']}"

--- a/helmfile/values/fluentd-wc.yaml.gotmpl
+++ b/helmfile/values/fluentd-wc.yaml.gotmpl
@@ -312,11 +312,7 @@ extraConfigMaps:
     </match>
     <match kubernetes.**>
       @id opensearch_kubernetes
-      {{- if .Values.opensearch.indexPerNamespace }}
-      @type elasticsearch_dynamic
-      {{- else }}
       @type "#{ENV['OUTPUT_TYPE']}"
-      {{- end }}
       @log_level "#{ENV['OUTPUT_LOG_LEVEL']}"
       include_tag_key "#{ENV['OUTPUT_INCLUDE_TAG_KEY']}"
       hosts "#{ENV['OUTPUT_HOSTS']}"
@@ -337,13 +333,17 @@ extraConfigMaps:
       include_timestamp true # defaults to false
       {{- if .Values.opensearch.indexPerNamespace }}
       logstash_format true
-      logstash_prefix ${record['kubernetes']['namespace_name']}
+      logstash_prefix ${$.kubernetes.namespace_name}
       {{- else }}
       index_name kubernetes
       {{- end }}
       default_opensearch_version 1
 
+      {{- if .Values.opensearch.indexPerNamespace }}
+      <buffer tag, $.kubernetes.namespace_name>
+      {{- else }}
       <buffer>
+      {{- end }}
         @type "#{ENV['OUTPUT_BUFFER_TYPE']}"
         path /var/log/fluentd-buffers/kubernetes.kubernetes.system.buffer
         flush_mode "#{ENV['OUTPUT_BUFFER_FLUSH_MODE']}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Index per namespace was broken for opensearch. This fixes it.

This should be part of a patch release for v0.21

**Which issue this PR fixes**: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
