### PR TITLE
apps wc: dynamic add map fixing

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -21,6 +21,8 @@
 - Fixed Test User RBAC
 - Fixed the shifted comment after running init
 - Kubernetes cluster status Grafana dashboard not loading data for some panels
+- Fixed inevitable mapping conflicts in Opensearch by updating `elastisys/fluentd` to use image tag `v3.4.0-ck8s4`.
+  In this image `fluent-plugin-kubernetes_metadata_filter` has been downgraded to version `2.13.0`, which still includes the de_dot functionality that was removed in the prior tag of the image.
 
 ### Added
 

--- a/helmfile/values/fluentd-user.yaml.gotmpl
+++ b/helmfile/values/fluentd-user.yaml.gotmpl
@@ -6,7 +6,7 @@ tolerations:  {{- toYaml .Values.fluentd.user.tolerations | nindent 2  }}
 image:
   # This is our own fork-image(https://github.com/elastisys/fluentd-elasticsearch). This can later be replaces with the original image(https://github.com/monotek/fluentd-elasticsearch) when our changes is merged.
   repository: elastisys/fluentd
-  tag: v3.4.0-ck8s3
+  tag: v3.4.0-ck8s4
 
 elasticsearch:
   scheme: https

--- a/helmfile/values/fluentd-wc.yaml.gotmpl
+++ b/helmfile/values/fluentd-wc.yaml.gotmpl
@@ -6,7 +6,7 @@ tolerations:  {{- toYaml .Values.fluentd.tolerations | nindent 2  }}
 image:
   # This is our own fork-image(https://github.com/elastisys/fluentd-elasticsearch). This can later be replaces with the original image(https://github.com/monotek/fluentd-elasticsearch) when our changes is merged.
   repository: elastisys/fluentd
-  tag: v3.4.0-ck8s3
+  tag: v3.4.0-ck8s4
 
 elasticsearch:
   scheme: https


### PR DESCRIPTION
**What this PR does / why we need it**:
Our fluentd pods in the workload cluster started to have problems. The issue turned out to be an updated "fluentd-elasticsearch" image which then didn't match with the other updates we did in apps v0.26.0. We have now created an image that fits our needs and works.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1210

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
The image branch - https://github.com/elastisys/fluentd-elasticsearch/tree/kubernetes-metadata-filter-downgrade

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [x] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
