### PR TITLE
config: remove wcReader from configs

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -21,3 +21,4 @@
 - Added metrics for field mappings and an alert that will throw an error if the fields get close to the max limit.
 
 ### Removed
+- wcReader mentions from all configs files

--- a/config/config/flavors/dev/sc-config.yaml
+++ b/config/config/flavors/dev/sc-config.yaml
@@ -7,13 +7,6 @@ harbor:
   persistence:
     type: filesystem
 
-prometheus:
-  wcReader:
-    storage:
-      size: 2Gi
-    retention:
-      size: 1GiB
-
 opensearch:
   masterNode:
     storageSize: 20Gi

--- a/config/config/flavors/prod/sc-config.yaml
+++ b/config/config/flavors/prod/sc-config.yaml
@@ -10,12 +10,6 @@ alerts:
 prometheus:
   retention:
     age: 7d
-  wcReader:
-    storage:
-      size: 15Gi
-    retention:
-      size: 12GiB
-      age: 7d
 
 opensearch:
   sso:

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -226,24 +226,6 @@ prometheus:
   retention:
     alertmanager: 72h
 
-  wcReader:
-    resources:
-      requests:
-        memory: 1Gi
-        cpu: 300m
-      limits:
-        memory: 2Gi
-        cpu: "1"
-    storage:
-      enabled: false
-      size: 5Gi
-    retention:
-      size: 4GiB
-      age: 3d
-    tolerations: []
-    affinity: {}
-    nodeSelector: {}
-
   # Todo remove dependencie on alertmanager from service cluster
   alertmanagerSpec:
     replicas: 2


### PR DESCRIPTION
**What this PR does / why we need it**: remove wcReader mentions from config files

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
