### PR TITLE
apps: Add option for HA Prometheus

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -31,6 +31,8 @@
 - New 'Welcoming' Opensearch dashboard / home page.
 - New 'Welcoming' Grafana dashboard / home page.
 - Add allowlisting for kubeapi-metrics (wc) and thanos-receiver (sc) endpoints
+- Add support for running prometheus in HA mode
+- Add option for deduplication/vertical compaction with thanos-compactor
 
 ### Removed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -421,6 +421,11 @@ thanos:
     retentionResolution5m: 90d
     retentionResolution1h: 0s
 
+    # Deduplication of metrics in long term storage
+    # receiverReplicas: Deduplicate results from multple receivers, simpler dedup
+    # prometheusReplicas: Deduplicate results from multple receivers and multiple prometheis, heavier dedup
+    deduplication: none
+
     # Persistence is recommended for caching.
     # https://thanos.io/v0.24/components/compact.md/#disk
     persistence:

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -279,13 +279,21 @@ prometheusOperator:
 
 prometheus:
   prometheusSpec:
+    replicas: {{ .Values.prometheus.replicas }}
+
+    externalLabels:
+      cluster: {{ .Values.global.clusterName }}
+
+    # Don't add prometheus labels.
+    prometheusExternalLabelNameClear: true
+    {{- if le .Values.prometheus.replicas 1 }}
+    replicaExternalLabelNameClear: true
+    {{- end }}
+
     resources: {{- toYaml .Values.prometheus.resources | nindent 8  }}
     nodeSelector: {{- toYaml .Values.prometheus.nodeSelector | nindent 8 }}
     affinity: {{- toYaml .Values.prometheus.affinity | nindent 8 }}
     tolerations: {{- toYaml .Values.prometheus.tolerations | nindent 8 }}
-
-    externalLabels:
-      cluster: {{ .Values.global.clusterName }}
 
     {{- if and .Values.thanos.enabled .Values.thanos.receiver.enabled }}
     remoteWrite:
@@ -293,10 +301,6 @@ prometheus:
       headers:
         THANOS-TENANT: {{ .Values.global.clusterName }}
     {{- end }}
-
-    # Don't add prometheus info.
-    prometheusExternalLabelNameClear: true
-    replicaExternalLabelNameClear: true
 
     # Empty selector to select all namespaces
     podMonitorNamespaceSelector: {}

--- a/helmfile/values/kube-prometheus-stack-wc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-wc.yaml.gotmpl
@@ -47,8 +47,16 @@ prometheus:
     enabled: false
 
   prometheusSpec:
+    replicas: {{ .Values.prometheus.replicas }}
+
     externalLabels:
       cluster: {{ .Values.global.clusterName }}
+
+    # Dont add prometheus labels.
+    prometheusExternalLabelNameClear: true
+    {{- if le .Values.prometheus.replicas 1 }}
+    replicaExternalLabelNameClear: true
+    {{- end }}
 
     {{- if and .Values.thanos.enabled .Values.thanos.receiver.enabled }}
     remoteWrite:
@@ -66,9 +74,6 @@ prometheus:
           name: thanos-ingress-secret-basic-auth
     {{- end }}
 
-    # Dont add prometheus labels.
-    prometheusExternalLabelNameClear: true
-    replicaExternalLabelNameClear: true
 
     # Select everything
     serviceMonitorNamespaceSelector:

--- a/helmfile/values/thanos/query.yaml.gotmpl
+++ b/helmfile/values/thanos/query.yaml.gotmpl
@@ -3,6 +3,7 @@ existingObjstoreSecret: thanos-objectstorage-secret-objstore-secret
 query:
   enabled: true
   replicaCount: {{ .Values.thanos.query.replicaCount }}
+
   dnsDiscovery:
     enabled: false
   stores:
@@ -10,6 +11,11 @@ query:
     {{- range $i := until .Values.thanos.receiver.replicaCount }}
     - "thanos-receiver-receive-{{ $i }}.thanos-receiver-receive-headless.thanos.svc.cluster.local:10901"
     {{- end }}
+
+  replicaLabel:
+    - replica
+    - prometheus_replica
+
   resources: {{- toYaml .Values.thanos.query.resources | nindent 4 }}
 
 queryFrontend:

--- a/helmfile/values/thanos/receiver.yaml.gotmpl
+++ b/helmfile/values/thanos/receiver.yaml.gotmpl
@@ -8,10 +8,24 @@ queryFrontend:
 
 compactor:
   enabled: true
+
   retentionResolutionRaw: {{ .Values.thanos.compactor.retentionResolutionRaw }}
   retentionResolution5m: {{ .Values.thanos.compactor.retentionResolution5m }}
   retentionResolution1h: {{ .Values.thanos.compactor.retentionResolution1h }}
+
+  {{- if eq .Values.thanos.compactor.deduplication "receiverReplicas" }}
+  extraFlags:
+    - --deduplication.func=
+    - --deduplication.replica-label=replica
+  {{- else if eq .Values.thanos.compactor.deduplication "prometheusReplicas" }}
+  extraFlags:
+    - --deduplication.func=penalty
+    - --deduplication.replica-label=replica
+    - --deduplication.replica-label=prometheus_replica
+  {{- end }}
+
   resources: {{- toYaml .Values.thanos.compactor.resources | nindent 4 }}
+
   persistence:
     size: {{ .Values.thanos.compactor.persistence.size }}
 


### PR DESCRIPTION
And option for Thanos compactor to do deduplication.

**What this PR does / why we need it**:
HA metrics collection for the masses.

**Which issue this PR fixes**:
fixes #855

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
Basically adds the option to have multiple Prometheus replicas, and adds a replica label to them when they are more than one.
Thanos Query will then deduplicate based on this label (in addition to the already set Receiver label).

Thanos Compactor can be configured to run this deduplication as well when it runs.
Though due to the time it takes for it to progress I've haven't seen it actually dedup the `prometheus_replica` label just yet.

**Add a screenshot or an example to illustrate the proposed solution:**
![Screenshot 2022-05-24 at 15-28-17 New dashboard - Grafana](https://user-images.githubusercontent.com/58822152/170049142-c2149056-d7cf-4695-b82e-d14813d136b7.png)
With one Prometheus down in each cluster we still have metrics.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
