### PR TITLE
apps: allow enabling allowSnippetAnnotations from configs

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -18,5 +18,6 @@
 - Option to create custom solvers for letsencrypt issuers, including a simple way to add secrets.
 - Add external redis database as option for harbor
 - a new alert `FluentdAvailableSpaceBuffer`, notifies when the fluentd buffer is filling up
+- Option to enable `allowSnippetAnnotations` from the configs
 
 ### Removed

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -214,6 +214,7 @@ externalTrafficPolicy:
 ## Nginx ingress controller configuration
 ingressNginx:
   controller:
+    allowSnippetAnnotations: false
     resources:
       requests:
         cpu: 100m

--- a/helmfile/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile/values/ingress-nginx.yaml.gotmpl
@@ -29,7 +29,7 @@ controller:
   {{ end }}
 
   # Set allow-snippet-annotations to false in order to mitigate CVE-2021-25742
-  allowSnippetAnnotations: false
+  allowSnippetAnnotations: {{ .Values.ingressNginx.controller.allowSnippetAnnotations }}
 
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920


### PR DESCRIPTION
**What this PR does / why we need it**: to allow enabling allowSnippetAnnotations from configs

**Which issue this PR fixes**: fixes #1111

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
