### PR TITLE
release: Updated release scripts and document

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,30 +1,19 @@
 name: Release
 
 on:
-  pull_request:
-    types: [closed]
-    branches:
-      - 'release-[0-9]+.[0-9]+'
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true
-    name: Create Release
+    name: Create release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Release
+        uses: softprops/action-gh-release@v1
         with:
-          fetch-depth: 0 # Fetches all tags
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::$(git describe --tags --abbrev=0 HEAD)
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.get_version.outputs.VERSION }}
-          release_name: ${{ steps.get_version.outputs.VERSION }}
           body: |
-            See [CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/${{ steps.get_version.outputs.VERSION }}/CHANGELOG.md) for details.
+            See [CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/${{ github.ref_name }}/CHANGELOG.md) for details.

--- a/release/README.md
+++ b/release/README.md
@@ -5,211 +5,60 @@ https://semver.org/
 
 ## Major and minor releases
 
-1. To release a major or minor version create a release branch `release-X.Y` from the last minor release tag.
+1. To release a major or minor version, switch to the branch you want to create the release from (probably main) and run:
 
     ```bash
-    git checkout main
-    git checkout -b release-X.Y
-    git push -u origin release-X.Y
+    git switch main
+    release/feature-freeze-for-major-minor-release.sh vX.Y.0
     ```
 
-1. Reset changelog
-
-    ```bash
-    git checkout -b reset-changelog-X.Y
-    release/reset-changelog.sh X.Y.0
-    ```
-
-    The release script will:
-    * Append what is in `WIP-CHANGELOG.md` to `CHANGELOG.md`
-    * Clear `WIP-CHANGELOG.md`
-    * Create a git commit with message `Reset changelog for release vX.Y.Z`
-
-    Make sure that the changes only include changes mentioned above, and then push.
-
-    ```
-    git diff HEAD~1
-    git push -u origin reset-changelog-X.Y
-    ```
-
-1. Merge `reset-changelog-X.Y` into `release-X.Y` then, into `main` as soon as possible to minimize risk of conflicts
-
-    **NOTE**: The release action will fail since we haven't tagged the release commit.
-    We will do that after QA.
-
-1. Create a `QA-X.Y` branch and run QA checks on this branch.
-
-    ```bash
-    git checkout release-X.Y
-    git checkout -b QA-X.Y
-    git push -u origin QA-X.Y
-    ```
+1. Now you should be on the QA branch, so now is the time to do QA and add all fixes on this branch.
 
     **NOTE**: All changes made in QA should be added to `CHANGELOG.md` and **NOT** `WIP-CHANGELOG.md`.
-    Also, make sure to not merge any fixes into `release-X.Y` on this step.
 
-1. When the QA is finished, create the release tag.
+1. When you're done with QA, create a PR to the release branch and merge it.
 
-    ```bash
-    git tag vX.Y.0
-    ```
-
-1. Push the tagged commit, create a PR against the release branch and request a review.
-   If there are no changes, create the release manually instead by going to [releases](https://github.com/elastisys/compliantkubernetes-apps/releases) and clicking "Draft a new release".
-   Check older releases for how to word it.
+1. When the PR is merged switch to that branch and run:
 
     ```bash
-    git push --tags
+    release/create-major-minor-release.sh
     ```
 
-1. Merge it to finalize the release.
+    *When the script is done a [GitHub actions workflow pipeline](/.github/workflows/release.yml) should've created a GitHub release from that tag.*
 
-    Since the tag is referencing a specific commit hash we need to retain it after the PR (via e.g. fast-forward merge).
-
-    *GitHub currently does not support merging with fast-forward only in PRs.
-    Merge the release PR locally and push it instead.*
-
-    ```bash
-    git checkout release-X.Y
-    git merge --ff-only QA-X.Y
-    git push
-    ```
-
-    A [GitHub actions workflow pipeline](/.github/workflows/release.yml) will create a GitHub release from the tag.
-
-1. Merge any fixes from the release branch back to the `main` branch `git cherry-pick` can be used, e.g.
-
-    ```bash
-    git checkout main
-    git checkout -b release-X.Y-fixes
-    git cherry-pick <fix 1 hash> [<fix 2 hash>..]
-    git push -u origin release-X.Y-fixes
-    ```
-
-    Create a PR and merge the fixes into main.
-
-9. Update public release notes.
-
-    When a released is published the public [user-facing release notes](https://github.com/elastisys/compliantkubernetes/blob/main/docs/release-notes.md) needs to be updated. The new release needs to be added and the list can be trimmed down to only include the supported versions.
-
-    Add bullet points of major changes within the cluster that affects the user as defined [here](https://compliantkubernetes.io/user-guide/). This includes any change within the cluster that may impact the user experience, for example new or updated feature, or the deprecation of features.
-
-    Finish it of with one bullet point regarding the overall changes of the release in regards to updates, fixes, or other improvements.
+1. If there were any changes in the QA branch the script should've prompted you with some cherry-pick commands that you should run.
+    When you've run those commands you should create a PR from this branch to main so all QA fixes is merged back to main.
 
 ## Patch releases
 
-1. Create a new branch `patch-X.Y-<patch-name>` from the release branch to patch and commit the patch to it.
+1. Check out the release branch you want to create a release for:
 
     ```bash
     git switch release-X.Y
-    git pull
-    git switch -c patch-X.Y-<patch-name>
-    git cherry-pick [fixed commits from main]
-    git add -p [fixed files]
-    git commit
-    git push -u origin patch-X.Y-<patch-name>
     ```
 
-1. Reset changelog, increment `Z` from the previous version.
+1. Run the prepare patch command:
 
     ```bash
-    release/reset-changelog.sh X.Y.Z
+    release/prepare-patch-release.sh vX.Y.Z
     ```
 
-    Make sure that `CHANGELOG.md` is updated correctly.
+1. You should now be on the patch branch.
+    Cherry-pick or manually add all fixes that you want to include in the patch.
 
-1. Run QA checks on this branch related to the introduced changes.
-
-    **NOTE**: All changes made in QA should be added to `CHANGELOG.md` and **NOT** `WIP-CHANGELOG.md`.
-    Also, make sure to not merge any fixes into `release-X.Y` on this step.
-
-1. When the QA is finished, create the release tag and push it.
+1. Run reset-changelog:
 
     ```bash
-    git tag vX.Y.Z
-    git push --tags
+    release/reset-changelog.sh vX.Y.Z
     ```
 
-1. Create a PR against the release branch and request review.
+1. Create a PR into the release branch and merge it.
 
-1. Fast-forward merge the PR to finalize the release.
-
-    This is to keep the commit hash and tag with it after the merge.
-
-    *Since GitHub currently does not support fast-forward merge of PRs this has to be done manually.*
+1. When the PR is merged, switch to that branch and run:
 
     ```bash
     git switch release-X.Y
-    git merge --ff-only patch-X.Y-<patch-name>
-    git push
+    release/create-patch-release.sh vX.Y.Z
     ```
 
-    A [GitHub actions workflow pipeline](/.github/workflows/release.yml) will create a GitHub release from the tag.
-
-    The relese action will fail if the patch branch is merged in a way that does not preserve the commit hash and tag.
-    To fix this remove the previously created tag, recreate it on the release branch, and rerun the release action workflow.
-
-1. Follow the major/minor release from step 8 to merge eventual fixes into main and to update the public release notes.
-
-## While developing
-
-When a feature or change is developed on a branch fill out some human readable
-bullet points in the `WIP-CHANGELOG.md` this will make it easier to track the changes.
-Once the release is done this will be appended to the main changelog.
-
-## Structure
-
-The structure follow the guidelines of [keepachangelog](https://keepachangelog.com/en/1.0.0/).
-
-Changelogs are for humans, not machines. Keep messages in human readable form rather
-than commits or code. Commits or pull requests can off course be linked. Add messages
-as bullet points under one of theese categories:
-
-* Breaking changes
-* Release notes
-* Added
-* Changed
-* Deprecated
-* Removed
-* Fixed
-* Security
-
-When creating a major release a section of `Release highlights` should be added
-on top of the WIP-changelog with a summary of the most important changes.
-
-You can link comments to related pull requests with `PR#pr-number`. Commit ids can be linked
-by just writing that commits short hash or full hash.
-
-# Example changelog
-
-## v0.1.2 - 2020-01-14  (OBS! this line is automatically added by script)
-
-### Breaking changes
-
-* The API endpoint xxxx has been removed.
-
-### Release notes
-
-* To migrate the resources depending on yyyy you have to run this script.
-
-### Added
-
-* Option to add prometheus scrape endpoints
-* Retetion for elasticsearch
-
-### Changed
-
-* Updated grafana version to 6.7.0
-* Changed manifests for deploying ck8sdash into a helm chart PR#120
-
-### Deprecated
-
-* Option to disable OPA with `ENABLE_OPA` variable. Now always true
-
-### Removed
-
-* Curator has been removed. Now retention is configured with ILM.
-
-### Fixed
-
-* bugfix deploying elasticsearch operator 2310e74
+    *When the script is done a [GitHub actions workflow pipeline](/.github/workflows/release.yml) should've created a GitHub release from that tag.*

--- a/release/common.sh
+++ b/release/common.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+commit_lookback=10
+# shellcheck disable=SC2034
+this_repo="elastisys/compliantkubernetes-apps"
+
+make_sure_branch_is_up_to_date() {
+  git fetch origin
+  if [[ "$(git rev-parse "${1}")" != "$(git rev-parse "origin/${1}")" ]]; then
+    log_error "ERROR: Your branch isn't up to date with upstream, please run 'git pull' and try again"
+    exit 1
+  fi
+}
+
+reset_commit_found() {
+  if git log "-${commit_lookback}" --format=%s | grep -P "^Reset changelog for release v${1}.${2}.0$" > /dev/null; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+log_info_no_newline() {
+  echo -e -n "[\e[34mck8s\e[0m] ${*}" 1>&2
+}
+
+log_info() {
+  log_info_no_newline "${*}\n"
+}
+
+log_warning_no_newline() {
+    echo -e -n "[\e[33mck8s\e[0m] ${*}" 1>&2
+}
+
+log_warning() {
+    log_warning_no_newline "${*}\n"
+}
+
+log_error_no_newline() {
+    echo -e -n "[\e[31mck8s\e[0m] ${*}" 1>&2
+}
+
+log_error() {
+    log_error_no_newline "${*}\n"
+}

--- a/release/create-major-minor-release.sh
+++ b/release/create-major-minor-release.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+here="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+# shellcheck source=release/common.sh
+source "${here}/common.sh"
+
+current_branch=$(git symbolic-ref -q --short HEAD)
+if [[ ! "${current_branch}" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
+  log_error "Error: Expected to be on release branch, e.g. release-1.2. Got: ${current_branch}"
+  exit 1
+fi
+
+# shellcheck disable=SC2001
+major_version=$(echo "${current_branch}" | sed 's/release-\([0-9]\+\)\.[0-9]\+/\1/')
+# shellcheck disable=SC2001
+minor_version=$(echo "${current_branch}" | sed 's/release-[0-9]\+\.\([0-9]\+\)/\1/')
+
+# Make sure branch is up to date with upstream (might happen if someone missed to run pull after merging QA branch)
+make_sure_branch_is_up_to_date "release-${major_version}.${minor_version}"
+
+# Create the tag and push.
+# This will start the github action to create the release.
+tag="v${major_version}.${minor_version}.0"
+log_warning_no_newline "Your about to create the release ${tag} are you sure? (y/n): "
+read -r sure_to_release
+if [[ ! "${sure_to_release}" =~ ^[yY]$ ]]; then
+  exit 1
+fi
+
+git tag "${tag}"
+git push --tags
+
+if ! git log -1 --format=%s | grep -P "^Reset changelog for release ${tag}$" > /dev/null; then
+  release_head_commit=$(git rev-parse --short HEAD)
+  reset_commit=$(git log "-${commit_lookback}" --oneline | grep -P "Reset changelog for release ${tag}$" | awk '{print $1}')
+
+  git switch main
+  git pull
+
+  git switch -c "patches-from-release-${major_version}.${minor_version}"
+  git push -u origin "patches-from-release-${major_version}.${minor_version}"
+
+  log_info "Please run these commands from top to bottom and fix any merge conflicts, then merge this to the main branch:"
+  for commit in $(git log "${reset_commit}..${release_head_commit}" --format=%h); do
+    echo "git cherry-pick ${commit}"
+  done
+fi

--- a/release/create-patch-release.sh
+++ b/release/create-patch-release.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+here="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+# shellcheck source=release/common.sh
+source "${here}/common.sh"
+
+if [ $# -lt 1 ]; then
+  log_error "Usage: $0 vX.Y.Z"
+  exit 1
+fi
+
+current_branch=$(git symbolic-ref -q --short HEAD)
+
+if [[ ! "${current_branch}" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
+  log_error "Error: Expected to be on release branch, e.g. release-1.2. Got: ${current_branch}"
+  exit 1
+fi
+
+# shellcheck disable=SC2001
+expected_major_version=$(echo "${current_branch}" | sed 's/release-\([0-9]\+\)\.[0-9]\+/\1/')
+# shellcheck disable=SC2001
+expected_minor_version=$(echo "${current_branch}" | sed 's/release-[0-9]\+\.\([0-9]\+\)/\1/')
+
+# Make sure branch is up to date with upstream (might happen if someone missed to run pull after merging QA branch)
+make_sure_branch_is_up_to_date "release-${expected_major_version}.${expected_minor_version}"
+
+full_version="${1}"
+if [[ ! "${full_version}" =~ ^v[0-9]+.[0-9]+.[0-9]+$ ]]; then
+  log_error "ERROR: Version must be in the form vX.Y.Z (where X is major, Y is minor, and Z is patch version). Got: ${full_version}"
+  exit 1
+fi
+# shellcheck disable=SC2001
+major_version=$(echo "${full_version}" | sed 's/v\([0-9]\+\)\.[0-9]\+\.[0-9]\+/\1/')
+# shellcheck disable=SC2001
+minor_version=$(echo "${full_version}" | sed 's/v[0-9]\+\.\([0-9]\+\)\.[0-9]\+/\1/')
+# shellcheck disable=SC2001
+patch_version=$(echo "${full_version}" | sed 's/v[0-9]\+\.[0-9]\+\.\([0-9]\+\)/\1/')
+if [ "${expected_major_version}" -ne "${major_version}" ] || [ "${expected_minor_version}" -ne "${minor_version}" ]; then
+  log_error "Error: Version mismatch: Expected v${expected_major_version}.${expected_minor_version}.${patch_version} Got: v${major_version}.${minor_version}.${patch_version}"
+  exit 1
+fi
+
+current_tags=$(git tag --points-at HEAD)
+if [[ "${current_tags}" != "" ]]; then
+  log_error "Error: commit already has tags: ${current_tags}"
+  log_error "Maybe you forgot to cherry-pick fixes to this branch before running this"
+  exit 1
+fi
+
+tag="v${major_version}.${minor_version}.${patch_version}"
+log_warning_no_newline "You're about to create the release ${tag} are you sure? (y/n): "
+read -r sure_to_release
+if [[ ! "${sure_to_release}" =~ ^[yY]$ ]]; then
+  exit 1
+fi
+
+git tag "${tag}"
+git push --tags

--- a/release/feature-freeze-for-major-minor-release.sh
+++ b/release/feature-freeze-for-major-minor-release.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+here="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+# shellcheck source=release/common.sh
+source "${here}/common.sh"
+
+# log_info_no_newline "What version version to you want to create (like v1.2.0): "
+if [ $# -lt 1 ]; then
+  log_error "Usage: $0 vX.Y.0"
+  exit 1
+fi
+
+full_version="${1}"
+if [[ ! "${full_version}" =~ ^v[0-9]+.[0-9]+.0$ ]]; then
+  log_error "ERROR: Version must be in the form vX.Y.0 (where X is major and Y is minor version). Got: ${full_version}"
+  exit 1
+fi
+# shellcheck disable=SC2001
+major_version=$(echo "${full_version}" | sed 's/v\([0-9]\+\)\.[0-9]\+\.0/\1/')
+# shellcheck disable=SC2001
+minor_version=$(echo "${full_version}" | sed 's/v[0-9]\+\.\([0-9]\+\)\.0/\1/')
+
+if [[ ! "${major_version}" =~ ^[0-9]+$ ]]; then
+  log_error "ERROR: Major version must be a number. Got: ${major_version}"
+  exit 1
+fi
+
+if [[ ! "${minor_version}" =~ ^[0-9]+$ ]]; then
+  log_error "ERROR: Minor version must be a number. Got: ${minor_version}"
+  exit 1
+fi
+
+# Make sure we have latest info
+git fetch origin
+
+if git tag -l | grep -P "^v${major_version}.${minor_version}.0$" > /dev/null; then
+  log_error "ERROR: tag v${major_version}.${minor_version}.0 already exists"
+  exit 1
+fi
+
+current_commit_hash=$(git rev-parse HEAD)
+# Gets current branch name or if detached you get the short hash of the commit
+current_branch_or_hash=$(git symbolic-ref -q --short HEAD || git rev-parse --short HEAD)
+if git symbolic-ref -q --short HEAD > /dev/null; then
+  make_sure_branch_is_up_to_date "${current_branch_or_hash}"
+  log_warning_no_newline "Your current git branch is ${current_branch_or_hash}. Do you want to base the release from this (this should probably be main)? (y/n): "
+else
+  log_warning_no_newline "Your currently on a detached commit ${current_branch_or_hash}. Do you want to base the release from this (this should probably be main)? (y/n): "
+fi
+
+read -r sure_to_release
+if [[ ! "${sure_to_release}" =~ ^[yY]$ ]]; then
+  exit 1
+fi
+
+log_info "Creating release branch for version ${major_version}.${minor_version}"
+
+if git branch -a | grep -P "release-${major_version}\.${minor_version}$" > /dev/null; then
+  log_warning "Release branch release-${major_version}.${minor_version} already exists"
+  log_warning "This might happen if you needed to rerun this script"
+  log_info_no_newline "Do you want to reuse that one? (y/n): "
+  read -r reuse_existing_release_branch
+  if [[ ! "${reuse_existing_release_branch}" =~ ^[yY]$ ]]; then
+    exit 1
+  fi
+  git switch "release-${major_version}.${minor_version}"
+  make_sure_branch_is_up_to_date "release-${major_version}.${minor_version}"
+else
+  git switch -c "release-${major_version}.${minor_version}"
+  git push -u origin "release-${major_version}.${minor_version}"
+fi
+
+## Check if reset changelog commit exists
+if ! reset_commit_found "${major_version}" "${minor_version}"; then
+  git switch -c "reset-changelog-${major_version}.${minor_version}"
+  "${here}/reset-changelog.sh" "v${major_version}.${minor_version}.0"
+
+  for file in $(git diff "${current_commit_hash}" --name-only); do
+    if [[ ! "${file}" =~ ^(CHANGELOG.md|WIP-CHANGELOG.md)$ ]]; then
+      log_error "ERROR: Didn't expect file ${file} to have been commited, aborting"
+      exit 1
+    fi
+  done
+
+  git push -u origin "reset-changelog-${major_version}.${minor_version}"
+
+  log_warning "Create PRs: https://github.com/${this_repo}/compare/main...reset-changelog-${major_version}.${minor_version}"
+  log_warning "Create PRs: https://github.com/${this_repo}/compare/release-${major_version}.${minor_version}...reset-changelog-${major_version}.${minor_version}"
+  log_warning "Get these PRs merged NOW!!"
+else
+  log_info "Seems like changelog reset is already done, skipping to create it"
+fi
+
+
+is_merged="n"
+until [[ "${is_merged}" =~ ^[yY]$ ]]; do
+  log_info_no_newline "Is reset changelog commit merged to both release-${major_version}.${minor_version} and main? (y/n): "
+  read -r is_merged
+done
+
+git switch main
+git pull
+if ! reset_commit_found "${major_version}" "${minor_version}"; then
+  log_error "Reset changelog doesn't seem to be in the last 10 commits in main"
+  exit 1
+fi
+
+git switch "release-${major_version}.${minor_version}"
+git pull
+
+if ! reset_commit_found "${major_version}" "${minor_version}"; then
+  log_error "Reset changelog doesn't seem to be in the last 10 commits in release-${major_version}.${minor_version}"
+  exit 1
+fi
+
+git switch "release-${major_version}.${minor_version}"
+
+if git branch -a | grep -P "QA-${major_version}\.${minor_version}$" > /dev/null; then
+  log_warning "QA branch QA-${major_version}.${minor_version} already exists"
+  log_warning "This might happened if you needed to rerun this script"
+  log_info_no_newline "Do you want to reuse that one? (y/n): "
+  read -r reuse_existing_release_branch
+  if [[ ! "${reuse_existing_release_branch}" =~ ^[yY]$ ]]; then
+    exit 1
+  fi
+  git switch "QA-${major_version}.${minor_version}"
+  make_sure_branch_is_up_to_date "QA-${major_version}.${minor_version}"
+else
+  git switch -c "QA-${major_version}.${minor_version}"
+  git push -u origin "QA-${major_version}.${minor_version}"
+fi
+
+log_info "Now you're on the QA branch, finish all QA stuff and put all fixes here."
+log_info "All changes should be noted in the CHANGELOG.md directly"
+log_info "When it's done run the create-major-minor-release.sh script to create the release"

--- a/release/prepare-patch-release.sh
+++ b/release/prepare-patch-release.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+here="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+# shellcheck source=release/common.sh
+source "${here}/common.sh"
+
+if [ $# -lt 1 ]; then
+  log_error "Usage: $0 vX.Y.Z"
+  exit 1
+fi
+
+current_branch=$(git symbolic-ref -q --short HEAD)
+if [[ ! "${current_branch}" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
+  log_error "Error: Expected to be on release branch, e.g. release-1.2. Got: ${current_branch}"
+  exit 1
+fi
+
+# shellcheck disable=SC2001
+expected_major_version=$(echo "${current_branch}" | sed 's/release-\([0-9]\+\)\.[0-9]\+/\1/')
+# shellcheck disable=SC2001
+expected_minor_version=$(echo "${current_branch}" | sed 's/release-[0-9]\+\.\([0-9]\+\)/\1/')
+
+# Make sure branch is up to date with upstream (might happen if someone missed to run pull after merging QA branch)
+make_sure_branch_is_up_to_date "release-${expected_major_version}.${expected_minor_version}"
+
+# log_info_no_newline "What patch version do you want to release?: v${major_version}.${minor_version}."
+full_version="${1}"
+if [[ ! "${full_version}" =~ ^v[0-9]+.[0-9]+.[0-9]+$ ]]; then
+  log_error "ERROR: Version must be in the form vX.Y.Z (where X is major, Y is minor, and Z is patch version). Got: ${full_version}"
+  exit 1
+fi
+# shellcheck disable=SC2001
+major_version=$(echo "${full_version}" | sed 's/v\([0-9]\+\)\.[0-9]\+\.[0-9]\+/\1/')
+# shellcheck disable=SC2001
+minor_version=$(echo "${full_version}" | sed 's/v[0-9]\+\.\([0-9]\+\)\.[0-9]\+/\1/')
+# shellcheck disable=SC2001
+patch_version=$(echo "${full_version}" | sed 's/v[0-9]\+\.[0-9]\+\.\([0-9]\+\)/\1/')
+if [ "${expected_major_version}" -ne "${major_version}" ] || [ "${expected_minor_version}" -ne "${minor_version}" ]; then
+  log_error "Error: Version mismatch: Expected v${expected_major_version}.${expected_minor_version}.${patch_version} Got: v${major_version}.${minor_version}.${patch_version}"
+  exit 1
+fi
+
+if git branch -a | grep -P "patch-${major_version}.${minor_version}.${patch_version}$" > /dev/null; then
+  log_warning "Release branch patch-${major_version}.${minor_version}.${patch_version} already exists"
+  log_warning "This might happen if you needed to rerun this script"
+  log_info_no_newline "Do you want to reuse that one? (y/n): "
+  read -r reuse_existing_release_branch
+  if [[ ! "${reuse_existing_release_branch}" =~ ^[yY]$ ]]; then
+    exit 1
+  fi
+  git switch "patch-${major_version}.${minor_version}.${patch_version}"
+  make_sure_branch_is_up_to_date "patch-${major_version}.${minor_version}.${patch_version}"
+else
+  git switch -c "patch-${major_version}.${minor_version}.${patch_version}"
+  git push -u origin "patch-${major_version}.${minor_version}.${patch_version}"
+fi
+
+log_info "Now you're on the patch branch."
+log_info "Add all commits you want to include in this patch by running 'git cherry-pick <commit>' or manually update the files and commit the updates."
+log_info "Then run './reset-changelog.sh v${major_version}.${minor_version}.${patch_version}' and merge this branch into the release branch (release-${major_version}.${minor_version}). Do not merge it back to the main branch."
+log_info "When that's done, switch to that branch and run create-patch-release.sh"

--- a/release/reset-changelog.sh
+++ b/release/reset-changelog.sh
@@ -27,13 +27,13 @@ file_exists "${wip_changelog}"
 
 # Regex found from https://gist.github.com/rverst/1f0b97da3cbeb7d93f4986df6e8e5695
 function check_version() {
-    if [[ ! $1 =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
+    if [[ ! $1 =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
         echo "${1} is not a valid version" >&2
         exit 1
     fi
 
-    if git rev-parse "v${1}" >/dev/null 2>&1; then
-        echo "v${1} tag already exists" >&2
+    if git rev-parse "${1}" >/dev/null 2>&1; then
+        echo "${1} tag already exists" >&2
         exit 1
     fi
 }
@@ -51,9 +51,9 @@ sed -n '/<!-- BEGIN TOC -->/,/<!-- END TOC -->/{ /<!--/d; p }' "${changelog}" > 
 sed '1,/^<!-- END TOC -->$/d' "${changelog}" > temp-cl.md
 
 # Adding version to changelog
-echo -e "## v${new_version} - ${DATE}\n" | cat - "${wip_changelog}" temp-cl.md > temp-cl2.md
+echo -e "## ${new_version} - ${DATE}\n" | cat - "${wip_changelog}" temp-cl.md > temp-cl2.md
 # Adding link to TOC
-echo -e "- [v${new_version}](#v${short_version}---${DATE})" | cat - temp-toc.md > temp-toc2.md
+echo -e "- [${new_version}](#${short_version}---${DATE})" | cat - temp-toc.md > temp-toc2.md
 echo -e "<!-- END TOC -->" >> temp-toc2.md
 echo -e "<!-- BEGIN TOC -->" | cat - temp-toc2.md > temp-toc.md
 echo -e "\n-------------------------------------------------" >> temp-toc.md
@@ -65,4 +65,4 @@ rm temp-toc.md temp-toc2.md temp-cl.md temp-cl2.md
 true > "${wip_changelog}"
 
 git add "${changelog}" "${wip_changelog}"
-git commit -m "Reset changelog for release v${new_version}"
+git commit -m "Reset changelog for release ${new_version}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Simplifies the release process by automating most steps, and also changed the action trigger to trigger on the tag rather than the merge to the release branch. This makes it so we're not forced to fast-forward merge into the release branch.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes elastisys/ck8s-ops#1895

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
