### PR TITLE
apps sc: fix blackbox exporter target

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Fixed
 
+- Blackbox exporter now looks at the correct error code for the opensearch-dashboards target
+
 ### Added
 
 - Option to deny network traffic by default

--- a/helmfile/values/prometheus-blackbox-exporter-sc.yaml.gotmpl
+++ b/helmfile/values/prometheus-blackbox-exporter-sc.yaml.gotmpl
@@ -90,7 +90,7 @@ serviceMonitor:
       url: https://{{ .Values.opensearch.dashboards.subdomain }}.{{ .Values.global.baseDomain }}/api/status
       interval: 60s
       scrapeTimeout: 30s
-      module: http_2xx
+      module: http_401
     - name: user-api-server
       url: https://kube-apiserver.{{ .Values.global.baseDomain }}:/healthz
       interval: 60s


### PR DESCRIPTION
**What this PR does / why we need it**:

We got an alert saying opensearch-dashboards endpoint was down but it wasn't, blackbox exporter was looking for the wrong error code at the opensearch-dashboards target because opensearch-dashboards had done some changes.

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [X] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
