### PR TITLE
apps sc: added alert for evicted pods

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Option to deny network traffic by default
 - Network policies for monitoring stack (prometheus, thanos, grafana, some exporters)
+- An alert for failed evicted pods (KubeFailedEvictedPods)
 
 ### Removed
 

--- a/helmfile/charts/prometheus-alerts/CHANGELOG.md
+++ b/helmfile/charts/prometheus-alerts/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2022.10.04
+1. helmfile/charts/prometheus-alerts/templates/alerts/kubernetes-apps.yaml
+   - ADDED - KubeFailedEvictedPods alert
 ## 2022.08.17
 1. helmfile/charts/prometheus-alerts/files/missing-metrics-alerts.yaml
    - MODIFIED - MetricsFromScClusterIsMissing 'for' from 5m to 15m

--- a/helmfile/charts/prometheus-alerts/templates/alerts/kubernetes-apps.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/alerts/kubernetes-apps.yaml
@@ -261,4 +261,15 @@ spec:
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
+    - alert: KubeFailedEvictedPods
+      annotations:
+        description: '{{`{{`}} $value {{`}}`}} Failed Evicted pods in {{`{{`}} $labels.namespace {{`}}`}} namespace {{`{{`}} $labels.cluster {{`}}`}} cluster'
+        summary: Kubernetes failed evicted pods
+      expr: sum by (namespace, cluster) (kube_pod_status_phase{phase="Failed"} > 0 and on(namespace, cluster) kube_pod_status_reason{reason="Evicted"} > 0) > 0
+      for: 10m
+      labels:
+        severity: warning
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**: to add an alert to detect evicted pods

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1173 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).