### PR TITLE
apps: changed the default disklimit alert threshold

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -11,6 +11,7 @@
 - Upgrade Velero helm chart to `v2.31.8`, which also upgrades Velero to `v1.9.2`.
 - Update the provider plugins to a supported version for the new Velero release
 - Added support for anchors and aliases in override configs, not tested with merge aliases/tags
+- Changed the default limit for diskLimit alert, from 66 to 75
 
 ### Fixed
 

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -248,7 +248,7 @@ prometheus:
   ## Predictive alert if the resource usage will hit the set percentage in 3 days
   capacityManagementAlerts:
     enabled: true
-    disklimit: 66
+    disklimit: 75
     usagelimit: 95
     ## for each cpu and memory add the node pattern for which you want to create an alert
     requestlimit:


### PR DESCRIPTION
**What this PR does / why we need it**: increased the default disklimit alert threshold

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).