### PR TITLE
apps-wc: Patch Falco rules

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -16,6 +16,7 @@
 - Bump falco-exporter chart to v0.8.0.
 - Users are now not forced to use proxy for connecting to alertmanager but can use port-forward as well.
 - The OpenSearch security config will now be managed completely by securityadmin
+- Patched Falco rules and added the rules `Change thread namespace` & `System procs network activity`.
 
 ### Fixed
 

--- a/helmfile/values/falco.yaml.gotmpl
+++ b/helmfile/values/falco.yaml.gotmpl
@@ -209,6 +209,58 @@ customRules:
         command=%proc.cmdline container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag)
       priority: ERROR
       tags: [process, mitre_persistence]
+    - rule: Change thread namespace
+      desc: >
+        an attempt to change a program/thread\'s namespace (commonly done
+        as a part of creating a container) by calling setns.
+      condition: >
+        evt.type=setns and evt.dir=<
+        and proc_name_exists
+        and not (container.id=host and proc.name in (docker_binaries, k8s_binaries, lxd_binaries, nsenter))
+        and not proc.name in (sysdigcloud_binaries, sysdig, calico, oci-umount, cilium-cni, network_plugin_binaries)
+        and not proc.name in (user_known_change_thread_namespace_binaries)
+        and not proc.name startswith "runc"
+        and not proc.cmdline startswith "containerd"
+        and not proc.pname in (sysdigcloud_binaries, hyperkube, kubelet, protokube, dockerd, tini, aws)
+        and not java_running_sdjagent
+        and not kubelet_running_loopback
+        and not rancher_agent
+        and not rancher_network_manager
+        and not calico_node
+        and not weaveworks_scope
+        and not user_known_change_thread_namespace_activities
+      exceptions:
+       # snapd is part of the Ubuntu cloud image. Checked 2022-06-23 on the long-running-cluster.
+       - name: snapd
+         fields: [container.id, proc.pname, proc.cmdline]
+         comps: [=, =, startswith]
+         values:
+          - [host, snapd, snap-update-ns]
+      enabled: true
+      output: >
+        Namespace change (setns) by unexpected program (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline
+        parent=%proc.pname %container.info container_id=%container.id image=%container.image.repository:%container.image.tag)
+      priority: NOTICE
+      tags: [process, mitre_privilege_escalation, mitre_lateral_movement]
+    - rule: System procs network activity
+      desc: any network activity performed by system binaries that are not expected to send or receive any network traffic
+      condition: >
+        (fd.sockfamily = ip and (system_procs or proc.name in (shell_binaries)))
+        and (inbound_outbound)
+        and not proc.name in (known_system_procs_network_activity_binaries)
+        and not login_doing_dns_lookup
+        and not user_expected_system_procs_network_activity_conditions
+      exceptions:
+      - name: sidekick-system-procs
+        fields: [container.image.repository, k8s.ns.name, proc.cmdline]
+        comps: [=, =, =]
+        values:
+          - [falcosecurity/falco, falco, "sh -c curl -d @- falcosidekick:2801/\n"]
+      output: >
+        Known system binary sent/received network traffic
+        (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline connection=%fd.name container_id=%container.id image=%container.image.repository)
+      priority: NOTICE
+      tags: [network, mitre_exfiltration]
 
 falcosidekick:
   enabled: {{ .Values.falco.alerts.enabled }}


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes the Hard alert with adding the exceptions as per apps !! - Refer - https://github.com/elastisys/compliantkubernetes-apps/issues/898

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #898 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [X] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
