### PR TITLE
apps: kured notify to slack

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -27,5 +27,6 @@
 - Added a CIS kube-bench Grafana dashboard
 - Added `topologySpreadConstraints` rule to thanos and kube-prometheus-stack.
 - Network policies for harbor
+- Added option for kured to notify to slack when draning and rebooting nodes.
 
 ### Removed

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -574,6 +574,11 @@ kured:
     interval: 60s
     labels: {}
   extraArgs: {}
+  extraEnvVars: {}
+  notification:
+    slack:
+      enabled: false
+      channel: ""
   tolerations:
     - key: node-role.kubernetes.io/master
       operator: Exists

--- a/config/secrets/sc-secrets.yaml
+++ b/config/secrets/sc-secrets.yaml
@@ -58,6 +58,9 @@ alerts:
     apiUrl: somelongsecret
   opsGenie:
     apiKey: somelongsecret
+# kured:
+#   slack:
+#     botToken: "set-me"
 dex:
   staticPassword: $2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W
   kubeloginClientSecret: somelongsecret

--- a/config/secrets/wc-secrets.yaml
+++ b/config/secrets/wc-secrets.yaml
@@ -16,5 +16,8 @@ alerts:
     apiUrl: somelongsecret
   opsGenie:
     apiKey: somelongsecret
+# kured:
+#   slack:
+#     botToken: "set-me"
 dex:
   kubeloginClientSecret: somelongsecret

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -37,6 +37,17 @@ releases:
   values:
   - values/kured.yaml.gotmpl
 
+# Kured-secret
+- name: kured-secret
+  namespace: kured
+  labels:
+    app: kured
+  chart: ./charts/kured-secret
+  version: 0.1.0
+  missingFileHandler: Error
+  installed: {{ .Values.kured.enabled }}
+  values:
+  - values/kured.yaml.gotmpl
 
 # Cert-manager issuers
 - name: issuers

--- a/helmfile/charts/kured-secret/Chart.yaml
+++ b/helmfile/charts/kured-secret/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: This chart is for adding secrets to kured.
+name: kured-secret
+version: 0.1.0

--- a/helmfile/charts/kured-secret/templates/kured-secret.yaml
+++ b/helmfile/charts/kured-secret/templates/kured-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kured-secret
+type: Opaque
+data:
+  {{ if .Values.slack.enabled }}
+  notifyUrl: {{ (printf "slack://%s@%s" .Values.slack.botToken .Values.slack.channel ) | b64enc }}
+  {{ end }}

--- a/helmfile/charts/kured-secret/values.yaml
+++ b/helmfile/charts/kured-secret/values.yaml
@@ -1,0 +1,4 @@
+slack:
+  enabled: false
+  channel: ""
+  botToken: ""

--- a/helmfile/values/kured.yaml.gotmpl
+++ b/helmfile/values/kured.yaml.gotmpl
@@ -15,4 +15,21 @@ configuration: {{- toYaml .Values.kured.configuration | nindent 2 }}
 
 extraArgs: {{- toYaml .Values.kured.extraArgs | nindent 2 }}
 
+extraEnvVars:
+{{- if .Values.kured.extraEnvVars }}
+{{- toYaml .Values.kured.extraEnvVars | nindent 2 }}
+{{- end }}
+{{- if .Values.kured.notification.slack.enabled }}
+  - name: KURED_NOTIFY_URL
+    valueFrom:
+      secretKeyRef:
+        name: kured-secret
+        key: notifyUrl
+{{ end }}
+
 dsAnnotations: {{- toYaml .Values.kured.dsAnnotations | nindent 2 }}
+
+slack:
+  enabled: {{ .Values.kured.notification.slack.enabled }}
+  channel: {{ .Values.kured.notification.slack.channel }}
+  botToken: {{ .Values.kured.slack.botToken }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables the possibility for kured to notify to slack. 

**Which issue this PR fixes**: fixes #1092 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
