### PR TITLE
apps sc: fix removal of grafana test resources

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 - Fixed so grafana can show data from thanos that's older than 30 days (downsampled data)
 - Fixed so opensearch field limit alert handles metrics drop better
+- Fixed spelling error so now the grafana test framework in sc will be uninstalled
 
 ### Added
 

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -144,7 +144,7 @@ grafana:
   image:
     tag: 8.4.7
 
-  testFrameowrk:
+  testFramework:
     enabled: false
 
   # admin username is "admin"


### PR DESCRIPTION
**What this PR does / why we need it**:
Typo in sc-config caused resources for Grafana test framework to be installed in the sc cluster.
This PR fixes the typo.

**Which issue this PR fixes**: 
fixes #531 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

```diff
monitoring, kube-prometheus-stack-grafana-test, Role (rbac.authorization.k8s.io) has been removed:
- # Source: kube-prometheus-stack/charts/grafana/templates/tests/test-role.yaml
- apiVersion: rbac.authorization.k8s.io/v1
- kind: Role
- metadata:
-   name: kube-prometheus-stack-grafana-test
-   namespace: monitoring
-   labels:
-     helm.sh/chart: grafana-6.17.2
-     app.kubernetes.io/name: grafana
-     app.kubernetes.io/instance: kube-prometheus-stack
-     app.kubernetes.io/version: "8.4.7"
-     app.kubernetes.io/managed-by: Helm
- rules:
- - apiGroups:      ['policy']
-   resources:      ['podsecuritypolicies']
-   verbs:          ['use']
-   resourceNames:  [kube-prometheus-stack-grafana-test]
+ 
monitoring, kube-prometheus-stack-grafana-test, RoleBinding (rbac.authorization.k8s.io) has been removed:
- # Source: kube-prometheus-stack/charts/grafana/templates/tests/test-rolebinding.yaml
- apiVersion: rbac.authorization.k8s.io/v1
- kind: RoleBinding
- metadata:
-   name: kube-prometheus-stack-grafana-test
-   namespace: monitoring
-   labels:
-     helm.sh/chart: grafana-6.17.2
-     app.kubernetes.io/name: grafana
-     app.kubernetes.io/instance: kube-prometheus-stack
-     app.kubernetes.io/version: "8.4.7"
-     app.kubernetes.io/managed-by: Helm
- roleRef:
-   apiGroup: rbac.authorization.k8s.io
-   kind: Role
-   name: kube-prometheus-stack-grafana-test
- subjects:
- - kind: ServiceAccount
-   name: kube-prometheus-stack-grafana-test
-   namespace: monitoring
+ 
monitoring, kube-prometheus-stack-grafana-test, PodSecurityPolicy (policy) has been removed:
- # Source: kube-prometheus-stack/charts/grafana/templates/tests/test-podsecuritypolicy.yaml
- apiVersion: policy/v1beta1
- kind: PodSecurityPolicy
- metadata:
-   name: kube-prometheus-stack-grafana-test
-   labels:
-     helm.sh/chart: grafana-6.17.2
-     app.kubernetes.io/name: grafana
-     app.kubernetes.io/instance: kube-prometheus-stack
-     app.kubernetes.io/version: "8.4.7"
-     app.kubernetes.io/managed-by: Helm
- spec:
-   allowPrivilegeEscalation: true
-   privileged: false
-   hostNetwork: false
-   hostIPC: false
-   hostPID: false
-   fsGroup:
-     rule: RunAsAny
-   seLinux:
-     rule: RunAsAny
-   supplementalGroups:
-     rule: RunAsAny
-   runAsUser:
-     rule: RunAsAny
-   volumes:
-   - configMap
-   - downwardAPI
-   - emptyDir
-   - projected
-   - csi
-   - secret
+ 
monitoring, kube-prometheus-stack-grafana-test, ServiceAccount (v1) has been removed:
- # Source: kube-prometheus-stack/charts/grafana/templates/tests/test-serviceaccount.yaml
- apiVersion: v1
- kind: ServiceAccount
- metadata:
-   labels:
-     helm.sh/chart: grafana-6.17.2
-     app.kubernetes.io/name: grafana
-     app.kubernetes.io/instance: kube-prometheus-stack
-     app.kubernetes.io/version: "8.4.7"
-     app.kubernetes.io/managed-by: Helm
-   name: kube-prometheus-stack-grafana-test
-   namespace: monitoring
+ 
monitoring, kube-prometheus-stack-grafana-test, ConfigMap (v1) has been removed:
- # Source: kube-prometheus-stack/charts/grafana/templates/tests/test-configmap.yaml
- apiVersion: v1
- kind: ConfigMap
- metadata:
-   name: kube-prometheus-stack-grafana-test
-   namespace: monitoring
-   labels:
-     helm.sh/chart: grafana-6.17.2
-     app.kubernetes.io/name: grafana
-     app.kubernetes.io/instance: kube-prometheus-stack
-     app.kubernetes.io/version: "8.4.7"
-     app.kubernetes.io/managed-by: Helm
- data:
-   run.sh: |-
-     @test "Test Health" {
-       url="http://kube-prometheus-stack-grafana/api/health"
  
-       code=$(wget --server-response --spider --timeout 10 --tries 1 ${url} 2>&1 | awk '/^  HTTP/{print $2}')
-       [ "$code" == "200" ]
-     }
```

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
