### PR TITLE
apps sc: field limit alert handle metric drops better

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 - Fixed so grafana can show data from thanos that's older than 30 days (downsampled data)
+- Fixed so opensearch field limit alert handles metrics drop better
 
 ### Added
 

--- a/helmfile/charts/prometheus-alerts/templates/alerts/opensearch.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/alerts/opensearch.yaml
@@ -35,7 +35,7 @@ spec:
         description: The heap usage is over 90% for 15m
         summary: OpenSearch node {{`{{ $labels.node}}`}} heap usage is high
     - alert: OpenSearchFieldLimit
-      expr: (sum(elasticsearch_indices_mappings_stats_fields) by (index) / sum(elasticsearch_indices_settings_total_fields) by (index)) * 100 > 80
+      expr: (sum(max_over_time(elasticsearch_indices_mappings_stats_fields[5m])) by (index) / sum(max_over_time(elasticsearch_indices_settings_total_fields[5m])) by (index)) * 100 > 80
       for: 15m
       labels:
         severity: warning
@@ -43,7 +43,7 @@ spec:
         description: Index {{`{{ $labels.index }}`}} is using {{`{{ $value }}`}} percent of max field limit
         summary: Index {{`{{ $labels.index }}`}} is using {{`{{ $value }}`}} percent of max field limit
     - alert: OpenSearchFieldLimit
-      expr: (sum(elasticsearch_indices_mappings_stats_fields) by (index) / sum(elasticsearch_indices_settings_total_fields) by (index)) * 100 > 95
+      expr: (sum(max_over_time(elasticsearch_indices_mappings_stats_fields[5m])) by (index) / sum(max_over_time(elasticsearch_indices_settings_total_fields[5m])) by (index)) * 100 > 95
       for: 15m
       labels:
         severity: critical


### PR DESCRIPTION
**What this PR does / why we need it**:

Added `max_over_time(...[5m])` to handle metrics drops better for opensearch field limit.

**Which issue this PR fixes**: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
