### PR TITLE
apps sc: Split dashboard configmaplist into separate configmaps

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed conflicting type `ts` in opensearch, where multiple services log `ts` as different types.
 - Fixed conflicting type `@timestamp`, should always be `date` in opensearch.
 - Fluentd no longer tails its own container log. Fixes the issue when Fluentd failed to push to OpenSearch and started filling up its logs with `\`. Because recursive logging of its own errors to OpenSearch which kept failing and for each fail adding more `\`.
+- Split the grafana-ops configmaplist into separate configmaps, which in some instances caused errors in helm due to the size of the resulting resource
 
 ### Added
 

--- a/helmfile/charts/grafana-ops/templates/configmap-dashboards.yaml
+++ b/helmfile/charts/grafana-ops/templates/configmap-dashboards.yaml
@@ -1,33 +1,31 @@
-apiVersion: v1
-kind: ConfigMapList
-items:
 {{- range $key, $value := .Values.dashboards }}
 {{- $_ := set $ "key" $key }}
 {{- $_ := set $ "value" $value }}
 {{- if $value.enabled }}
-- apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    name: {{ printf "%s-%s" $.Release.Name $key }}
-    namespace: {{ $.Release.Namespace }}
-    labels:
-      {{- if $value.user_visible }}
-      {{ $.Values.labelKey }}: "1"
-      {{- else }}
-      {{ $.Values.labelKey }}: "ops"
-      {{- end }}
-  data:
-    {{- if eq $key "backup" }}
-    {{- $sync := (empty $value.sync) | ternary "**disabled**" (printf "**enabled** for bucket(s) %s" (join ", " (sortAlpha $value.sync))) }}
-    {{ $key }}.json: |-
-      {{- regexReplaceAll "<<rclone-sync-state>>" ($.Files.Get (printf "dashboards/%s-dashboard.json" $key)) $sync | nindent 6 }}
-    {{- else if eq $key "welcome" }}
-    {{- $markdown := (regexReplaceAll "\n" (tpl ($.Files.Get "files/welcome.md") $) "\\n") }}
-    {{ $key }}.json: |-
-      {{- regexReplaceAll "<<markdownstring>>" ($.Files.Get (printf "dashboards/%s-dashboard.json" $key)) $markdown | nindent 6 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-%s" $.Release.Name $key }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- if $value.user_visible }}
+    {{ $.Values.labelKey }}: "1"
     {{- else }}
-    {{ $key }}.json: |-
-      {{- regexReplaceAll "<<opensearchdashboardsURL>>" ($.Files.Get (printf "dashboards/%s-dashboard.json" $key)) ($value.logEndpoint | toString) | nindent 6 }}
+    {{ $.Values.labelKey }}: "ops"
     {{- end }}
+data:
+  {{- if eq $key "backup" }}
+  {{- $sync := (empty $value.sync) | ternary "**disabled**" (printf "**enabled** for bucket(s) %s" (join ", " (sortAlpha $value.sync))) }}
+  {{ $key }}.json: |-
+    {{- regexReplaceAll "<<rclone-sync-state>>" ($.Files.Get (printf "dashboards/%s-dashboard.json" $key)) $sync | nindent 6 }}
+  {{- else if eq $key "welcome" }}
+  {{- $markdown := (regexReplaceAll "\n" (tpl ($.Files.Get "files/welcome.md") $) "\\n") }}
+  {{ $key }}.json: |-
+    {{- regexReplaceAll "<<markdownstring>>" ($.Files.Get (printf "dashboards/%s-dashboard.json" $key)) $markdown | nindent 6 }}
+  {{- else }}
+  {{ $key }}.json: |-
+    {{- regexReplaceAll "<<opensearchdashboardsURL>>" ($.Files.Get (printf "dashboards/%s-dashboard.json" $key)) ($value.logEndpoint | toString) | nindent 6 }}
+  {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes each dashboard a separate configmap instead of a massive configmaplist that sometimes causes issues in helm. 

**Which issue this PR fixes**:
fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
I had strange issues when running dry-run on the service cluster and narrowed it down to the `grafana-ops`, where the command would fail and close the shell session. And it only happened when I tried to enable rclone-sync which adds changes into the backup dashboard. But I knew it could render the chart so the problem was when it tried to run diff or apply.

So I look in to it and saw that it rendered all dashboards into one massive resource, which I think is to large for helm to handle properly in all situations.

This change has the added benefit of showing us changes in individual dashboards rather than print out a massive log each time.

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
