### PR TITLE
apps sc: harbor backup pointed to correct service

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,10 +403,6 @@ See <https://compliantkubernetes.io/operator-manual/>.
 
 ## Known issues
 
-- When using local volumes, OpenSearch might not start properly unless all worker nodes in the cluster has a local volume attatched to it.
-- Users must explicitly be given privileges in Grafana, OpenSearch and Kubernetes instead of automatically getting assigned roles based on group membership when logging in using OIDC.
-- The OPA policies are not enforced by default.
-  Unfortunately the policies breaks cert-manager so they have been set to "dry-run" by default.
 - OpenSearch Dashboards Single Sign On (SSO) via OpenID/Dex requires LetsEncrypt Production.
 
 For more, please the the public GitHub issues: <https://github.com/elastisys/compliantkubernetes-apps/issues>.

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -37,6 +37,7 @@
 - An alert for failed evicted pods (KubeFailedEvictedPods)
 - Resource config for user-alertmanager, config-reloader, gatekeeper
 - Config option for gatekeeper audit interval
+- Network policies for logging stack (fluentd and opensearch)
 
 ### Removed
 

--- a/bin/apps.bash
+++ b/bin/apps.bash
@@ -91,9 +91,31 @@ apps_wc() {
 # ENTRYPOINT
 #
 if [[ $1 == "wc" ]]; then
+    if ! "${here}/update-ips.bash" "wc" "dry-run"; then
+        log_warning "Diff in wc config for network policy IPs, run 'ck8s update-ips wc update' to fix this issue."
+
+        if ! ${CK8S_AUTO_APPROVE}; then
+            log_warning_no_newline "Do you want to continue anyway? (y/N): "
+            read -r reply
+            if [[ ! "${reply}" =~ ^[yY]$ ]]; then
+                exit 1
+            fi
+        fi
+    fi
     config_load "$1"
     apps_wc "$2" "$3"
 elif [[ $1 == "sc" ]]; then
+    if ! "${here}/update-ips.bash" "sc" "dry-run"; then
+        log_warning "Diff in sc config for network policy IPs, run 'ck8s update-ips sc update' to fix this issue."
+
+        if ! ${CK8S_AUTO_APPROVE}; then
+            log_warning_no_newline "Do you want to continue anyway? (y/N): "
+            read -r reply
+            if [[ ! "${reply}" =~ ^[yY]$ ]]; then
+                exit 1
+            fi
+        fi
+    fi
     config_load "$1"
     apps_sc "$2" "$3"
 else

--- a/bin/ck8s
+++ b/bin/ck8s
@@ -33,6 +33,7 @@ usage() {
     echo "  validate <wc|sc>                                  validates config files" 1>&2
     echo "  providers                                         lists supported cloud providers" 1>&2
     echo "  flavors                                           lists supported configuration flavors" 1>&2
+    echo "  update-ips <wc|sc|both> <update|dry-run>          Automatically fetches and updates the IPs for network policies" 1>&2
     exit 1
 }
 
@@ -129,5 +130,10 @@ case "${1}" in
         ;;
     providers) echo "${ck8s_cloud_providers[@]}" ;;
     flavors) echo "${ck8s_flavors[@]}" ;;
+    update-ips)
+        [[ "${2}" =~ ^(wc|sc|both)$ ]] || usage
+        [[ "${3}" =~ ^(update|dry-run)$ ]] || usage
+        "${here}/update-ips.bash" "${2}" "${3}"
+        ;;
     *) usage ;;
 esac

--- a/bin/update-ips.bash
+++ b/bin/update-ips.bash
@@ -1,0 +1,191 @@
+#!/bin/bash
+
+# This script checks the IPs that are setup for network policies and reports the diff
+# If set to update the config, it will also update the config files.
+
+# Usage: update-ips.bash <cluster> <action>
+#   cluster: What cluster config to check for (sc, wc or both)
+#   action: If the script should update the config or not (update or dry-run)
+
+set -eu -o pipefail
+
+here="$(dirname "$(readlink -f "$0")")"
+# shellcheck source=bin/common.bash
+source "${here}/common.bash"
+
+CHECK_CLUSTER="${1}" # sc, wc or both
+DRY_RUN=true
+if [[ "${2}" == "update" ]]; then
+    DRY_RUN=false
+fi
+has_diff=0
+
+# Compares a list IPs with the list of IPs in the yaml path and file specified and returns the diff return code.
+# If DRY_RUN is set, it will output to stdout, otherwise it will just return the diff return code silently.
+diffIPs() {
+    local yaml_path
+    local file
+    local IPS
+    yaml_path="${1}"
+    file="${2}"
+    shift 2
+    IPS=("$@")
+    tmp_file=$(mktemp --suffix=.yaml)
+
+    yq4 -n '. = []' > "${tmp_file}"
+    for ip in "${IPS[@]}"; do
+        yq4 -i '. |= . + ["'"${ip}"'/32"]' "${tmp_file}"
+    done
+
+    if $DRY_RUN; then
+        out_file=/dev/stdout
+    else
+        out_file=/dev/null
+    fi
+
+    diff -U3 --color=always \
+        --label "${file//${CK8S_CONFIG_PATH}\//}" <(yq4 -P "${yaml_path}"' // [] | sort_by(.)' "${file}") \
+        --label expected <(yq4 -P '. | sort_by(.)' "${tmp_file}") > "${out_file}"
+    DIFF_RETURN=$?
+    rm "${tmp_file}"
+    return ${DIFF_RETURN}
+}
+
+# Fetches the IPs from a specified address
+getDNSIPs() {
+    local IPS
+    mapfile -t IPS < <(dig +short "${1}" | grep '^[.0-9]*$')
+    if [ ${#IPS[@]} -eq 0 ]; then
+        log_error "No ips for ${1} was found"
+        exit 1
+    fi
+    echo "${IPS[@]}"
+}
+
+diffDNSIPs() {
+    local IPS
+    read -r -a IPS <<< "$(getDNSIPs "${1}")"
+    diffIPs "${2}" "${3}" "${IPS[@]}"
+    return $?
+}
+
+# Updates the list from the file and yaml path specified with IPs fetched from the domain
+updateDNSIPs() {
+    read -r -a IPS <<< "$(getDNSIPs "${1}")"
+
+    yq4 -i "${2}"' = []' "${3}"
+    for ip in "${IPS[@]}"; do
+        yq4 -i "${2}"' |= . + ["'"${ip}"'/32"]' "${3}"
+    done
+}
+
+# Fetches the Internal IP and calico tunnel ip of kubernetes nodes using the label selector.
+# If label selector isn't specified, all nodes will be returned.
+getKubectlIPs() {
+    local IPS_internal
+    local IPS_calico
+    local IPS
+    local label_argument=""
+    if [[ "${2}" != "" ]]; then
+        label_argument="-l ${2}"
+    fi
+    mapfile -t IPS_internal < <("${here}/ops.bash" kubectl "${1}" get node "${label_argument}" -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+    mapfile -t IPS_calico < <("${here}/ops.bash" kubectl "${1}" get node "${label_argument}" -ojsonpath='{.items[*].metadata.annotations.projectcalico\.org/IPv4IPIPTunnelAddr}')
+    read -r -a IPS <<< "${IPS_internal[*]} ${IPS_calico[*]}"
+    if [ ${#IPS[@]} -eq 0 ]; then
+        log_error "No ips for ${1} nodes with labels ${2} was found"
+        exit 1
+    fi
+    echo "${IPS[@]}"
+}
+
+diffKubectlIPs() {
+    local IPS
+    read -r -a IPS <<< "$(getKubectlIPs "${1}" "${2}")"
+    diffIPs "${3}" "${4}" "${IPS[@]}"
+    return $?
+}
+
+# Updates the list from the file and yaml path specified with IPs fetched from the nodes
+updateKubectlIPs() {
+    local IPS
+    read -r -a IPS <<< "$(getKubectlIPs "${1}" "${2}")"
+
+    yq4 -i "${3}"' = []' "${4}"
+    for ip in "${IPS[@]}"; do
+        yq4 -i "${3}"' |= . + ["'"${ip}"'/32"]' "${4}"
+    done
+}
+
+checkIfDiffAndUpdateDNSIPs() {
+    if ! diffDNSIPs "${1}" "${2}" "${3}"; then
+        if ! $DRY_RUN; then
+            updateDNSIPs "${1}" "${2}" "${3}"
+        else
+            log_warning "Diff found for ${2} in ${3//${CK8S_CONFIG_PATH}\//} (diff shows actions needed to be up to date)"
+        fi
+        has_diff=$(( has_diff + 1 ))
+    fi
+}
+
+checkIfDiffAndUpdateKubectlIPs() {
+    if ! diffKubectlIPs "${1}" "${2}" "${3}" "${4}"; then
+        if ! $DRY_RUN; then
+            updateKubectlIPs "${1}" "${2}" "${3}" "${4}"
+        else
+            log_warning "Diff found for ${3} in ${4//${CK8S_CONFIG_PATH}\//} (diff shows actions needed to be up to date)"
+        fi
+        has_diff=$(( has_diff + 1 ))
+    fi
+}
+
+S3_ENDPOINT="$(yq4 '.objectStorage.s3.regionEndpoint' "${config["override_common"]}" | sed 's/https\?:\/\///')"
+if [[ "${S3_ENDPOINT}" == "" ]]; then
+    log_error "No S3 endpoint found, check your common-config.yaml"
+    exit 1
+fi
+
+OPS_DOMAIN="$(yq4 '.global.opsDomain' "${CK8S_CONFIG_PATH}/common-config.yaml")"
+if [[ "${OPS_DOMAIN}" == "" ]]; then
+    log_error "No ops domain found, check your common-config.yaml"
+    exit 1
+fi
+
+BASE_DOMAIN="$(yq4 '.global.baseDomain' "${CK8S_CONFIG_PATH}/common-config.yaml")"
+if [[ "${BASE_DOMAIN}" == "" ]]; then
+    log_error "No base domain found, check your common-config.yaml"
+    exit 1
+fi
+
+## Add object storage ips to common config
+checkIfDiffAndUpdateDNSIPs "${S3_ENDPOINT}" ".networkPolicies.global.objectStorage.ips" "${config["override_common"]}"
+
+## Add sc ingress ips to common config
+checkIfDiffAndUpdateDNSIPs "grafana.${OPS_DOMAIN}" ".networkPolicies.global.scIngress.ips" "${config["override_common"]}"
+
+## Add wc ingress ips to sc config
+if [[ "${CHECK_CLUSTER}" =~ ^(sc|both)$ ]]; then
+    checkIfDiffAndUpdateDNSIPs "non-existing-subdomain.${BASE_DOMAIN}" ".networkPolicies.global.wcIngress.ips" "${config["override_sc"]}"
+fi
+
+## Add sc apiserver ips
+if [[ "${CHECK_CLUSTER}" =~ ^(sc|both)$ ]]; then
+    checkIfDiffAndUpdateKubectlIPs "sc" "node-role.kubernetes.io/control-plane=" ".networkPolicies.global.scApiserver.ips" "${config["override_sc"]}"
+fi
+
+## Add wc apiserver ips
+if [[ "${CHECK_CLUSTER}" =~ ^(wc|both)$ ]]; then
+    checkIfDiffAndUpdateKubectlIPs "wc" "node-role.kubernetes.io/control-plane=" ".networkPolicies.global.wcApiserver.ips" "${config["override_wc"]}"
+fi
+
+## Add sc nodes ips to sc config
+if [[ "${CHECK_CLUSTER}" =~ ^(sc|both)$ ]]; then
+    checkIfDiffAndUpdateKubectlIPs "sc" "" ".networkPolicies.global.scNodes.ips" "${config["override_sc"]}"
+fi
+
+## Add wc nodes ips to wc config
+if [[ "${CHECK_CLUSTER}" =~ ^(wc|both)$ ]]; then
+    checkIfDiffAndUpdateKubectlIPs "wc" "" ".networkPolicies.global.wcNodes.ips" "${config["override_wc"]}"
+fi
+
+exit ${has_diff}

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -1077,19 +1077,12 @@ networkPolicies:
         - set-me
     externalLoadBalancer: false # only true if loadbalancer is not controlled by a kubernetes cloud controller
   harbor:
-    enable: true
-    chartmuseum:
-      # IP to S3
-      egressIPs:
-        - "0.0.0.0/0"
-    core:
-      # IP to S3, dex
-      egressIPs:
-        - "0.0.0.0/0"
+    enabled: true
     jobservice:
       # IP to pull images, docker hub etc
-      egressIPs:
-        - "0.0.0.0/0"
+      ips:
+        - "set-me"
+      port: 443
     database:
       internal:
         - ingressNSMatchLabels:
@@ -1099,14 +1092,11 @@ networkPolicies:
       external: []
     redis:
       external: []
-    registry:
-       # IP to S3
-      egressIPs:
-        - "0.0.0.0/0"
     trivy:
       # IP to trivy vulnerability database
-      egressIPs:
-        - "0.0.0.0/0"
+      ips:
+        - "set-me"
+      port: 443
   monitoring:
     enabled: true
     grafana:
@@ -1122,4 +1112,15 @@ networkPolicies:
         ports:
           - 443
   thanos:
+    enabled: true
+
+  opensearch:
+    enabled: true
+    plugins:
+      ips:
+        - "set-me"
+      ports:
+        - 443
+
+  fluentd:
     enabled: true

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -271,3 +271,5 @@ networkPolicies:
     enabled: true
   monitoring:
     enabled: true
+  fluentd:
+    enabled: true

--- a/helmfile/charts/networkpolicy-service/templates/fluentd/aggregator.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/fluentd/aggregator.yaml
@@ -1,0 +1,46 @@
+{{ if .Values.fluentd.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-fluentd-aggregator
+  namespace: fluentd
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: aggregator
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: forwarder
+              app.kubernetes.io/name: fluentd
+      ports:
+        - port: 24224
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+              app.kubernetes.io/instance: kube-prometheus-stack-prometheus
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 24231
+  egress:
+    - to:
+        {{- range $ip := .Values.global.objectStorage.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        {{- range $port := .Values.global.objectStorage.ports }}
+        - protocol: TCP
+          port: {{ $port }}
+        {{- end }}
+    - ports:
+        - port: 53
+          protocol: UDP
+{{- end }}

--- a/helmfile/charts/networkpolicy-service/templates/fluentd/default-deny.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/fluentd/default-deny.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.fluentd.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: fluentd-default-deny-all
+  namespace: fluentd
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+{{ end }}

--- a/helmfile/charts/networkpolicy-service/templates/fluentd/forwarder.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/fluentd/forwarder.yaml
@@ -1,0 +1,52 @@
+{{ if .Values.fluentd.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-fluentd-forwarder
+  namespace: fluentd
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: forwarder
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+              app.kubernetes.io/instance: kube-prometheus-stack-prometheus
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 24231
+    - from:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/instance: prometheus-blackbox-exporter
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 9880
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: aggregator
+              app.kubernetes.io/name: fluentd
+      ports:
+        - port: 24224
+    - to:
+        {{- range $ip := .Values.global.scApiserver.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.global.scApiserver.port }}
+    - ports:
+        - port: 53
+          protocol: UDP
+{{- end }}

--- a/helmfile/charts/networkpolicy-service/templates/fluentd/retention.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/fluentd/retention.yaml
@@ -1,0 +1,27 @@
+{{ if .Values.fluentd.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-fluentd-retention
+  namespace: fluentd
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: sc-logs-retention
+  egress:
+    - to:
+        {{- range $ip := .Values.global.objectStorage.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        {{- range $port := .Values.global.objectStorage.ports }}
+        - protocol: TCP
+          port: {{ $port }}
+        {{- end }}
+    - ports:
+        - port: 53
+          protocol: UDP
+{{- end }}

--- a/helmfile/charts/networkpolicy-service/templates/harbor-np.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/harbor-np.yaml
@@ -1,4 +1,15 @@
-{{ if .Values.harbor.enable }}
+{{ if .Values.harbor.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: harbor-default-deny-all
+  namespace: harbor
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -19,15 +30,15 @@ spec:
       ports:
         - port: 9999
   egress:
-{{- if eq .Values.harbor.redis.type "internal" }}
+  {{- if eq .Values.harbor.redis.type "internal" }}
     - to:
         - podSelector:
             matchLabels:
               component: redis
       ports:
         - port: 6379
-{{- else if eq .Values.harbor.redis.type "external" }}
-  {{- range .Values.harbor.redis.external }}
+  {{- else if eq .Values.harbor.redis.type "external" }}
+    {{- range .Values.harbor.redis.external }}
     - to:
       {{- if .egressNSMatchLabels }}
         - namespaceSelector:
@@ -44,19 +55,21 @@ spec:
           {{- end }}
       {{- end }}
       ports:
-    {{- range $port := .ports }}
+      {{- range $port := .ports }}
         - port: {{ $port }}
+      {{- end }}
     {{- end }}
   {{- end }}
-{{- end }}
     - to:
-{{- range $IP := .Values.harbor.chartmuseum.egressIPs }}
+        {{- range $IP := .Values.global.objectStorage.ips }}
         - ipBlock:
             cidr: {{ $IP }}
-{{- end }}
+        {{- end }}
       ports:
+        {{- range $port := .Values.global.objectStorage.ports }}
         - protocol: TCP
-          port: 443
+          port: {{ $port }}
+        {{- end }}
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -76,13 +89,38 @@ spec:
           protocol: TCP
   egress:
     - to:
-{{- range $IP := .Values.harbor.core.egressIPs }}
+      {{- if .Values.global.externalLoadBalancer }}
+        {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
-            cidr: {{ $IP }}
-{{- end }}
+            cidr: {{ $ip }}
+        {{- end }}
+      {{- else if .Values.global.ingressUsingHostNetwork }}
+        {{- range $ip := .Values.global.scNodes.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      {{- else }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: controller
+              app.kubernetes.io/instance: ingress-nginx
+      {{- end }}
       ports:
         - protocol: TCP
           port: 443
+    - to:
+        {{- range $IP := .Values.global.objectStorage.ips }}
+        - ipBlock:
+            cidr: {{ $IP }}
+        {{- end }}
+      ports:
+        {{- range $port := .Values.global.objectStorage.ports }}
+        - protocol: TCP
+          port: {{ $port }}
+        {{- end }}
     - to:
         - podSelector:
             matchLabels:
@@ -96,15 +134,15 @@ spec:
       ports:
         - port: 5000
         - port: 8080
-{{- if eq .Values.harbor.redis.type "internal" }}
+    {{- if eq .Values.harbor.redis.type "internal" }}
     - to:
         - podSelector:
             matchLabels:
               component: redis
       ports:
         - port: 6379
-{{- else if eq .Values.harbor.redis.type "external" }}
-  {{- range .Values.harbor.redis.external }}
+    {{- else if eq .Values.harbor.redis.type "external" }}
+    {{- range .Values.harbor.redis.external }}
     - to:
       {{- if .egressNSMatchLabels }}
         - namespaceSelector:
@@ -121,20 +159,20 @@ spec:
           {{- end }}
       {{- end }}
       ports:
-    {{- range $port := .ports }}
+        {{- range $port := .ports }}
         - port: {{ $port }}
+        {{- end }}
     {{- end }}
-  {{- end }}
-{{- end }}
-{{- if eq .Values.harbor.database.type "internal" }}
+    {{- end }}
+    {{- if eq .Values.harbor.database.type "internal" }}
     - to:
         - podSelector:
             matchLabels:
               component: database
       ports:
         - port: 5432
-{{- else if eq .Values.harbor.database.type "external" }}
-  {{- range .Values.harbor.database.external }}
+    {{- else if eq .Values.harbor.database.type "external" }}
+    {{- range .Values.harbor.database.external }}
     - to:
       {{- if .egressNSMatchLabels }}
         - namespaceSelector:
@@ -151,11 +189,11 @@ spec:
           {{- end }}
       {{- end }}
       ports:
-    {{- range $port := .ports }}
+        {{- range $port := .ports }}
         - port: {{ $port }}
+        {{- end }}
     {{- end }}
-  {{- end }}
-{{- end }}
+    {{- end }}
     - to:
         - podSelector:
             matchLabels:
@@ -208,7 +246,7 @@ spec:
         - podSelector:
             matchLabels:
               component: jobservice
-      {{- range .Values.harbor.database.internal }}
+        {{- range .Values.harbor.database.internal }}
         {{- if .ingressNSMatchLabels }}
         - namespaceSelector:
             matchLabels:
@@ -223,7 +261,7 @@ spec:
                 {{- end }}
           {{- end }}
         {{- end }}
-      {{- end }}
+        {{- end }}
       ports:
         - port: 5432
 {{- end }}
@@ -249,22 +287,22 @@ spec:
         - port: 8080
   egress:
     - to:
-{{- range $IP := .Values.harbor.jobservice.egressIPs }}
+        {{- range $IP := .Values.harbor.jobservice.ips }}
         - ipBlock:
             cidr: {{ $IP }}
-{{- end }}
+        {{- end }}
       ports:
         - protocol: TCP
           port: 443
-{{- if eq .Values.harbor.redis.type "internal" }}
+    {{- if eq .Values.harbor.redis.type "internal" }}
     - to:
         - podSelector:
             matchLabels:
               component: redis
       ports:
         - port: 6379
-{{- else if eq .Values.harbor.redis.type "external" }}
-  {{- range .Values.harbor.redis.external }}
+    {{- else if eq .Values.harbor.redis.type "external" }}
+    {{- range .Values.harbor.redis.external }}
     - to:
       {{- if .egressNSMatchLabels }}
         - namespaceSelector:
@@ -281,20 +319,20 @@ spec:
           {{- end }}
       {{- end }}
       ports:
-    {{- range $port := .ports }}
+        {{- range $port := .ports }}
         - port: {{ $port }}
+        {{- end }}
     {{- end }}
-  {{- end }}
-{{- end }}
-{{- if eq .Values.harbor.database.type "internal" }}
+    {{- end }}
+    {{- if eq .Values.harbor.database.type "internal" }}
     - to:
         - podSelector:
             matchLabels:
               component: database
       ports:
         - port: 5432
-{{- else if eq .Values.harbor.database.type "external" }}
-  {{- range .Values.harbor.database.external }}
+    {{- else if eq .Values.harbor.database.type "external" }}
+    {{- range .Values.harbor.database.external }}
     - to:
       {{- if .egressNSMatchLabels }}
         - namespaceSelector:
@@ -311,11 +349,11 @@ spec:
           {{- end }}
       {{- end }}
       ports:
-    {{- range $port := .ports }}
+        {{- range $port := .ports }}
         - port: {{ $port }}
+        {{- end }}
     {{- end }}
-  {{- end }}
-{{- end }}
+    {{- end }}
     - to:
         - podSelector:
             matchLabels:
@@ -352,15 +390,15 @@ spec:
               component: notary-signer
       ports:
         - port: 7899
-{{- if eq .Values.harbor.database.type "internal" }}
+    {{- if eq .Values.harbor.database.type "internal" }}
     - to:
         - podSelector:
             matchLabels:
               component: database
       ports:
         - port: 5432
-{{- else if eq .Values.harbor.database.type "external" }}
-  {{- range .Values.harbor.database.external }}
+    {{- else if eq .Values.harbor.database.type "external" }}
+    {{- range .Values.harbor.database.external }}
     - to:
       {{- if .egressNSMatchLabels }}
         - namespaceSelector:
@@ -377,11 +415,11 @@ spec:
           {{- end }}
       {{- end }}
       ports:
-    {{- range $port := .ports }}
+        {{- range $port := .ports }}
         - port: {{ $port }}
+        {{- end }}
     {{- end }}
-  {{- end }}
-{{- end }}
+    {{- end }}
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -403,15 +441,15 @@ spec:
       ports:
         - port: 7899
   egress:
-{{- if eq .Values.harbor.database.type "internal" }}
+    {{- if eq .Values.harbor.database.type "internal" }}
     - to:
         - podSelector:
             matchLabels:
               component: database
       ports:
         - port: 5432
-{{- else if eq .Values.harbor.database.type "external" }}
-  {{- range .Values.harbor.database.external }}
+    {{- else if eq .Values.harbor.database.type "external" }}
+    {{- range .Values.harbor.database.external }}
     - to:
       {{- if .egressNSMatchLabels }}
         - namespaceSelector:
@@ -428,11 +466,11 @@ spec:
           {{- end }}
       {{- end }}
       ports:
-    {{- range $port := .ports }}
+        {{- range $port := .ports }}
         - port: {{ $port }}
+        {{- end }}
     {{- end }}
-  {{- end }}
-{{- end }}
+    {{- end }}
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -513,22 +551,24 @@ spec:
         - port: 8080
   egress:
     - to:
-{{- range $IP := .Values.harbor.registry.egressIPs }}
+        {{- range $IP := .Values.global.objectStorage.ips }}
         - ipBlock:
             cidr: {{ $IP }}
-{{- end }}
+        {{- end }}
       ports:
+        {{- range $port := .Values.global.objectStorage.ports }}
         - protocol: TCP
-          port: 443
-{{- if eq .Values.harbor.redis.type "internal" }}
+          port: {{ $port }}
+        {{- end }}
+    {{- if eq .Values.harbor.redis.type "internal" }}
     - to:
         - podSelector:
             matchLabels:
               component: redis
       ports:
         - port: 6379
-{{- else if eq .Values.harbor.redis.type "external" }}
-  {{- range .Values.harbor.redis.external }}
+    {{- else if eq .Values.harbor.redis.type "external" }}
+    {{- range .Values.harbor.redis.external }}
     - to:
       {{- if .egressNSMatchLabels }}
         - namespaceSelector:
@@ -545,11 +585,11 @@ spec:
           {{- end }}
       {{- end }}
       ports:
-    {{- range $port := .ports }}
+        {{- range $port := .ports }}
         - port: {{ $port }}
+        {{- end }}
     {{- end }}
-  {{- end }}
-{{- end }}
+    {{- end }}
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -574,15 +614,15 @@ spec:
       ports:
         - port: 8080
   egress:
-{{- if eq .Values.harbor.redis.type "internal" }}
+    {{- if eq .Values.harbor.redis.type "internal" }}
     - to:
         - podSelector:
             matchLabels:
               component: redis
       ports:
         - port: 6379
-{{- else if eq .Values.harbor.redis.type "external" }}
-  {{- range .Values.harbor.redis.external }}
+    {{- else if eq .Values.harbor.redis.type "external" }}
+    {{- range .Values.harbor.redis.external }}
     - to:
       {{- if .egressNSMatchLabels }}
         - namespaceSelector:
@@ -599,11 +639,11 @@ spec:
           {{- end }}
       {{- end }}
       ports:
-    {{- range $port := .ports }}
+        {{- range $port := .ports }}
         - port: {{ $port }}
+        {{- end }}
     {{- end }}
-  {{- end }}
-{{- end }}
+    {{- end }}
     - to:
         - podSelector:
             matchLabels:
@@ -611,13 +651,13 @@ spec:
       ports:
         - port: 8080
     - to:
-{{- range $IP := .Values.harbor.trivy.egressIPs }}
+        {{- range $IP := .Values.harbor.trivy.ips }}
         - ipBlock:
             cidr: {{ $IP }}
-{{- end }}
+        {{- end }}
       ports:
         - protocol: TCP
-          port: 443
+          port: {{ .Values.harbor.trivy.port }}
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -636,4 +676,64 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-init-harbor-job
+  namespace: harbor
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      job-name: init-harbor-job
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              component: core
+      ports:
+        - port: 8080
+          protocol: TCP
+    - ports:
+        - port: 53
+          protocol: UDP
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-harbor-acme-pods
+  namespace: harbor
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchLabels:
+      acme.cert-manager.io/http01-solver: "true"
+  ingress:
+    - from:
+      {{- if .Values.global.externalLoadBalancer }}
+        {{- range $ip := .Values.global.scIngress.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      {{- else if .Values.global.ingressUsingHostNetwork }}
+        {{- range $ip := .Values.global.scNodes.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      {{- else }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: controller
+              app.kubernetes.io/instance: ingress-nginx
+      {{- end }}
+      ports:
+      - port: 8089
+        protocol: TCP
+---
 {{- end }}

--- a/helmfile/charts/networkpolicy-service/templates/opensearch/backup.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/opensearch/backup.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.opensearch.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-opensearch-backup
+  namespace: opensearch-system
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: opensearch-backup
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-master
+      ports:
+        - port: 9200
+    - ports:
+        - port: 53
+          protocol: UDP
+{{ end }}

--- a/helmfile/charts/networkpolicy-service/templates/opensearch/client.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/opensearch/client.yaml
@@ -1,0 +1,73 @@
+{{ if .Values.opensearch.enabled }}
+{{- if .Values.opensearch.client.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-opensearch-client
+  namespace: opensearch-system
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: opensearch-client
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-master
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-data
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-client
+      ports:
+        - port: 9300
+    # Allow api port from ingress-ngix
+    - from:
+      {{- if .Values.global.ingressUsingHostNetwork }}
+        {{- range $ip := .Values.global.scNodes.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      {{- else }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: controller
+              app.kubernetes.io/instance: ingress-nginx
+      {{- end }}
+      ports:
+        - port: 9200
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-master
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-data
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-client
+      ports:
+        - port: 9300
+    - to:
+        {{- range $ip := .Values.opensearch.plugins.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        {{- range $port := .Values.opensearch.plugins.ports }}
+        - protocol: TCP
+          port: {{ $port }}
+        {{- end }}
+    - ports:
+        - port: 53
+          protocol: UDP
+{{- end }}
+{{ end }}

--- a/helmfile/charts/networkpolicy-service/templates/opensearch/configurer.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/opensearch/configurer.yaml
@@ -1,0 +1,29 @@
+{{ if .Values.opensearch.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-opensearch-configurer
+  namespace: opensearch-system
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app: configurer
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-master
+      ports:
+        - port: 9200
+    - to:
+        - podSelector:
+            matchLabels:
+              app: opensearch-dashboards
+      ports:
+        - port: 5601
+    - ports:
+        - port: 53
+          protocol: UDP
+{{ end }}

--- a/helmfile/charts/networkpolicy-service/templates/opensearch/curator.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/opensearch/curator.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.opensearch.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-opensearch-curator
+  namespace: opensearch-system
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: opensearch-curator
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-master
+      ports:
+        - port: 9200
+    - ports:
+        - port: 53
+          protocol: UDP
+{{ end }}

--- a/helmfile/charts/networkpolicy-service/templates/opensearch/dashboard.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/opensearch/dashboard.yaml
@@ -1,0 +1,68 @@
+{{ if .Values.opensearch.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-opensearch-dashboard
+  namespace: opensearch-system
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app: opensearch-dashboards
+  ingress:
+    - from:
+      {{- if .Values.global.ingressUsingHostNetwork }}
+        {{- range $ip := .Values.global.scNodes.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      {{- else }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: controller
+              app.kubernetes.io/instance: ingress-nginx
+      {{- end }}
+        - podSelector:
+            matchLabels:
+              app: configurer
+      ports:
+        - port: 5601
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-master
+      ports:
+        - port: 9200
+    - ports:
+        - port: 53
+          protocol: UDP
+    - to:
+      {{- if .Values.global.externalLoadBalancer }}
+        {{- range $ip := .Values.global.scIngress.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      {{- else if .Values.global.ingressUsingHostNetwork }}
+        {{- range $ip := .Values.global.scNodes.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      {{- else }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: controller
+              app.kubernetes.io/instance: ingress-nginx
+      {{- end }}
+      ports:
+        - protocol: TCP
+          port: 443
+{{ end }}

--- a/helmfile/charts/networkpolicy-service/templates/opensearch/data.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/opensearch/data.yaml
@@ -1,0 +1,55 @@
+{{ if .Values.opensearch.enabled }}
+{{- if .Values.opensearch.data.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-opensearch-data
+  namespace: opensearch-system
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: opensearch-data
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-master
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-data
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-client
+      ports:
+        - port: 9300
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-master
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-data
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-client
+      ports:
+        - port: 9300
+    - to:
+        {{- range $ip := .Values.opensearch.plugins.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        {{- range $port := .Values.opensearch.plugins.ports }}
+        - protocol: TCP
+          port: {{ $port }}
+        {{- end }}
+    - ports:
+        - port: 53
+          protocol: UDP
+{{- end }}
+{{ end }}

--- a/helmfile/charts/networkpolicy-service/templates/opensearch/default-deny.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/opensearch/default-deny.yaml
@@ -1,0 +1,43 @@
+{{ if .Values.opensearch.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-opensearch
+  namespace: opensearch-system
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-opensearch-acme-pods
+  namespace: opensearch-system
+spec:
+  policyTypes:
+    - Ingress
+  podSelector:
+    matchLabels:
+      acme.cert-manager.io/http01-solver: "true"
+  ingress:
+    - from:
+      {{- if .Values.global.ingressUsingHostNetwork }}
+        {{- range $ip := .Values.global.scNodes.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      {{- else }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: controller
+              app.kubernetes.io/instance: ingress-nginx
+      {{- end }}
+      ports:
+      - port: 8089
+        protocol: TCP
+{{ end }}

--- a/helmfile/charts/networkpolicy-service/templates/opensearch/master.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/opensearch/master.yaml
@@ -1,0 +1,137 @@
+{{ if .Values.opensearch.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-opensearch-master
+  namespace: opensearch-system
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: opensearch-master
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: opensearch-curator
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: opensearch-backup
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: opensearch-slm
+        - podSelector:
+            matchLabels:
+              app: opensearch-dashboards
+        - podSelector:
+            matchLabels:
+              app: prometheus-elasticsearch-exporter
+        - podSelector:
+            matchLabels:
+              app: configurer
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: opensearch-securityadmin
+      {{- if not .Values.opensearch.client.enabled }}
+      # Allow api port from ingress-ngix
+      {{- if .Values.global.ingressUsingHostNetwork }}
+        {{- range $ip := .Values.global.scNodes.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      {{- else }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: controller
+              app.kubernetes.io/instance: ingress-nginx
+      {{- end }}
+      {{- end }}
+      ports:
+        - port: 9200
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-master
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-data
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-client
+      ports:
+        - port: 9300
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-master
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-data
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-client
+      ports:
+        - port: 9300
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: dex
+              app.kubernetes.io/instance: dex
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: dex
+      ports:
+        - port: 5556
+    - to:
+        {{- range $ip := .Values.global.objectStorage.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        {{- range $port := .Values.global.objectStorage.ports }}
+        - protocol: TCP
+          port: {{ $port }}
+        {{- end }}
+    - to:
+        {{- range $ip := .Values.opensearch.plugins.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        {{- range $port := .Values.opensearch.plugins.ports }}
+        - protocol: TCP
+          port: {{ $port }}
+        {{- end }}
+    - to:
+      {{- if .Values.global.externalLoadBalancer }}
+        {{- range $ip := .Values.global.scIngress.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      {{- else if .Values.global.ingressUsingHostNetwork }}
+        {{- range $ip := .Values.global.scNodes.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      {{- else }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: controller
+              app.kubernetes.io/instance: ingress-nginx
+      {{- end }}
+      ports:
+        - protocol: TCP
+          port: 443
+    - ports:
+        - port: 53
+          protocol: UDP
+{{ end }}

--- a/helmfile/charts/networkpolicy-service/templates/opensearch/prometheus-exporter.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/opensearch/prometheus-exporter.yaml
@@ -1,0 +1,35 @@
+{{ if .Values.opensearch.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-opensearch-prometheus-exporter
+  namespace: opensearch-system
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app: prometheus-elasticsearch-exporter
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: kube-prometheus-stack-prometheus
+              app.kubernetes.io/name: prometheus
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 9108
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-master
+      ports:
+        - port: 9200
+    - ports:
+        - port: 53
+          protocol: UDP
+{{ end }}

--- a/helmfile/charts/networkpolicy-service/templates/opensearch/security-admin.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/opensearch/security-admin.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.opensearch.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-opensearch-securityadmin
+  namespace: opensearch-system
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: opensearch-securityadmin
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-master
+      ports:
+        - port: 9200
+    - ports:
+        - port: 53
+          protocol: UDP
+{{ end }}

--- a/helmfile/charts/networkpolicy-service/templates/opensearch/slm.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/opensearch/slm.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.opensearch.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-opensearch-slm
+  namespace: opensearch-system
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: opensearch-slm
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: opensearch-master
+      ports:
+        - port: 9200
+    - ports:
+        - port: 53
+          protocol: UDP
+{{ end }}

--- a/helmfile/charts/networkpolicy-service/values.yaml
+++ b/helmfile/charts/networkpolicy-service/values.yaml
@@ -37,13 +37,7 @@ global:
   externalLoadBalancer: false # not true if loadbalancer is controlled by a kubernetes cloud controller
 
 harbor:
-  enable: true
-  chartmuseum:
-    egressIPs:
-      - "0.0.0.0/0" # S3
-  core:
-    egressIPs:
-      - "0.0.0.0/0" # S3, openid
+  enabled: true
   database:
     type: internal
     internal: []
@@ -56,22 +50,24 @@ harbor:
       #   ports:
       #    - 5432
   jobservice:
-    egressIPs:
-      - "0.0.0.0/0" # image pull
+    # IP to pull images, docker hub etc
+    ips:
+      - "0.0.0.0/0"
+    ports:
+      - 443
   redis:
-    type: external
+    type: internal
     external: []
       # - egressNSMatchLabels:
       #     kubernetes.io/metadata.name: <redis namespace>
       #   egressPodMatchLabels: {}
       #   ports:
       #    - 6379
-  registry:
-    egressIPs:
-      - "0.0.0.0/0" # S3
   trivy:
-    egressIPs:
-      - "0.0.0.0/0" # trivy vulnerability database
+    # IP to trivy vulnerability database
+    ips:
+      - "0.0.0.0/0"
+    port: 443
 
 monitoring:
   enabled: true
@@ -87,3 +83,12 @@ monitoring:
         - "0.0.0.0/0"
       ports:
         - 443
+opensearch:
+  enabled: true
+  plugins:
+    ips:
+      - "0.0.0.0/0"
+    port: 443
+
+fluentd:
+  enabled: true

--- a/helmfile/charts/networkpolicy-workload/templates/fluentd/default-deny.yaml
+++ b/helmfile/charts/networkpolicy-workload/templates/fluentd/default-deny.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.fluentd.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: fluentd-default-deny-all
+  namespace: fluentd
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+{{ end }}

--- a/helmfile/charts/networkpolicy-workload/templates/fluentd/kube-system-fluentd.yaml
+++ b/helmfile/charts/networkpolicy-workload/templates/fluentd/kube-system-fluentd.yaml
@@ -1,0 +1,44 @@
+{{ if .Values.fluentd.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-kube-system-fluentd
+  namespace: kube-system
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: fluentd-elasticsearch
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+              app.kubernetes.io/instance: kube-prometheus-stack-prometheus
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 24231
+  egress:
+    - to:
+        {{- range $ip := .Values.global.scIngress.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 443
+    - ports:
+        - port: 53
+          protocol: UDP
+    - to:
+        {{- range $ip := .Values.global.wcApiserver.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.global.wcApiserver.port }}
+{{ end }}

--- a/helmfile/charts/networkpolicy-workload/templates/fluentd/user-fluentd.yaml
+++ b/helmfile/charts/networkpolicy-workload/templates/fluentd/user-fluentd.yaml
@@ -1,0 +1,44 @@
+{{ if .Values.fluentd.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-user-fluentd
+  namespace: fluentd
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: fluentd-elasticsearch
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+              app.kubernetes.io/instance: kube-prometheus-stack-prometheus
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 24231
+  egress:
+    - to:
+        {{- range $ip := .Values.global.scIngress.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 443
+    - ports:
+        - port: 53
+          protocol: UDP
+    - to:
+        {{- range $ip := .Values.global.wcApiserver.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.global.wcApiserver.port }}
+{{ end }}

--- a/helmfile/charts/networkpolicy-workload/values.yaml
+++ b/helmfile/charts/networkpolicy-workload/values.yaml
@@ -17,3 +17,6 @@ certManager:
 
 monitoring:
   enabled: true
+
+fluentd:
+  enabled: true

--- a/helmfile/values/service-cluster-networkpolicy.yaml.gotmpl
+++ b/helmfile/values/service-cluster-networkpolicy.yaml.gotmpl
@@ -20,13 +20,10 @@ global:
   ingressUsingHostNetwork: {{ .Values.ingressNginx.controller.useHostPort }}
 
 harbor:
-  enable: {{ .Values.networkPolicies.harbor.enable }}
-  chartmuseum:
-    egressIPs: {{- toYaml .Values.networkPolicies.harbor.chartmuseum.egressIPs | nindent 6 }}
-  core:
-    egressIPs: {{- toYaml .Values.networkPolicies.harbor.core.egressIPs | nindent 6 }}
+  enabled: {{ and .Values.harbor.enabled .Values.networkPolicies.harbor.enabled }}
   jobservice:
-    egressIPs: {{- toYaml .Values.networkPolicies.harbor.jobservice.egressIPs | nindent 6 }}
+    ips: {{- toYaml .Values.networkPolicies.harbor.jobservice.ips | nindent 6 }}
+    port: {{ .Values.networkPolicies.harbor.jobservice.port }}
   database:
     type: {{ .Values.harbor.database.type }}
     internal: {{- toYaml .Values.networkPolicies.harbor.database.internal | nindent 6 }}
@@ -34,10 +31,9 @@ harbor:
   redis:
     type: {{ .Values.harbor.redis.type }}
     external: {{- toYaml .Values.networkPolicies.harbor.redis.external | nindent 6 }}
-  registry:
-    egressIPs: {{- toYaml .Values.networkPolicies.harbor.registry.egressIPs | nindent 6 }}
   trivy:
-    egressIPs: {{- toYaml .Values.networkPolicies.harbor.trivy.egressIPs | nindent 6 }}
+    ips: {{- toYaml .Values.networkPolicies.harbor.trivy.ips | nindent 6 }}
+    port: {{ .Values.networkPolicies.harbor.trivy.port }}
 
 monitoring:
   enabled: {{ .Values.networkPolicies.monitoring.enabled }}
@@ -52,3 +48,16 @@ monitoring:
 
 thanos:
   enabled: {{ .Values.networkPolicies.thanos.enabled }}
+
+opensearch:
+  enabled: {{ .Values.networkPolicies.opensearch.enabled }}
+  data:
+    enabled: {{ .Values.opensearch.dataNode.dedicatedPods }}
+  client:
+    enabled: {{ .Values.opensearch.clientNode.dedicatedPods }}
+  plugins:
+    ips: {{- toYaml .Values.networkPolicies.opensearch.plugins.ips | nindent 8 }}
+    ports: {{- toYaml .Values.networkPolicies.opensearch.plugins.ports | nindent 8 }}
+
+fluentd:
+  enabled: {{ and .Values.fluentd.enabled .Values.networkPolicies.fluentd.enabled }}

--- a/helmfile/values/workload-cluster-networkpolicy.yaml.gotmpl
+++ b/helmfile/values/workload-cluster-networkpolicy.yaml.gotmpl
@@ -14,3 +14,6 @@ certManager:
 
 monitoring:
   enabled: {{ .Values.networkPolicies.monitoring.enabled }}
+
+fluentd:
+  enabled: {{ .Values.networkPolicies.fluentd.enabled }}

--- a/pipeline/config/exoscale/common-config.yaml
+++ b/pipeline/config/exoscale/common-config.yaml
@@ -27,3 +27,11 @@ clusterAdmin:
 monitoring:
   rook:
     enabled: true
+networkPolicies:
+  global:
+    scIngress:
+      ips:
+        - "0.0.0.0/0"
+    objectStorage:
+      ips:
+        - "0.0.0.0/0"

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -32,3 +32,14 @@ fluentd:
 s3Exporter:
   interval: 120s
   scrapeTimeout: 30s
+networkPolicies:
+  global:
+    scApiserver:
+      ips:
+        - "0.0.0.0/0"
+    scNodes:
+      ips:
+        - "0.0.0.0/0"
+    wcIngress:
+      ips:
+        - "0.0.0.0/0"

--- a/pipeline/config/exoscale/wc-config.yaml
+++ b/pipeline/config/exoscale/wc-config.yaml
@@ -13,3 +13,12 @@ user:
   adminUsers:
     - user-admin@example.com
   adminGroups: []
+
+networkPolicies:
+  global:
+    wcApiserver:
+      ips:
+        - "0.0.0.0/0"
+    wcNodes:
+      ips:
+        - "0.0.0.0/0"


### PR DESCRIPTION
…script

Replaces become with become_user where appropriate**What this PR does / why we need it**:

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
