### PR TITLE
apps wc: velero will backup alertmanager ns on condition

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -9,6 +9,7 @@
 - Renamed `predictLinear` alerts to `capacityManagementAlerts`
 - The `capacitymanagementAlerts` for CPU and Memory request alerts are now per cluster and you can add a `pattern` in the configs, `.prometheus.capacityManagementAlerts.requestlimit`, to create an alert for a certain group of nodes
 - Increased blackbox exporter default resources to reduce cpu throttling.
+- Add the alertmanager namespace to wc velero, only if `user.alertmanager` is enabled
 
 ### Fixed
 

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -188,10 +188,6 @@ externalTrafficPolicy:
     # global: 0.0.0.0/0
     kubeapiMetrics: false
 
-velero:
-  includedNamespaces:
-    - alertmanager
-
 prometheusBlackboxExporter:
   targets:
     gatekeeper: true

--- a/helmfile/values/velero-wc.yaml.gotmpl
+++ b/helmfile/values/velero-wc.yaml.gotmpl
@@ -95,7 +95,9 @@ schedules:
       storageLocation: default
       includedNamespaces:
       {{ .Values.user.namespaces | toYaml | nindent 8 }}
-      {{ .Values.velero.includedNamespaces | toYaml | nindent 8 }}
+      {{- if .Values.user.alertmanager.enabled }}
+        - alertmanager
+      {{- end }}
       ttl: {{ .Values.velero.retentionPeriod }}
       labelSelector:
         matchExpressions:


### PR DESCRIPTION
**What this PR does / why we need it**: velero to create a backup of the alertmanager ns in wc only if `user.alertmanager` is enabled

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

