### PR TITLE
apps sc: expose external redis db for harbor

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,22 @@ The user will first need to add pull secrets that gives some ServiceAccount acce
 
 For more details and a list of available services see the [user guide](https://compliantkubernetes.io/user-guide/).
 
+#### Redis
+
+**Config**
+In `$CK8S_CONFIG_PATH/sc-config.yaml` set the following configs
+```
+harbor:
+  ...
+  redis:
+    type: internal
+    external:
+      addr: "rfs-redis-harbor.redis-system.svc.cluster.local:26379"
+      sentinelMasterSet: "mymaster"
+```
+
+
+
 ### Management of the clusters
 
 The [`bin/ck8s`](bin/ck8s) script provides an entrypoint to the clusters.

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -6,9 +6,6 @@
 - cert-manager from v1.6.1 to v1.8.2. [Full changelog](https://github.com/cert-manager/cert-manager/releases?page=1)
     - In 1.7 the cert-manager API versions v1alpha2, v1alpha3, and v1beta1, that were deprecated in 1.4, have been removed from the custom resource definitions (CRDs). Read [Migrating Deprecated API Resources](https://cert-manager.io/docs/installation/upgrading/remove-deprecated-apis/) for full instructions.
     - The field spec.privateKey.rotationPolicy on Certificate resources is now validated. Valid options are Never and Always. If you are using a GitOps flow and one of your YAML manifests contains a Certificate with an invalid value, you will need to update it with a valid value to prevent your GitOps tool from failing on the new validation. Please follow the instructions listed on the page [Upgrading from v1.7 to v1.8](https://cert-manager.io/docs/installation/upgrading/upgrading-1.7-1.8/).
-
-### Updated
-
 - Upgraded Opensearch helm chart to `1.13.1`, this upgrades Opensearch to `1.3.4`. For more information about the upgrade, check out their [1.3 Launch Announcement](https://opensearch.org/blog/releases/2022/03/launch-announcement-1-3-0/).
 - Upgraded Opensearch-Dashboards helm chart to `1.7.4`, this upgrades Opensearch-Dashboards to `1.3.4`
 
@@ -19,5 +16,6 @@
 
 ### Added
 - Option to create custom solvers for letsencrypt issuers, including a simple way to add secrets.
+- Add external redis database as option for harbor
 
 ### Removed

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -154,12 +154,19 @@ harbor:
           cpu: 250m
           memory: 250Mi
   redis:
-    persistentVolumeClaim:
-      size: 1Gi
-    resources:
-      requests:
-        memory: 32Mi
-        cpu: 10m
+    type: internal
+    internal:
+      persistentVolumeClaim:
+        size: 1Gi
+      resources:
+        requests:
+          memory: 32Mi
+          cpu: 10m
+    # if external redis database is used, please uncomment and update the below lines
+    external: {}
+    #  addr: "rfs-redis-harbor.redis-system.svc.cluster.local:26379"
+    #  sentinelMasterSet: "mymaster"
+
   notary:
     replicas: 1
     subdomain: notary.harbor

--- a/helmfile/values/harbor.yaml.gotmpl
+++ b/helmfile/values/harbor.yaml.gotmpl
@@ -34,7 +34,7 @@ persistence:
     database:
       size: {{ .Values.harbor.database.persistentVolumeClaim.size }}
     redis:
-      size: {{ .Values.harbor.redis.persistentVolumeClaim.size }}
+      size: {{ .Values.harbor.redis.internal.persistentVolumeClaim.size }}
     trivy:
       size: {{ .Values.harbor.trivy.persistentVolumeClaim.size }}
   imageChartStorage:
@@ -157,11 +157,15 @@ notary:
   tolerations:  {{- toYaml .Values.harbor.tolerations | nindent 4 }}
 
 redis:
+  type: {{ .Values.harbor.redis.type }}
   internal:
-    resources:    {{- toYaml .Values.harbor.redis.resources | nindent 6 }}
+    resources:    {{- toYaml .Values.harbor.redis.internal.resources | nindent 6 }}
     nodeSelector: {{- toYaml .Values.harbor.nodeSelector | nindent 6 }}
     affinity:     {{- toYaml .Values.harbor.affinity | nindent 6 }}
     tolerations:  {{- toYaml .Values.harbor.tolerations | nindent 6 }}
-
+  {{- if and (eq .Values.harbor.redis.type "external") (.Values.harbor.redis.external) }}
+  external:
+    {{ toYaml .Values.harbor.redis.external | nindent 4 }}
+  {{- end }}
 updateStrategy:
   type: Recreate

--- a/migration/v0.24.x-v0.25.x/migrate-harbor-redis-variables.sh
+++ b/migration/v0.24.x-v0.25.x/migrate-harbor-redis-variables.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
+sc_config="${CK8S_CONFIG_PATH}/sc-config.yaml"
+
+move_value_to() {
+    length_root=$(yq4 "$1 | length" "$3")
+    length_internal=$(yq4 "$2 | length" "$3")
+
+    if [[ "${length_root}" -eq 0 ]]; then
+        echo "$1 missing from $3, skipping."
+    elif [[ "${length_internal}" -eq 0 ]]; then
+        echo "moving .redis variables under .redis.internal"
+        # shellcheck disable=SC2016
+        yq4 -i ''"$1"' as $value | '"$2"' = $value' "$3"
+    else
+        echo "$1 was already migrated, skipping."
+    fi
+}
+
+delete_value() {
+    length=$(yq4 "$1 | length" "$2")
+
+    if [[ "${length}" -eq 0 ]]; then
+        echo "$1 missing from $2, skipping."
+    else
+        echo "deleting $1"
+        yq4 -i "del($1)" "$2"
+    fi
+}
+
+if [[ ! -f "$sc_config" ]]; then
+    echo "$sc_config does not exist, skipping."
+else
+   move_value_to '.harbor.redis' '.harbor.redis.internal' "$sc_config"
+   delete_value '.harbor.redis.persistentVolumeClaim' "$sc_config"
+   delete_value '.harbor.redis.resources' "$sc_config"
+fi

--- a/migration/v0.24.x-v0.25.x/upgrade-apps.md
+++ b/migration/v0.24.x-v0.25.x/upgrade-apps.md
@@ -1,0 +1,23 @@
+# Upgrade v0.24.x to v0.25.x
+
+## Steps
+
+1. Update apps configuration:
+
+    This will take a backup into `backups/` before modifying any files.
+
+    ```bash
+    bin/ck8s init
+    ```
+
+1. Migrate harbor redis variables
+
+    ```console
+    migration/v0.24.x-v0.25.x/migrate-harbor-redis-variables.sh
+    ```
+
+1. Upgrade applications:
+
+    ```bash
+    bin/ck8s apply {sc|wc}
+    ```


### PR DESCRIPTION
**What this PR does / why we need it**: to expose external redis database for harbor

**Special notes for reviewer**:
- the migration script works with yq4 only

**Add a screenshot or an example to illustrate the proposed solution:**
![redis-harbor1](https://user-images.githubusercontent.com/77267293/181710212-b901b99a-c691-4b82-8fc1-242811368241.png)
![redis-harbor2](https://user-images.githubusercontent.com/77267293/181710236-999dd321-7264-42b1-b52d-91680320b509.png)


**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [x] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
