### PR TITLE
apps wc: Added groups for alertmanager rbac

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - `prometheus-blackbox-exporter's` internal thanos servicemonitor changed name to avoid name collisions.
 - dex `topologySpreadConstraints` matchLabel was changed from `app: dex` to `app.kubernetes.io/name: dex` to increase stability of replica placements.
+- Fixed issue where user admin groups wasn't added to the user alertmanager rolebinding
 
 ### Added
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Bump falco-exporter chart to v0.8.0.
+- Users are now not forced to use proxy for connecting to alertmanager but can use port-forward as well.
 
 ### Fixed
 

--- a/helmfile/charts/user-alertmanager/templates/role.yaml
+++ b/helmfile/charts/user-alertmanager/templates/role.yaml
@@ -69,3 +69,11 @@ rules:
   - roles
   verbs:
   - bind
+- apiGroups:
+  - ""
+  resources:
+  - pods/portforward
+  verbs:
+  - create
+  resourceNames:
+  - alertmanager-alertmanager-0

--- a/helmfile/charts/user-alertmanager/templates/rolebinding.yaml
+++ b/helmfile/charts/user-alertmanager/templates/rolebinding.yaml
@@ -13,3 +13,8 @@ subjects:
   kind: User
   name: {{ $user }}
 {{- end }}
+{{- range $group := .Values.groups }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: {{ $group }}
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Added group support for user-alertmanger and port-forward support

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
