### PR TITLE
apps: Add option for custom solver for letsencrypt issuers

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -15,5 +15,6 @@
 ### Fixed
 
 ### Added
+- Option to create custom solvers for letsencrypt issuers, including a simple way to add secrets.
 
 ### Removed

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -300,9 +300,24 @@ issuers:
     prod:
       ## Mail through which letsencrypt can contact you.
       email: set-me
+      ## Solvers, sets a default http01 when empty.
+      solvers: []
+      # - selector:
+      #     dnsZones:
+      #     - example.org
+      #   dns01:
+      #     route53:
+      #       region: eu-north-1
+      #       hostedZoneID: set-me
+      #       accessKeyID: set-me
+      #       secretAccessKeySecretRef:
+      #         name: route53-credentials-secret # Can be created in secrets.yaml
+      #         key: secretKey
     staging:
       ## Mail through which letsencrypt can contact you.
       email: set-me
+      ## Solvers, sets a default http01 when empty.
+      solvers: []
 
   ## Additional issuers to create.
   ## ref: https://cert-manager.io/docs/configuration/

--- a/config/secrets/sc-secrets.yaml
+++ b/config/secrets/sc-secrets.yaml
@@ -140,3 +140,7 @@ dex:
     #    name: 'Example App'
     #    redirectURIs:
     #      - 'http://192.168.42.219:31850/oauth2/callback'
+issuers:
+  secrets: {}
+    # route53-credentials-secret:
+    #   secretKey: set-me

--- a/helmfile/charts/issuers/templates/letsencrypt-prod.yaml
+++ b/helmfile/charts/issuers/templates/letsencrypt-prod.yaml
@@ -11,10 +11,14 @@ spec:
       name: letsencrypt-prod
     server: https://acme-v02.api.letsencrypt.org/directory
     solvers:
+    {{- if .Values.letsencrypt.prod.solvers }}
+    {{- toYaml .Values.letsencrypt.prod.solvers | nindent 4 }}
+    {{- else }}
     # An empty selector will 'match' all Certificate resources that
     # reference this Issuer.
     - selector: {}
       http01:
         ingress:
           class: nginx
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/issuers/templates/letsencrypt-staging.yaml
+++ b/helmfile/charts/issuers/templates/letsencrypt-staging.yaml
@@ -11,10 +11,14 @@ spec:
       name: letsencrypt-staging
     server: https://acme-staging-v02.api.letsencrypt.org/directory
     solvers:
+    {{- if .Values.letsencrypt.staging.solvers }}
+    {{- toYaml .Values.letsencrypt.staging.solvers | nindent 4 }}
+    {{- else }}
     # An empty selector will 'match' all Certificate resources that
     # reference this Issuer.
     - selector: {}
       http01:
         ingress:
           class: nginx
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/issuers/templates/secrets.yaml
+++ b/helmfile/charts/issuers/templates/secrets.yaml
@@ -1,0 +1,8 @@
+{{- range $k, $v := .Values.secrets }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $k }}
+stringData: {{ toYaml $v | nindent 2 }}
+{{- end }}

--- a/helmfile/charts/issuers/values.yaml
+++ b/helmfile/charts/issuers/values.yaml
@@ -3,7 +3,10 @@ letsencrypt:
   namespaces: []
   prod:
     email: ""
+    solvers: []
   staging:
     email: ""
+    solvers: []
 
 extraIssuers: []
+secrets: {}

--- a/helmfile/values/letsencrypt.yaml.gotmpl
+++ b/helmfile/values/letsencrypt.yaml.gotmpl
@@ -3,8 +3,12 @@ letsencrypt:
   {{ if .Values.issuers.letsencrypt.enabled }}
   prod:
     email: {{ .Values.issuers.letsencrypt.prod.email }}
+    solvers: {{ toYaml .Values.issuers.letsencrypt.prod.solvers | nindent 6 }}
   staging:
     email: {{ .Values.issuers.letsencrypt.staging.email }}
+    solvers: {{ toYaml .Values.issuers.letsencrypt.staging.solvers | nindent 6 }}
   {{ end }}
 
 extraIssuers: {{- toYaml .Values.issuers.extraIssuers | nindent 2 }}
+
+secrets: {{- toYaml .Values.issuers.secrets | nindent 2 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an option for custom solvers for letsencrypt issuers and includes a simple way to add secrets.
This enables support for DNS01 challenges.

**Which issue this PR fixes**:
fixes #841

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
Was easier to add it on both, it can still be configured per cluster.
And it can be useful in some scenarios where we want a certificate for something that isn't exposed through an ingress.

**Add a screenshot or an example to illustrate the proposed solution:**
Running with this test (I already had it generate a cert for `test.aarnq.dev-ck8s.com` but forgot to capture the moment it got generated):
```yaml
# certificate.yaml
---
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: test-cert
spec:
  secretName: test-cert-tls
  commonName: test.aarnq.dev-ck8s.com
  dnsNames:
    - test.aarnq.dev-ck8s.com
    - "*.wild.aarnq.dev-ck8s.com"
  issuerRef:
    name: letsencrypt-staging
    kind: ClusterIssuer
```
```console
$ kubectl --context aarnq-sc apply -f certificate.yaml
certificate.cert-manager.io/test-cert configured

$ kubectl --context aarnq-sc describe certificates.cert-manager.io
...
Events:
  Type     Reason     Age               From          Message
  ----     ------     ----              ----          -------
  ...
  Normal   Issuing    2s                cert-manager  Fields on existing CertificateRequest resource not up to date: [spec.dnsNames]
  Normal   Reused     2s                cert-manager  Reusing private key stored in existing Secret resource "test-cert-tls"
  Normal   Requested  0s                cert-manager  Created new CertificateRequest resource "test-cert-t5zrf"

$ kubectl --context aarnq-sc describe challenges.acme.cert-manager.io test-cert-t5zrf-2993432670-3219732635 
...
Spec:
  ...
  Dns Name: wild.aarnq.dev-ck8s.com
  ...
  Solver:
    dns01:
      route53:
        Access Key ID:   <redacted>
        Hosted Zone ID:  <redacted>
        Region:          eu-north-1
        Secret Access Key Secret Ref:
          Key:   secretKey
          Name:  route53-credentials-secret
    Selector:
      Dns Zones:
        dev-ck8s.com
  ...
  Type:      DNS-01
  ...
  Wildcard:  true
  ...

$ dig @1.1.1.1 _acme-challenge.wild.aarnq.dev-ck8s.com txt
...
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 64616
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
...
;; ANSWER SECTION:
_acme-challenge.wild.aarnq.dev-ck8s.com. 10 IN TXT "<redacted>"
...

$ dig @1.1.1.1 be.wild.aarnq.dev-ck8s.com
...
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 28008
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
...
;; AUTHORITY SECTION:
dev-ck8s.com.		900	IN	SOA	ns-1465.awsdns-55.org. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400
...

$ kubectl --context aarnq-sc get certificate
NAME        READY   SECRET          AGE
test-cert   True    test-cert-tls   13m
```
During which there were no domain records pointing to the cluster on the `aarnq.dev-ck8s.com` domain, so no HTTP01.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
