### PR TITLE
config: update OIDC config

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -6,6 +6,8 @@
 ### Updated
 
 ### Changed
+- OIDC scope to include groups for all services
+- OIDC enabled by default for ops grafana
 
 ### Fixed
 - Fixed so grafana can show data from thanos that's older than 30 days (downsampled data)

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -73,7 +73,7 @@ user:
     affinity: {}
     nodeSelector: {}
     oidc:
-      scopes: profile email openid
+      scopes: profile email openid groups
       userGroups:
         grafanaAdmin: grafana_admin   # maps to grafana role admin
         grafanaEditor: grafana_editor # maps to grafana role editor
@@ -383,7 +383,7 @@ harbor:
     disableRedirect: set-me
   oidc:
     # group claim name used by OIDC Provider
-    groupClaimName: set-me
+    groupClaimName: groups
     # Name of the group that autmatically will get admin
     # Set to "" to disable
     adminGroupName: set-me
@@ -444,14 +444,14 @@ prometheus:
     affinity: {}
     nodeSelector: {}
     oidc:
-      enabled: false
-      # Only used if the above is true
-      # userGroups:
-      #   grafanaAdmin: grafana_admin   # maps to grafana role admin
-      #   grafanaEditor: grafana_editor # maps to grafana role editor
-      #   grafanaViewer: grafana_viewer # maps to grafana role viewer
-      # scopes: "openid profile email groups"
-      # allowedDomains: []
+      enabled: true
+      userGroups:
+        grafanaAdmin: grafana_admin   # maps to grafana role admin
+        grafanaEditor: grafana_editor # maps to grafana role editor
+        grafanaViewer: grafana_viewer # maps to grafana role viewer
+      scopes: openid profile email groups
+      allowedDomains:
+        - set-me
     viewersCanEdit: true
 
     sidecar:
@@ -664,8 +664,7 @@ opensearch:
     subjectKey: email
     # Where to find roles
     rolesKey: groups
-    # Scope - add 'groups' if groups claim is supported
-    scope: openid profile email
+    scope: openid profile email groups
 
   extraRoles: []
     # - role_name: log_reader


### PR DESCRIPTION
**What this PR does / why we need it**: We want this in all clusters anyway. It also does not seem to conflict with setups where the dex connector does not have group support, so the changes should be rather safe.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
