### PR TITLE
Reset changelog for release v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Compliant Kubernetes changelog
 <!-- BEGIN TOC -->
+- [v0.23.0](#v0230---2022-06-28)
 - [v0.22.0](#v0220---2022-06-01)
 - [v0.21.2](#v0212---2022-06-08)
 - [v0.21.1](#v0211---2022-05-09)
@@ -23,6 +24,54 @@
 - [v0.6.0](#v060---2020-10-16)
 - [v0.5.0](#v050---2020-08-06)
 <!-- END TOC -->
+
+-------------------------------------------------
+## v0.23.0 - 2022-06-28
+
+### Release notes
+
+### Updated
+
+- Update the Velero plugin for AWS to v1.3.1
+- Updated ingress-nginx helm chart to v4.1.3 and ingress-nginx controller image to v1.2.1
+   > **Breaking changes**
+      - deprecated http2_recv_timeout in favor of client_header_timeout (client-header-timeout);
+      - deprecated http2_max_field_size (http2-max-field-size) and http2_max_header_size (http2-max-header-size) in favor of large_client_header_buffers (large-client-header-buffers);
+      - deprecated http2_idle_timeout and http2_max_requests (http2-max-requests) in favor of keepalive_timeout (upstream-keepalive-timeout?) and keepalive_requests (upstream-keepalive-requests?) respectively;
+      - added an option to jail/chroot the nginx process, inside the controller container, is being introduced;
+      - implemented an object deep inspector. The inspection is a walk through of all the spec, checking for possible attempts to escape configs.
+- Updated the prometheus-alerts chart alerts and rules
+
+### Changed
+
+- Bump falco-exporter chart to v0.8.0.
+- Users are now not forced to use proxy for connecting to alertmanager but can use port-forward as well.
+- The OpenSearch security config will now be managed completely by securityadmin
+- Patched Falco rules and added the rules `Change thread namespace` & `System procs network activity`.
+- set the user-alertmanager default receiver to null
+
+### Fixed
+
+- `prometheus-blackbox-exporter's` internal thanos servicemonitor changed name to avoid name collisions.
+- dex `topologySpreadConstraints` matchLabel was changed from `app: dex` to `app.kubernetes.io/name: dex` to increase stability of replica placements.
+- Fixed issue where user admin groups wasn't added to the user alertmanager rolebinding
+
+### Added
+
+- Add option to encrypt off-site buckets replicated with rclone sync
+- Added metrics for field mappings and an alert that will throw an error if the fields get close to the max limit.
+- Add support for automatic reloading of the security config for OpenSearch
+  - **Warning**: When this runs the security plugin settings will be reset. All users, roles, and role mappings created via the API will be removed, so create a backup or be prepared to recreate the resources.
+  - The securityadmin can be disabled to protect manually created resources, but it will prevent the OpenSearch cluster to initialize the security plugin when the cluster is forming.
+- Add missing roles for alerting in OpenSearch
+- Make the clean script more verbose what cluster will be cleaned.
+- Added possibility to use either encrypted or unencrypted kubeconfigs. The scripts will automatically detect if the file is encrypted or not.
+- Added the possibility to override what kubeconfig to use. If the env variable `KUBECONFIG` is set, then the scripts will use that kubeconfig path as the kubeconfig for both workload and service clusters. So if you are using that variable and want to switch between working on wc and sc you need to reset `KUBECONFIG`.
+
+### Removed
+
+- wcReader mentions from all configs files
+- removed the command `ck8s kubeconfig admin <wc|sc>`. Creation of admin OIDC kubeconfigs have moved to the compliantkubernetes-kubespray github repo.
 
 -------------------------------------------------
 ## v0.22.0 - 2022-06-01

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -2,43 +2,10 @@
 
 ### Updated
 
-- Update the Velero plugin for AWS to v1.3.1
-- Updated ingress-nginx helm chart to v4.1.3 and ingress-nginx controller image to v1.2.1
-   > **Breaking changes**
-      - deprecated http2_recv_timeout in favor of client_header_timeout (client-header-timeout);
-      - deprecated http2_max_field_size (http2-max-field-size) and http2_max_header_size (http2-max-header-size) in favor of large_client_header_buffers (large-client-header-buffers);
-      - deprecated http2_idle_timeout and http2_max_requests (http2-max-requests) in favor of keepalive_timeout (upstream-keepalive-timeout?) and keepalive_requests (upstream-keepalive-requests?) respectively;
-      - added an option to jail/chroot the nginx process, inside the controller container, is being introduced;
-      - implemented an object deep inspector. The inspection is a walk through of all the spec, checking for possible attempts to escape configs.
-- Updated the prometheus-alerts chart alerts and rules
-
 ### Changed
-
-- Bump falco-exporter chart to v0.8.0.
-- Users are now not forced to use proxy for connecting to alertmanager but can use port-forward as well.
-- The OpenSearch security config will now be managed completely by securityadmin
-- Patched Falco rules and added the rules `Change thread namespace` & `System procs network activity`.
-- set the user-alertmanager default receiver to null
 
 ### Fixed
 
-- `prometheus-blackbox-exporter's` internal thanos servicemonitor changed name to avoid name collisions.
-- dex `topologySpreadConstraints` matchLabel was changed from `app: dex` to `app.kubernetes.io/name: dex` to increase stability of replica placements.
-- Fixed issue where user admin groups wasn't added to the user alertmanager rolebinding
-
 ### Added
 
-- Add option to encrypt off-site buckets replicated with rclone sync
-- Added metrics for field mappings and an alert that will throw an error if the fields get close to the max limit.
-- Add support for automatic reloading of the security config for OpenSearch
-  - **Warning**: When this runs the security plugin settings will be reset. All users, roles, and role mappings created via the API will be removed, so create a backup or be prepared to recreate the resources.
-  - The securityadmin can be disabled to protect manually created resources, but it will prevent the OpenSearch cluster to initialize the security plugin when the cluster is forming.
-- Add missing roles for alerting in OpenSearch
-- Make the clean script more verbose what cluster will be cleaned.
-- Added possibility to use either encrypted or unencrypted kubeconfigs. The scripts will automatically detect if the file is encrypted or not.
-- Added the possibility to override what kubeconfig to use. If the env variable `KUBECONFIG` is set, then the scripts will use that kubeconfig path as the kubeconfig for both workload and service clusters. So if you are using that variable and want to switch between working on wc and sc you need to reset `KUBECONFIG`.
-
 ### Removed
-
-- wcReader mentions from all configs files
-- removed the command `ck8s kubeconfig admin <wc|sc>`. Creation of admin OIDC kubeconfigs have moved to the compliantkubernetes-kubespray github repo.


### PR DESCRIPTION
**What this PR does / why we need it**:

Reset changelog for v0.23.0

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
