### PR TITLE
apps: tolerate control-plane taint

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -24,5 +24,6 @@
 - Option to enable `allowSnippetAnnotations` from the configs
 - Add external database as option for harbor
 - the possibility to enable falco in the service cluster and added some rules or alert exceptions
+- Added the `node-role.kubernetes.io/control-plane:NoSchedule` toleration
 
 ### Removed

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -121,6 +121,10 @@ falco:
   ## Run on master nodes.
   tolerations:
     - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
       effect: NoSchedule
   affinity: {}
   nodeSelector: {}
@@ -154,8 +158,12 @@ falco:
         cpu: 30m
         memory: 20Mi
     tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
     affinity: {}
     nodeSelector: {}
 
@@ -452,6 +460,10 @@ calicoAccountant:
   enabled: true
   tolerations:
     - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
       effect: NoSchedule
   resources:
     limits:
@@ -530,6 +542,10 @@ kured:
   extraArgs: {}
   tolerations:
     - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
       effect: NoSchedule
   resources:
     requests:

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -89,10 +89,19 @@ fluentd:
     - effect: NoSchedule
       key: node-role.kubernetes.io/master
       value: ""
+    - key: node-role.kubernetes.io/control-plane
+      effect: NoSchedule
+      value: ""
 
   ## Only run on master nodes.
-  nodeSelector:
-    node-role.kubernetes.io/master: ""
+  nodeSelector: ""
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
 
   resources:
     limits:
@@ -101,8 +110,6 @@ fluentd:
     requests:
       cpu: 200m
       memory: 300Mi
-
-  affinity: {}
 
   ## Extra fluentd config to mount.
   extraConfigMaps: {}

--- a/helmfile/charts/calico-accountant/values.yaml
+++ b/helmfile/charts/calico-accountant/values.yaml
@@ -12,3 +12,5 @@ resources:
 tolerations:
   - key: node-role.kubernetes.io/master
     effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
+    effect: NoSchedule

--- a/migration/v0.24.x-v0.25.x/add-control-plane-toleration.sh
+++ b/migration/v0.24.x-v0.25.x/add-control-plane-toleration.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
+common_config="${CK8S_CONFIG_PATH}/common-config.yaml"
+sc_config="${CK8S_CONFIG_PATH}/sc-config.yaml"
+wc_config="${CK8S_CONFIG_PATH}/wc-config.yaml"
+
+add_toleration() {
+    echo "Adding control-plane toleration in $i."
+    yq4 -i '((.. | select(key == "tolerations") | (select(tag == "!!seq" and contains([{"key": "'"$1"'"}]) and contains([{"key": "'"$2"'"}]) == false))) += [{"key": "'"$2"'", "operator": "Exists", "effect": "NoSchedule"}])' "$3"
+}
+
+add_affinity() {
+    echo "Replace master affinity label with control-plane in $i."
+    yq4 -i '((.. | select(key == "matchExpressions") | select(tag == "!!seq" and contains([{"key": "'"$1"'"}]))) = [{"key": "'"$2"'", "operator": "Exists"}])' "$3"
+}
+
+for i in ${sc_config} ${wc_config} ${common_config}; do
+    if [[ ! -f "$i" ]]; then
+        echo "$i does not exist, skipping."
+        exit 1
+    else
+       add_toleration 'node-role.kubernetes.io/master' 'node-role.kubernetes.io/control-plane' "$i"
+       add_affinity 'node-role.kubernetes.io/master' 'node-role.kubernetes.io/control-plane' "$i"
+    fi
+done

--- a/migration/v0.24.x-v0.25.x/upgrade-apps.md
+++ b/migration/v0.24.x-v0.25.x/upgrade-apps.md
@@ -22,6 +22,12 @@
     migration/v0.24.x-v0.25.x/migrate-harbor-database-variables.sh
     ```
 
+1. Add the new control-plane toleration:
+
+    ```console
+    migration/v0.24.x-v0.25.x/add-control-plane-toleration.sh
+    ```
+
 1. Upgrade applications:
 
     ```bash

--- a/pipeline/test/services/service-cluster/testPrometheusTargets.sh
+++ b/pipeline/test/services/service-cluster/testPrometheusTargets.sh
@@ -8,7 +8,7 @@ source "$INNER_SCRIPTS_PATH/../prometheus-common.sh"
 
 # Get amount of nodes in cluster
 totalNodes=$(kubectl get nodes --no-headers | wc -l)
-masterNodes=$(kubectl get nodes -l node-role.kubernetes.io/master --no-headers | wc -l)
+masterNodes=$(kubectl get nodes -l node-role.kubernetes.io/control-plane --no-headers | wc -l)
 
 totalPrometheus=$(yq4 -e '.prometheus.replicas' "${CONFIG_FILE}")
 

--- a/pipeline/test/services/workload-cluster/testPrometheusTargets.sh
+++ b/pipeline/test/services/workload-cluster/testPrometheusTargets.sh
@@ -8,7 +8,7 @@ source "$INNER_SCRIPTS_PATH/../prometheus-common.sh"
 
 # Get amount of nodes in cluster
 totalNodes=$(kubectl get nodes --no-headers | wc -l)
-masterNodes=$(kubectl get nodes -l node-role.kubernetes.io/master --no-headers | wc -l)
+masterNodes=$(kubectl get nodes -l node-role.kubernetes.io/control-plane --no-headers | wc -l)
 
 echo
 echo


### PR DESCRIPTION
**What this PR does / why we need it**: to support the new `node-role.kubernetes.io/control-plane:NoSchedule` taint

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #970 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
