### PR TITLE
apps sc: Added field mapping metric for opensearch

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -18,5 +18,6 @@
 ### Added
 
 - Add option to encrypt off-site buckets replicated with rclone sync
+- Added metrics for field mappings and an alert that will throw an error if the fields get close to the max limit.
 
 ### Removed

--- a/helmfile/charts/prometheus-alerts/templates/alerts/opensearch.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/alerts/opensearch.yaml
@@ -42,4 +42,20 @@ spec:
       annotations:
         description: OpenSearch disk full Warning
         summary: OpenSearch disk full Warning
+    - alert: OpenSearchFieldLimit
+      expr: (sum(elasticsearch_indices_mappings_stats_fields) by (index) / sum(elasticsearch_indices_settings_total_fields) by (index)) * 100 > 80
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        description: Index {{`{{ $labels.index }}`}} is using {{`{{ $value }}`}} percent of max field limit
+        summary: Index {{`{{ $labels.index }}`}} is using {{`{{ $value }}`}} percent of max field limit
+    - alert: OpenSearchFieldLimit
+      expr: (sum(elasticsearch_indices_mappings_stats_fields) by (index) / sum(elasticsearch_indices_settings_total_fields) by (index)) * 100 > 95
+      for: 15m
+      labels:
+        severity: critical
+      annotations:
+        description: Index {{`{{ $labels.index }}`}} is using {{`{{ $value }}`}} percent of max field limit
+        summary: Index {{`{{ $labels.index }}`}} is using {{`{{ $value }}`}} percent of max field limit
 {{- end }}

--- a/helmfile/values/opensearch/configurer.yaml.gotmpl
+++ b/helmfile/values/opensearch/configurer.yaml.gotmpl
@@ -163,6 +163,7 @@ config:
           allowed_actions:
           - "indices:monitor/stats"
           - "indices:monitor/settings/get"
+          - "indices:admin/mappings/get"
     {{- with .Values.opensearch.extraRoles }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/helmfile/values/prometheus-elasticsearch-exporter.yaml.gotmpl
+++ b/helmfile/values/prometheus-elasticsearch-exporter.yaml.gotmpl
@@ -8,7 +8,7 @@ es:
   shards: true
   snapshots: true
   cluster_settings: false
-  indices_mappings: false
+  indices_mappings: true
   {{- if or (contains "m" .Values.opensearch.exporter.serviceMonitor.scrapeTimeout) (contains "h" .Values.opensearch.exporter.serviceMonitor.scrapeTimeout) }}
   {{- fail "scrapeTimeout must only be given in seconds" }}
   {{ else }}


### PR DESCRIPTION
**What this PR does / why we need it**:

We want to be notified before customers hit the field limit. 

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1031

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
