### PR TITLE
apps wc: added group subjects to rolebindings

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -28,5 +28,6 @@
 - Added `topologySpreadConstraints` rule to thanos and kube-prometheus-stack.
 - Network policies for harbor
 - Added option for kured to notify to slack when draning and rebooting nodes.
+- Added group subjects to `falco-viewer` and `fluentd-configurer` rolebindings.
 
 ### Removed

--- a/helmfile/charts/user-rbac/templates/rolebindings/falco-viewer.yaml
+++ b/helmfile/charts/user-rbac/templates/rolebindings/falco-viewer.yaml
@@ -15,4 +15,9 @@ subjects:
   kind: User
   name: {{ $user }}
 {{- end }}
+{{- range $group := .Values.groups }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: {{ $group }}
+{{- end }}
 {{- end }}

--- a/helmfile/charts/user-rbac/templates/rolebindings/fluentd-configurer.yaml
+++ b/helmfile/charts/user-rbac/templates/rolebindings/fluentd-configurer.yaml
@@ -14,3 +14,8 @@ subjects:
   kind: User
   name: {{ $user }}
 {{- end }}
+{{- range $group := .Values.groups }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: {{ $group }}
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Added missing group subjects in some rolebindings.

**Which issue this PR fixes** : fixes #1141 

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [X] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
