### PR TITLE
all: minor cleanup of helmfile statefiles

### DIFF
--- a/helmfile/11-prometheus-operator.yaml
+++ b/helmfile/11-prometheus-operator.yaml
@@ -32,7 +32,6 @@ releases:
     app: kube-prometheus-stack
   chart: ./upstream/kube-prometheus-stack
   version: 19.2.2
-  missingFileHandler: Error
   # https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations
   # The --dry-run flag of helm install and helm upgrade is not currently supported for CRDs.
   disableValidationOnInstall: true
@@ -55,6 +54,5 @@ releases:
   chart: ./charts/thanos/ingress-secret
   version: 0.1.0
   installed: {{ .Values.thanos.enabled }}
-  missingFileHandler: Error
   values:
   - values/thanos/ingress-secret.yaml.gotmpl

--- a/helmfile/12-gatekeeper.yaml
+++ b/helmfile/12-gatekeeper.yaml
@@ -38,7 +38,6 @@ releases:
   disableValidationOnInstall: true
   version: 3.7.0
   installed: {{ .Values.opa.enabled }}
-  missingFileHandler: Error
   wait: true
   values:
   - values/gatekeeper.yaml.gotmpl

--- a/helmfile/13-gatekeeper-templates.yaml
+++ b/helmfile/13-gatekeeper-templates.yaml
@@ -35,7 +35,6 @@ releases:
   chart: ./charts/gatekeeper-templates
   version: 1.6.0
   installed: {{ .Values.opa.enabled }}
-  missingFileHandler: Error
   # https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations
   # The --dry-run flag of helm install and helm upgrade is not currently supported for CRDs.
   disableValidationOnInstall: true

--- a/helmfile/14-cert-manager.yaml
+++ b/helmfile/14-cert-manager.yaml
@@ -32,7 +32,6 @@ releases:
     app: cert-manager
   chart: ./upstream/cert-manager
   version: v1.8.2
-  missingFileHandler: Error
   # https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations
   # The --dry-run flag of helm install and helm upgrade is not currently supported for CRDs.
   disableValidationOnInstall: true

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -32,7 +32,6 @@ releases:
     app: kured
   chart: ./upstream/kured
   version: 2.11.2
-  missingFileHandler: Error
   installed: {{ .Values.kured.enabled }}
   values:
   - values/kured.yaml.gotmpl
@@ -44,7 +43,6 @@ releases:
     app: kured
   chart: ./charts/kured-secret
   version: 0.1.0
-  missingFileHandler: Error
   installed: {{ .Values.kured.enabled }}
   values:
   - values/kured.yaml.gotmpl
@@ -56,7 +54,6 @@ releases:
     app: issuers
   chart: ./charts/issuers
   version: 0.1.0
-  missingFileHandler: Error
   values:
   - values/letsencrypt.yaml.gotmpl
 
@@ -67,7 +64,6 @@ releases:
     app: ingress-nginx
   chart: ./upstream/ingress-nginx
   version: 4.1.3
-  missingFileHandler: Error
   wait: true
   values:
   - values/ingress-nginx.yaml.gotmpl
@@ -80,7 +76,6 @@ releases:
   chart: ./upstream/velero
   version: 2.27.3
   installed: {{ .Values.velero.enabled }}
-  missingFileHandler: Error
   values:
 {{ if eq .Environment.Name "service_cluster" }}
   - values/velero-sc.yaml.gotmpl
@@ -95,7 +90,6 @@ releases:
     app: node-local-dns
   chart: ./charts/node-local-dns
   version: 0.1.1
-  missingFileHandler: Error
   values:
   - values/node-local-dns.yaml.gotmpl
 
@@ -107,7 +101,6 @@ releases:
   chart: ./upstream/metrics-server
   version: 3.7.0
   installed: {{ .Values.metricsServer.enabled }}
-  missingFileHandler: Error
   values:
   - values/metrics-server.yaml.gotmpl
 
@@ -119,7 +112,6 @@ releases:
   chart: ./charts/calico-accountant
   version: 0.1.0
   installed: {{ .Values.calicoAccountant.enabled }}
-  missingFileHandler: Error
   values:
   - values/calico-accountant.yaml.gotmpl
 
@@ -131,7 +123,6 @@ releases:
   chart: ./charts/calico-felix-metrics
   version: 0.1.0
   installed: {{ .Values.calicoFelixMetrics.enabled }}
-  missingFileHandler: Error
 
 # Prometheus blackboc exporter
 - name: prometheus-blackbox-exporter
@@ -140,7 +131,6 @@ releases:
     app: blackbox
   chart: ./upstream/prometheus-blackbox-exporter
   version: 5.3.1
-  missingFileHandler: Error
   values:
 {{ if eq .Environment.Name "service_cluster" }}
   - values/prometheus-blackbox-exporter-sc.yaml.gotmpl
@@ -156,7 +146,6 @@ releases:
     app: cluster-admin-rbac
   chart: ./charts/cluster-admin-rbac
   version: 0.1.0
-  missingFileHandler: Error
   values:
   - values/cluster-admin-rbac.yaml.gotmpl
 
@@ -169,7 +158,6 @@ releases:
   chart: ./charts/starboard/starboard-operator-psp-rbac
   version: 0.1.0
   installed: {{ .Values.starboard.enabled }}
-  missingFileHandler: Error
 
 # starboard-operator
 - name: starboard-operator
@@ -180,7 +168,6 @@ releases:
   chart: ./upstream/starboard-operator
   version: 0.9.1
   installed: {{ .Values.starboard.enabled }}
-  missingFileHandler: Error
   values:
   - values/starboard/starboard-operator.yaml.gotmpl
 
@@ -193,7 +180,6 @@ releases:
   chart: ./charts/starboard/vulnerability-exporter
   version: 0.1.0
   installed: {{ .Values.starboard.enabled }}
-  missingFileHandler: Error
   values:
   - values/starboard/vulnerability-exporter.yaml.gotmpl
 
@@ -206,7 +192,6 @@ releases:
   chart: ./charts/starboard/ciskubebench-exporter
   version: 0.1.0
   installed: {{ .Values.starboard.enabled }}
-  missingFileHandler: Error
   values:
   - values/starboard/ciskubebench-exporter.yaml.gotmpl
 
@@ -218,7 +203,6 @@ releases:
   chart: ./upstream/falco
   version: 1.16.0
   installed: {{ .Values.falco.enabled }}
-  missingFileHandler: Error
   values:
   - values/falco.yaml.gotmpl
 
@@ -230,7 +214,6 @@ releases:
   chart: ./upstream/falco-exporter
   version: 0.8.0
   installed: {{ .Values.falco.enabled }}
-  missingFileHandler: Error
   values:
     - values/falco-exporter.yaml.gotmpl
 
@@ -254,7 +237,6 @@ releases:
     app: dex
   chart: ./upstream/dex
   version: 0.8.2
-  missingFileHandler: Error
   wait: true
   values:
   - values/dex.yaml.gotmpl
@@ -266,7 +248,6 @@ releases:
     prometheus: sc
   chart: ./charts/prometheus-servicemonitor
   version: 0.1.1
-  missingFileHandler: Error
   values:
   - values/sc-servicemonitor.yaml.gotmpl
 
@@ -278,7 +259,6 @@ releases:
     prometheus: sc
   chart: ./charts/prometheus-alerts
   version: 0.1.1
-  missingFileHandler: Error
   values:
   - values/prometheus-alerts-sc.yaml.gotmpl
 
@@ -290,7 +270,6 @@ releases:
     prometheus: sc
   chart: ./charts/grafana-ops
   version: 0.2.1
-  missingFileHandler: Error
   values:
   - values/grafana-ops.yaml.gotmpl
 
@@ -304,7 +283,6 @@ releases:
   chart: ./upstream/grafana
   version: 6.1.11
   installed: {{ .Values.user.grafana.enabled }}
-  missingFileHandler: Error
   values:
   - values/grafana-user.yaml.gotmpl
 
@@ -316,7 +294,6 @@ releases:
   chart: ./charts/grafana-label-enforcer
   version: 0.1.0
   installed: {{ and .Values.thanos.enabled .Values.thanos.receiver.enabled }}
-  missingFileHandler: Error
   values:
   - values/grafana-label-enforcer.yaml.gotmpl
 
@@ -328,7 +305,6 @@ releases:
     group: opensearch
   chart: ./charts/opensearch/secrets
   version: 0.1.0
-  installed: true
   values:
   - values/opensearch/secrets.yaml.gotmpl
 
@@ -339,7 +315,6 @@ releases:
     group: opensearch
   chart: ./upstream/opensearch
   version: 2.6.0
-  installed: true
   wait: true
   needs:
   {{- if .Values.opensearch.sso.enabled }}
@@ -387,7 +362,6 @@ releases:
     group: opensearch
   chart: ./upstream/opensearch-dashboards
   version: 2.5.1
-  installed: true
   wait: true
   needs:
   - opensearch-system/opensearch-master
@@ -402,7 +376,6 @@ releases:
   chart: ./charts/opensearch/backup
   version: 0.1.0
   installed: {{ .Values.opensearch.snapshot.enabled }}
-  missingFileHandler: Error
   needs:
   - opensearch-system/opensearch-configurer
   values:
@@ -416,7 +389,6 @@ releases:
   chart: ./charts/opensearch/slm
   version: 0.1.0
   installed: {{ .Values.opensearch.snapshot.enabled }}
-  missingFileHandler: Error
   needs:
   - opensearch-system/opensearch-configurer
   values:
@@ -430,7 +402,6 @@ releases:
   chart: ./charts/opensearch/curator
   version: 0.1.0
   installed: {{ .Values.opensearch.curator.enabled }}
-  missingFileHandler: Error
   needs:
   - opensearch-system/opensearch-configurer
   values:
@@ -462,7 +433,6 @@ releases:
     group: opensearch
   chart: ./charts/opensearch/configurer
   version: 0.1.0
-  installed: true
   needs:
   {{- if .Values.opensearch.securityadmin.enabled }}
   - opensearch-system/opensearch-securityadmin
@@ -482,8 +452,6 @@ releases:
     group: opensearch
   chart: ./upstream/prometheus-elasticsearch-exporter
   version: 4.11.0
-  installed: true
-  missingFileHandler: Error
   needs:
   - opensearch-system/opensearch-configurer
   values:
@@ -497,7 +465,6 @@ releases:
   chart: ./charts/harbor/harbor-certs
   version: 0.1.0
   installed: {{ .Values.harbor.enabled }}
-  missingFileHandler: Error
   values:
   - values/harbor-certs.yaml.gotmpl
 
@@ -508,7 +475,6 @@ releases:
   chart: ./upstream/harbor
   version: 1.6.1
   installed: {{ .Values.harbor.enabled }}
-  missingFileHandler: Error
   wait: true
   timeout: 600
   values:
@@ -521,7 +487,6 @@ releases:
   chart: ./charts/harbor/init-harbor
   version: 0.1.0
   installed: {{ .Values.harbor.enabled }}
-  missingFileHandler: Error
   needs:
   - harbor/harbor
   values:
@@ -535,7 +500,6 @@ releases:
   chart: ./charts/harbor/harbor-backup
   version: 0.1.0
   installed: {{ and .Values.harbor.enabled .Values.harbor.backup.enabled }}
-  missingFileHandler: Error
   values:
   - values/harbor-backup.yaml.gotmpl
 
@@ -547,7 +511,6 @@ releases:
   chart: ./upstream/thanos
   version: 9.0.1
   installed: {{ .Values.thanos.enabled }}
-  missingFileHandler: Error
   values:
   - values/thanos/objectstorage-secret.yaml.gotmpl
 
@@ -558,7 +521,6 @@ releases:
   chart: ./upstream/thanos
   version: 9.0.1
   installed: {{ and .Values.thanos.enabled .Values.thanos.receiver.enabled }}
-  missingFileHandler: Error
   values:
   - values/thanos/receiver.yaml.gotmpl
 
@@ -570,7 +532,6 @@ releases:
   chart: ./upstream/thanos
   version: 9.0.1
   installed: {{ and .Values.thanos.enabled .Values.thanos.query.enabled }}
-  missingFileHandler: Error
   values:
   - values/thanos/query.yaml.gotmpl
 
@@ -582,7 +543,6 @@ releases:
   chart: ./charts/thanos/ruler
   version: 0.1.0
   installed: {{ and .Values.thanos.enabled .Values.thanos.ruler.enabled }}
-  missingFileHandler: Error
   values:
   - values/thanos/ruler.yaml.gotmpl
 
@@ -593,7 +553,6 @@ releases:
   chart: ./charts/s3-exporter
   version: 0.1.0
   installed: {{ and (eq .Values.objectStorage.type "s3") .Values.s3Exporter.enabled }}
-  missingFileHandler: Error
   values:
   - values/s3-exporter.yaml.gotmpl
 
@@ -605,7 +564,6 @@ releases:
   chart: ./upstream/fluentd
   version: 5.0.15
   installed: {{ .Values.fluentd.enabled }}
-  missingFileHandler: Error
   needs:
   - fluentd/fluentd-configmap
   values:
@@ -619,7 +577,6 @@ releases:
   chart: ./charts/fluentd-configmap
   version: 0.1.0
   installed: {{ .Values.fluentd.enabled }}
-  missingFileHandler: Error
   values:
   - values/fluentd-configmap.yaml.gotmpl
 
@@ -631,7 +588,6 @@ releases:
   chart: ./charts/sc-logs-retention
   version: 0.1.0
   installed: {{ .Values.fluentd.enabled }}
-  missingFileHandler: Error
   needs:
   - fluentd/fluentd
   values:
@@ -644,7 +600,6 @@ releases:
   chart: ./charts/rclone-sync
   version: 0.1.0
   installed: {{ .Values.objectStorage.sync.enabled }}
-  missingFileHandler: Error
   values:
   - values/rclone-sync.yaml.gotmpl
 
@@ -662,7 +617,6 @@ releases:
     prometheus: wc-prometheus
   chart: ./charts/prometheus-servicemonitor
   version: 0.1.1
-  missingFileHandler: Error
   values:
   - values/wc-servicemonitor.yaml.gotmpl
 
@@ -673,7 +627,6 @@ releases:
   chart: ./charts/user-alertmanager
   version: 0.1.0
   installed: {{ .Values.user.alertmanager.enabled }}
-  missingFileHandler: Error
   values:
   - values/user-alertmanager.yaml.gotmpl
 
@@ -684,7 +637,6 @@ releases:
     app: fluentd
   chart: ./upstream/fluentd-elasticsearch
   version: 13.3.0
-  missingFileHandler: Error
   values:
   - values/fluentd-wc.yaml.gotmpl
 
@@ -695,7 +647,6 @@ releases:
     app: fluentd
   chart: ./upstream/fluentd-elasticsearch
   version: 13.3.0
-  missingFileHandler: Error
   values:
   - values/fluentd-user.yaml.gotmpl
 
@@ -707,7 +658,6 @@ releases:
   chart: ./charts/gatekeeper-metrics
   version: 0.1.0
   installed: {{ .Values.opa.enabled }}
-  missingFileHandler: Error
 
 # gatekeeper-constraints
 - name: gatekeeper-constraints
@@ -717,7 +667,6 @@ releases:
   chart: ./charts/gatekeeper-constraints
   version: 1.6.0
   installed: {{ .Values.opa.enabled }}
-  missingFileHandler: Error
   values:
   - values/gatekeeper-constraints.yaml.gotmpl
 
@@ -729,7 +678,6 @@ releases:
   chart: ./charts/hnc
   version: 0.1.0
   installed: {{ .Values.hnc.enabled }}
-  missingFileHandler: Error
   values:
   - values/hnc.yaml.gotmpl
 
@@ -745,7 +693,6 @@ releases:
     app: prometheus-alerts
   chart: ./charts/prometheus-alerts
   version: 0.1.1
-  missingFileHandler: Info
   values:
   - values/prometheus-user-alerts-wc.yaml.gotmpl
 
@@ -756,7 +703,6 @@ releases:
     app: kubeapi-metrics
   chart: ./charts/kubeapi-metrics
   version: 0.1.0
-  missingFileHandler: Error
   values:
   - values/kubeapi-metrics.yaml.gotmpl
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The default behavior for missing files is to error out so I don't think that we need to specify that in our releases.
Also removed `installed: true` for opensearch, as I only think that `installed` should be in the release spec if it is actually possible to disable.

**Which issue this PR fixes**:

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
