### PR TITLE
apps: enable publishService in ingress-nginx

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -15,5 +15,6 @@
 - Pass snapshot list by tempfile in opensearch-slm to prevent piped commands to fail due to short circuiting
 
 ### Added
+- The option to enable `publishService` from configs
 
 ### Removed

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -224,7 +224,7 @@ ingressNginx:
     tolerations: []
     affinity: {}
     nodeSelector: {}
-
+    enablepublishService: false
     config:
       ## If 'true', use PROXY protocol
       ## ref: https://docs.nginx.com/nginx/admin-guide/load-balancer/using-proxy-protocol/

--- a/helmfile/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile/values/ingress-nginx.yaml.gotmpl
@@ -49,7 +49,7 @@ controller:
   ## by the service. If disable, the status field reports the IP address of the
   ## node or nodes where an ingress controller pod is running.
   publishService:
-    enabled: false
+    enabled:  {{ .Values.ingressNginx.controller.enablepublishService }}
 
   ## DaemonSet or Deployment
   ##


### PR DESCRIPTION
**What this PR does / why we need it**: we added the option to enable publish service in ingress-nginx from configs

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).