### PR TITLE
pipeline: Fix harbor xsrf length

### DIFF
--- a/pipeline/config/exoscale/secrets.yaml
+++ b/pipeline/config/exoscale/secrets.yaml
@@ -6,7 +6,7 @@ harbor:
     password: somelongsecret
     databasePassword: somelongsecret
     clientSecret: somelongsecret
-    xsrf: somelongsecret
+    xsrf: somelongsecretandsomelongsecrets
     coreSecret: somelongsecret
     jobserviceSecret: somelongsecret
     registrySecret: somelongsecret


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix for the pipeline

**Add a screenshot or an example to illustrate the proposed solution:**
```
 in ./50-applications.yaml: failed processing release harbor: failed to render values files "values/harbor.yaml.gotmpl": failed to render [values/harbor.yaml.gotmpl], because of template: stringTemplate:102:5: executing "stringTemplate" at <fail "\nERROR: The xsrf key (found at harbor.xsrf) must be exactly 32 characters long">: error calling fail: 
ERROR: The xsrf key (found at harbor.xsrf) must be exactly 32 characters long
exit status 1
```

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
