### PR TITLE
apps-sc: Fixed bug where thanos didn't show downsampled only data

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,12 @@
+### Release notes
+
+### Updated
+
+### Changed
+
+### Fixed
+- Fixed so grafana can show data from thanos that's older than 30 days (downsampled data)
+
+### Added
+
+### Removed

--- a/helmfile/values/thanos/query.yaml.gotmpl
+++ b/helmfile/values/thanos/query.yaml.gotmpl
@@ -4,6 +4,9 @@ query:
   enabled: true
   replicaCount: {{ .Values.thanos.query.replicaCount }}
 
+  extraFlags:
+    - "--query.auto-downsampling"
+
   dnsDiscovery:
     enabled: false
   stores:


### PR DESCRIPTION
**What this PR does / why we need it**:

Since we are using thanos and only store 30 days worth of non-downsampled data but keep downsampled data for even longer, we would like to be able to actually look at that.

According to [this issue](https://github.com/thanos-io/thanos/issues/1353) the issue is that grafana doesn't query the data and requeets the downsampled data. So the fix is to add the flag `--query.auto-downsampling` and let querier make this automatically.

I tried it on long-running and it looks like it works. (see screenshot)

So now when you have a window larger than 30 days (roughly) the querier will automatically use the downsampled data while using the raw data when zoomed in further

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

Before:
![screenshot_2022-08-24-143708](https://user-images.githubusercontent.com/2071713/186420164-a9d76f46-6bdd-43ef-b862-edee58fb6fb3.png)
After:
![screenshot_2022-08-24-143510](https://user-images.githubusercontent.com/2071713/186420198-539d046b-37d5-4719-b756-9ee47071a93e.png)

Note that the data looks a bit strange since the downsampled data isn't perfect.


**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
