### PR TITLE
apps sc: Pass snapshot list by tempfile in opensearch-slm

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Pass snapshot list by tempfile in opensearch-slm to prevent piped commands to fail due to short circuiting
+
 ### Added
 
 ### Removed

--- a/helmfile/charts/opensearch/slm/scripts/slm-retention.bash
+++ b/helmfile/charts/opensearch/slm/scripts/slm-retention.bash
@@ -43,7 +43,7 @@ function get_snapshot_age {
     local now_seconds
     local age_seconds
 
-    snapshot_start_date_seconds=$(echo "${snapshots}" | sed "${idx}q;d" | awk '{ print $3 }')
+    snapshot_start_date_seconds=$(sed "${idx}q;d" <(echo "${snapshots}") | awk '{ print $3 }')
     now_seconds=$(date +%s)
     age_seconds=$((now_seconds - snapshot_start_date_seconds))
     echo "${age_seconds}"
@@ -97,7 +97,7 @@ function remove_old_snapshots {
         age_seconds=$(get_snapshot_age "${snapshots}" "${idx}")
         if [ "${age_seconds}" -gt "${MAX_AGE_SECONDS}" ]; then
             local snapshot_name
-            snapshot_name=$(echo "${snapshots}" | sed "${idx}q;d" | awk '{ print $1 }')
+            snapshot_name=$(sed "${idx}q;d" <(echo "${snapshots}") | awk '{ print $1 }')
             echo "Snapshot ${snapshot_name} is ${age_seconds} s old, max ${MAX_AGE_SECONDS} s"
             snapshots_to_delete="${snapshots_to_delete}${snapshot_name},"
         fi
@@ -128,7 +128,7 @@ function remove_excess_snapshots {
 
     while [ $((snapshot_count - idx )) -ge "${MAX_SNAPSHOTS}" ]; do
         local snapshot_name
-        snapshot_name=$(echo "${snapshots}" | sed "${idx}q;d" | awk '{ print $1 }')
+        snapshot_name=$(sed "${idx}q;d" <(echo "${snapshots}") | awk '{ print $1 }')
         echo "Too many snapshots: $snapshot_count, max ${MAX_SNAPSHOTS}"
         snapshots_to_delete="${snapshots_to_delete}${snapshot_name},"
         idx=$((idx + 1))


### PR DESCRIPTION
**What this PR does / why we need it**:
This prevents the SLM job from failing on clusters having a lot of snapshots.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
