### PR TITLE
apps: add option for denying network traffic by default

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -9,4 +9,6 @@
 
 ### Added
 
+- Option to deny network traffic by default
+
 ### Removed

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -596,3 +596,10 @@ kured:
   affinity: {}
   nodeSelector: {}
   dsAnnotations: {}
+
+networkPolicies:
+  # Default deny requires Calico as network plugin
+  defaultDeny: false
+  allowedNameSpaces: []
+  additionalEgressPolicies: []
+  additionalIngressPolicies: []

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -234,6 +234,17 @@ releases:
   values:
     - values/falco-exporter.yaml.gotmpl
 
+# Calico default deny
+- name: calico-default-deny
+  labels:
+    app: calico-default-deny
+  chart: ./charts/calico-default-deny
+  version: 0.1.0
+  installed: {{ .Values.networkPolicies.defaultDeny }}
+  missingFileHandler: Error
+  values:
+    - values/calico-default-deny.yaml.gotmpl
+
 # Service cluster releases
 {{ if eq .Environment.Name "service_cluster" }}
 # Dex

--- a/helmfile/charts/calico-default-deny/.helmignore
+++ b/helmfile/charts/calico-default-deny/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helmfile/charts/calico-default-deny/Chart.yaml
+++ b/helmfile/charts/calico-default-deny/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for calico default deny network policies
+name: calico-default-deny
+version: 0.1.0

--- a/helmfile/charts/calico-default-deny/README.md
+++ b/helmfile/charts/calico-default-deny/README.md
@@ -1,0 +1,5 @@
+# calico-default-deny
+
+This helm chart deploys `calico-default-deny`, a global network policy that denies all traffic in a cluster by default.
+
+Currently, usage of this chart requires that the user adds several `additionalEgressPolicies` and `additionalIngressPolicies` in order for the cluster to function correctly.

--- a/helmfile/charts/calico-default-deny/templates/globalnetworkpolicy.yaml
+++ b/helmfile/charts/calico-default-deny/templates/globalnetworkpolicy.yaml
@@ -1,0 +1,13 @@
+apiVersion: crd.projectcalico.org/v1
+kind: GlobalNetworkPolicy
+metadata:
+  name: deny-app-policy
+spec:
+  namespaceSelector: {{ .Values.namespaceSelector }}
+  types:
+  - Ingress
+  - Egress
+  egress:
+{{ toYaml .Values.egressPolicies | indent 4 }}
+  ingress:
+{{ toYaml .Values.ingressPolicies | indent 4 }}

--- a/helmfile/values/calico-default-deny.yaml.gotmpl
+++ b/helmfile/values/calico-default-deny.yaml.gotmpl
@@ -1,0 +1,10 @@
+namespaceSelector:
+{{- if .Values.networkPolicies.allowedNameSpaces }}
+  has(projectcalico.org/name) && projectcalico.org/name not in {"{{- join "\", \"" .Values.networkPolicies.allowedNameSpaces }}"}
+{{- else }}
+  has(projectcalico.org/name)
+{{- end }}
+
+egressPolicies: {{- toYaml .Values.networkPolicies.additionalEgressPolicies | nindent 2 }}
+
+ingressPolicies: {{- toYaml .Values.networkPolicies.additionalIngressPolicies | nindent 2 }}


### PR DESCRIPTION
**What this PR does / why we need it**: Add option for denying network traffic by default.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1040

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**: Note that if you apply this setting to a cluster, you need to set several `additionalEgressPolicies` / `additionalIngressPolicies` in order for the cluster to function properly. Perhaps we would like a config option to add this automatically, but I deemed it not part of this task.

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
