### PR TITLE
apps sc: expose external db values for harbor

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -23,5 +23,6 @@
 - a new alert `FluentdAvailableSpaceBuffer`, notifies when the fluentd buffer is filling up
 - Option to enable `allowSnippetAnnotations` from the configs
 - the possibility to enable falco in the service cluster
+- Add external database as option for harbor
 
 ### Removed

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -422,7 +422,7 @@ generate_secrets() {
     yq4 --inplace ".grafana.clientSecret= \"$(pwgen -cns 20 1)\"" "${tmpfile}"
     yq4 --inplace ".grafana.opsClientSecret= \"$(pwgen -cns 20 1)\"" "${tmpfile}"
     yq4 --inplace ".harbor.password= \"$(pwgen -cns 20 1)\"" "${tmpfile}"
-    yq4 --inplace ".harbor.databasePassword= \"$(pwgen -cns 20 1)\"" "${tmpfile}"
+    yq4 --inplace ".harbor.internal.databasePassword= \"$(pwgen -cns 20 1)\"" "${tmpfile}"
     yq4 --inplace ".harbor.clientSecret= \"$(pwgen -cns 20 1)\"" "${tmpfile}"
     yq4 --inplace ".harbor.xsrf= \"$(pwgen -cns 20 1)\"" "${tmpfile}"
     yq4 --inplace ".harbor.coreSecret= \"$(pwgen -cns 20 1)\"" "${tmpfile}"

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -129,12 +129,29 @@ harbor:
         cpu: 250m
         memory: 500Mi
   database:
-    persistentVolumeClaim:
-      size: 1Gi
-    resources:
-      requests:
-        memory: 512Mi
-        cpu: 250m
+    type: internal
+    internal:
+      persistentVolumeClaim:
+        size: 1Gi
+      resources:
+        requests:
+          memory: 512Mi
+          cpu: 250m
+    external:
+      # host: "set-me"
+      port: "5432"
+      # username: "set-me"
+      coreDatabase: "registry"
+      notaryServerDatabase: "notaryserver"
+      notarySignerDatabase: "notarysigner"
+      # "disable" - No SSL
+      # "require" - Always SSL (skip verification)
+      # "verify-ca" - Always SSL (verify that the certificate presented by the
+      # server was signed by a trusted CA)
+      # "verify-full" - Always SSL (verify that the certification presented by the
+      # server was signed by a trusted CA and the server host name matches the one
+      # in the certificate)
+      # sslmode: "set-me"
   jobservice:
     persistentVolumeClaim:
       size: 1Gi

--- a/config/secrets/sc-secrets.yaml
+++ b/config/secrets/sc-secrets.yaml
@@ -22,12 +22,15 @@ grafana:
   opsClientSecret: somelongsecret
 harbor:
   password: somelongsecret
-  databasePassword: somelongsecret
   clientSecret: somelongsecret
   xsrf: somelongsecret
   coreSecret: somelongsecret
   jobserviceSecret: somelongsecret
   registrySecret: somelongsecret
+  internal:
+    databasePassword: somelongsecret
+  # external:
+  #   databasePassword: set-me # password for external database user
   # persistence:
   #   swift:
   #     username: "set-me"

--- a/helmfile/values/harbor-backup.yaml.gotmpl
+++ b/helmfile/values/harbor-backup.yaml.gotmpl
@@ -1,7 +1,11 @@
 {{ if not (or (eq .Values.objectStorage.type "s3") (eq .Values.objectStorage.type "gcs") ) }}
 {{ fail "\nERROR: Harbor backup requires s3 or gcs object storage, see Values.objectStorage.type" }}
 {{ end }}
-dbPassword: {{ .Values.harbor.databasePassword }}
+{{ if and .Values.harbor.backup.enabled (eq .Values.harbor.database.type "external") }}
+{{ fail "\nERROR: Harbor backup is not available for external database" }}
+{{ end }}
+
+dbPassword: {{ .Values.harbor.internal.databasePassword }}
 retentionDays: {{ .Values.harbor.backup.retentionDays }}
 {{ if eq .Values.objectStorage.type "s3" -}}
 s3:

--- a/helmfile/values/harbor.yaml.gotmpl
+++ b/helmfile/values/harbor.yaml.gotmpl
@@ -31,8 +31,10 @@ persistence:
       size: {{ .Values.harbor.registry.persistentVolumeClaim.size }}
     jobservice:
       size: {{ .Values.harbor.jobservice.persistentVolumeClaim.size }}
+    {{ if eq .Values.harbor.database.type "internal" }}
     database:
-      size: {{ .Values.harbor.database.persistentVolumeClaim.size }}
+      size: {{ .Values.harbor.database.internal.persistentVolumeClaim.size }}
+    {{ end }}
     redis:
       size: {{ .Values.harbor.redis.internal.persistentVolumeClaim.size }}
     trivy:
@@ -115,13 +117,25 @@ notary:
   tolerations:  {{- toYaml .Values.harbor.tolerations | nindent 4 }}
 
 database:
+  type: {{ .Values.harbor.database.type }}
+  {{ if eq .Values.harbor.database.type "internal" }}
   internal:
-    password:     {{ .Values.harbor.databasePassword }}
-    resources:    {{- toYaml .Values.harbor.database.resources | nindent 6 }}
+    password:     {{ .Values.harbor.internal.databasePassword }}
+    resources:    {{- toYaml .Values.harbor.database.internal.resources | nindent 6 }}
     nodeSelector: {{- toYaml .Values.harbor.nodeSelector | nindent 6 }}
     affinity:     {{- toYaml .Values.harbor.affinity | nindent 6 }}
     tolerations:  {{- toYaml .Values.harbor.tolerations | nindent 6 }}
-
+  {{ else if eq .Values.harbor.database.type "external" }}
+  external:
+    host: {{ .Values.harbor.database.external.host }}
+    port: {{ .Values.harbor.database.external.port }}
+    username: {{ .Values.harbor.database.external.username }}
+    password: {{ .Values.harbor.external.databasePassword }}
+    coreDatabase: {{ .Values.harbor.database.external.coreDatabase }}
+    notaryServerDatabase: {{ .Values.harbor.database.external.notaryServerDatabase }}
+    notarySignerDatabase: {{ .Values.harbor.database.external.notarySignerDatabase }}
+    sslmode: {{ .Values.harbor.database.external.sslmode }}
+  {{ end }}
 trivy:
   replicas: {{ .Values.harbor.trivy.replicas }}
   resources:    {{- toYaml .Values.harbor.trivy.resources | nindent 4 }}

--- a/migration/v0.24.x-v0.25.x/migrate-harbor-database-variables.sh
+++ b/migration/v0.24.x-v0.25.x/migrate-harbor-database-variables.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
+sc_config="${CK8S_CONFIG_PATH}/sc-config.yaml"
+secret_config="${CK8S_CONFIG_PATH}/secrets.yaml"
+sops_config="${CK8S_CONFIG_PATH}/.sops.yaml"
+
+move_value_to() {
+    value=$(yq4 "${1}" "${3}")
+
+    if [[ -z "${value}" ]]; then
+        echo "${1} missing from ${3}, skipping."
+    else
+        yq4 "${1}" "${3}" | yq4 "${2}" - | yq4 eval-all -i 'select(fi == 0) * select(fi == 1)' "${3}" -
+    fi
+}
+
+delete_value() {
+    value=$(yq4 "${1}" "${2}")
+
+    if [[ -z "${value}" ]]; then
+        echo "$1 missing from $2, skipping."
+    else
+        yq4 "del(${1})" -i "$2"
+    fi
+}
+
+move_value_to '.harbor.database.persistentVolumeClaim' '{"harbor":{"database":{"internal":{"persistentVolumeClaim": . }}}}' "${sc_config}"
+move_value_to '.harbor.database.resources' '{"harbor":{"database":{"internal":{"resources": . }}}}' "${sc_config}"
+delete_value '.harbor.database.persistentVolumeClaim'  "${sc_config}"
+delete_value '.harbor.database.resources' "${sc_config}"
+
+sops --config "${sops_config}" -d -i "${secret_config}"
+
+move_value_to '.harbor.databasePassword' '{"harbor":{"internal": {"databasePassword": . }}}' "${secret_config}"
+delete_value '.harbor.databasePassword' "${secret_config}"
+
+sops --config "${sops_config}" -e -i "${secret_config}"

--- a/migration/v0.24.x-v0.25.x/upgrade-apps.md
+++ b/migration/v0.24.x-v0.25.x/upgrade-apps.md
@@ -16,6 +16,12 @@
     migration/v0.24.x-v0.25.x/migrate-harbor-redis-variables.sh
     ```
 
+1. Migrate harbor database variables
+
+    ```console
+    migration/v0.24.x-v0.25.x/migrate-harbor-database-variables.sh
+    ```
+
 1. Upgrade applications:
 
     ```bash


### PR DESCRIPTION
**What this PR does / why we need it**:

Expose external db settings for harbor 

**Which issue this PR fixes**: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
