### PR TITLE
apps sc: Add option to encrypt with rclone sync

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,6 +1,16 @@
 ### Release notes
 
+### Updated
+
+### Changed
+
 ### Fixed
 
 - `prometheus-blackbox-exporter's` internal thanos servicemonitor changed name to avoid name collisions.
 - dex `topologySpreadConstraints` matchLabel was changed from `app: dex` to `app.kubernetes.io/name: dex` to increase stability of replica placements.
+
+### Added
+
+- Add option to encrypt off-site buckets replicated with rclone sync
+
+### Removed

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Updated
 
+- Update the Velero plugin for AWS to v1.3.1
+
 ### Changed
 
 ### Fixed

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -41,6 +41,14 @@ objectStorage:
       #   # destination: destination-bucket # if unset it will be the same as 'source'
       #   # schedule: 0 5 * * *             # if unset it will be the same as 'defaultSchedule'
 
+    # Encrypt (symmetric) before syncing
+    encrypt:
+      enabled: false
+
+      # Enable to encrypt directory or file names
+      directoryName: false
+      fileName: false
+
     ## Sync job resources
     resources:
       requests:

--- a/config/secrets/sc-secrets.yaml
+++ b/config/secrets/sc-secrets.yaml
@@ -11,6 +11,11 @@ objectStorage: {}
   #   s3:
   #     accessKey: "set-me"
   #     secretKey: "set-me"
+  #   encrypt:
+  #     password: "set-me" # generate with `pwgen 32 1`
+  #     salt: "set-me" # generate with `pwgen 32 1`
+  #     passwordObscure: "set-me" # generate with `rclone obscure <password>`
+  #     saltObscure: "set-me" # generate with `rclone obscure <salt>`
 grafana:
   password: somelongsecret
   clientSecret: somelongsecret

--- a/helmfile/charts/rclone-sync/files/rclone.conf
+++ b/helmfile/charts/rclone-sync/files/rclone.conf
@@ -19,3 +19,21 @@ endpoint = {{ .Values.config.destination.s3.regionEndpoint }}
 force_path_style = {{ .Values.config.destination.s3.forcePathStyle }}
 v2_auth = {{.Values.config.destination.s3.v2Auth }}
 {{- end }}
+
+{{- if .Values.config.encrypt.enabled }}
+{{- range .Values.buckets }}
+
+[{{ $.Values.config.encrypt.name }}-{{ .destination }}]
+type = crypt
+remote = {{ $.Values.config.destination.name }}:{{ .destination }}
+password = {{ $.Values.config.encrypt.password }}
+password2 = {{ $.Values.config.encrypt.salt }}
+{{- if not $.Values.config.encrypt.directoryNames }}
+directory_name_encryption = false
+{{- end }}
+{{- if not $.Values.config.encrypt.fileNames }}
+filename_encryption = off
+{{- end }}
+
+{{- end }}
+{{- end }}

--- a/helmfile/charts/rclone-sync/templates/cronjob.yaml
+++ b/helmfile/charts/rclone-sync/templates/cronjob.yaml
@@ -27,10 +27,10 @@ spec:
               args:
                 - sync
                 - {{ $.Values.config.source.name }}:{{ .source }}
-                {{- if hasKey . "destination" }}
-                - {{ $.Values.config.destination.name }}:{{ .destination }}
+                {{- if $.Values.config.encrypt.enabled }}
+                - "{{ $.Values.config.encrypt.name }}-{{ .destination }}:"
                 {{- else }}
-                - {{ $.Values.config.destination.name }}:{{ .source }}
+                - {{ $.Values.config.destination.name }}:{{ .destination }}
                 {{- end }}
                 - --log-level
                 - DEBUG

--- a/helmfile/charts/rclone-sync/values.yaml
+++ b/helmfile/charts/rclone-sync/values.yaml
@@ -27,6 +27,16 @@ config:
       forcePathStyle: true
       v2Auth: false
 
+  encrypt:
+    enabled: false
+    name: encrypt
+    # rclone obscure of "somelongsecret"
+    password: OYAvXLS7N7LYYqgvmQejHIepyHwdt2q852PRTxpb
+    # rclone obscure of "somelongsecret"
+    salt: wc2BQGqZ4lD4I_Vtwyncv47QZ6Okrc7hY5ONzWQC
+    directoryNames: false
+    fileNames: false
+
 defaultSchedule: 0 5 * * *
 
 buckets:

--- a/helmfile/values/rclone-sync.yaml.gotmpl
+++ b/helmfile/values/rclone-sync.yaml.gotmpl
@@ -41,16 +41,39 @@ config:
     {{- end }}
   {{- end }}
 
+  encrypt:
+  {{- if .Values.objectStorage.sync.encrypt.enabled }}
+    enabled: true
+    name: encrypt
+    password: {{ .Values.objectStorage.sync.encrypt.passwordObscured }}
+    salt: {{ .Values.objectStorage.sync.encrypt.saltObscured }}
+    directoryNames: {{ .Values.objectStorage.sync.encrypt.directoryNames }}
+    fileNames: {{ .Values.objectStorage.sync.encrypt.fileNames }}
+  {{- else }}
+    enabled: false
+  {{- end }}
+
 defaultSchedule: {{ .Values.objectStorage.sync.defaultSchedule }}
 
 buckets:
 {{- if .Values.objectStorage.sync.syncDefaultBuckets }}
-{{- range (values .Values.objectStorage.buckets | sortAlpha) }}
+  {{- range (values .Values.objectStorage.buckets | sortAlpha) }}
   - source: {{ . }}
-{{- end }}
+    destination: {{ . }}
+  {{- end }}
 {{- end }}
 {{- if .Values.objectStorage.sync.buckets }}
-{{- toYaml .Values.objectStorage.sync.buckets | nindent 2 }}
+  {{- range .Values.objectStorage.sync.buckets }}
+  - source: {{ .source }}
+    {{- if hasKey . "destination" }}
+    destination: {{ .destination }}
+    {{- else }}
+    destination: {{ .source }}
+    {{- end }}
+    {{- if hasKey . "schedule" }}
+    schedule: {{ .schedule }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 resources: {{- toYaml .Values.objectStorage.sync.resources | nindent 2 }}

--- a/helmfile/values/velero-sc.yaml.gotmpl
+++ b/helmfile/values/velero-sc.yaml.gotmpl
@@ -8,7 +8,7 @@ nodeSelector: {{- toYaml .Values.velero.nodeSelector | nindent 2  }}
 initContainers:
   {{- if eq .Values.objectStorage.type "s3" }}
   - name: velero-plugin-for-aws
-    image: velero/velero-plugin-for-aws:v1.0.0
+    image: velero/velero-plugin-for-aws:v1.3.1
     imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /target

--- a/helmfile/values/velero-wc.yaml.gotmpl
+++ b/helmfile/values/velero-wc.yaml.gotmpl
@@ -8,7 +8,7 @@ nodeSelector: {{- toYaml .Values.velero.nodeSelector | nindent 2  }}
 initContainers:
   {{- if eq .Values.objectStorage.type "s3" }}
   - name: velero-plugin-for-aws
-    image: velero/velero-plugin-for-aws:v1.0.0
+    image: velero/velero-plugin-for-aws:v1.3.1
     imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /target

--- a/scripts/restore-sync/README.md
+++ b/scripts/restore-sync/README.md
@@ -1,0 +1,52 @@
+# Restore off-site backups
+
+This will guide you through restoring a bucket from an off-site backup.
+
+> Make sure that the `rclone-sync` CronJobs are suspended so it won't destroy the off-site backup!
+
+## Extract rclone config
+
+- If you still have `rclone-sync` deployed then you can use its config:
+  ```bash
+  export RCLONE_CONFIG="rclone-sync-config"
+  ```
+
+- Else have sync configured, template the `rclone-sync-config` secret, and apply:
+  ```bash
+  ./bin/ck8s ops helmfile sc -l app=rclone-sync template | \
+    yq r -c -d '*' -D '[]' - | yq r - 'kind==Secret' | \
+    yq w - 'metadata.name' 'rclone-sync-restore-config' | \
+    ./bin/ck8s ops kubectl sc -n kube-system apply -f -
+
+  export RCLONE_CONFIG="rclone-sync-restore-config"
+  ```
+
+## Run
+
+The destination S3 service must be set with a prefix when setting the destination bucket for the restore.
+Setting the prefix `default` will restore into the main S3 service, and `backup` will restore into the off-site service.
+
+The destination bucket will be created automatically if it does not exists already.
+
+
+### Encrypted
+
+With `<encrypted-bucket>` being the name of the encrypted bucket to restore, `<restored-bucket>` being the bucket to restore to, and `<prefix>` being the destination S3 service (`default` or `backup`):
+
+```bash
+SOURCE="encrypt-<encrypted-bucket>:" DESTINATION="<prefix>:<restored-bucket>" envsubst < ./scripts/restore-sync-encrypt/template.job.yaml | ./bin/ck8s ops kubectl sc apply -f -
+```
+
+> Important here that the value set for `SOURCE` is prefixed with `encrypt-` and ends with `:`!
+
+> Make sure that the two buckets have separate names when restoring into the off-site S3 service!
+
+### Unencrypted
+
+In the event that the off-site backup is unencrypted but still needs to be restored into the main S3 service.
+
+With `<backup-bucket>` being the unencrypted bucket to restore, and `<restored-bucket>` being the bucket to restore to:
+
+```bash
+SOURCE="backup:<backup-bucket>" DESTINATION="default:<restored-bucket>" envsubst < ./scripts/restore-sync-encrypt/template.job.yaml | ./bin/ck8s ops kubectl sc apply -f -
+```

--- a/scripts/restore-sync/template.job.yaml
+++ b/scripts/restore-sync/template.job.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rclone-restore
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: rclone
+          image: elastisys/rclone-sync:1.3.0
+          args:
+            - sync
+            - "${SOURCE}"
+            - "${DESTINATION}"
+            - --log-level
+            - DEBUG
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /home/rclone/.config/rclone/
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: ${RCLONE_CONFIG}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows the contents of a bucket to be encrypted before it's sent when using rclone sync.

**Which issue this PR fixes**: 
fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [x] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
