### PR TITLE
bin: upgrade falco-exporter

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Bump falco-exporter chart to v0.8.0.
+
 ### Fixed
 
 - `prometheus-blackbox-exporter's` internal thanos servicemonitor changed name to avoid name collisions.

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -584,7 +584,7 @@ releases:
   labels:
     app: falco-exporter
   chart: ./upstream/falco-exporter
-  version: 0.3.8
+  version: 0.8.0
   installed: {{ .Values.falco.enabled }}
   missingFileHandler: Error
   values:

--- a/helmfile/upstream/falco-exporter/CHANGELOG.md
+++ b/helmfile/upstream/falco-exporter/CHANGELOG.md
@@ -3,6 +3,86 @@
 This file documents all notable changes to `falco-exporter` Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.8.0
+
+* Upgrade falco-exporter version to v0.7.0 (see the [falco-exporter changelog](https://github.com/falcosecurity/falco-exporter/releases/tag/v0.7.0)) 
+
+### Major Changes
+
+* Add option to add labels to the Daemonset pods
+
+## v0.7.2
+
+### Minor Changes
+
+* Add option to add labels to the Daemonset pods
+
+## v0.7.1
+
+### Minor Changes
+
+* Fix `FalcoExporterAbsent` expression
+
+## v0.7.0
+
+### Major Changes
+
+* Adds ability to create custom PrometheusRules for alerting
+
+## v0.6.2
+
+## Minor Changes
+
+* Add Check availability of 'monitoring.coreos.com/v1' api version
+
+## v0.6.1
+
+### Minor Changes
+
+* Add option the add annotations to the Daemonset
+
+## v0.6.0
+
+### Minor Changes
+
+* Upgrade falco-exporter version to v0.6.0 (see the [falco-exporter changelog](https://github.com/falcosecurity/falco-exporter/releases/tag/v0.6.0))
+
+## v0.5.2
+
+### Minor changes
+
+* Make image registry configurable
+
+## v0.5.1
+
+* Display only non-zero rates in Grafana dashboard template
+
+## v0.5.0
+
+### Minor Changes
+
+* Upgrade falco-exporter version to v0.5.0
+* Add metrics about Falco drops
+* Make `unix://` prefix optional
+
+## v0.4.2
+
+### Minor Changes
+
+* Fix Prometheus datasource name reference in grafana dashboard template
+
+## v0.4.1
+
+### Minor Changes
+
+* Support release namespace configuration
+
+## v0.4.0
+
+### Mayor Changes
+
+* Add Mutual TLS for falco-exporter enable/disabled feature
+
 ## v0.3.8
 
 ### Minor Changes

--- a/helmfile/upstream/falco-exporter/Chart.yaml
+++ b/helmfile/upstream/falco-exporter/Chart.yaml
@@ -1,18 +1,36 @@
 apiVersion: v2
-appVersion: 0.3.0
-description: Prometheus Metrics Exporter for Falco output events
-keywords:
-- monitoring
-- security
-- alerting
-- metric
-- troubleshooting
-- run-time
-maintainers:
-- email: me@leonardograsso.com
-  name: leogr
 name: falco-exporter
-sources:
-- https://github.com/falcosecurity/falco-exporter
+description: Prometheus Metrics Exporter for Falco output events
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-version: 0.3.8
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.8.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 0.7.0
+
+keywords:
+  - monitoring
+  - security
+  - alerting
+  - metric
+  - troubleshooting
+  - run-time
+
+sources:
+  - https://github.com/falcosecurity/falco-exporter
+
+maintainers:
+  - name: leogr
+    email: me@leonardograsso.com

--- a/helmfile/upstream/falco-exporter/README.md
+++ b/helmfile/upstream/falco-exporter/README.md
@@ -45,23 +45,27 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the main configurable parameters of the chart and their default values.
 
-| Parameter                         | Description                                                                                      | Default                            |
-| --------------------------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------- |
-| `image.repository`                | The image repository to pull from                                                                | `falcosecurity/falco-exporter`     |
-| `image.tag`                       | The image tag to pull                                                                            | `0.3.0`                            |
-| `image.pullPolicy`                | The image pull policy                                                                            | `IfNotPresent`                     |
-| `falco.grpcUnixSocketPath`        | Unix socket path for connecting to a Falco gRPC server                                           | `unix:///var/run/falco/falco.sock` |
-| `falco.grpcTimeout`               | gRPC connection timeout                                                                          | `2m`                               |
-| `serviceAccount.create`           | Specify if a service account should be created                                                   | `true`                             |
-| `podSecurityPolicy.create`        | Specify if a PSP, Role & RoleBinding should be created                                           | `false`                            |
-| `serviceMonitor.enabled`          | Enabled deployment of a Prometheus operator Service Monitor                                      | `false`                            |
-| `serviceMonitor.additionalLabels` | Add additional Labels to the Service Monitor                                                     | `{}`                               |
-| `serviceMonitor.interval`         | Specify a user defined interval for the Service Monitor                                          | `""`                               |
-| `serviceMonitor.scrapeTimeout`    | Specify a user defined scrape timeout for the Service Monitor                                    | `""`                               |
-| `grafanaDashboard.enabled`        | Enable the falco security dashboard, see https://github.com/falcosecurity/falco-exporter#grafana | `false`                            |
-| `grafanaDashboard.namespace`      | The namespace to deploy the dashboard configmap in                                               | `default`                          |
-| `scc.create`                      | Create OpenShift's Security Context Constraint                                                   | `true`                             |
-
+| Parameter                                        | Description                                                                                      | Default                            |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------ | ---------------------------------- |
+| `image.registry`                                 | The image registry to pull from                                                                  | `docker.io`                        |
+| `image.repository`                               | The image repository to pull from                                                                | `falcosecurity/falco-exporter`     |
+| `image.tag`                                      | The image tag to pull                                                                            | `0.6.0`                            |
+| `image.pullPolicy`                               | The image pull policy                                                                            | `IfNotPresent`                     |
+| `falco.grpcUnixSocketPath`                       | Unix socket path for connecting to a Falco gRPC server                                           | `unix:///var/run/falco/falco.sock` |
+| `falco.grpcTimeout`                              | gRPC connection timeout                                                                          | `2m`                               |
+| `serviceAccount.create`                          | Specify if a service account should be created                                                   | `true`                             |
+| `podSecurityPolicy.create`                       | Specify if a PSP, Role & RoleBinding should be created                                           | `false`                            |
+| `serviceMonitor.enabled`                         | Enabled deployment of a Prometheus operator Service Monitor                                      | `false`                            |
+| `serviceMonitor.additionalLabels`                | Add additional Labels to the Service Monitor                                                     | `{}`                               |
+| `serviceMonitor.interval`                        | Specify a user defined interval for the Service Monitor                                          | `""`                               |
+| `serviceMonitor.scrapeTimeout`                   | Specify a user defined scrape timeout for the Service Monitor                                    | `""`                               |
+| `grafanaDashboard.enabled`                       | Enable the falco security dashboard, see https://github.com/falcosecurity/falco-exporter#grafana | `false`                            |
+| `grafanaDashboard.namespace`                     | The namespace to deploy the dashboard configmap in                                               | `default`                          |
+| `grafanaDashboard.prometheusDatasourceName`      | The prometheus datasource name to be used for the dashboard                                      | `Prometheus`                       |
+| `scc.create`                                     | Create OpenShift's Security Context Constraint                                                   | `true`                             |
+| `service.mTLS.enabled`                           | Enable falco-exporter server Mutual TLS feature                                                  | `false`                            |
+| `prometheusRules.enabled`                        | Enable the creation of falco-exporter PrometheusRules                                            | `false`                            |
+| `daemonset.podLabels`                            | Customized Daemonset pod labels                                                                  | `{}`
 
 Please, refer to [values.yaml](./values.yaml) for the full list of configurable parameters.
 
@@ -75,6 +79,21 @@ Alternatively, a YAML file that specifies the parameters' values can be provided
 
 ```bash
 helm install falco-exporter -f values.yaml falcosecurity/falco-exporter
+```
+
+### Enable Mutual TLS
+
+Mutual TLS for `/metrics` endpoint can be enabled to prevent alerts content from being consumed by unauthorized components.
+
+To install falco-exporter with Mutual TLS enabled, you have to:
+
+```shell
+helm install falco-exporter \
+  --set service.mTLS.enabled=true \
+  --set-file service.mTLS.server.key=/path/to/server.key \
+  --set-file service.mTLS.server.crt=/path/to/server.crt \
+  --set-file service.mTLS.ca.crt=/path/to/ca.crt \
+  falcosecurity/falco-exporter
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/helmfile/upstream/falco-exporter/templates/NOTES.txt
+++ b/helmfile/upstream/falco-exporter/templates/NOTES.txt
@@ -2,14 +2,15 @@ Get the falco-exporter metrics URL by running these commands:
 {{- if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "falco-exporter.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT/metrics
+  echo {{- if .Values.service.mTLS.enabled }} https{{- else }} http{{- end }}://$NODE_IP:$NODE_PORT/metrics
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ template "falco-exporter.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "falco-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}/metrics
+  echo {{- if .Values.service.mTLS.enabled }} https{{- else }} http{{- end }}://$SERVICE_IP:{{ .Values.service.port }}/metrics
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "falco-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:{{ .Values.service.targetPort }}/metrics to use your application"
+  echo "Visit {{- if .Values.service.mTLS.enabled }} https{{- else }} http{{- end }}://127.0.0.1:{{ .Values.service.targetPort }}/metrics to use your application"
   kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ .Values.service.targetPort }}
 {{- end }}
+  echo {{- if .Values.service.mTLS.enabled }} "You'll need a valid client certificate and its corresponding key for Mutual TLS handshake" {{- end }}

--- a/helmfile/upstream/falco-exporter/templates/daemonset.yaml
+++ b/helmfile/upstream/falco-exporter/templates/daemonset.yaml
@@ -13,6 +13,13 @@ spec:
     metadata:
       labels:
         {{- include "falco-exporter.selectorLabels" . | nindent 8 }}
+        {{- if .Values.daemonset.podLabels }}
+        {{ toYaml .Values.daemonset.podLabels | nindent 8 }}
+        {{- end }}
+      {{- if .Values.daemonset.annotations }}
+      annotations:
+      {{ toYaml .Values.daemonset.annotations | nindent 8 }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -28,7 +35,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - /usr/bin/falco-exporter
@@ -40,18 +47,23 @@ spec:
             {{- end }}
             - --timeout={{ .Values.falco.grpcTimeout }}
             - --listen-address=0.0.0.0:{{ .Values.service.port }}
+            {{- if .Values.service.mTLS.enabled }}
+            - --server-ca=/etc/falco/server-certs/ca.crt
+            - --server-cert=/etc/falco/server-certs/server.crt
+            - --server-key=/etc/falco/server-certs/server.key
+            {{- end }}
           ports:
             - name: metrics
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /metrics
-              port: {{ .Values.service.port }}
+              path: /liveness
+              port: {{ .Values.probesPort }}
           readinessProbe:
             httpGet:
               path: /readiness
-              port: {{ .Values.service.port }}
+              port: {{ .Values.probesPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
@@ -62,6 +74,11 @@ spec:
           {{- else }}
             - mountPath: /etc/falco/certs
               name: certs-volume
+              readOnly: true
+          {{- end }}
+          {{- if .Values.service.mTLS.enabled }}
+            - mountPath: /etc/falco/server-certs
+              name: server-certs-volume
               readOnly: true
           {{- end }}
       volumes:
@@ -78,6 +95,18 @@ spec:
                 path: client.key
               - key: client.crt
                 path: client.crt
+              - key: ca.crt
+                path: ca.crt
+      {{- end }}
+      {{- if .Values.service.mTLS.enabled }}
+        - name: server-certs-volume
+          secret:
+            secretName: {{ include "falco-exporter.fullname" . }}-server-certs
+            items:
+              - key: server.key
+                path: server.key
+              - key: server.crt
+                path: server.crt
               - key: ca.crt
                 path: ca.crt
       {{- end }}

--- a/helmfile/upstream/falco-exporter/templates/grafana-dashboard.yaml
+++ b/helmfile/upstream/falco-exporter/templates/grafana-dashboard.yaml
@@ -4,14 +4,6 @@ data:
   grafana-falco.json: |-
     {
         "__inputs": [
-          {
-            "name": "DS_PROMETHEUS",
-            "label": "Prometheus",
-            "description": "",
-            "type": "datasource",
-            "pluginId": "prometheus",
-            "pluginName": "{{ .Values.grafanaDashboard.source }}"
-          }
         ],
         "__requires": [
           {
@@ -63,7 +55,7 @@ data:
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "${DS_PROMETHEUS}",
+            "datasource": "$datasource",
             "description": "",
             "fill": 1,
             "fillGradient": 0,
@@ -88,7 +80,7 @@ data:
             },
             "lines": true,
             "linewidth": 1,
-            "nullPointMode": "null",
+            "nullPointMode": "null as zero",
             "options": {
               "dataLinks": []
             },
@@ -102,7 +94,7 @@ data:
             "steppedLine": false,
             "targets": [
               {
-                "expr": "rate(falco_events[5m])",
+                "expr": "rate(falco_events[5m]) > 0",
                 "interval": "",
                 "intervalFactor": 1,
                 "legendFormat": "{{`{{rule}} (node=\"{{kubernetes_node}}\",ns=\"{{k8s_ns_name}}\",pod=\"{{k8s_pod_name}}\")"`}},
@@ -152,7 +144,7 @@ data:
           },
           {
             "columns": [],
-            "datasource": "${DS_PROMETHEUS}",
+            "datasource": "$datasource",
             "fontSize": "100%",
             "gridPos": {
               "h": 10,
@@ -275,6 +267,28 @@ data:
         "templating": {
           "list": []
         },
+        "templating": {
+           "list": [
+             {
+               "current": {
+                 "selected": false,
+                 "text": "{{ .Values.grafanaDashboard.prometheusDatasourceName }}",
+                 "value": "{{ .Values.grafanaDashboard.prometheusDatasourceName }}"
+               },
+               "hide": 0,
+               "includeAll": false,
+               "label": null,
+               "multi": false,
+               "name": "datasource",
+               "options": [],
+               "query": "prometheus",
+               "refresh": 1,
+               "regex": "",
+               "skipUrlSync": false,
+               "type": "datasource"
+             }
+           ]
+        },
         "time": {
           "from": "now-6h",
           "to": "now"
@@ -289,5 +303,9 @@ metadata:
   labels:
     grafana_dashboard: "1"
   name: grafana-falco
+  {{- if .Values.grafanaDashboard.namespace }}
   namespace: {{ .Values.grafanaDashboard.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end}}
 {{- end -}}

--- a/helmfile/upstream/falco-exporter/templates/prometheusrule.yaml
+++ b/helmfile/upstream/falco-exporter/templates/prometheusrule.yaml
@@ -1,0 +1,81 @@
+{{- if and .Values.prometheusRules.enabled .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "falco-exporter.fullname" . }}
+  {{- if .Values.prometheusRules.namespace }}
+  namespace: {{ .Values.prometheusRules.namespace }}
+  {{- end }}
+  labels:
+    {{- include "falco-exporter.labels" . | nindent 4 }}
+    {{- if .Values.prometheusRules.additionalLabels }}
+    {{- toYaml .Values.prometheusRules.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+  - name: falco-exporter
+    rules:
+    {{- if .Values.prometheusRules.enabled }}
+    - alert: FalcoExporterAbsent
+      expr: absent(up{job="{{- include "falco-exporter.fullname" . }}"})
+      for: 10m
+      annotations:
+        summary: Falco Exporter has dissapeared from Prometheus service discovery.
+        description: No metrics are being scraped from falco. No events will trigger any alerts.
+      labels:
+        severity: critical
+    {{- end }}
+    {{- if .Values.prometheusRules.alerts.warning.enabled }}
+    - alert: FalcoWarningEventsRateHigh
+      annotations:
+        summary: Falco is experiencing high rate of warning events
+        description: A high rate of warning events are being detected by Falco
+      expr: rate(falco_events{priority="4"}[{{ .Values.prometheusRules.alerts.warning.rate_interval }}]) > {{ .Values.prometheusRules.alerts.warning.threshold }}
+      for: 15m
+      labels:
+        severity: warning
+    {{- end }}
+    {{- if .Values.prometheusRules.alerts.error.enabled }}
+    - alert: FalcoErrorEventsRateHigh
+      annotations:
+        summary: Falco is experiencing high rate of error events
+        description: A high rate of error events are being detected by Falco
+      expr: rate(falco_events{priority="3"}[{{ .Values.prometheusRules.alerts.error.rate_interval }}]) > {{ .Values.prometheusRules.alerts.error.threshold }}
+      for: 15m
+      labels:
+        severity: warning
+    {{- end }}
+    {{- if .Values.prometheusRules.alerts.critical.enabled }}
+    - alert: FalcoCriticalEventsRateHigh
+      annotations:
+        summary: Falco is experiencing high rate of critical events
+        description: A high rate of critical events are being detected by Falco
+      expr: rate(falco_events{priority="2"}[{{ .Values.prometheusRules.alerts.critical.rate_interval }}]) > {{ .Values.prometheusRules.alerts.critical.threshold }}
+      for: 15m
+      labels:
+        severity: critical
+    {{- end }}
+    {{- if .Values.prometheusRules.alerts.alert.enabled }}
+    - alert: FalcoAlertEventsRateHigh
+      annotations:
+        summary: Falco is experiencing high rate of alert events
+        description: A high rate of alert events are being detected by Falco
+      expr: rate(falco_events{priority="1"}[{{ .Values.prometheusRules.alerts.alert.rate_interval }}]) > {{ .Values.prometheusRules.alerts.alert.threshold }}
+      for: 5m
+      labels:
+        severity: critical
+    {{- end }}
+    {{- if .Values.prometheusRules.alerts.emergency.enabled }}
+    - alert: FalcoEmergencyEventsRateHigh
+      annotations:
+        summary: Falco is experiencing high rate of emergency events
+        description: A high rate of emergency events are being detected by Falco
+      expr: rate(falco_events{priority="0"}[{{ .Values.prometheusRules.alerts.emergency.rate_interval }}]) > {{ .Values.prometheusRules.alerts.emergency.threshold }}
+      for: 1m
+      labels:
+        severity: critical
+    {{- end }}
+    {{- with .Values.prometheusRules.additionalAlerts }}
+    {{ . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/helmfile/upstream/falco-exporter/templates/role.yaml
+++ b/helmfile/upstream/falco-exporter/templates/role.yaml
@@ -3,13 +3,13 @@ kind: Role
 apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   name: {{ include "falco-exporter.podSecurityPolicyName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "falco-exporter.labels" . | nindent 4 }}
   {{- with .Values.podSecurityPolicy.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
     - policy

--- a/helmfile/upstream/falco-exporter/templates/rolebinding.yaml
+++ b/helmfile/upstream/falco-exporter/templates/rolebinding.yaml
@@ -3,13 +3,13 @@ kind: RoleBinding
 apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   name: {{ include "falco-exporter.podSecurityPolicyName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "falco-exporter.labels" . | nindent 4 }}
   {{- with .Values.podSecurityPolicy.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "falco-exporter.serviceAccountName" . }}

--- a/helmfile/upstream/falco-exporter/templates/secret-certs.yaml
+++ b/helmfile/upstream/falco-exporter/templates/secret-certs.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "falco-exporter.fullname" . }}-certs
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "falco-exporter.labels" . | nindent 4 }}
 type: Opaque

--- a/helmfile/upstream/falco-exporter/templates/securitycontextconstraints.yaml
+++ b/helmfile/upstream/falco-exporter/templates/securitycontextconstraints.yaml
@@ -6,6 +6,7 @@ metadata:
     kubernetes.io/description: |
       This provides the minimum requirements Falco-exporter to run in Openshift.
   name: {{ template "falco-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "falco-exporter.labels" . | nindent 4 }}
 allowHostDirVolumePlugin: true

--- a/helmfile/upstream/falco-exporter/templates/server-secret-certs.yaml
+++ b/helmfile/upstream/falco-exporter/templates/server-secret-certs.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.service.mTLS.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "falco-exporter.fullname" . }}-server-certs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "falco-exporter.labels" . | nindent 4 }}
+type: Opaque
+data:
+  server.crt: {{ .Values.service.mTLS.server.crt | b64enc | quote }}
+  server.key: {{ .Values.service.mTLS.server.key | b64enc | quote }}
+  ca.crt: {{ .Values.service.mTLS.ca.crt | b64enc | quote }}
+{{- end }}

--- a/helmfile/upstream/falco-exporter/templates/servicemonitor.yaml
+++ b/helmfile/upstream/falco-exporter/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.serviceMonitor.enabled }}
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/helmfile/upstream/falco-exporter/values.yaml
+++ b/helmfile/upstream/falco-exporter/values.yaml
@@ -12,10 +12,17 @@ service:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9376"
+  # Enable Mutual TLS for HTTP metrics server
+  mTLS:
+    enabled: false
+
+# /readiness and /liveness probes port
+probesPort: 19376
 
 image:
+  registry: docker.io
   repository: falcosecurity/falco-exporter
-  tag: 0.3.0
+  tag: 0.7.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -47,10 +54,17 @@ podSecurityPolicy:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+daemonset:
+  # Annotations to add to the DaemonSet pods
+  annotations: {}
+  podLabels: {}
+
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -58,7 +72,8 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -92,7 +107,33 @@ serviceMonitor:
 grafanaDashboard:
   enabled: false
   namespace: default
-
+  prometheusDatasourceName: Prometheus
 scc:
   # true here enabled creation of Security Context Constraints in Openshift
   create: true
+
+# Create PrometheusRules for alerting on priority events
+prometheusRules:
+  enabled: false
+  alerts:
+    warning:
+      enabled: true
+      rate_interval: "5m"
+      threshold: 0
+    error:
+      enabled: true
+      rate_interval: "5m"
+      threshold: 0
+    critical:
+      enabled: true
+      rate_interval: "5m"
+      threshold: 0
+    alert:
+      enabled: true
+      rate_interval: "5m"
+      threshold: 0
+    emergency:
+      enabled: true
+      rate_interval: "1m"
+      threshold: 0
+    additionalAlerts: {}

--- a/helmfile/values/falco-exporter.yaml.gotmpl
+++ b/helmfile/values/falco-exporter.yaml.gotmpl
@@ -1,7 +1,3 @@
-image:
-  tag: 0.3.0
-  pullPolicy: IfNotPresent
-
 resources: {{- toYaml .Values.falco.falcoExporter.resources | nindent 2  }}
 nodeSelector: {{- toYaml .Values.falco.falcoExporter.nodeSelector | nindent 2  }}
 affinity: {{- toYaml .Values.falco.falcoExporter.affinity | nindent 2  }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump falco-exporter chart to v0.8.0

**Which issue this PR fixes** : fixes elastisys/compliantkubernetes-apps#807 

**Special notes for reviewer**:
Falco-exporter was running and I was able to get metrics from it after upgrade.

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [X] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
