### PR TITLE
apps sc: Add securityadmin job and alerting roles

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Bump falco-exporter chart to v0.8.0.
 - Users are now not forced to use proxy for connecting to alertmanager but can use port-forward as well.
+- The OpenSearch security config will now be managed completely by securityadmin
 
 ### Fixed
 
@@ -26,6 +27,10 @@
 
 - Add option to encrypt off-site buckets replicated with rclone sync
 - Added metrics for field mappings and an alert that will throw an error if the fields get close to the max limit.
+- Add support for automatic reloading of the security config for OpenSearch
+  - **Warning**: When this runs the security plugin settings will be reset. All users, roles, and role mappings created via the API will be removed, so create a backup or be prepared to recreate the resources.
+  - The securityadmin can be disabled to protect manually created resources, but it will prevent the OpenSearch cluster to initialize the security plugin when the cluster is forming.
+- Add missing roles for alerting in OpenSearch
 
 ### Removed
 - wcReader mentions from all configs files

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -651,6 +651,19 @@ opensearch:
     nodeSelector: {}
     tolerations: []
 
+  # Initializes and reconfigures the OpenSearch security plugin
+  # Disable after the cluster is initialized to prevent it from removing manually created user, roles, role mappings, etc.
+  securityadmin:
+    enabled: true
+    activeDeadlineSeconds: 1200
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 250m
+        memory: 256Mi
+
   # Config for https://www.elastic.co/guide/en/elasticsearch/client/curator/5.8/about.html
   curator:
     enabled: true

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -268,6 +268,7 @@ releases:
   chart: ./upstream/opensearch
   version: 1.7.1
   installed: true
+  wait: true
   needs:
   {{- if .Values.opensearch.sso.enabled }}
   - dex/dex
@@ -313,6 +314,7 @@ releases:
   chart: ./upstream/opensearch-dashboards
   version: 1.1.2
   installed: true
+  wait: true
   needs:
   - opensearch-system/opensearch-master
   values:
@@ -328,7 +330,7 @@ releases:
   installed: {{ .Values.opensearch.snapshot.enabled }}
   missingFileHandler: Error
   needs:
-  - opensearch-system/opensearch-master
+  - opensearch-system/opensearch-configurer
   values:
   - values/opensearch/backup.yaml.gotmpl
 
@@ -342,7 +344,7 @@ releases:
   installed: {{ .Values.opensearch.snapshot.enabled }}
   missingFileHandler: Error
   needs:
-  - opensearch-system/opensearch-master
+  - opensearch-system/opensearch-configurer
   values:
   - values/opensearch/slm.yaml.gotmpl
 
@@ -356,9 +358,22 @@ releases:
   installed: {{ .Values.opensearch.curator.enabled }}
   missingFileHandler: Error
   needs:
-  - opensearch-system/opensearch-master
+  - opensearch-system/opensearch-configurer
   values:
   - values/opensearch/curator.yaml.gotmpl
+
+- name: opensearch-securityadmin
+  namespace: opensearch-system
+  labels:
+    app: opensearch-securityadmin
+    group: opensearch
+  chart: ./charts/opensearch/securityadmin
+  version: 0.1.0
+  installed: {{ .Values.opensearch.securityadmin.enabled }}
+  needs:
+  - opensearch-system/opensearch-master
+  values:
+  - values/opensearch/securityadmin.yaml.gotmpl
 
 - name: opensearch-configurer
   namespace: opensearch-system
@@ -369,9 +384,14 @@ releases:
   version: 0.1.0
   installed: true
   needs:
+  {{- if .Values.opensearch.securityadmin.enabled }}
+  - opensearch-system/opensearch-securityadmin
+  {{- else }}
   - opensearch-system/opensearch-master
+  {{- end }}
   - opensearch-system/opensearch-dashboards
   values:
+  - values/opensearch/securityadmin.yaml.gotmpl
   - values/opensearch/configurer.yaml.gotmpl
 
 # prometheus-elasticsearch-exporter
@@ -385,7 +405,7 @@ releases:
   installed: true
   missingFileHandler: Error
   needs:
-  - opensearch-system/opensearch-master
+  - opensearch-system/opensearch-configurer
   values:
   - values/prometheus-elasticsearch-exporter.yaml.gotmpl
 

--- a/helmfile/charts/opensearch/configurer/templates/job.yaml
+++ b/helmfile/charts/opensearch/configurer/templates/job.yaml
@@ -9,6 +9,7 @@ metadata:
     # Use higher value so that the secret is created before this job
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": {{ .Values.helm.deletePolicy }}
+    checksum/securityconfig: {{ print .Values.securityConfig | sha256sum }}
 spec:
   activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds }}
   backoffLimit: {{ .Values.backoffLimit }}

--- a/helmfile/charts/opensearch/configurer/values.yaml
+++ b/helmfile/charts/opensearch/configurer/values.yaml
@@ -9,6 +9,9 @@ baseDomain: ""
 nameOverride: ""
 fullnameOverride: ""
 
+# Only used to template a checksum, the config is loaded via secret.
+securityConfig: {}
+
 opensearch:
   userSecret: opensearch-configurer-user
   clusterEndpoint: opensearch-cluster-master:9200

--- a/helmfile/charts/opensearch/securityadmin/.helmignore
+++ b/helmfile/charts/opensearch/securityadmin/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helmfile/charts/opensearch/securityadmin/Chart.yaml
+++ b/helmfile/charts/opensearch/securityadmin/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: opensearch-securityadmin
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/helmfile/charts/opensearch/securityadmin/templates/NOTES.txt
+++ b/helmfile/charts/opensearch/securityadmin/templates/NOTES.txt
@@ -1,0 +1,2 @@
+
+>>> Make sure to run opensearch-configurer afterwards!

--- a/helmfile/charts/opensearch/securityadmin/templates/_helpers.tpl
+++ b/helmfile/charts/opensearch/securityadmin/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "securityadmin.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "securityadmin.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "securityadmin.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "securityadmin.labels" -}}
+helm.sh/chart: {{ include "securityadmin.chart" . }}
+{{ include "securityadmin.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "securityadmin.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "securityadmin.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "securityadmin.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "securityadmin.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helmfile/charts/opensearch/securityadmin/templates/job.yaml
+++ b/helmfile/charts/opensearch/securityadmin/templates/job.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "securityadmin.fullname" . }}
+  annotations:
+    helm.sh/hook: {{ .Values.helm.hook }}
+    helm.sh/hook-delete-policy: {{ .Values.helm.deletePolicy }}
+    checksum/securityconfig: {{ print .Values.securityConfig | sha256sum }}
+  labels:
+    {{- include "securityadmin.labels" . | nindent 4 }}
+spec:
+  activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds }}
+  backoffLimit: {{ .Values.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "securityadmin.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          command:
+            - /usr/share/opensearch/plugins/opensearch-security/tools/securityadmin.sh
+          args:
+            - -h
+            - "$(OPENSEARCH_HOST)"
+            - -p
+            - "$(OPENSEARCH_PORT)"
+            - -cd
+            - /etc/config/security/
+            - -icl
+            - -nhnv
+            - -cacert
+            - /etc/cert/admin/ca.crt
+            - -cert
+            - /etc/cert/admin/tls.crt
+            - -key
+            - /etc/cert/admin/tls.key
+          env:
+            - name: OPENSEARCH_HOST
+              value: "{{ .Values.opensearch.clusterService }}"
+            - name: OPENSEARCH_PORT
+              value: "{{ .Values.opensearch.clusterPort }}"
+          volumeMounts:
+            - name: admin-cert
+              mountPath: /etc/cert/admin
+            - name: security-config
+              mountPath: /etc/config/security
+          {{- with .Values.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: admin-cert
+          secret:
+            secretName: {{ .Values.opensearch.adminCertSecret }}
+        - name: security-config
+          secret:
+            secretName: {{ .Values.opensearch.securityConfigSecret }}

--- a/helmfile/charts/opensearch/securityadmin/templates/secret.yaml
+++ b/helmfile/charts/opensearch/securityadmin/templates/secret.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.opensearch.securityConfigSecret }}
+  annotations:
+    helm.sh/hook: {{ .Values.helm.hook }}
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: {{ .Values.helm.deletePolicy }}
+  labels:
+    {{- include "securityadmin.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- toYaml .Values.securityConfig | nindent 2 }}

--- a/helmfile/charts/opensearch/securityadmin/values.yaml
+++ b/helmfile/charts/opensearch/securityadmin/values.yaml
@@ -1,0 +1,39 @@
+fullnameOverride: ""
+nameOverride: ""
+
+imagePullSecrets: []
+image:
+  repository: opensearchproject/opensearch
+  pullPolicy: IfNotPresent
+  tag: 1.2.4
+
+helm:
+  hook: post-install,post-upgrade
+  deletePolicy: before-hook-creation,hook-failed
+
+# Only used to template a checksum, the config is loaded via secret.
+securityConfig: {}
+
+opensearch:
+  clusterService: opensearch-master
+  clusterPort: 9300
+
+  adminCertSecret: opensearch-admin-cert
+  securityConfigSecret: opensearch-securityconfig
+
+activeDeadlineSeconds: 600
+backoffLimit: 10
+
+podSecurityContext:
+  fsGroup: 1000
+  runAsUser: 1000
+
+securityContext: {}
+
+tolerations: []
+nodeSelector: {}
+affinity: {}
+
+resources:
+  requests: {}
+  limits: {}

--- a/helmfile/values/opensearch/common.yaml.gotmpl
+++ b/helmfile/values/opensearch/common.yaml.gotmpl
@@ -42,7 +42,7 @@ config:
           http:
             enabled: false
         allow_unsafe_democertificates: false
-        allow_default_init_securityindex: true
+        allow_default_init_securityindex: false
         authcz:
           admin_dn:
             - "CN=admin.opensearch-system.cluster.local,O=compliantkubernetes"
@@ -110,10 +110,6 @@ extraInitContainers:
       runAsUser: 0
 
 secretMounts:
-  - secretName: opensearch-admin-cert
-    name: opensearch-admin-cert
-    path: /usr/share/opensearch/config/admin
-    defaultMode: 0400
   - secretName: opensearch-transport-cert
     name: opensearch-transport-cert
     path: /usr/share/opensearch/config/transport
@@ -128,133 +124,6 @@ podSecurityPolicy:
 
 networkPolicy:
   create: true
-
-securityConfig:
-  config:
-    data:
-      config.yml: |-
-        _meta:
-          type: "config"
-          config_version: 2
-
-        config:
-          dynamic:
-            authc:
-              basic_internal_auth_domain:
-                description: "Authenticate via HTTP Basic against internal users database"
-                http_enabled: true
-                transport_enabled: true
-                order: 0
-                http_authenticator:
-                  type: basic
-                  challenge: false
-                authentication_backend:
-                  type: internal
-              {{ if .Values.opensearch.sso.enabled }}
-              openid_auth_domain:
-                description: "OpenID Connect"
-                http_enabled: true
-                transport_enabled: true
-                order: 1
-                http_authenticator:
-                  type: openid
-                  challenge: false
-                  config:
-                    openid_connect_url: http://dex.dex.svc.cluster.local:5556/.well-known/openid-configuration
-                    openid_connect_idp:
-                      enable_ssl: false
-                      verify_hostnames: false
-                    subject_key: {{ .Values.opensearch.sso.subjectKey }}
-                    roles_key: {{ .Values.opensearch.sso.rolesKey }}
-                authentication_backend:
-                  type: noop
-              {{ end }}
-
-      internal_users.yml: |-
-        _meta:
-          type: "internalusers"
-          config_version: 2
-
-        admin:
-          hash: {{ .Values.opensearch.adminHash }}
-          reserved: true
-          opendistro_security_roles:
-          - "all_access"
-          - "manage_snapshots"
-          description: "Admin user"
-
-        dashboards:
-          hash: {{ .Values.opensearch.dashboardsHash }}
-          reserved: true
-          opendistro_security_roles:
-          - "kibana_server"
-          description: "OpenSearch Dashboards user"
-
-        configurer:
-          hash: {{ .Values.opensearch.configurerHash }}
-          reserved: true
-          opendistro_security_roles:
-          - "kibana_user"
-          - "configurer"
-          description: "Configurer user"
-
-      roles.yml: |-
-        _meta:
-          type: "roles"
-          config_version: 2
-
-        # Can probably be locked down further
-        configurer:
-          static: false
-          hidden: false
-          reserved: false
-          cluster_permissions:
-          - "cluster:admin/repository/put"
-          - "cluster_manage_index_templates"
-          - "cluster:admin/opendistro/ism/policy/*"
-          index_permissions:
-          - index_patterns:
-            - "*"
-            allowed_actions:
-            - "create_index"
-            - "crud"
-            - "manage_aliases"
-            - "indices:admin/index_template/*"
-            - "indices:admin/opensearch/ism/managedindex"
-            - "indices:admin/rollover"
-            - "indices:monitor/stats"
-
-      # Needed
-      roles_mapping.yml: |-
-        _meta:
-          type: "rolesmapping"
-          config_version: 2
-
-      # Needed
-      tenants.yml: |-
-        _meta:
-          type: "tenants"
-          config_version: 2
-
-      # Needed
-      action_groups.yml: |-
-        _meta:
-          type: "actiongroups"
-          config_version: 2
-
-      # Optional
-      nodes_dn.yml: |-
-        _meta:
-          type: "nodesdn"
-          config_version: 2
-
-      # Optional
-      whitelist.yml: |-
-        _meta:
-          type: "whitelist"
-          config_version: 2
-        config:
-          enabled: false
 
 {{- if .Values.opensearch.snapshot.enabled }}
 keystore:

--- a/helmfile/values/opensearch/configurer.yaml.gotmpl
+++ b/helmfile/values/opensearch/configurer.yaml.gotmpl
@@ -13,9 +13,6 @@ resources:
    cpu: 10m
    memory: 32Mi
 
-helm:
-  deletePolicy: before-hook-creation
-
 dashboard:
   ck8sVersion: {{ .Values.global.ck8sVersion }}
 

--- a/helmfile/values/opensearch/securityadmin.yaml.gotmpl
+++ b/helmfile/values/opensearch/securityadmin.yaml.gotmpl
@@ -1,0 +1,162 @@
+opensearch:
+  clusterService: {{ .Values.opensearch.clusterName }}-master
+
+securityConfig:
+  config.yml: |-
+    _meta:
+      type: "config"
+      config_version: 2
+
+    config:
+      dynamic:
+        authc:
+          basic_internal_auth_domain:
+            description: "Authenticate via HTTP Basic against internal users database"
+            http_enabled: true
+            transport_enabled: true
+            order: 0
+            http_authenticator:
+              type: basic
+              challenge: false
+            authentication_backend:
+              type: internal
+
+          {{ if .Values.opensearch.sso.enabled -}}
+          openid_auth_domain:
+            description: "OpenID Connect"
+            http_enabled: true
+            transport_enabled: true
+            order: 1
+            http_authenticator:
+              type: openid
+              challenge: false
+              config:
+                openid_connect_url: http://dex.dex.svc.cluster.local:5556/.well-known/openid-configuration
+                openid_connect_idp:
+                  enable_ssl: false
+                  verify_hostnames: false
+                subject_key: {{ .Values.opensearch.sso.subjectKey }}
+                roles_key: {{ .Values.opensearch.sso.rolesKey }}
+            authentication_backend:
+              type: noop
+          {{- end }}
+
+  internal_users.yml: |-
+    _meta:
+      type: "internalusers"
+      config_version: 2
+
+    admin:
+      hash: {{ .Values.opensearch.adminHash }}
+      reserved: true
+      opendistro_security_roles:
+      - "all_access"
+      - "manage_snapshots"
+      description: "Admin user"
+
+    dashboards:
+      hash: {{ .Values.opensearch.dashboardsHash }}
+      reserved: true
+      opendistro_security_roles:
+      - "kibana_server"
+      description: "OpenSearch Dashboards user"
+
+    configurer:
+      hash: {{ .Values.opensearch.configurerHash }}
+      reserved: true
+      opendistro_security_roles:
+      - "kibana_user"
+      - "configurer"
+      description: "Configurer user"
+
+  roles.yml: |-
+    _meta:
+      type: "roles"
+      config_version: 2
+
+    # Allows users to view monitors, destinations and alerts
+    alerting_read_access:
+      reserved: false
+      cluster_permissions:
+        - cluster:admin/opendistro/alerting/alerts/get
+        - cluster:admin/opendistro/alerting/destination/get
+        - cluster:admin/opendistro/alerting/monitor/get
+        - cluster:admin/opendistro/alerting/monitor/search
+
+    # Allows users to view and acknowledge alerts
+    alerting_ack_alerts:
+      reserved: false
+      cluster_permissions:
+        - cluster:admin/opendistro/alerting/alerts/*
+
+    # Allows users to use all alerting functionality
+    alerting_full_access:
+      reserved: false
+      cluster_permissions:
+        - cluster_monitor
+        - cluster:admin/opendistro/alerting/*
+      index_permissions:
+        - index_patterns:
+            - kubernetes-*
+            - kubeaudit-*
+          allowed_actions:
+            - indices_monitor
+            - indices:admin/aliases/get
+            - indices:admin/mappings/get
+
+    # Can probably be locked down further
+    configurer:
+      static: false
+      hidden: false
+      reserved: false
+      cluster_permissions:
+      - "cluster:admin/repository/put"
+      - "cluster_manage_index_templates"
+      - "cluster:admin/opendistro/ism/policy/*"
+      index_permissions:
+      - index_patterns:
+        - "*"
+        allowed_actions:
+        - "create_index"
+        - "crud"
+        - "manage_aliases"
+        - "indices:admin/index_template/*"
+        - "indices:admin/opensearch/ism/managedindex"
+        - "indices:admin/rollover"
+        - "indices:monitor/stats"
+
+  # Needed
+  roles_mapping.yml: |-
+    _meta:
+      type: "rolesmapping"
+      config_version: 2
+
+  # Needed
+  tenants.yml: |-
+    _meta:
+      type: "tenants"
+      config_version: 2
+
+  # Needed
+  action_groups.yml: |-
+    _meta:
+      type: "actiongroups"
+      config_version: 2
+
+  # Optional
+  nodes_dn.yml: |-
+    _meta:
+      type: "nodesdn"
+      config_version: 2
+
+  # Optional
+  whitelist.yml: |-
+    _meta:
+      type: "whitelist"
+      config_version: 2
+    config:
+      enabled: false
+
+activeDeadlineSeconds: {{ .Values.opensearch.securityadmin.activeDeadlineSeconds }}
+
+resources: {{- toYaml .Values.opensearch.securityadmin.resources | nindent 2 }}

--- a/migration/v0.22.x-v0.23.x/migrate-opensearch-roles.sh
+++ b/migration/v0.22.x-v0.23.x/migrate-opensearch-roles.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
+sc_config="${CK8S_CONFIG_PATH}/sc-config.yaml"
+if [[ ! -f "${sc_config}" ]]; then
+    echo "Override sc-config does not exist, aborting."
+    exit 1
+fi
+
+read_access='{"cluster_permissions":["cluster:admin/opendistro/alerting/alerts/get","cluster:admin/opendistro/alerting/destination/get","cluster:admin/opendistro/alerting/monitor/get","cluster:admin/opendistro/alerting/monitor/search"]}'
+ack_alerts='{"cluster_permissions":["cluster:admin/opendistro/alerting/alerts/*"]}'
+full_access='{"cluster_permissions":["cluster_monitor","cluster:admin/opendistro/alerting/*"],"index_permissions":[{"allowed_actions":["indices_monitor","indices:admin/aliases/get","indices:admin/mappings/get"],"index_patterns":["kubernetes-*","kubeaudit-*"]}]}'
+
+migrate() {
+    echo "$1:"
+
+    role=$(yq r -j "$sc_config" "opensearch.extraRoles[role_name==$1].definition" | jq -cS)
+
+    if [ -z "$role" ]; then
+        echo "- missing role, skipping"
+
+    elif yq x <(echo "$role") <(echo "$2") -P; then
+        echo "- identical role, clearing"
+        yq d -i "$sc_config" "opensearch.extraRoles[role_name==$1]"
+
+    else
+        echo -n "- modified role, clear from $sc_config?: [y/N]: "
+        read -r reply
+        if [[ "${reply}" != "y" ]]; then
+            echo "- skipping"
+        else
+            echo "- clearing"
+            yq d -i "$sc_config" "opensearch.extraRoles[role_name==$1]"
+        fi
+    fi
+
+    mapping=$(yq r -j "$sc_config" "opensearch.extraRoleMappings[mapping_name==$1]" | jq -cS)
+    if [ -z "$mapping" ]; then
+        echo "- missing mapping, adding"
+        yq w -i -P "$sc_config" "opensearch.extraRoleMappings[+].mapping_name" "$1"
+        yq w -i -P "$sc_config" "opensearch.extraRoleMappings[mapping_name==$1].definition.users[0]" "set-me"
+    else
+        echo "- existing mapping, skipping"
+    fi
+
+    echo
+}
+
+migrate "alerting_read_access" "$read_access"
+migrate "alerting_ack_alerts" "$ack_alerts"
+migrate "alerting_full_access" "$full_access"
+
+if [ "$(yq r "$sc_config" "opensearch.extraRoles")" = "[]" ]; then
+    yq d -i "$sc_config" "opensearch.extraRoles"
+fi
+
+echo "done"

--- a/migration/v0.22.x-v0.23.x/upgrade-apps.md
+++ b/migration/v0.22.x-v0.23.x/upgrade-apps.md
@@ -10,6 +10,25 @@
     bin/ck8s init
     ```
 1. Check if any of the [deprecated configurations](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.1.3/Changelog.md#113) are present in the wc-config.yaml
+
+1. **Warning** regarding OpenSearch securityadmin:
+
+    The new securityadmin job will reset the security plugin when it runs.
+    This means that any user, role, role mapping etc. that was created manually will be removed.
+
+    Either prepare a backup to restore after it runs, or consider disabling securityadmin to protect manually created resources.
+
+1. Migrate OpenSearch alerting roles:
+
+    > Skip this step if securityadmin was disabled in the previous step.
+
+    This will help clear out alerting roles comparing them to the new default ones.
+    As well as add example mappings for the new default roles.
+
+    ```bash
+    ./migration/v0.22.x-v0.23.x/migrate-opensearch-roles.sh
+    ```
+
 1. Upgrade applications:
 
     ```bash

--- a/pipeline/lint.bash
+++ b/pipeline/lint.bash
@@ -31,6 +31,7 @@ charts_ignore_list=(
   "app!=opensearch-client"
   "app!=opensearch-dashboards"
   "app!=opensearch-secrets"
+  "app!=opensearch-securityadmin"
   "app!=opensearch-configurer"
   "app!=falco"
   "app!=falco-exporter"


### PR DESCRIPTION
**What this PR does / why we need it**:
To automatically reload security config in OpenSearch.
To use the "predefined" alerting roles.

**Which issue this PR fixes**:
Fixes #804 

**Special notes for reviewer**:
I figured it was best to set it up as a separate job since it would allow a simple way to disable it completely, and you also get a release you can sync to run it manually.

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
