### PR TITLE
apps wc: Remove undefined macro preventing falco rule compilation

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fluentd no longer tails its own container log. Fixes the issue when Fluentd failed to push to OpenSearch and started filling up its logs with `\`. Because recursive logging of its own errors to OpenSearch which kept failing and for each fail adding more `\`.
 - Split the grafana-ops configmaplist into separate configmaps, which in some instances caused errors in helm due to the size of the resulting resource
 - PrometheusNotConnectedToAlertmanagers alert will be sent to `null` if Alertmanger is disabled in wc
+- Removed undefined macro preventing falco rules to be compiled
 
 ### Added
 

--- a/helmfile/values/falco.yaml.gotmpl
+++ b/helmfile/values/falco.yaml.gotmpl
@@ -182,7 +182,6 @@ customRules:
         and not mcafee_writing_cma_d
         and not avinetworks_supervisor_writing_ssh
         and not multipath_writing_conf
-        and not calico_node
     - macro: falco_sensitive_mount_containers
       condition: (user_trusted_containers or
               aws_eks_image_sensitive_mount or


### PR DESCRIPTION
**What this PR does / why we need it**:
Saw that the falco ds rollout was stuck due to a missing macro in the falco rule.
```console
Tue May 24 13:44:05 2022: Runtime error: Could not load rules file /etc/falco/rules.d/overwrites.yaml: 1 errors:
Compilation error when compiling "...": Undefined macro calico_node used in filter.
---
- macro: write_etc_common
  condition: >
...
    and not calico_node
---
. Exiting.

```

**Special notes for reviewer**:
I don't know if there is one that should be included instead.
I tried to include the one in the default rules but it did not work, it still failed to compile.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
