### PR TITLE
apps sc: kured prometheus-alert optimization

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Updated
 
 ### Changed
+- The ThanosReceiveHttpRequestErrorRateHigh, OpenSearchTooFewNodesRunning, and MetricsFromScClusterIsMissing prometheus-alerts were optimized to not be triggered by kured and to reduce other unwanted behaviors.
 
 ### Fixed
 - Fixed so grafana can show data from thanos that's older than 30 days (downsampled data)

--- a/helmfile/charts/prometheus-alerts/CHANGELOG.md
+++ b/helmfile/charts/prometheus-alerts/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2022.08.17
+1. helmfile/charts/prometheus-alerts/files/missing-metrics-alerts.yaml
+   - MODIFIED - MetricsFromScClusterIsMissing 'for' from 5m to 15m
+2. helmfile/charts/prometheus-alerts/files/thanos.yaml
+   - MODIFIED - ThanosReceiveHttpRequestErrorRateHigh 'for' from 5m to 20m
+3. helmfile/charts/prometheus-alerts/templates/alerts/opensearch.yaml
+   - MODIFIED - OpenSearchTooFewNodesRunning 'for' from 5m to 15m
+
 ## 2022.08.10
 1. fluentd.yaml
    - ADDED - new FluentdAvailableSpaceBuffer alerts

--- a/helmfile/charts/prometheus-alerts/files/missing-metrics-alerts.yaml
+++ b/helmfile/charts/prometheus-alerts/files/missing-metrics-alerts.yaml
@@ -15,6 +15,6 @@
       summary: Metrics from the service cluster is not being received.
     expr: |
       absent(prometheus_tsdb_head_series{job="kube-prometheus-stack-prometheus",tenant_id!~".*-wc"}) > 0 or prometheus_tsdb_head_series{job="kube-prometheus-stack-prometheus",tenant_id!~".*-wc"} == 0
-    for: 5m
+    for: 15m
     labels:
       severity: critical

--- a/helmfile/charts/prometheus-alerts/files/thanos.yaml
+++ b/helmfile/charts/prometheus-alerts/files/thanos.yaml
@@ -186,7 +186,7 @@ groups:
       /
         sum by (cluster, job) (rate(http_requests_total{job=~".*thanos-receiver-receive.*", handler="receive"}[5m]))
       ) * 100 > 5
-    for: 5m
+    for: 20m
     labels:
       severity: critical
   - alert: ThanosReceiveHttpRequestLatencyHigh

--- a/helmfile/charts/prometheus-alerts/templates/alerts/blackbox.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/alerts/blackbox.yaml
@@ -19,7 +19,7 @@ spec:
       rules:
         - alert: EndpointDown
           expr: probe_success == 0
-          for: 15s
+          for: 60s
           labels:
             severity: "critical"
           annotations:

--- a/helmfile/charts/prometheus-alerts/templates/alerts/opensearch.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/alerts/opensearch.yaml
@@ -19,7 +19,7 @@ spec:
     rules:
     - alert: OpenSearchTooFewNodesRunning
       expr: elasticsearch_cluster_health_number_of_nodes < {{ .Values.osNodeCount }}
-      for: 5m
+      for: 15m
       labels:
         severity: critical
       annotations:


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/elastisys/compliantkubernetes-apps/issues/1054

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1054

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
Sometimes easy solutions are the best ones? After thinking a bit about it, it seems like the best solution is to increase the "for"-parameter to make sure the alert is triggered by a long-term state rather than just a temporary one? It feels like a bad idea to increase the limits themselves - for example, ThanosReceiveHttpRequestErrorRateHigh has peaks over 35%(https://elastisys.app.eu.opsgenie.com/alert/detail/5c660bc7-e722-4df0-bc13-a9baaecc6708-1660716939410/details)... It would be a bad idea I think to increase/change our limits to suit that. It may be wiser to just make it less sensitive to temporary states? Im up for a talk about it for sure! :+1:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [x] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
