### PR TITLE
for non-AWS implementation of s3 prepend protocol in the url

### DIFF
--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -72,7 +72,7 @@ objectStorage:
   #   project: set-me
   # s3:
   #   region: set-me
-  #   for non-AWS implementation of s3 please prepend the protocol (i.e., https:// or http://) with the url, e.g., https://s3.sto1.safedc.net
+  #   # S3 endpoint for non-AWS implementation of S3. Make sure to prepend the protocol (i.e., https:// or http://) with the URL, e.g., https://s3.sto1.safedc.net
   #   regionEndpoint: set-me
   #   # Generally false when using AWS and Exoscale and true for other providers.
   #   forcePathStyle: set-me

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -72,6 +72,7 @@ objectStorage:
   #   project: set-me
   # s3:
   #   region: set-me
+  #   for non-AWS implementation of s3 please prepend the protocol (i.e., https:// or http://) with the url, e.g., https://s3.sto1.safedc.net
   #   regionEndpoint: set-me
   #   # Generally false when using AWS and Exoscale and true for other providers.
   #   forcePathStyle: set-me


### PR DESCRIPTION
**What this PR does / why we need it**:
In the current version of ck8s, fluentd-aggregator fails to communicate with s3 for non-AWS implementation without prepending http(s) protocol in **_regionEndpoint_** . This PR adds a comment regarding the issue. Here is an example:
```  
objectStorage:
  type: s3
  s3:
    region: sto1
    regionEndpoint: https://s3.sto1.safedc.net
    forcePathStyle: true
```
**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**
The log below shows the error encountered:

`022-08-23 13:25:02 +0000 [info]: adding match pattern="kubernetes.var.log.containers.fluentd-**" type="null"
2022-08-23 13:25:02 +0000 [info]: adding match pattern="**" type="s3"
2022-08-23 13:25:04 +0000 [warn]: #0 'force_path_style' parameter is deprecated: S3 will drop path style API in 2020: See https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
2022-08-23 13:25:04 +0000 [warn]: #0 [output-s3] The default value of s3_object_key_format will use ${chunk_id} instead of %{index} to avoid object conflict in v2
2022-08-23 13:25:04 +0000 [info]: adding source type="prometheus"
2022-08-23 13:25:04 +0000 [info]: adding source type="prometheus_monitor"
2022-08-23 13:25:04 +0000 [info]: adding source type="prometheus_output_monitor"
2022-08-23 13:25:04 +0000 [info]: adding source type="forward"
2022-08-23 13:25:04 +0000 [info]: adding source type="http"
2022-08-23 13:25:04 +0000 [warn]: #0 define <match fluent.**> to capture fluentd logs in top level is deprecated. Use <label @FLUENT_LOG> instead
2022-08-23 13:25:04 +0000 [info]: #0 starting fluentd worker pid=60 ppid=1 worker=0
2022-08-23 13:25:04 +0000 [error]: #0 unexpected error error_class=ArgumentError error="expected :endpoint to be a HTTP or HTTPS endpoint"
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/aws-sdk-core-3.130.0/lib/seahorse/client/plugins/endpoint.rb:39:in `after_initialize'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/aws-sdk-core-3.130.0/lib/seahorse/client/base.rb:81:in `block in after_initialize'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/aws-sdk-core-3.130.0/lib/seahorse/client/base.rb:80:in `each'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/aws-sdk-core-3.130.0/lib/seahorse/client/base.rb:80:in `after_initialize'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/aws-sdk-core-3.130.0/lib/seahorse/client/base.rb:24:in `initialize'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/aws-sdk-s3-1.113.0/lib/aws-sdk-s3/client.rb:435:in `initialize'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/aws-sdk-core-3.130.0/lib/seahorse/client/base.rb:102:in `new'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/fluent-plugin-s3-1.6.1/lib/fluent/plugin/out_s3.rb:255:in `start'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/fluentd-1.14.6/lib/fluent/root_agent.rb:203:in `block in start'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/fluentd-1.14.6/lib/fluent/root_agent.rb:192:in `block (2 levels) in lifecycle'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/fluentd-1.14.6/lib/fluent/root_agent.rb:191:in `each'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/fluentd-1.14.6/lib/fluent/root_agent.rb:191:in `block in lifecycle'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/fluentd-1.14.6/lib/fluent/root_agent.rb:178:in `each'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/fluentd-1.14.6/lib/fluent/root_agent.rb:178:in `lifecycle'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/fluentd-1.14.6/lib/fluent/root_agent.rb:202:in `start'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/fluentd-1.14.6/lib/fluent/engine.rb:248:in `start'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/fluentd-1.14.6/lib/fluent/engine.rb:147:in `run'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/fluentd-1.14.6/lib/fluent/supervisor.rb:720:in `block in run_worker'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/fluentd-1.14.6/lib/fluent/supervisor.rb:971:in `main_process'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/fluentd-1.14.6/lib/fluent/supervisor.rb:711:in `run_worker'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/fluentd-1.14.6/lib/fluent/command/fluentd.rb:376:in `<top (required)>'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/ruby/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:85:in `require'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/ruby/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:85:in `require'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/gems/fluentd-1.14.6/bin/fluentd:15:in `<top (required)>'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/bin/fluentd:23:in `load'
  2022-08-23 13:25:04 +0000 [error]: #0 /opt/bitnami/fluentd/bin/fluentd:23:in `<main>'
2022-08-23 13:25:04 +0000 [error]: #0 unexpected error error_class=ArgumentError error="expected :endpoint to be a HTTP or HTTPS endpoint"
  2022-08-23 13:25:04 +0000 [error]: #0 suppressed same stacktrace
2022-08-23 13:25:04 +0000 [info]: Received graceful stop
2022-08-23 13:25:05 +0000 [info]: Worker 0 finished with status 1`
**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
