### PR TITLE
ingress-nginx: upgrade helm chart to v4.1.3

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -3,6 +3,13 @@
 ### Updated
 
 - Update the Velero plugin for AWS to v1.3.1
+- Updated ingress-nginx helm chart to v4.1.3 and ingress-nginx controller image to v1.2.1
+   > **Breaking changes**
+      - deprecated http2_recv_timeout in favor of client_header_timeout (client-header-timeout);
+      - deprecated http2_max_field_size (http2-max-field-size) and http2_max_header_size (http2-max-header-size) in favor of large_client_header_buffers (large-client-header-buffers);
+      - deprecated http2_idle_timeout and http2_max_requests (http2-max-requests) in favor of keepalive_timeout (upstream-keepalive-timeout?) and keepalive_requests (upstream-keepalive-requests?) respectively;
+      - added an option to jail/chroot the nginx process, inside the controller container, is being introduced;
+      - implemented an object deep inspector. The inspection is a walk through of all the spec, checking for possible attempts to escape configs.
 
 ### Changed
 

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -55,7 +55,7 @@ releases:
   labels:
     app: ingress-nginx
   chart: ./upstream/ingress-nginx
-  version: 3.34.0
+  version: 4.1.3
   missingFileHandler: Error
   wait: true
   values:

--- a/helmfile/upstream/ingress-nginx/CHANGELOG.md
+++ b/helmfile/upstream/ingress-nginx/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.1.2
+
+- "[8587](https://github.com/kubernetes/ingress-nginx/pull/8587) Add CAP_SYS_CHROOT to DS/PSP when needed"
+- "[8458](https://github.com/kubernetes/ingress-nginx/pull/8458) Add portNamePreffix Helm chart parameter"
+- "[8522](https://github.com/kubernetes/ingress-nginx/pull/8522) Add documentation for controller.service.loadBalancerIP in Helm chart"
+
+### 4.1.0
+
+- "[8481](https://github.com/kubernetes/ingress-nginx/pull/8481) Fix log creation in chroot script"
+- "[8479](https://github.com/kubernetes/ingress-nginx/pull/8479) changed nginx base img tag to img built with alpine3.14.6"
+- "[8478](https://github.com/kubernetes/ingress-nginx/pull/8478) update base images and protobuf gomod"
+- "[8468](https://github.com/kubernetes/ingress-nginx/pull/8468) Fallback to ngx.var.scheme for redirectScheme with use-forward-headers when X-Forwarded-Proto is empty"
+- "[8456](https://github.com/kubernetes/ingress-nginx/pull/8456) Implement object deep inspector"
+- "[8455](https://github.com/kubernetes/ingress-nginx/pull/8455) Update dependencies"
+- "[8454](https://github.com/kubernetes/ingress-nginx/pull/8454) Update index.md"
+- "[8447](https://github.com/kubernetes/ingress-nginx/pull/8447) typo fixing"
+- "[8446](https://github.com/kubernetes/ingress-nginx/pull/8446) Fix suggested annotation-value-word-blocklist"
+- "[8444](https://github.com/kubernetes/ingress-nginx/pull/8444) replace deprecated topology key in example with current one"
+- "[8443](https://github.com/kubernetes/ingress-nginx/pull/8443) Add dependency review enforcement"
+- "[8434](https://github.com/kubernetes/ingress-nginx/pull/8434) added new auth-tls-match-cn annotation"
+- "[8426](https://github.com/kubernetes/ingress-nginx/pull/8426) Bump github.com/prometheus/common from 0.32.1 to 0.33.0"
+
+### 4.0.18
+
+- "[8291](https://github.com/kubernetes/ingress-nginx/pull/8291) remove git tag env from cloud build"
+- "[8286](https://github.com/kubernetes/ingress-nginx/pull/8286) Fix OpenTelemetry sidecar image build"
+- "[8277](https://github.com/kubernetes/ingress-nginx/pull/8277) Add OpenSSF Best practices badge"
+- "[8273](https://github.com/kubernetes/ingress-nginx/pull/8273) Issue#8241"
+- "[8267](https://github.com/kubernetes/ingress-nginx/pull/8267) Add fsGroup value to admission-webhooks/job-patch charts"
+- "[8262](https://github.com/kubernetes/ingress-nginx/pull/8262) Updated confusing error"
+- "[8256](https://github.com/kubernetes/ingress-nginx/pull/8256) fix: deny locations with invalid auth-url annotation"
+- "[8253](https://github.com/kubernetes/ingress-nginx/pull/8253) Add a certificate info metric"
+- "[8236](https://github.com/kubernetes/ingress-nginx/pull/8236) webhook: remove useless code."
+- "[8227](https://github.com/kubernetes/ingress-nginx/pull/8227) Update libraries in webhook image"
+- "[8225](https://github.com/kubernetes/ingress-nginx/pull/8225) fix inconsistent-label-cardinality for prometheus metrics: nginx_ingress_controller_requests"
+- "[8221](https://github.com/kubernetes/ingress-nginx/pull/8221) Do not validate ingresses with unknown ingress class in admission webhook endpoint"
+- "[8210](https://github.com/kubernetes/ingress-nginx/pull/8210) Bump github.com/prometheus/client_golang from 1.11.0 to 1.12.1"
+- "[8209](https://github.com/kubernetes/ingress-nginx/pull/8209) Bump google.golang.org/grpc from 1.43.0 to 1.44.0"
+- "[8204](https://github.com/kubernetes/ingress-nginx/pull/8204) Add Artifact Hub lint"
+- "[8203](https://github.com/kubernetes/ingress-nginx/pull/8203) Fix Indentation of example and link to cert-manager tutorial"
+- "[8201](https://github.com/kubernetes/ingress-nginx/pull/8201) feat(metrics): add path and method labels to requests countera"
+- "[8199](https://github.com/kubernetes/ingress-nginx/pull/8199) use functional options to reduce number of methods creating an EchoDeployment"
+- "[8196](https://github.com/kubernetes/ingress-nginx/pull/8196) docs: fix inconsistent controller annotation"
+- "[8191](https://github.com/kubernetes/ingress-nginx/pull/8191) Using Go install for misspell"
+- "[8186](https://github.com/kubernetes/ingress-nginx/pull/8186) prometheus+grafana using servicemonitor"
+- "[8185](https://github.com/kubernetes/ingress-nginx/pull/8185) Append elements on match, instead of removing for cors-annotations"
+- "[8179](https://github.com/kubernetes/ingress-nginx/pull/8179) Bump github.com/opencontainers/runc from 1.0.3 to 1.1.0"
+- "[8173](https://github.com/kubernetes/ingress-nginx/pull/8173) Adding annotations to the controller service account"
+- "[8163](https://github.com/kubernetes/ingress-nginx/pull/8163) Update the $req_id placeholder description"
+- "[8162](https://github.com/kubernetes/ingress-nginx/pull/8162) Versioned static manifests"
+- "[8159](https://github.com/kubernetes/ingress-nginx/pull/8159) Adding some geoip variables and default values"
+- "[8155](https://github.com/kubernetes/ingress-nginx/pull/8155) #7271 feat: avoid-pdb-creation-when-default-backend-disabled-and-replicas-gt-1"
+- "[8151](https://github.com/kubernetes/ingress-nginx/pull/8151) Automatically generate helm docs"
+- "[8143](https://github.com/kubernetes/ingress-nginx/pull/8143) Allow to configure delay before controller exits"
+- "[8136](https://github.com/kubernetes/ingress-nginx/pull/8136) add ingressClass option to helm chart - back compatibility with ingress.class annotations"
+- "[8126](https://github.com/kubernetes/ingress-nginx/pull/8126) Example for JWT"
+
+
 ### 4.0.15
 
 - [8120] https://github.com/kubernetes/ingress-nginx/pull/8120    Update go in runner and release v1.1.1
@@ -84,11 +142,11 @@ This file documents all notable changes to [ingress-nginx](https://github.com/ku
 
 - [7707] https://github.com/kubernetes/ingress-nginx/pull/7707 Release v1.0.2 of ingress-nginx
 
-### 4.0.2 
+### 4.0.2
 
 - [7681] https://github.com/kubernetes/ingress-nginx/pull/7681 Release v1.0.1 of ingress-nginx
 
-### 4.0.1 
+### 4.0.1
 
 - [7535] https://github.com/kubernetes/ingress-nginx/pull/7535 Release v1.0.0 ingress-nginx
 

--- a/helmfile/upstream/ingress-nginx/Chart.yaml
+++ b/helmfile/upstream/ingress-nginx/Chart.yaml
@@ -1,43 +1,16 @@
 annotations:
   artifacthub.io/changes: |
-    - "#8120    Update go in runner and release v1.1.1"
-    - "#8119    Update to go v1.17.6"
-    - "#8118    Remove deprecated libraries, update other libs"
-    - "#8117    Fix codegen errors"
-    - "#8115    chart/ghaction: set the correct permission to have access to push a release"
-    - "#8098    generating SHA for CA only certs in backend_ssl.go + comparision of P…"
-    - "#8088    Fix Edit this page link to use main branch"
-    - "#8072    Expose GeoIP2 Continent code as variable"
-    - "#8061    docs(charts): using helm-docs for chart"
-    - "#8058    Bump github.com/spf13/cobra from 1.2.1 to 1.3.0"
-    - "#8054    Bump google.golang.org/grpc from 1.41.0 to 1.43.0"
-    - "#8051    align bug report with feature request regarding kind documentation"
-    - "#8046    Report expired certificates (#8045)"
-    - "#8044    remove G109 check till gosec resolves issues"
-    - "#8042    docs_multiple_instances_one_cluster_ticket_7543"
-    - "#8041    docs: fix typo'd executible name"
-    - "#8035    Comment busy owners"
-    - "#8029    Add stream-snippet as a ConfigMap and Annotation option"
-    - "#8023    fix nginx compilation flags"
-    - "#8021    Disable default modsecurity_rules_file if modsecurity-snippet is specified"
-    - "#8019    Revise main documentation page"
-    - "#8018    Preserve order of plugin invocation"
-    - "#8015    Add newline indenting to admission webhook annotations"
-    - "#8014    Add link to example error page manifest in docs"
-    - "#8009    Fix spelling in documentation and top-level files"
-    - "#8008    Add relabelings in controller-servicemonitor.yaml"
-    - "#8003    Minor improvements (formatting, consistency) in install guide"
-    - "#8001    fix: go-grpc Dockerfile"
-    - "#7999    images: use k8s-staging-test-infra/gcb-docker-gcloud"
-    - "#7996    doc: improvement"
-    - "#7983    Fix a couple of misspellings in the annotations documentation."
-    - "#7979    allow set annotations for admission Jobs"
-    - "#7977    Add ssl_reject_handshake to defaul server"
-    - "#7975    add legacy version update v0.50.0 to main changelog"
-    - "#7972    updated service upstream definition"
+    - "[8459](https://github.com/kubernetes/ingress-nginx/pull/8459) Update default allowed CORS headers"
+    - "[8202](https://github.com/kubernetes/ingress-nginx/pull/8202) disable modsecurity on error page"
+    - "[8178](https://github.com/kubernetes/ingress-nginx/pull/8178) Add header Host into mirror annotations"
+    - "[8213](https://github.com/kubernetes/ingress-nginx/pull/8213) feat: always set auth cookie"
+    - "[8548](https://github.com/kubernetes/ingress-nginx/pull/8548) Implement reporting status classes in metrics"
+    - "[8612](https://github.com/kubernetes/ingress-nginx/pull/8612) move so files under /etc/nginx/modules"
+    - "[8624](https://github.com/kubernetes/ingress-nginx/pull/8624) Add patch to remove root and alias directives"
+    - "[8623](https://github.com/kubernetes/ingress-nginx/pull/8623) Improve path rule"
   artifacthub.io/prerelease: "false"
 apiVersion: v2
-appVersion: 1.1.1
+appVersion: 1.2.1
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and
   load balancer
 home: https://github.com/kubernetes/ingress-nginx
@@ -47,9 +20,11 @@ keywords:
 - nginx
 kubeVersion: '>=1.19.0-0'
 maintainers:
-- name: ChiefAlexander
+- name: rikatz
+- name: strongjz
+- name: tao12345666333
 name: ingress-nginx
 sources:
 - https://github.com/kubernetes/ingress-nginx
 type: application
-version: 4.0.17
+version: 4.1.3

--- a/helmfile/upstream/ingress-nginx/README.md
+++ b/helmfile/upstream/ingress-nginx/README.md
@@ -2,7 +2,7 @@
 
 [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 
-![Version: 4.0.17](https://img.shields.io/badge/Version-4.0.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
+![Version: 4.1.3](https://img.shields.io/badge/Version-4.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.1](https://img.shields.io/badge/AppVersion-1.2.1-informational?style=flat-square)
 
 To use, add `ingressClassName: nginx` spec field or the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
 
@@ -111,7 +111,7 @@ controller:
 
 ### AWS L7 ELB with SSL Termination
 
-Annotate the controller as shown in the [nginx-ingress l7 patch](https://github.com/kubernetes/ingress-nginx/blob/main/deploy/aws/l7/service-l7.yaml):
+Annotate the controller as shown in the [nginx-ingress l7 patch](https://github.com/kubernetes/ingress-nginx/blob/ab3a789caae65eec4ad6e3b46b19750b481b6bce/deploy/aws/l7/service-l7.yaml):
 
 ```yaml
 controller:
@@ -128,7 +128,7 @@ controller:
 
 ### AWS route53-mapper
 
-To configure the LoadBalancer service with the [route53-mapper addon](https://github.com/kubernetes/kops/tree/master/addons/route53-mapper), add the `domainName` annotation and `dns` label:
+To configure the LoadBalancer service with the [route53-mapper addon](https://github.com/kubernetes/kops/blob/be63d4f1a7a46daaf1c4c482527328236850f111/addons/route53-mapper/README.md), add the `domainName` annotation and `dns` label:
 
 ```yaml
 controller:
@@ -250,6 +250,7 @@ Kubernetes: `>=1.19.0-0`
 | controller.admissionWebhooks.namespaceSelector | object | `{}` |  |
 | controller.admissionWebhooks.objectSelector | object | `{}` |  |
 | controller.admissionWebhooks.patch.enabled | bool | `true` |  |
+| controller.admissionWebhooks.patch.fsGroup | int | `2000` |  |
 | controller.admissionWebhooks.patch.image.digest | string | `"sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"` |  |
 | controller.admissionWebhooks.patch.image.image | string | `"ingress-nginx/kube-webhook-certgen"` |  |
 | controller.admissionWebhooks.patch.image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -305,12 +306,14 @@ Kubernetes: `>=1.19.0-0`
 | controller.hostPort.ports.https | int | `443` | 'hostPort' https port |
 | controller.hostname | object | `{}` | Optionally customize the pod hostname. |
 | controller.image.allowPrivilegeEscalation | bool | `true` |  |
-| controller.image.digest | string | `"sha256:0bc88eb15f9e7f84e8e56c14fa5735aaa488b840983f87bd79b1054190e660de"` |  |
+| controller.image.chroot | bool | `false` |  |
+| controller.image.digest | string | `"sha256:5516d103a9c2ecc4f026efbd4b40662ce22dc1f824fb129ed121460aaa5c47f8"` |  |
+| controller.image.digestChroot | string | `"sha256:d301551cf62bc3fb75c69fa56f7aa1d9e87b5079333adaf38afe84d9b7439355"` |  |
 | controller.image.image | string | `"ingress-nginx/controller"` |  |
 | controller.image.pullPolicy | string | `"IfNotPresent"` |  |
 | controller.image.registry | string | `"k8s.gcr.io"` |  |
 | controller.image.runAsUser | int | `101` |  |
-| controller.image.tag | string | `"v1.1.1"` |  |
+| controller.image.tag | string | `"v1.2.1"` |  |
 | controller.ingressClass | string | `"nginx"` | For backwards compatibility with ingress.class annotation, use ingressClass. Algorithm is as follows, first ingressClassName is considered, if not present, controller looks for ingress.class annotation |
 | controller.ingressClassByName | bool | `false` | Process IngressClass per name (additionally as per spec.controller). |
 | controller.ingressClassResource.controllerValue | string | `"k8s.io/ingress-nginx"` | Controller-value of the controller that is processing this ingressClass |
@@ -398,6 +401,7 @@ Kubernetes: `>=1.19.0-0`
 | controller.service.ipFamilies | list | `["IPv4"]` | List of IP families (e.g. IPv4, IPv6) assigned to the service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. |
 | controller.service.ipFamilyPolicy | string | `"SingleStack"` | Represents the dual-stack-ness requested or required by this Service. Possible values are SingleStack, PreferDualStack or RequireDualStack. The ipFamilies and clusterIPs fields depend on the value of this field. |
 | controller.service.labels | object | `{}` |  |
+| controller.service.loadBalancerIP | string | `""` | Used by cloud providers to connect the resulting `LoadBalancer` to a pre-existing static IP according to https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer |
 | controller.service.loadBalancerSourceRanges | list | `[]` |  |
 | controller.service.nodePorts.http | string | `""` |  |
 | controller.service.nodePorts.https | string | `""` |  |
@@ -408,6 +412,7 @@ Kubernetes: `>=1.19.0-0`
 | controller.service.targetPorts.http | string | `"http"` |  |
 | controller.service.targetPorts.https | string | `"https"` |  |
 | controller.service.type | string | `"LoadBalancer"` |  |
+| controller.shareProcessNamespace | bool | `false` |  |
 | controller.sysctls | object | `{}` | See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for notes on enabling and using sysctls |
 | controller.tcp.annotations | object | `{}` | Annotations to be added to the tcp config configmap |
 | controller.tcp.configMapNamespace | string | `""` | Allows customization of the tcp-services-configmap; defaults to $(POD_NAMESPACE) |
@@ -473,6 +478,7 @@ Kubernetes: `>=1.19.0-0`
 | dhParam | string | `nil` | A base64-encoded Diffie-Hellman parameter. This can be generated with: `openssl dhparam 4096 2> /dev/null | base64` |
 | imagePullSecrets | list | `[]` | Optional array of imagePullSecrets containing private registry credentials |
 | podSecurityPolicy.enabled | bool | `false` |  |
+| portNamePrefix | string | `""` | Prefix for TCP and UDP ports names in ingress controller service |
 | rbac.create | bool | `true` |  |
 | rbac.scope | bool | `false` |  |
 | revisionHistoryLimit | int | `10` | Rollback limit |
@@ -480,6 +486,6 @@ Kubernetes: `>=1.19.0-0`
 | serviceAccount.automountServiceAccountToken | bool | `true` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
-| tcp | object | `{}` | TCP service key:value pairs |
-| udp | object | `{}` | UDP service key:value pairs |
+| tcp | object | `{}` | TCP service key-value pairs |
+| udp | object | `{}` | UDP service key-value pairs |
 

--- a/helmfile/upstream/ingress-nginx/README.md.gotmpl
+++ b/helmfile/upstream/ingress-nginx/README.md.gotmpl
@@ -110,7 +110,7 @@ controller:
 
 ### AWS L7 ELB with SSL Termination
 
-Annotate the controller as shown in the [nginx-ingress l7 patch](https://github.com/kubernetes/ingress-nginx/blob/main/deploy/aws/l7/service-l7.yaml):
+Annotate the controller as shown in the [nginx-ingress l7 patch](https://github.com/kubernetes/ingress-nginx/blob/ab3a789caae65eec4ad6e3b46b19750b481b6bce/deploy/aws/l7/service-l7.yaml):
 
 ```yaml
 controller:
@@ -127,7 +127,7 @@ controller:
 
 ### AWS route53-mapper
 
-To configure the LoadBalancer service with the [route53-mapper addon](https://github.com/kubernetes/kops/tree/master/addons/route53-mapper), add the `domainName` annotation and `dns` label:
+To configure the LoadBalancer service with the [route53-mapper addon](https://github.com/kubernetes/kops/blob/be63d4f1a7a46daaf1c4c482527328236850f111/addons/route53-mapper/README.md), add the `domainName` annotation and `dns` label:
 
 ```yaml
 controller:

--- a/helmfile/upstream/ingress-nginx/ci/daemonset-tcp-udp-portNamePrefix-values.yaml
+++ b/helmfile/upstream/ingress-nginx/ci/daemonset-tcp-udp-portNamePrefix-values.yaml
@@ -1,0 +1,18 @@
+controller:
+  kind: DaemonSet
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
+
+tcp:
+  9000: "default/test:8080"
+
+udp:
+  9001: "default/test:8080"
+
+portNamePrefix: "port"

--- a/helmfile/upstream/ingress-nginx/ci/deployment-tcp-udp-portNamePrefix-values.yaml
+++ b/helmfile/upstream/ingress-nginx/ci/deployment-tcp-udp-portNamePrefix-values.yaml
@@ -1,0 +1,17 @@
+controller:
+  image:
+    repository: ingress-controller/controller
+    tag: 1.0.0-dev
+    digest: null
+  admissionWebhooks:
+    enabled: false
+  service:
+    type: ClusterIP
+
+tcp:
+  9000: "default/test:8080"
+
+udp:
+  9001: "default/test:8080"
+
+portNamePrefix: "port"

--- a/helmfile/upstream/ingress-nginx/templates/NOTES.txt
+++ b/helmfile/upstream/ingress-nginx/templates/NOTES.txt
@@ -47,7 +47,8 @@ An example Ingress that makes use of the controller:
       - host: www.example.com
         http:
           paths:
-            - backend:
+            - pathType: Prefix
+              backend:
                 service:
                   name: exampleService
                   port:

--- a/helmfile/upstream/ingress-nginx/templates/_helpers.tpl
+++ b/helmfile/upstream/ingress-nginx/templates/_helpers.tpl
@@ -43,9 +43,38 @@ capabilities:
   - ALL
   add:
   - NET_BIND_SERVICE
+  {{- if .Values.controller.image.chroot }}
+  - SYS_CHROOT
+  {{- end }}
 runAsUser: {{ .Values.controller.image.runAsUser }}
 allowPrivilegeEscalation: {{ .Values.controller.image.allowPrivilegeEscalation }}
 {{- end }}
+{{- end -}}
+
+{{/*
+Get specific image
+*/}}
+{{- define "ingress-nginx.image" -}}
+{{- if .chroot -}}
+{{- printf "%s-chroot" .image -}}
+{{- else -}}
+{{- printf "%s" .image -}}
+{{- end }}
+{{- end -}}
+
+{{/*
+Get specific image digest
+*/}}
+{{- define "ingress-nginx.imageDigest" -}}
+{{- if .chroot -}}
+{{- if .digestChroot -}}
+{{- printf "@%s" .digestChroot -}}
+{{- end }}
+{{- else -}}
+{{ if .digest -}}
+{{- printf "@%s" .digest -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -72,4 +72,5 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: {{ .Values.controller.admissionWebhooks.patch.runAsUser }}
+        fsGroup: {{ .Values.controller.admissionWebhooks.patch.fsGroup }}
 {{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -74,4 +74,5 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: {{ .Values.controller.admissionWebhooks.patch.runAsUser }}
+        fsGroup: {{ .Values.controller.admissionWebhooks.patch.fsGroup }}
 {{- end }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-daemonset.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-daemonset.yaml
@@ -68,10 +68,13 @@ spec:
           value: {{ $value | quote }}
     {{- end }}
     {{- end }}
+    {{- if .Values.controller.shareProcessNamespace }}
+      shareProcessNamespace: {{ .Values.controller.shareProcessNamespace }}
+    {{- end }}
       containers:
         - name: {{ .Values.controller.containerName }}
           {{- with .Values.controller.image }}
-          image: "{{- if .repository -}}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{- end -}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
+          image: "{{- if .repository -}}{{ .repository }}{{ else }}{{ .registry }}/{{ include "ingress-nginx.image" . }}{{- end -}}:{{ .tag }}{{ include "ingress-nginx.imageDigest" . }}"
           {{- end }}
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         {{- if .Values.controller.lifecycle }}
@@ -79,14 +82,7 @@ spec:
         {{- end }}
           args:
             {{- include "ingress-nginx.params" . | nindent 12 }}
-          securityContext:
-            capabilities:
-                drop:
-                - ALL
-                add:
-                - NET_BIND_SERVICE
-            runAsUser: {{ .Values.controller.image.runAsUser }}
-            allowPrivilegeEscalation: {{ .Values.controller.image.allowPrivilegeEscalation }}
+          securityContext: {{ include "controller.containerSecurityContext" . | nindent 12 }}
           env:
             - name: POD_NAME
               valueFrom:
@@ -128,7 +124,7 @@ spec:
               protocol: TCP
           {{- end }}
           {{- range $key, $value := .Values.tcp }}
-            - name: {{ $key }}-tcp
+            - name: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-tcp
               containerPort: {{ $key }}
               protocol: TCP
               {{- if $.Values.controller.hostPort.enabled }}
@@ -136,7 +132,7 @@ spec:
               {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.udp }}
-            - name: {{ $key }}-udp
+            - name: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-udp
               containerPort: {{ $key }}
               protocol: UDP
               {{- if $.Values.controller.hostPort.enabled }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-deployment.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-deployment.yaml
@@ -72,10 +72,13 @@ spec:
           value: {{ $value | quote }}
     {{- end }}
     {{- end }}
+    {{- if .Values.controller.shareProcessNamespace }}
+      shareProcessNamespace: {{ .Values.controller.shareProcessNamespace }}
+    {{- end }}
       containers:
         - name: {{ .Values.controller.containerName }}
           {{- with .Values.controller.image }}
-          image: "{{- if .repository -}}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{- end -}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
+          image: "{{- if .repository -}}{{ .repository }}{{ else }}{{ .registry }}/{{ include "ingress-nginx.image" . }}{{- end -}}:{{ .tag }}{{ include "ingress-nginx.imageDigest" . }}"
           {{- end }}
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         {{- if .Values.controller.lifecycle }}
@@ -125,7 +128,7 @@ spec:
               protocol: TCP
           {{- end }}
           {{- range $key, $value := .Values.tcp }}
-            - name: {{ $key }}-tcp
+            - name: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-tcp
               containerPort: {{ $key }}
               protocol: TCP
               {{- if $.Values.controller.hostPort.enabled }}
@@ -133,7 +136,7 @@ spec:
               {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.udp }}
-            - name: {{ $key }}-udp
+            - name: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-udp
               containerPort: {{ $key }}
               protocol: UDP
               {{- if $.Values.controller.hostPort.enabled }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-psp.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-psp.yaml
@@ -12,6 +12,9 @@ metadata:
 spec:
   allowedCapabilities:
     - NET_BIND_SERVICE
+  {{- if .Values.controller.image.chroot }}
+    - SYS_CHROOT
+  {{- end }}
 {{- if .Values.controller.sysctls }}
   allowedUnsafeSysctls:
   {{- range $sysctl, $value := .Values.controller.sysctls }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-service-internal.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-service-internal.yaml
@@ -52,10 +52,10 @@ spec:
     {{- end }}
   {{- end }}
   {{- range $key, $value := .Values.tcp }}
-    - name: {{ $key }}-tcp
+    - name: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-tcp
       port: {{ $key }}
       protocol: TCP
-      targetPort: {{ $key }}-tcp
+      targetPort: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-tcp
     {{- if $.Values.controller.service.nodePorts.tcp }}
     {{- if index $.Values.controller.service.nodePorts.tcp $key }}
       nodePort: {{ index $.Values.controller.service.nodePorts.tcp $key }}
@@ -63,10 +63,10 @@ spec:
     {{- end }}
   {{- end }}
   {{- range $key, $value := .Values.udp }}
-    - name: {{ $key }}-udp
+    - name: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-udp
       port: {{ $key }}
       protocol: UDP
-      targetPort: {{ $key }}-udp
+      targetPort: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-udp
     {{- if $.Values.controller.service.nodePorts.udp }}
     {{- if index $.Values.controller.service.nodePorts.udp $key }}
       nodePort: {{ index $.Values.controller.service.nodePorts.udp $key }}

--- a/helmfile/upstream/ingress-nginx/templates/controller-service.yaml
+++ b/helmfile/upstream/ingress-nginx/templates/controller-service.yaml
@@ -37,12 +37,12 @@ spec:
 {{- if .Values.controller.service.healthCheckNodePort }}
   healthCheckNodePort: {{ .Values.controller.service.healthCheckNodePort }}
 {{- end }}
-{{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version -}}
+{{- if semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version -}}
 {{- if .Values.controller.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ .Values.controller.service.ipFamilyPolicy }}
 {{- end }}
 {{- end }}
-{{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version -}}
+{{- if semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version -}}
 {{- if .Values.controller.service.ipFamilies }}
   ipFamilies: {{ toYaml .Values.controller.service.ipFamilies | nindent 4 }}
 {{- end }}
@@ -74,10 +74,10 @@ spec:
     {{- end }}
   {{- end }}
   {{- range $key, $value := .Values.tcp }}
-    - name: {{ $key }}-tcp
+    - name: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-tcp
       port: {{ $key }}
       protocol: TCP
-      targetPort: {{ $key }}-tcp
+      targetPort: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-tcp
     {{- if $.Values.controller.service.nodePorts.tcp }}
     {{- if index $.Values.controller.service.nodePorts.tcp $key }}
       nodePort: {{ index $.Values.controller.service.nodePorts.tcp $key }}
@@ -85,10 +85,10 @@ spec:
     {{- end }}
   {{- end }}
   {{- range $key, $value := .Values.udp }}
-    - name: {{ $key }}-udp
+    - name: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-udp
       port: {{ $key }}
       protocol: UDP
-      targetPort: {{ $key }}-udp
+      targetPort: {{ if $.Values.portNamePrefix }}{{ $.Values.portNamePrefix }}-{{ end }}{{ $key }}-udp
     {{- if $.Values.controller.service.nodePorts.udp }}
     {{- if index $.Values.controller.service.nodePorts.udp $key }}
       nodePort: {{ index $.Values.controller.service.nodePorts.udp $key }}

--- a/helmfile/upstream/ingress-nginx/values.yaml
+++ b/helmfile/upstream/ingress-nginx/values.yaml
@@ -16,13 +16,16 @@ commonLabels: {}
 controller:
   name: controller
   image:
+    ## Keep false as default for now!
+    chroot: false
     registry: k8s.gcr.io
     image: ingress-nginx/controller
     ## for backwards compatibility consider setting the full image url via the repository value below
     ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
     ## repository:
-    tag: "v1.1.1"
-    digest: sha256:0bc88eb15f9e7f84e8e56c14fa5735aaa488b840983f87bd79b1054190e660de
+    tag: "v1.2.1"
+    digest: sha256:5516d103a9c2ecc4f026efbd4b40662ce22dc1f824fb129ed121460aaa5c47f8
+    digestChroot: sha256:d301551cf62bc3fb75c69fa56f7aa1d9e87b5079333adaf38afe84d9b7439355
     pullPolicy: IfNotPresent
     # www-data -> uid 101
     runAsUser: 101
@@ -272,7 +275,7 @@ controller:
   ##
   topologySpreadConstraints: []
     # - maxSkew: 1
-    #   topologyKey: failure-domain.beta.kubernetes.io/zone
+    #   topologyKey: topology.kubernetes.io/zone
     #   whenUnsatisfiable: DoNotSchedule
     #   labelSelector:
     #     matchLabels:
@@ -457,7 +460,8 @@ controller:
     ##
     externalIPs: []
 
-    # loadBalancerIP: ""
+    # -- Used by cloud providers to connect the resulting `LoadBalancer` to a pre-existing static IP according to https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+    loadBalancerIP: ""
     loadBalancerSourceRanges: []
 
     enableHttp: true
@@ -529,6 +533,10 @@ controller:
       ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
       # externalTrafficPolicy: ""
 
+  # shareProcessNamespace enables process namespace sharing within the pod.
+  # This can be used for example to signal log rotation using `kill -USR1` from a sidecar.
+  shareProcessNamespace: false
+
   # -- Additional containers to be added to the controller pod.
   # See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example.
   extraContainers: []
@@ -572,7 +580,7 @@ controller:
   extraModules: []
   ## Modules, which are mounted into the core nginx image
   # - name: opentelemetry
-  #   image: busybox
+  #   image: k8s.gcr.io/ingress-nginx/opentelemetry:v20220415-controller-v1.2.0-beta.0-2-g81c2afd97@sha256:ce61e2cf0b347dffebb2dcbf57c33891d2217c1bad9c0959c878e5be671ef941
   #
   # The image must contain a `/usr/local/bin/init_module.sh` executable, which
   # will be executed as initContainers, to move its config files within the
@@ -641,6 +649,7 @@ controller:
       # -- Labels to be added to patch job resources
       labels: {}
       runAsUser: 2000
+      fsGroup: 2000
 
   metrics:
     port: 10254
@@ -900,17 +909,21 @@ serviceAccount:
 imagePullSecrets: []
 # - name: secretName
 
-# -- TCP service key:value pairs
+# -- TCP service key-value pairs
 ## Ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/exposing-tcp-udp-services.md
 ##
 tcp: {}
 #  8080: "default/example-tcp-svc:9000"
 
-# -- UDP service key:value pairs
+# -- UDP service key-value pairs
 ## Ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/exposing-tcp-udp-services.md
 ##
 udp: {}
 #  53: "kube-system/kube-dns:53"
+
+# -- Prefix for TCP and UDP ports names in ingress controller service
+## Some cloud providers, like Yandex Cloud may have a requirements for a port name regex to support cloud load balancer integration
+portNamePrefix: ""
 
 # -- (string) A base64-encoded Diffie-Hellman parameter.
 # This can be generated with: `openssl dhparam 4096 2> /dev/null | base64`

--- a/migration/v0.22.x-v0.23.x/upgrade-apps.md
+++ b/migration/v0.22.x-v0.23.x/upgrade-apps.md
@@ -1,0 +1,17 @@
+# Upgrade v0.22.x to v0.23.x
+
+## Steps
+
+1. Update apps configuration:
+
+    This will take a backup into `backups/` before modifying any files.
+
+    ```bash
+    bin/ck8s init
+    ```
+1. Check if any of the [deprecated configurations](https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.1.3/Changelog.md#113) are present in the wc-config.yaml
+1. Upgrade applications:
+
+    ```bash
+    bin/ck8s apply {sc|wc}
+    ```


### PR DESCRIPTION
**What this PR does / why we need it**: to upgrade the ingress-nginx helm chart to v4.1.3 and ingress-nginx-controller image to 1.2.1

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1789

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [x] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [x] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
