### PR TITLE
apps sc: fix harbor backup

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -8,7 +8,8 @@
 ### Fixed
 
 - Blackbox exporter now looks at the correct error code for the opensearch-dashboards target
-- Harbor backup is now pointed to the correct service to make backups from
+- Harbor backup is now pointed to the correct internal service to make backups from
+- Bumped backup-postgres image to use tag `1.2.0`, which includes newer versions of the postgresql client
 
 ### Added
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 - Blackbox exporter now looks at the correct error code for the opensearch-dashboards target
+- Harbor backup is now pointed to the correct service to make backups from
 
 ### Added
 

--- a/helmfile/charts/harbor/harbor-backup/templates/harbor-backup-job.yaml
+++ b/helmfile/charts/harbor/harbor-backup/templates/harbor-backup-job.yaml
@@ -19,7 +19,7 @@ spec:
            fsGroup: 1000
           containers:
             - name: run
-              image: elastisys/backup-postgres:1.1.0
+              image: elastisys/backup-postgres:1.2.0
               command: ['/bin/bash', '/scripts/harbor-backup.sh']
               env:
               {{- if .Values.s3.enabled }}

--- a/helmfile/charts/harbor/harbor-backup/values.yaml
+++ b/helmfile/charts/harbor/harbor-backup/values.yaml
@@ -1,4 +1,4 @@
-pgHostname: harbor-harbor-database
+pgHostname: harbor-database
 dbPassword: ""
 retentionDays: 7
 schedule: "0 0 * * *"

--- a/scripts/restore/restore-harbor-job.yaml
+++ b/scripts/restore/restore-harbor-job.yaml
@@ -20,7 +20,7 @@ spec:
      restartPolicy: Never
      containers:
      - name: run
-       image: elastisys/backup-postgres:1.1.0
+       image: elastisys/backup-postgres:1.2.0
        command: ['/bin/bash', '/scripts/restore-harbor.sh']
        env:
          - name: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
**What this PR does / why we need it**:

Harbor backup was pointed to the wrong service name, so it could not take backups.

@OlleLarsson Also made a new tag for the `elastisys/backup-postgres` image which uses newer postgres version

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [X] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
