### PR TITLE
apps sc: add exception for elastisys/curl-jq used by opensearch

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -22,7 +22,7 @@
 - Add external redis database as option for harbor
 - a new alert `FluentdAvailableSpaceBuffer`, notifies when the fluentd buffer is filling up
 - Option to enable `allowSnippetAnnotations` from the configs
-- the possibility to enable falco in the service cluster
 - Add external database as option for harbor
+- the possibility to enable falco in the service cluster and added some rules or alert exceptions
 
 ### Removed

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -100,6 +100,9 @@ falco:
       - macro: user_known_contact_k8s_api_server_activities
         append: true
         condition: or (container.image.repository in (ghcr.io/dexidp/dex))
+    opensearch.yaml: |-
+      - macro: user_privileged_containers
+        condition: container.image.repository=docker.io/elastisys/curl-jq and k8s.pod.name startswith opensearch-
 
 harbor:
   enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**: to add an exception for a know falco alert

**Which issue this PR fixes**: fixes #1115 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
