### PR TITLE
apps: make clean script more verbose

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -31,6 +31,7 @@
   - **Warning**: When this runs the security plugin settings will be reset. All users, roles, and role mappings created via the API will be removed, so create a backup or be prepared to recreate the resources.
   - The securityadmin can be disabled to protect manually created resources, but it will prevent the OpenSearch cluster to initialize the security plugin when the cluster is forming.
 - Add missing roles for alerting in OpenSearch
+- Make the clean script more verbose what cluster will be cleaned.
 
 ### Removed
 - wcReader mentions from all configs files

--- a/scripts/clean-sc.sh
+++ b/scripts/clean-sc.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
 echo "WARNING:"
 echo "This script will remove compliant kubernetes apps from your service cluster."
+echo -e "Your current \u1b[33mCK8S_CONFIG_PATH\033[m is set to: \u1b[33;4m${CK8S_CONFIG_PATH}\033[m"
 echo -n "Do you want to continue (y/N): "
 read -r reply
 if [[ ${reply} != "y" ]]; then

--- a/scripts/clean-wc.sh
+++ b/scripts/clean-wc.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
 echo "WARNING:"
 echo "This script will remove compliant kubernetes apps from your workload cluster."
 echo "It will also remove any user namespaces managed by compliant kubernetes apps."
+echo -e "Your current \u1b[33mCK8S_CONFIG_PATH\033[m is set to: \u1b[33;4m${CK8S_CONFIG_PATH}\033[m"
 echo -n "Do you want to continue (y/N): "
 read -r reply
 if [[ ${reply} != "y" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

Make the clean script indicate which config that is used. This to reduce the change of cleaning the wrong cluster. 

Before:
![image](https://user-images.githubusercontent.com/12862587/174802875-ede6aaf1-4457-4bc8-a2c9-a35154dd7e67.png)
After:
![image](https://user-images.githubusercontent.com/12862587/174802738-59159cec-093e-44ed-b40e-279566f0ce96.png)

**Which issue this PR fixes**: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
