### PR TITLE
apps wc: gives users web access to prometheus

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -29,5 +29,6 @@
 - Network policies for harbor
 - Added option for kured to notify to slack when draning and rebooting nodes.
 - Added group subjects to `falco-viewer` and `fluentd-configurer` rolebindings.
+- Allow users to proxy and port-forward to prometheus running in the workload cluster
 
 ### Removed

--- a/helmfile/charts/user-rbac/templates/rolebindings/prometheus.yaml
+++ b/helmfile/charts/user-rbac/templates/rolebindings/prometheus.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-port-fwd
+  namespace: monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-port-fwd
+subjects:
+{{- range $user := .Values.users }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ $user }}
+{{- end }}
+{{- range $group := .Values.groups }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: {{ $group }}
+{{- end }}

--- a/helmfile/charts/user-rbac/templates/roles/prometheus-port-fwd.yaml
+++ b/helmfile/charts/user-rbac/templates/roles/prometheus-port-fwd.yaml
@@ -1,0 +1,46 @@
+# This role grants users privileges to proxy or port-forward to prometheus
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-port-fwd
+  namespace: monitoring
+rules:
+# Allow proxying prometheus service
+- apiGroups:
+  - ""
+  resourceNames:
+  - kube-prometheus-stack-prometheus:web
+  resources:
+  - services/proxy
+  verbs:
+  - get
+  - create
+  - delete
+# Allow binding this role specifically
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - prometheus-port-fwd
+  resources:
+  - roles
+  verbs:
+  - bind
+# Allow port-forward to prometheus service
+- apiGroups:
+  - ""
+  resources:
+  - pods/portforward
+  verbs:
+  - create
+  resourceNames:
+  - prometheus-kube-prometheus-stack-prometheus-0
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  resourceNames:
+  - kube-prometheus-stack-prometheus


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**: 
fixes #819 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

Naming suggestions for the role/binding is welcome

**Add a screenshot or an example to illustrate the proposed solution:**

Proxy:
```
$ kubectl -n monitoring --as admin@example.com proxy
Starting to serve on 127.0.0.1:8001

# go to http://127.0.0.1:8001/api/v1/namespaces/monitoring/services/kube-prometheus-stack-prometheus:web/proxy/
```
![image](https://user-images.githubusercontent.com/12396964/190110310-502f3415-10bd-41e6-99c6-8bed779b51a3.png)

Port-forward:
```
# kubectl -n monitoring --as admin@example.com port-forward svc/kube-prometheus-stack-prometheus 9090
Forwarding from 127.0.0.1:9090 -> 9090
Forwarding from [::1]:9090 -> 9090

# goto http://127.0.0.1:9090
```
![image](https://user-images.githubusercontent.com/12396964/190110606-f98a3257-b280-4833-a1bf-c6730cba002c.png)

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [x] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
