### PR TITLE
apps:upgrade velero to 2.31.8

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Lowered the default retention age for kubernetes logs in the prod flavor down to 30 days
 - Changed grafana's communication with dex to use internal service
+- Upgrade Velero helm chart to `v2.31.8`, which also upgrades Velero to `v1.9.2`.
+- Update the provider plugins to a supported version for the new Velero release
 
 ### Fixed
 

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -74,7 +74,7 @@ releases:
   labels:
     app: velero
   chart: ./upstream/velero
-  version: 2.27.3
+  version: 2.31.8
   installed: {{ .Values.velero.enabled }}
   values:
 {{ if eq .Environment.Name "service_cluster" }}

--- a/helmfile/upstream/velero/Chart.yaml
+++ b/helmfile/upstream/velero/Chart.yaml
@@ -1,20 +1,19 @@
 apiVersion: v2
-appVersion: 1.7.1
+appVersion: 1.9.2
 description: A Helm chart for velero
-name: velero
-version: 2.27.3
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
+kubeVersion: '>=1.16.0-0'
+maintainers:
+- email: hsiaoairplane@gmail.com
+  name: jenting
+- email: sseago@redhat.com
+  name: sseago
+- email: jiangd@vmware.com
+  name: reasonerjt
+- email: yinw@vmware.com
+  name: ywk253100
+name: velero
 sources:
 - https://github.com/vmware-tanzu/velero
-maintainers:
-  - name: jenting
-    email: jenting.hsiao@suse.com
-  - name: sseago
-    email: sseago@redhat.com
-  - name: reasonerjt
-    email: jiangd@vmware.com
-  - name: ywk253100
-    email: yinw@vmware.com
-  - name: zubron
-    email: bmcerlean@vmware.com
+version: 2.31.8

--- a/helmfile/upstream/velero/OWNERS
+++ b/helmfile/upstream/velero/OWNERS
@@ -3,10 +3,8 @@ approvers:
 - sseago
 - reasonerjt
 - ywk253100
-- zubron
 reviewers:
 - jenting
 - sseago
 - reasonerjt
 - ywk253100
-- zubron

--- a/helmfile/upstream/velero/README.md
+++ b/helmfile/upstream/velero/README.md
@@ -6,7 +6,7 @@ Velero has two main components: a CLI, and a server-side Kubernetes deployment.
 
 ## Installing the Velero CLI
 
-See the different options for installing the [Velero CLI](https://velero.io/docs/v1.7/basic-install/#install-the-cli).
+See the different options for installing the [Velero CLI](https://velero.io/docs/v1.9/basic-install/#install-the-cli).
 
 ## Installing the Velero server
 
@@ -16,7 +16,7 @@ Kubernetes v1.16+, because this helm chart uses CustomResourceDefinition `apiext
 
 ### Velero version
 
-This helm chart installs Velero version v1.7 https://velero.io/docs/v1.7/. See the [#Upgrading](#upgrading) section for information on how to upgrade from other versions.
+This helm chart installs Velero version v1.9 https://velero.io/docs/v1.9/. See the [#Upgrading](#upgrading) section for information on how to upgrade from other versions.
 
 ### Provider credentials
 
@@ -26,7 +26,7 @@ When installing using the Helm chart, the provider's credential information will
 
 The default configuration values for this chart are listed in values.yaml.
 
-See Velero's full [official documentation](https://velero.io/docs/v1.7/basic-install/). More specifically, find your provider in the Velero list of [supported providers](https://velero.io/docs/v1.7/supported-providers/) for specific configuration information and examples.
+See Velero's full [official documentation](https://velero.io/docs/v1.9/basic-install/). More specifically, find your provider in the Velero list of [supported providers](https://velero.io/docs/v1.9/supported-providers/) for specific configuration information and examples.
 
 #### Set up Helm
 
@@ -88,6 +88,14 @@ helm upgrade vmware-tanzu/velero <RELEASE NAME> --reuse-values --set configurati
 ```
 
 ## Upgrading
+
+### Upgrading to v1.9
+
+The [instructions found here](https://velero.io/docs/v1.9/upgrade-to-1.9/) will assist you in upgrading from version v1.8.x to v1.9.
+
+### Upgrading to v1.8
+
+The [instructions found here](https://velero.io/docs/v1.8/upgrade-to-1.8/) will assist you in upgrading from version v1.7.x to v1.8.
 
 ### Upgrading to v1.7
 

--- a/helmfile/upstream/velero/crds/backups.yaml
+++ b/helmfile/upstream/velero/crds/backups.yaml
@@ -4,10 +4,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: backups.velero.io
 spec:
@@ -40,6 +39,11 @@ spec:
           spec:
             description: BackupSpec defines the specification for a Velero backup.
             properties:
+              csiSnapshotTimeout:
+                description: CSISnapshotTimeout specifies the time used to wait for
+                  CSI VolumeSnapshot status turns to ReadyToUse during creation, before
+                  returning error as timeout. The default value is 10 minute.
+                type: string
               defaultVolumesToRestic:
                 description: DefaultVolumesToRestic specifies whether restic should
                   be used to take a backup of all pod volumes by default.
@@ -317,6 +321,61 @@ spec:
                       type: string
                     type: object
                 type: object
+              orLabelSelectors:
+                description: OrLabelSelectors is list of metav1.LabelSelector to filter
+                  with when adding individual objects to the backup. If multiple provided
+                  they will be joined by the OR operator. LabelSelector as well as
+                  OrLabelSelectors cannot co-exist in backup request, only one of
+                  them can be used.
+                items:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                nullable: true
+                type: array
               orderedResources:
                 additionalProperties:
                   type: string
@@ -357,6 +416,14 @@ spec:
                 format: date-time
                 nullable: true
                 type: string
+              csiVolumeSnapshotsAttempted:
+                description: CSIVolumeSnapshotsAttempted is the total number of attempted
+                  CSI VolumeSnapshots for this backup.
+                type: integer
+              csiVolumeSnapshotsCompleted:
+                description: CSIVolumeSnapshotsCompleted is the total number of successfully
+                  completed CSI VolumeSnapshots for this backup.
+                type: integer
               errors:
                 description: Errors is a count of all error messages that were generated
                   during execution of the backup.  The actual errors are in the backup's
@@ -366,6 +433,10 @@ spec:
                 description: Expiration is when this Backup is eligible for garbage-collection.
                 format: date-time
                 nullable: true
+                type: string
+              failureReason:
+                description: FailureReason is an error that caused the entire backup
+                  to fail.
                 type: string
               formatVersion:
                 description: FormatVersion is the backup format version, including

--- a/helmfile/upstream/velero/crds/backupstoragelocations.yaml
+++ b/helmfile/upstream/velero/crds/backupstoragelocations.yaml
@@ -4,10 +4,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: backupstoragelocations.velero.io
 spec:
@@ -161,6 +160,10 @@ spec:
                 format: date-time
                 nullable: true
                 type: string
+              message:
+                description: Message is a message about the backup storage location's
+                  status.
+                type: string
               phase:
                 description: Phase is the current state of the BackupStorageLocation.
                 enum:
@@ -171,8 +174,7 @@ spec:
         type: object
     served: true
     storage: true
-    subresources:
-      status: {}
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/helmfile/upstream/velero/crds/deletebackuprequests.yaml
+++ b/helmfile/upstream/velero/crds/deletebackuprequests.yaml
@@ -4,10 +4,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: deletebackuprequests.velero.io
 spec:
@@ -19,7 +18,16 @@ spec:
     singular: deletebackuprequest
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: The name of the backup to be deleted
+      jsonPath: .spec.backupName
+      name: BackupName
+      type: string
+    - description: The status of the deletion request
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: DeleteBackupRequest is a request to delete one or more backups.
@@ -66,6 +74,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/helmfile/upstream/velero/crds/downloadrequests.yaml
+++ b/helmfile/upstream/velero/crds/downloadrequests.yaml
@@ -4,10 +4,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: downloadrequests.velero.io
 spec:
@@ -49,9 +48,12 @@ spec:
                     - BackupLog
                     - BackupContents
                     - BackupVolumeSnapshots
+                    - BackupItemSnapshots
                     - BackupResourceList
                     - RestoreLog
                     - RestoreResults
+                    - CSIBackupVolumeSnapshots
+                    - CSIBackupVolumeSnapshotContents
                     type: string
                   name:
                     description: Name is the name of the kubernetes resource with
@@ -87,8 +89,6 @@ spec:
         type: object
     served: true
     storage: true
-    subresources:
-      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/helmfile/upstream/velero/crds/podvolumebackups.yaml
+++ b/helmfile/upstream/velero/crds/podvolumebackups.yaml
@@ -4,10 +4,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: podvolumebackups.velero.io
 spec:
@@ -19,7 +18,40 @@ spec:
     singular: podvolumebackup
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Pod Volume Backup status such as New/InProgress
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Time when this backup was started
+      jsonPath: .status.startTimestamp
+      name: Created
+      type: date
+    - description: Namespace of the pod containing the volume to be backed up
+      jsonPath: .spec.pod.namespace
+      name: Namespace
+      type: string
+    - description: Name of the pod containing the volume to be backed up
+      jsonPath: .spec.pod.name
+      name: Pod
+      type: string
+    - description: Name of the volume to be backed up
+      jsonPath: .spec.volume
+      name: Volume
+      type: string
+    - description: Restic repository identifier for this backup
+      jsonPath: .spec.repoIdentifier
+      name: Restic Repo
+      type: string
+    - description: Name of the Backup Storage Location where this backup should be
+        stored
+      jsonPath: .spec.backupStorageLocation
+      name: Storage Location
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         properties:
@@ -156,6 +188,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/helmfile/upstream/velero/crds/podvolumerestores.yaml
+++ b/helmfile/upstream/velero/crds/podvolumerestores.yaml
@@ -4,10 +4,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: podvolumerestores.velero.io
 spec:
@@ -19,7 +18,37 @@ spec:
     singular: podvolumerestore
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Namespace of the pod containing the volume to be restored
+      jsonPath: .spec.pod.namespace
+      name: Namespace
+      type: string
+    - description: Name of the pod containing the volume to be restored
+      jsonPath: .spec.pod.name
+      name: Pod
+      type: string
+    - description: Name of the volume to be restored
+      jsonPath: .spec.volume
+      name: Volume
+      type: string
+    - description: Pod Volume Restore status such as New/InProgress
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Pod Volume Restore status such as New/InProgress
+      format: int64
+      jsonPath: .status.progress.totalBytes
+      name: TotalBytes
+      type: integer
+    - description: Pod Volume Restore status such as New/InProgress
+      format: int64
+      jsonPath: .status.progress.bytesDone
+      name: BytesDone
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         properties:
@@ -139,6 +168,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/helmfile/upstream/velero/crds/resticrepositories.yaml
+++ b/helmfile/upstream/velero/crds/resticrepositories.yaml
@@ -4,10 +4,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: resticrepositories.velero.io
 spec:
@@ -19,7 +18,11 @@ spec:
     singular: resticrepository
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         properties:
@@ -84,6 +87,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/helmfile/upstream/velero/crds/restores.yaml
+++ b/helmfile/upstream/velero/crds/restores.yaml
@@ -2,10 +2,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: restores.velero.io
 spec:
@@ -56,6 +55,11 @@ spec:
                   type: string
                 nullable: true
                 type: array
+              existingResourcePolicy:
+                description: ExistingResourcePolicy specifies the restore behaviour
+                  for the kubernetes resource to be restored
+                nullable: true
+                type: string
               hooks:
                 description: Hooks represent custom behaviors that should be executed
                   during or post restore.
@@ -208,8 +212,10 @@ spec:
                                             are expanded using the container''s environment.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
                                             Escaped references will never be expanded,
                                             regardless of whether the variable exists
                                             or not. Cannot be updated. More info:
@@ -224,12 +230,14 @@ spec:
                                             references $(VAR_NAME) are expanded using
                                             the container''s environment. If a variable
                                             cannot be resolved, the reference in the
-                                            input string will be unchanged. The $(VAR_NAME)
-                                            syntax can be escaped with a double $$,
-                                            ie: $$(VAR_NAME). Escaped references will
-                                            never be expanded, regardless of whether
-                                            the variable exists or not. Cannot be
-                                            updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                            input string will be unchanged. Double
+                                            $$ are reduced to a single $, which allows
+                                            for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string
+                                            literal "$(VAR_NAME)". Escaped references
+                                            will never be expanded, regardless of
+                                            whether the variable exists or not. Cannot
+                                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                           items:
                                             type: string
                                           type: array
@@ -247,17 +255,19 @@ spec:
                                               value:
                                                 description: 'Variable references
                                                   $(VAR_NAME) are expanded using the
-                                                  previous defined environment variables
+                                                  previously defined environment variables
                                                   in the container and any service
                                                   environment variables. If a variable
                                                   cannot be resolved, the reference
                                                   in the input string will be unchanged.
-                                                  The $(VAR_NAME) syntax can be escaped
-                                                  with a double $$, ie: $$(VAR_NAME).
-                                                  Escaped references will never be
-                                                  expanded, regardless of whether
-                                                  the variable exists or not. Defaults
-                                                  to "".'
+                                                  Double $$ are reduced to a single
+                                                  $, which allows for escaping the
+                                                  $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                                  will produce the string literal
+                                                  "$(VAR_NAME)". Escaped references
+                                                  will never be expanded, regardless
+                                                  of whether the variable exists or
+                                                  not. Defaults to "".'
                                                 type: string
                                               valueFrom:
                                                 description: Source for the environment
@@ -807,6 +817,30 @@ spec:
                                               required:
                                               - port
                                               type: object
+                                            terminationGracePeriodSeconds:
+                                              description: Optional duration in seconds
+                                                the pod needs to terminate gracefully
+                                                upon probe failure. The grace period
+                                                is the duration in seconds after the
+                                                processes running in the pod are sent
+                                                a termination signal and the time
+                                                when the processes are forcibly halted
+                                                with a kill signal. Set this value
+                                                longer than the expected cleanup time
+                                                for your process. If this value is
+                                                nil, the pod's terminationGracePeriodSeconds
+                                                will be used. Otherwise, this value
+                                                overrides the value provided by the
+                                                pod spec. Value must be non-negative
+                                                integer. The value zero indicates
+                                                stop immediately via the kill signal
+                                                (no opportunity to shut down). This
+                                                is a beta field and requires enabling
+                                                ProbeTerminationGracePeriod feature
+                                                gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                                is used if unset.
+                                              format: int64
+                                              type: integer
                                             timeoutSeconds:
                                               description: 'Number of seconds after
                                                 which the probe times out. Defaults
@@ -865,6 +899,7 @@ spec:
                                                   by services.
                                                 type: string
                                               protocol:
+                                                default: TCP
                                                 description: Protocol for port. Must
                                                   be UDP, TCP, or SCTP. Defaults to
                                                   "TCP".
@@ -1009,6 +1044,30 @@ spec:
                                               required:
                                               - port
                                               type: object
+                                            terminationGracePeriodSeconds:
+                                              description: Optional duration in seconds
+                                                the pod needs to terminate gracefully
+                                                upon probe failure. The grace period
+                                                is the duration in seconds after the
+                                                processes running in the pod are sent
+                                                a termination signal and the time
+                                                when the processes are forcibly halted
+                                                with a kill signal. Set this value
+                                                longer than the expected cleanup time
+                                                for your process. If this value is
+                                                nil, the pod's terminationGracePeriodSeconds
+                                                will be used. Otherwise, this value
+                                                overrides the value provided by the
+                                                pod spec. Value must be non-negative
+                                                integer. The value zero indicates
+                                                stop immediately via the kill signal
+                                                (no opportunity to shut down). This
+                                                is a beta field and requires enabling
+                                                ProbeTerminationGracePeriod feature
+                                                gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                                is used if unset.
+                                              format: int64
+                                              type: integer
                                             timeoutSeconds:
                                               description: 'Number of seconds after
                                                 which the probe times out. Defaults
@@ -1020,7 +1079,7 @@ spec:
                                         resources:
                                           description: 'Compute Resources required
                                             by this container. Cannot be updated.
-                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -1031,7 +1090,7 @@ spec:
                                                 x-kubernetes-int-or-string: true
                                               description: 'Limits describes the maximum
                                                 amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -1046,12 +1105,14 @@ spec:
                                                 a container, it defaults to Limits
                                                 if that is explicitly specified, otherwise
                                                 to an implementation-defined value.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                               type: object
                                           type: object
                                         securityContext:
-                                          description: 'Security options the pod should
-                                            run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                          description: 'SecurityContext defines the
+                                            security options the container should
+                                            be run with. If set, the fields of SecurityContext
+                                            override the equivalent fields of PodSecurityContext.
                                             More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                           properties:
                                             allowPrivilegeEscalation:
@@ -1220,6 +1281,25 @@ spec:
                                                     is the name of the GMSA credential
                                                     spec to use.
                                                   type: string
+                                                hostProcess:
+                                                  description: HostProcess determines
+                                                    if a container should be run as
+                                                    a 'Host Process' container. This
+                                                    field is alpha-level and will
+                                                    only be honored by components
+                                                    that enable the WindowsHostProcessContainers
+                                                    feature flag. Setting this field
+                                                    without the feature flag will
+                                                    result in errors when validating
+                                                    the Pod. All of a Pod's containers
+                                                    must have the same effective HostProcess
+                                                    value (it is not allowed to have
+                                                    a mix of HostProcess containers
+                                                    and non-HostProcess containers).  In
+                                                    addition, if HostProcess is true
+                                                    then HostNetwork must also be
+                                                    set to true.
+                                                  type: boolean
                                                 runAsUserName:
                                                   description: The UserName in Windows
                                                     to run the entrypoint of the container
@@ -1372,6 +1452,30 @@ spec:
                                               required:
                                               - port
                                               type: object
+                                            terminationGracePeriodSeconds:
+                                              description: Optional duration in seconds
+                                                the pod needs to terminate gracefully
+                                                upon probe failure. The grace period
+                                                is the duration in seconds after the
+                                                processes running in the pod are sent
+                                                a termination signal and the time
+                                                when the processes are forcibly halted
+                                                with a kill signal. Set this value
+                                                longer than the expected cleanup time
+                                                for your process. If this value is
+                                                nil, the pod's terminationGracePeriodSeconds
+                                                will be used. Otherwise, this value
+                                                overrides the value provided by the
+                                                pod spec. Value must be non-negative
+                                                integer. The value zero indicates
+                                                stop immediately via the kill signal
+                                                (no opportunity to shut down). This
+                                                is a beta field and requires enabling
+                                                ProbeTerminationGracePeriod feature
+                                                gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                                is used if unset.
+                                              format: int64
+                                              type: integer
                                             timeoutSeconds:
                                               description: 'Number of seconds after
                                                 which the probe times out. Defaults
@@ -1606,6 +1710,61 @@ spec:
                   included in the map will be restored into namespaces of the same
                   name.
                 type: object
+              orLabelSelectors:
+                description: OrLabelSelectors is list of metav1.LabelSelector to filter
+                  with when restoring individual objects from the backup. If multiple
+                  provided they will be joined by the OR operator. LabelSelector as
+                  well as OrLabelSelectors cannot co-exist in restore request, only
+                  one of them can be used
+                items:
+                  description: A label selector is a label query over a set of resources.
+                    The result of matchLabels and matchExpressions are ANDed. An empty
+                    label selector matches all objects. A null label selector matches
+                    no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                nullable: true
+                type: array
               preserveNodePorts:
                 description: PreserveNodePorts specifies whether to restore old nodePorts
                   from backup.
@@ -1616,6 +1775,26 @@ spec:
                   PVs from snapshot (via the cloudprovider).
                 nullable: true
                 type: boolean
+              restoreStatus:
+                description: RestoreStatus specifies which resources we should restore
+                  the status field. If nil, no objects are included. Optional.
+                nullable: true
+                properties:
+                  excludedResources:
+                    description: ExcludedResources specifies the resources to which
+                      will not restore the status.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  includedResources:
+                    description: IncludedResources specifies the resources to which
+                      will restore the status. If empty, it applies to all resources.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                type: object
               scheduleName:
                 description: ScheduleName is the unique name of the Velero schedule
                   to restore from. If specified, and BackupName is empty, Velero will

--- a/helmfile/upstream/velero/crds/schedules.yaml
+++ b/helmfile/upstream/velero/crds/schedules.yaml
@@ -4,10 +4,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: schedules.velero.io
 spec:
@@ -19,7 +18,23 @@ spec:
     singular: schedule
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Status of the schedule
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: A Cron expression defining when to run the Backup
+      jsonPath: .spec.schedule
+      name: Schedule
+      type: string
+    - description: The last time a Backup was run for this schedule
+      jsonPath: .status.lastBackup
+      name: LastBackup
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: Schedule is a Velero resource that represents a pre-scheduled
@@ -48,6 +63,11 @@ spec:
                 description: Template is the definition of the Backup to be run on
                   the provided schedule
                 properties:
+                  csiSnapshotTimeout:
+                    description: CSISnapshotTimeout specifies the time used to wait
+                      for CSI VolumeSnapshot status turns to ReadyToUse during creation,
+                      before returning error as timeout. The default value is 10 minute.
+                    type: string
                   defaultVolumesToRestic:
                     description: DefaultVolumesToRestic specifies whether restic should
                       be used to take a backup of all pod volumes by default.
@@ -330,6 +350,61 @@ spec:
                           type: string
                         type: object
                     type: object
+                  orLabelSelectors:
+                    description: OrLabelSelectors is list of metav1.LabelSelector
+                      to filter with when adding individual objects to the backup.
+                      If multiple provided they will be joined by the OR operator.
+                      LabelSelector as well as OrLabelSelectors cannot co-exist in
+                      backup request, only one of them can be used.
+                    items:
+                      description: A label selector is a label query over a set of
+                        resources. The result of matchLabels and matchExpressions
+                        are ANDed. An empty label selector matches all objects. A
+                        null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    nullable: true
+                    type: array
                   orderedResources:
                     additionalProperties:
                       type: string
@@ -396,6 +471,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/helmfile/upstream/velero/crds/serverstatusrequests.yaml
+++ b/helmfile/upstream/velero/crds/serverstatusrequests.yaml
@@ -4,10 +4,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: serverstatusrequests.velero.io
 spec:
@@ -80,8 +79,6 @@ spec:
         type: object
     served: true
     storage: true
-    subresources:
-      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/helmfile/upstream/velero/crds/volumesnapshotlocations.yaml
+++ b/helmfile/upstream/velero/crds/volumesnapshotlocations.yaml
@@ -4,10 +4,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/name: velero
     component: velero
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: volumesnapshotlocations.velero.io
 spec:

--- a/helmfile/upstream/velero/templates/backupstoragelocation.yaml
+++ b/helmfile/upstream/velero/templates/backupstoragelocation.yaml
@@ -3,6 +3,7 @@ apiVersion: velero.io/v1
 kind: BackupStorageLocation
 metadata:
   name: {{ include "velero.backupStorageLocation.name" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -16,6 +17,7 @@ spec:
   {{- with .Values.configuration.backupStorageLocation.default }}
   default: {{ . }}
   {{- end }}
+  accessMode: {{ .Values.configuration.backupStorageLocation.accessMode }}
 {{- with .Values.configuration.backupStorageLocation }}
   objectStorage:
     bucket: {{ .bucket | quote }}

--- a/helmfile/upstream/velero/templates/cleanup-crds.yaml
+++ b/helmfile/upstream/velero/templates/cleanup-crds.yaml
@@ -1,6 +1,8 @@
 {{- if .Values.cleanUpCRDs }}
 # This job is meant primarily for cleaning up on CI systems.
 # Using this on production systems, especially those that have multiple releases of Velero, will be destructive.
+{{/* 'securityContext' got renamed to 'podSecurityContext', merge both dicts into one for backward compatibility */}}
+{{- $podSecurityContext := merge (.Values.podSecurityContext | default dict) (.Values.securityContext | default dict) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -54,12 +56,20 @@ spec:
               kubectl delete backupstoragelocation --all;
               kubectl delete volumesnapshotlocation --all;
               kubectl delete podvolumerestore --all;
-              kubectl delete crd -l app.kubernetes.io/name=velero;
+              kubectl delete crd -l component=velero;
+          {{- with .Values.kubectl.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.kubectl.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       restartPolicy: OnFailure
+      {{- with $podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helmfile/upstream/velero/templates/clusterrolebinding.yaml
+++ b/helmfile/upstream/velero/templates/clusterrolebinding.yaml
@@ -15,6 +15,6 @@ subjects:
     name: {{ include "velero.serverServiceAccount" . }}
 roleRef:
   kind: ClusterRole
-  name: cluster-admin
+  name: {{ .Values.rbac.clusterAdministratorName }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/helmfile/upstream/velero/templates/configmaps.yaml
+++ b/helmfile/upstream/velero/templates/configmaps.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "velero.fullname" $ }}-{{ $configMapName }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}

--- a/helmfile/upstream/velero/templates/deployment.yaml
+++ b/helmfile/upstream/velero/templates/deployment.yaml
@@ -6,6 +6,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "velero.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -108,8 +109,14 @@ spec:
             {{- with .clientBurst }}
             - --client-burst={{ . }}
             {{- end }}
+            {{- with .clientPageSize }}
+            - --client-page-size={{ . }}
+            {{- end }}
             {{- with .disableControllers }}
             - --disable-controllers={{ . }}
+            {{- end }}
+            {{- with .storeValidationFrequency }}
+            - --store-validation-frequency={{ . }}
             {{- end }}
           {{- end }}
           {{- with .Values.resources }}
@@ -169,7 +176,7 @@ spec:
           {{- with .Values.configuration.extraEnvVars }}
           {{- range $key, $value := . }}
             - name: {{ default "none" $key }}
-              value: {{ default "none" $value }}
+              value: {{ default "none" $value | quote }}
           {{- end }}
           {{- end }}
           {{- with .Values.credentials.extraEnvVars }}
@@ -180,6 +187,9 @@ spec:
                   name: {{ include "velero.secretName" $ }}
                   key: {{ default "none" $key }}
           {{- end }}
+          {{- end }}
+          {{- if .Values.lifecycle }}
+          lifecycle: {{ toYaml .Values.lifecycle | nindent 12 }}
           {{- end }}
       dnsPolicy: {{ .Values.dnsPolicy }}
 {{- if .Values.initContainers }}
@@ -213,6 +223,10 @@ spec:
     {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.dnsConfig }}
+      dnsConfig:
         {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.tolerations }}

--- a/helmfile/upstream/velero/templates/extra-manifests.yaml
+++ b/helmfile/upstream/velero/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/helmfile/upstream/velero/templates/prometheusrule.yaml
+++ b/helmfile/upstream/velero/templates/prometheusrule.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.metrics.enabled .Values.metrics.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "velero.fullname" . }}
+  {{- if .Values.metrics.prometheusRule.namespace }}
+  namespace: {{ .Values.metrics.prometheusRule.namespace }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "velero.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.metrics.prometheusRule.additionalLabels }}
+    {{- toYaml .Values.metrics.prometheusRule.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+  - name: {{ include "velero.name" . }}
+    rules:
+    {{- toYaml .Values.metrics.prometheusRule.spec | nindent 4 }}
+{{- end }}

--- a/helmfile/upstream/velero/templates/restic-daemonset.yaml
+++ b/helmfile/upstream/velero/templates/restic-daemonset.yaml
@@ -6,6 +6,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: restic
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.restic.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -142,7 +143,7 @@ spec:
           {{- with .Values.configuration.extraEnvVars }}
           {{- range $key, $value := . }}
             - name: {{ default "none" $key }}
-              value: {{ default "none" $value }}
+              value: {{ default "none" $value | quote }}
           {{- end }}
           {{- end }}
           {{- with .Values.credentials.extraEnvVars }}
@@ -153,6 +154,15 @@ spec:
                   name: {{ include "velero.secretName" $ }}
                   key: {{ default "none" $key }}
           {{- end }}
+          {{- end }}
+          {{- with .Values.restic.extraEnvVars }}
+          {{- range $key, $value := . }}
+            - name: {{ default "none" $key }}
+              value: {{ default "none" $value | quote }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.lifecycle }}
+          lifecycle: {{ toYaml .Values.restic.lifecycle | nindent 12 }}
           {{- end }}
           securityContext:
             privileged: {{ .Values.restic.privileged }}
@@ -171,4 +181,12 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.restic.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}      
+    {{- with .Values.restic.dnsConfig }}
+    dnsConfig:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/helmfile/upstream/velero/templates/role.yaml
+++ b/helmfile/upstream/velero/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "velero.fullname" . }}-server
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: {{ include "velero.name" . }}

--- a/helmfile/upstream/velero/templates/rolebinding.yaml
+++ b/helmfile/upstream/velero/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "velero.fullname" . }}-server
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: {{ include "velero.name" . }}

--- a/helmfile/upstream/velero/templates/schedule.yaml
+++ b/helmfile/upstream/velero/templates/schedule.yaml
@@ -4,6 +4,7 @@ apiVersion: velero.io/v1
 kind: Schedule
 metadata:
   name: {{ include "velero.fullname" $ }}-{{ $scheduleName }}
+  namespace: {{ $.Release.Namespace }}
   annotations:
   {{- if $schedule.annotations }}
     {{- toYaml $schedule.annotations | nindent 4 }}

--- a/helmfile/upstream/velero/templates/secret.yaml
+++ b/helmfile/upstream/velero/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "velero.secretName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helmfile/upstream/velero/templates/service.yaml
+++ b/helmfile/upstream/velero/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "velero.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.metrics.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helmfile/upstream/velero/templates/serviceaccount-server.yaml
+++ b/helmfile/upstream/velero/templates/serviceaccount-server.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "velero.serverServiceAccount" . }}
+  namespace: {{ .Release.Namespace }}
 {{- if .Values.serviceAccount.server.annotations }}
   annotations:
 {{ toYaml .Values.serviceAccount.server.annotations | nindent 4 }}

--- a/helmfile/upstream/velero/templates/servicemonitor.yaml
+++ b/helmfile/upstream/velero/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -26,4 +26,11 @@ spec:
   - port: http-monitoring
     interval: {{ .Values.metrics.scrapeInterval }}
     scrapeTimeout: {{ .Values.metrics.scrapeTimeout }}
+    {{- if .Values.metrics.serviceMonitor.scheme }}
+    scheme: {{ .Values.metrics.serviceMonitor.scheme }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.tlsConfig }}
+    tlsConfig:
+      {{- toYaml .Values.metrics.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/helmfile/upstream/velero/templates/upgrade-crds.yaml
+++ b/helmfile/upstream/velero/templates/upgrade-crds.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.upgradeCRDs }}
+{{/* 'securityContext' got renamed to 'podSecurityContext', merge both dicts into one for backward compatibility */}}
+{{- $podSecurityContext := merge (.Values.podSecurityContext | default dict) (.Values.securityContext | default dict) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -52,6 +54,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.kubectl.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /tmp
               name: crds
@@ -72,6 +78,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /tmp
               name: crds
@@ -79,6 +89,10 @@ spec:
         - name: crds
           emptyDir: {}
       restartPolicy: OnFailure
+      {{- with $podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helmfile/upstream/velero/templates/volumesnapshotlocation.yaml
+++ b/helmfile/upstream/velero/templates/volumesnapshotlocation.yaml
@@ -3,6 +3,7 @@ apiVersion: velero.io/v1
 kind: VolumeSnapshotLocation
 metadata:
   name: {{ include "velero.volumeSnapshotLocation.name" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/helmfile/upstream/velero/values.yaml
+++ b/helmfile/upstream/velero/values.yaml
@@ -6,7 +6,7 @@
 # enabling restic). Required.
 image:
   repository: velero/velero
-  tag: v1.7.1
+  tag: v1.9.2
   # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
   # If used, it will take precedence over the image.tag.
   # digest:
@@ -53,13 +53,13 @@ dnsPolicy: ClusterFirst
 # If the value is a string then it is evaluated as a template.
 initContainers:
   # - name: velero-plugin-for-csi
-  #   image: velero/velero-plugin-for-csi:v0.2.0
+  #   image: velero/velero-plugin-for-csi:v0.3.1
   #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target
   #       name: plugins
   # - name: velero-plugin-for-aws
-  #   image: velero/velero-plugin-for-aws:v1.3.0
+  #   image: velero/velero-plugin-for-aws:v1.5.1
   #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target
@@ -80,6 +80,9 @@ containerSecurityContext: {}
   #   add: []
   # readOnlyRootFilesystem: true
 
+# Container Lifecycle Hooks to use for the Velero deployment. Optional.
+lifecycle: {}
+
 # Pod priority class name to use for the Velero deployment. Optional.
 priorityClassName: ""
 
@@ -92,11 +95,40 @@ affinity: {}
 # Node selector to use for the Velero deployment. Optional.
 nodeSelector: {}
 
+# DNS configuration to use for the Velero deployment. Optional.
+dnsConfig: {}
+
 # Extra volumes for the Velero deployment. Optional.
 extraVolumes: []
 
 # Extra volumeMounts for the Velero deployment. Optional.
 extraVolumeMounts: []
+
+# Extra K8s manifests to deploy
+extraObjects: []
+  # - apiVersion: secrets-store.csi.x-k8s.io/v1
+  #   kind: SecretProviderClass
+  #   metadata:
+  #     name: velero-secrets-store
+  #   spec:
+  #     provider: aws
+  #     parameters:
+  #       objects: |
+  #         - objectName: "velero"
+  #           objectType: "secretsmanager"
+  #           jmesPath:
+  #               - path: "access_key"
+  #                 objectAlias: "access_key"
+  #               - path: "secret_key"
+  #                 objectAlias: "secret_key"
+  #     secretObjects:
+  #       - data:
+  #         - key: access_key
+  #           objectName: client-id
+  #         - key: client-secret
+  #           objectName: client-secret
+  #         secretName: velero-secrets-store
+  #         type: Opaque
 
 # Settings for Velero's prometheus metrics. Enabled by default.
 metrics:
@@ -120,6 +152,35 @@ metrics:
     additionalLabels: {}
     # ServiceMonitor namespace. Default to Velero namespace.
     # namespace:
+    # ServiceMonitor connection scheme. Defaults to HTTP.
+    # scheme: ""
+    # ServiceMonitor connection tlsConfig. Defaults to {}.
+    # tlsConfig: {}
+
+  prometheusRule:
+    enabled: false
+    # Additional labels to add to deployed PrometheusRule
+    additionalLabels: {}
+    # PrometheusRule namespace. Defaults to Velero namespace.
+    # namespace: ""
+    # Rules to be deployed
+    spec: []
+    # - alert: VeleroBackupPartialFailures
+    #   annotations:
+    #     message: Velero backup {{ $labels.schedule }} has {{ $value | humanizePercentage }} partialy failed backups.
+    #   expr: |-
+    #     velero_backup_partial_failure_total{schedule!=""} / velero_backup_attempt_total{schedule!=""} > 0.25
+    #   for: 15m
+    #   labels:
+    #     severity: warning
+    # - alert: VeleroBackupFailures
+    #   annotations:
+    #     message: Velero backup {{ $labels.schedule }} has {{ $value | humanizePercentage }} failed backups.
+    #   expr: |-
+    #     velero_backup_failure_total{schedule!=""} / velero_backup_attempt_total{schedule!=""} > 0.25
+    #   for: 15m
+    #   labels:
+    #     severity: warning
 
 kubectl:
   image:
@@ -129,6 +190,9 @@ kubectl:
     # digest:
     # kubectl image tag. If used, it will take precedence over the cluster Kubernetes version.
     # tag: 1.16.15
+  # Container Level Security Context for the 'kubectl' container of the crd jobs. Optional.
+  # See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  containerSecurityContext: {}
   # Resource requests/limits to specify for the upgrade/cleanup job. Optional
   resources: {}
   # Annotations to set for the upgrade/cleanup job. Optional.
@@ -173,6 +237,9 @@ configuration:
     prefix:
     # default indicates this location is the default backup storage location. Optional.
     default:
+    # accessMode determines if velero can write to this backup storage location. Optional.
+    # default to ReadWrite, ReadOnly is used during migrations and restores.
+    accessMode: ReadWrite
     # Additional provider-specific configuration. See link above
     # for details of required/optional fields for your provider.
     config: {}
@@ -227,7 +294,11 @@ configuration:
   # `velero server` default: 30
   clientBurst:
   # `velero server` default: empty
+  clientPageSize:
+  # `velero server` default: empty
   disableControllers:
+  # `velero server` default: 1m
+  storeValidationFrequency:
   #
 
   # additional key/value pairs to be used as environment variables such as "AWS_CLUSTER_NAME: 'yourcluster.domain.tld'"
@@ -263,6 +334,8 @@ rbac:
   create: true
   # Whether to create the cluster role binding to give administrator permissions to Velero
   clusterAdministrator: true
+  # Name of the ClusterRole.
+  clusterAdministratorName: cluster-admin
 
 # Information about the Kubernetes service account Velero uses.
 serviceAccount:
@@ -348,6 +421,9 @@ restic:
   # Extra volumeMounts for the Restic daemonset. Optional.
   extraVolumeMounts: []
 
+  # Key/value pairs to be used as environment variables for the Restic daemonset. Optional.
+  extraEnvVars: {}
+
   # Configure the dnsPolicy of the Restic daemonset
   # See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ClusterFirst
@@ -363,8 +439,17 @@ restic:
   # See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   containerSecurityContext: {}
 
+  # Container Lifecycle Hooks to use for the Restic daemonset. Optional.
+  lifecycle: {}
+
   # Node selector to use for the Restic daemonset. Optional.
   nodeSelector: {}
+
+  # Affinity to use with Restic daemonset. Optional.
+  affinity: {}
+
+  # DNS configuration to use for the Restic daemonset. Optional.
+  dnsConfig: {}
 
 # Backup schedules to create.
 # Eg:
@@ -376,7 +461,7 @@ restic:
 #     annotations:
 #       myenv: foo
 #     schedule: "0 0 * * *"
-#     useOwnerReferencesInBackup: true
+#     useOwnerReferencesInBackup: false
 #     template:
 #       ttl: "240h"
 #       includedNamespaces:
@@ -391,7 +476,7 @@ schedules: {}
 #       velero.io/plugin-config: ""
 #       velero.io/restic: RestoreItemAction
 #     data:
-#       image: velero/velero-restic-restore-helper:v1.7.1
+#       image: velero/velero-restic-restore-helper:v1.9.2
 configMaps: {}
 
 ##

--- a/helmfile/values/velero-sc.yaml.gotmpl
+++ b/helmfile/values/velero-sc.yaml.gotmpl
@@ -8,14 +8,14 @@ nodeSelector: {{- toYaml .Values.velero.nodeSelector | nindent 2  }}
 initContainers:
   {{- if eq .Values.objectStorage.type "s3" }}
   - name: velero-plugin-for-aws
-    image: velero/velero-plugin-for-aws:v1.3.1
+    image: velero/velero-plugin-for-aws:v1.5.1
     imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /target
         name: plugins
   {{- else if eq .Values.objectStorage.type "gcs" }}
   - name: velero-plugin-for-gcs
-    image: velero/velero-plugin-for-gcp:v1.1.0
+    image: velero/velero-plugin-for-gcp:v1.5.1
     imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /target

--- a/helmfile/values/velero-wc.yaml.gotmpl
+++ b/helmfile/values/velero-wc.yaml.gotmpl
@@ -8,14 +8,14 @@ nodeSelector: {{- toYaml .Values.velero.nodeSelector | nindent 2  }}
 initContainers:
   {{- if eq .Values.objectStorage.type "s3" }}
   - name: velero-plugin-for-aws
-    image: velero/velero-plugin-for-aws:v1.3.1
+    image: velero/velero-plugin-for-aws:v1.5.1
     imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /target
         name: plugins
   {{- else if eq .Values.objectStorage.type "gcs" }}
   - name: velero-plugin-for-gcs
-    image: velero/velero-plugin-for-gcp:v1.1.0
+    image: velero/velero-plugin-for-gcp:v1.5.1
     imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /target

--- a/migration/v0.26.x-v0.27.x/upgrade-apps.md
+++ b/migration/v0.26.x-v0.27.x/upgrade-apps.md
@@ -1,0 +1,13 @@
+# Upgrade v0.26.x to v0.27.x
+
+## Steps
+
+1. Update apps configuration:
+    This will take a backup into `backups/` before modifying any files.
+    ```bash
+    bin/ck8s init
+    ```
+1. Upgrade applications:
+    ```bash
+    bin/ck8s apply {sc|wc}
+    ```


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade velero to 2.31.8
**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [x] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
