### PR TITLE
apps: upgrade node local dns

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -4,6 +4,7 @@
 - Helm upgraded to `v3.8.0`.
 - Helmfile upgraded to `v0.144.0`.
 - Helm-secrets upgraded to `v3.12.0`.
+- Node-local-dns to use image `registry.k8s.io/dns/k8s-dns-node-cache:1.21.1`
 
 ### Changed
 - Renamed `predictLinear` alerts to `capacityManagementAlerts`

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -83,7 +83,7 @@ releases:
   labels:
     app: node-local-dns
   chart: ./charts/node-local-dns
-  version: 0.1.0
+  version: 0.1.1
   missingFileHandler: Error
   values:
   - values/node-local-dns.yaml.gotmpl

--- a/helmfile/charts/node-local-dns/Chart.yaml
+++ b/helmfile/charts/node-local-dns/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v1
 name: node-local-dns
-version: 0.1.0
+version: 0.1.1

--- a/helmfile/charts/node-local-dns/templates/node-local-dns.yaml
+++ b/helmfile/charts/node-local-dns/templates/node-local-dns.yaml
@@ -115,11 +115,8 @@ spec:
       k8s-app: node-local-dns
   template:
     metadata:
-       labels:
-          k8s-app: node-local-dns
-       annotations:
-        prometheus.io/port: "9253"
-        prometheus.io/scrape: "true"
+      labels:
+        k8s-app: node-local-dns
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: node-local-dns
@@ -134,7 +131,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: k8s.gcr.io/dns/k8s-dns-node-cache:1.17.0
+        image: registry.k8s.io/dns/k8s-dns-node-cache:1.21.1
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         args: [ "-localip", "{{ .Values.localIP }},{{ .Values.clusterDNS }}", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream"]


### PR DESCRIPTION
**What this PR does / why we need it**:

Tested upgrading node-local-dns on a apps v0.23.0 cluster and everything seems to be working as expected.

**Which issue this PR fixes** : fixes #1056 

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [X] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
