### PR TITLE
apps: added new fluentd buffer alerts

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -17,5 +17,6 @@
 ### Added
 - Option to create custom solvers for letsencrypt issuers, including a simple way to add secrets.
 - Add external redis database as option for harbor
+- a new alert `FluentdAvailableSpaceBuffer`, notifies when the fluentd buffer is filling up
 
 ### Removed

--- a/helmfile/charts/prometheus-alerts/CHANGELOG.md
+++ b/helmfile/charts/prometheus-alerts/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2022.08.10
+1. fluentd.yaml
+   - ADDED - new FluentdAvailableSpaceBuffer alerts
+
 ## 2022.07.07
 1. predict-linear.yaml
    - ADDED - the custom CPURequest and MemoryRequest alerts for the node patterns from common-config.yaml

--- a/helmfile/charts/prometheus-alerts/templates/alerts/fluentd.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/alerts/fluentd.yaml
@@ -53,6 +53,24 @@ spec:
       annotations:
         summary: fluentd node are critical
         description: In the last 5 minutes, fluentd queues increased 50%. Current value is {{ "{{ $value }}" }}
+    - alert: FluentdAvailableSpaceBuffer
+      expr: sum(fluentd_output_status_buffer_available_space_ratio) by (pod, cluster, plugin_id) < 50
+      for: 5m
+      labels:
+        service: fluentd
+        severity: warning
+      annotations:
+        summary: fluentd available space in buffer is less than 50%
+        description: For the last 5 minutes, the available buffer space for pod {{ "{{ $labels.pod }}" }}, plugin-id {{  "{{ $labels.plugin_id }}" }} in cluster {{ "{{ $labels.cluster }}" }} is below 50%. Current value is {{ "{{ $value }}" }}
+    - alert: FluentdAvailableSpaceBuffer
+      expr: sum(fluentd_output_status_buffer_available_space_ratio) by (pod, cluster, plugin_id) < 10
+      for: 5m
+      labels:
+        service: fluentd
+        severity: critical
+      annotations:
+        summary: fluentd available space in buffer is less than 90%
+        description: For the last 5 minutes, the available buffer space for pod {{ "{{ $labels.pod }}" }}, plugin-id {{  "{{ $labels.plugin_id }}" }} in cluster {{ "{{ $labels.cluster }}" }} is below 10%. Current value is {{ "{{ $value }}" }}
     - alert: FluentdRecordsCountsHigh
       expr: >
         sum(rate(fluentd_output_status_emit_records{job="fluentd-metrics"}[5m]))


### PR DESCRIPTION
**What this PR does / why we need it**: have alerts for when the fluentd buffers get full

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1102

**Add a screenshot or an example to illustrate the proposed solution:**
![flunetbufferfull](https://user-images.githubusercontent.com/77267293/183866505-4393ffeb-43bd-45e4-9a38-0fdea6ee7619.png)

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

