### PR TITLE
apps sc: added index size alerts for opensearch

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Release notes
 
 - Several default resource requests and limits have changed. When upgrading these might need to be adjusted.
+- The settings for the new Opensearch index size alerts might need to be tweaked to better suit the environment.
 
 ### Updated
 
@@ -31,7 +32,7 @@
 - Fixed harbor network policies
 
 ### Added
-
+- Option to configure alerts for growing indices in OpenSearch
 - Option to deny network traffic by default
 - Network policies for monitoring stack (prometheus, thanos, grafana, some exporters)
 - An alert for failed evicted pods (KubeFailedEvictedPods)

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -902,6 +902,19 @@ opensearch:
     nodeSelector: {}
     tolerations: []
 
+  # Config for https://github.com/elastisys/compliantkubernetes-apps/blob/main/helmfile/charts/prometheus-alerts/templates/alerts/opensearch.yaml#L70:L77
+  promIndexAlerts:
+    - prefix: kubernetes-default
+      alertSizeMB: 5500
+    - prefix: kubeaudit-default
+      alertSizeMB: 5500
+    - prefix: other-default
+      alertSizeMB: 400
+    - prefix: security-auditlog
+      alertSizeMB: 16
+    - prefix: authlog-default
+      alertSizeMB: 0.2
+
   # Snapshot and snapshot lifecycle configuration
   # Requires S3 or GCS to be enabled
   snapshot:

--- a/helmfile/charts/prometheus-alerts/CHANGELOG.md
+++ b/helmfile/charts/prometheus-alerts/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 2022.10.04
 1. helmfile/charts/prometheus-alerts/templates/alerts/kubernetes-apps.yaml
    - ADDED - KubeFailedEvictedPods alert
+
+## 2022.09.28
+1. helmfile/charts/prometheus-alerts/templates/alerts/opensearch.yaml
+   - ADDED - OpensearchClusterYellow, OpensearchClusterRed and $indexSizeIncreasedOverLimit
+
 ## 2022.08.17
 1. helmfile/charts/prometheus-alerts/files/missing-metrics-alerts.yaml
    - MODIFIED - MetricsFromScClusterIsMissing 'for' from 5m to 15m

--- a/helmfile/charts/prometheus-alerts/templates/alerts/opensearch.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/alerts/opensearch.yaml
@@ -50,4 +50,30 @@ spec:
       annotations:
         description: Index {{`{{ $labels.index }}`}} is using {{`{{ $value }}`}} percent of max field limit
         summary: Index {{`{{ $labels.index }}`}} is using {{`{{ $value }}`}} percent of max field limit
+    - alert: OpensearchClusterYellow
+      expr: elasticsearch_cluster_health_status{color="yellow"} == 1
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        summary: Opensearch Cluster Yellow (instance {{`{{ $labels.instance }}`}})
+        description: Opensearch Cluster is in a Yellow status VALUE = {{`{{ $value }}`}}  LABELS = {{`{{ $labels }}`}}
+    - alert: OpensearchClusterRed
+      expr: elasticsearch_cluster_health_status{color="red"} == 1
+      for: 15m
+      labels:
+        severity: critical
+      annotations:
+        summary: Opensearch Cluster Red (instance {{`{{ $labels.instance }}`}})
+        description: Opensearch Cluster is in a Red status VALUE = {{`{{ $value }}`}}  LABELS = {{`{{ $labels }}`}}
+    {{- range $prefixes := .Values.osIndexAlerts }}
+    - alert: {{ $prefixes.prefix | title }}SizeIncreasedOverLimit
+      expr: elasticsearch_indices_store_size_bytes_primary{index=~"{{ $prefixes.prefix }}.+"} / (1024^2) > {{ $prefixes.alertSizeMB }}
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        message: Primary shard size for index {{`{{ $labels.index }}`}} has increased over the limit of {{ $prefixes.alertSizeMB }}MB current size is {{`{{ $value | printf "%.0f" }}`}}MB
+        description: If the size keeps increasing, that might indicate a problem with ISM
+    {{- end }}
 {{- end }}

--- a/helmfile/values/prometheus-alerts-sc.yaml.gotmpl
+++ b/helmfile/values/prometheus-alerts-sc.yaml.gotmpl
@@ -5,6 +5,7 @@
 # TODO: We should update the rules for things with set namespace and job name to be able to monitor instances in the workload cluster.
 
 osNodeCount: {{ add .Values.opensearch.dataNode.count .Values.opensearch.clientNode.count .Values.opensearch.masterNode.count }}
+osIndexAlerts: {{ toYaml .Values.opensearch.promIndexAlerts | nindent 2 }}
 
 defaultRules:
   alertLabels:
@@ -40,8 +41,7 @@ defaultRules:
 
 capacityManagementAlertsDiskLimit: {{ .Values.prometheus.capacityManagementAlerts.disklimit }}
 capacityManagementAlertsUsageLimit: {{ .Values.prometheus.capacityManagementAlerts.usagelimit }}
-capacityManagementAlertsRequestLimit:
-{{ toYaml .Values.prometheus.capacityManagementAlerts.requestlimit | indent 2}}
+capacityManagementAlertsRequestLimit: {{ toYaml .Values.prometheus.capacityManagementAlerts.requestlimit | nindent 2 }}
 
 s3BucketPercentLimit: {{ .Values.prometheus.s3BucketPercentLimit }}
 s3BucketSizeQuotaGB: {{ .Values.prometheus.s3BucketSizeQuotaGB }}


### PR DESCRIPTION
**What this PR does / why we need it**: to detect when an index size becomes too big. that might indicate an issue with the ISM

**Special notes for reviewer**:
- I also added alerts for cluster status to alerts on issues that are not covered by the existing alerts
- the default index size is based on the highest value from a dev cluster multiplied by 2

**Add a screenshot or an example to illustrate the proposed solution:**
![index_alert](https://user-images.githubusercontent.com/77267293/192478531-58d5c37a-6bf1-44b8-b760-c2959975c661.png)


**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
