### PR TITLE
Aarnq/add support for anchors and aliases in override

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -18,6 +18,7 @@
 - Harbor backup is now pointed to the correct internal service to make backups from
 - Bumped backup-postgres image to use tag `1.2.0`, which includes newer versions of the postgresql client
 - Fixed Test User RBAC
+- Fixed the shifted comment after running init
 
 ### Added
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -10,6 +10,7 @@
 - Changed grafana's communication with dex to use internal service
 - Upgrade Velero helm chart to `v2.31.8`, which also upgrades Velero to `v1.9.2`.
 - Update the provider plugins to a supported version for the new Velero release
+- Added support for anchors and aliases in override configs, not tested with merge aliases/tags
 
 ### Fixed
 

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -357,9 +357,8 @@ update_config() {
     else
         preamble="# Changes made here will override the default values as well as the common config for this cluster."
     fi
-    preamble="${preamble}
-    # See the default configuration under \"defaults/\" to see available and suggested options."
-    echo "${preamble}" | cat - "${new_config}" > "${override_config}"
+    preamble="${preamble}\n# See the default configuration under \"defaults/\" to see available and suggested options."
+    echo -e "${preamble}" | cat - "${new_config}" > "${override_config}"
 }
 
 # Usage: update_secrets <config-file> <false|true>


### PR DESCRIPTION
**What this PR does / why we need it**:
Does what it says on the tin.

**Which issue this PR fixes**: -

**Special notes for reviewer**:
Adds a copy step from anchors in case they get destroyed from being too common.
If you don't use anchors and aliases it won't do anything different.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
