### PR TITLE
apps wc: set user-alertmanager default receiver to null

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -17,6 +17,7 @@
 - Users are now not forced to use proxy for connecting to alertmanager but can use port-forward as well.
 - The OpenSearch security config will now be managed completely by securityadmin
 - Patched Falco rules and added the rules `Change thread namespace` & `System procs network activity`.
+- set the user-alertmanager default receiver to null
 
 ### Fixed
 

--- a/helmfile/charts/user-alertmanager/files/alertmanager-config.yaml
+++ b/helmfile/charts/user-alertmanager/files/alertmanager-config.yaml
@@ -14,7 +14,7 @@ route:
   group_interval: 5m
   repeat_interval: 12h
   # Default receiver
-  receiver: slack
+  receiver: 'null'
   # Specify other receivers depending on match
   routes:
   - match:
@@ -23,29 +23,29 @@ route:
     receiver: 'null'
 receivers:
 - name: 'null'
-- name: slack
-  slack_configs:
-  # Note: the channel here does not apply if the webhook URL is for a specific channel
-  - channel: notifications
-    # Webhook URL for slack, see https://api.slack.com/apps
-    api_url: https://alertmanagerwebhook.example.com
-    # Do you want only alerts firing or also alerts resolved?
-    send_resolved: true
-    # Alertmanager templating: https://prometheus.io/docs/alerting/notifications/
-    text: |-
-      <!channel>
-      Attention! You have an alert!
-
-      *Common summary:* {{ .CommonAnnotations.summary }}
-      *Common description:* {{ .CommonAnnotations.description }}
-      {{ range .CommonLabels.SortedPairs }}
-      *{{ .Name }}:* {{ .Value }}
-      {{ end }}
-
-      *Individual alerts below*
-      {{ range .Alerts }}
-      *Status:* {{ .Status }}
-      {{ range .Annotations.SortedPairs }}
-      *{{ .Name }}:* {{ .Value }}
-      {{ end }}
-      {{ end }}
+#- name: slack
+#  slack_configs:
+#  # Note: the channel here does not apply if the webhook URL is for a specific channel
+#  - channel: notifications
+#    # Webhook URL for slack, see https://api.slack.com/apps
+#    api_url: https://alertmanagerwebhook.example.com
+#    # Do you want only alerts firing or also alerts resolved?
+#    send_resolved: true
+#    # Alertmanager templating: https://prometheus.io/docs/alerting/notifications/
+#    text: |-
+#      <!channel>
+#      Attention! You have an alert!
+#
+#      *Common summary:* {{ .CommonAnnotations.summary }}
+#      *Common description:* {{ .CommonAnnotations.description }}
+#      {{ range .CommonLabels.SortedPairs }}
+#      *{{ .Name }}:* {{ .Value }}
+#      {{ end }}
+#
+#      *Individual alerts below*
+#      {{ range .Alerts }}
+#      *Status:* {{ .Status }}
+#      {{ range .Annotations.SortedPairs }}
+#      *{{ .Name }}:* {{ .Value }}
+#      {{ end }}
+#      {{ end }}

--- a/migration/v0.22.x-v0.23.x/upgrade-apps.md
+++ b/migration/v0.22.x-v0.23.x/upgrade-apps.md
@@ -34,3 +34,4 @@
     ```bash
     bin/ck8s apply {sc|wc}
     ```
+1. Change user-alertmanager receiver to `null` if the default slack receiver is being used: `migration/v0.22.x-v0.23.x/user-alertmanager-reconfig.sh`

--- a/migration/v0.22.x-v0.23.x/user-alertmanager-reconfig.sh
+++ b/migration/v0.22.x-v0.23.x/user-alertmanager-reconfig.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
+here="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+alertmanager_config_bk="${CK8S_CONFIG_PATH}/user-alertmanager.yaml.bk"
+alertmanager_config_new="${CK8S_CONFIG_PATH}/user-alertmanager.yaml"
+common_config="${CK8S_CONFIG_PATH}/common-config.yaml"
+wc_config="${CK8S_CONFIG_PATH}/wc-config.yaml"
+
+cleanup(){
+  echo -n "Do you want to remove the user-alertmanager config backups? [y/N]: "
+  read -r reply
+  if [[ "${reply}" == "y" ]]; then
+      rm "$@"
+  fi
+}
+
+if [[ ! -f "${common_config}" ]]; then
+    echo "Override common-config does not exist, aborting."
+    exit 1
+elif [[ ! -f "${wc_config}" ]]; then
+    echo "Override wc-config does not exist, aborting."
+    exit 1
+fi
+
+wc=$(yq m -x -a overwrite -j "${common_config}" "${wc_config}" | yq r - 'user.alertmanager')
+
+if [[ $(yq r <(echo "${wc}") 'enabled') != "true" ]]; then
+    echo "User Alertmanager is not enabled, skipping."
+    exit 0
+fi
+
+echo "Saving existing configuration for user-alertmanager"
+
+"${here}/../../bin/ck8s" ops kubectl wc -n alertmanager get secret alertmanager-alertmanager -o "jsonpath='{.data.alertmanager\.yaml}'" | base64 -d > "${alertmanager_config_bk}"
+
+echo "A backup was created here: ${alertmanager_config_bk}"
+
+default_receiver=$(yq r "${alertmanager_config_bk}" 'route.receiver')
+default_slack_url=$(yq r "${alertmanager_config_bk}" 'receivers.*.slack_configs.*.api_url')
+
+if [[ "${default_receiver}" == 'slack' && "${default_slack_url}" == 'https://alertmanagerwebhook.example.com' ]]; then
+    echo "Changing the default slack receiver to null."
+    cp "${alertmanager_config_bk}" "${alertmanager_config_new}"
+    yq w -i --style single "${alertmanager_config_new}" 'route.receiver' 'null'
+
+    echo "Applying the new user-alertmanager config."
+    "${here}/../../bin/ck8s" ops kubectl wc -n alertmanager patch secret alertmanager-alertmanager -p "'{\"data\":{\"alertmanager.yaml\":\"$(base64 -w 0 < "${alertmanager_config_new}")\"}}'"
+    cleanup "${alertmanager_config_bk}" "${alertmanager_config_new}"
+else
+    echo "The default receiver has already been changed, skipping."
+    cleanup "${alertmanager_config_bk}"
+    exit 0
+fi


### PR DESCRIPTION
**What this PR does / why we need it**: when using the default slack receiver alertmanager will generate errors

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1049 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [x] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).