### PR TITLE
apps sc: added new section to welcoming dashboards

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -45,6 +45,7 @@
 - Network policies for Velero
 - Network policies for rclone-sync
 - Network policies for s3-exporter
+- New section in the welcoming dashboards, displaying the most relevant features and changes for the user added in the last two releases.
 
 ### Removed
 

--- a/helmfile/charts/grafana-ops/files/welcome.md
+++ b/helmfile/charts/grafana-ops/files/welcome.md
@@ -1,5 +1,12 @@
 # Welcome to Compliant Kubernetes!
 
+## What's new
+
+Here you can find the most relevant features and changes for the last couple of releases of Compliant Kubernetes
+
+- You are now allowed to proxy and port-forward to prometheus in the Workload Cluster, more about that [here](https://elastisys.io/compliantkubernetes/user-guide/metrics/#accessing-prometheus). **[v0.26]**
+- As a User admin, you can now create namespaces yourself using [HNC](https://kubernetes.io/blog/2020/08/14/introducing-hierarchical-namespaces/), we have written a guide [here](https://elastisys.io/compliantkubernetes/user-guide/faq/#how-do-i-add-a-new-namespace) on how you do this in Compliant Kubernetes. **[v0.25]**
+
 ## Public docs
 
 In case you get lost, don't forget to check out the [public docs](https://elastisys.io/compliantkubernetes/). Here are the most common topics:

--- a/helmfile/charts/opensearch/configurer/files/dashboards-resources/welcome.md
+++ b/helmfile/charts/opensearch/configurer/files/dashboards-resources/welcome.md
@@ -1,5 +1,12 @@
 # Welcome to Compliant Kubernetes!
 
+## What's new
+
+Here you can find the most relevant features and changes for the last couple of releases of Compliant Kubernetes
+
+- You are now allowed to proxy and port-forward to prometheus in the Workload Cluster, more about that [here](https://elastisys.io/compliantkubernetes/user-guide/metrics/#accessing-prometheus). **[v0.26]**
+- As a User admin, you can now create namespaces yourself using [HNC](https://kubernetes.io/blog/2020/08/14/introducing-hierarchical-namespaces/), we have written a guide [here](https://elastisys.io/compliantkubernetes/user-guide/faq/#how-do-i-add-a-new-namespace) on how you do this in Compliant Kubernetes. **[v0.25]**
+
 ## Public docs
 
 In case you get lost, don't forget to check out the [public docs](https://elastisys.io/compliantkubernetes/). Here are the most common topics:

--- a/release/README.md
+++ b/release/README.md
@@ -16,6 +16,15 @@ https://semver.org/
 
     **NOTE**: All changes made in QA should be added to `CHANGELOG.md` and **NOT** `WIP-CHANGELOG.md`.
 
+1. Update the Welcoming Dashboards "What's New" section
+
+    Write about some new feature or change that is relevant for the user, e.g. for `v0.25` "- As an admin user, you can now create namespaces yourself using HNC ..."
+
+    Also remove the items in this section from two+ older minor versions, meaning if you release apps `v0.28` you can keep previous items that were added to the list in `v0.27` but remove the stuff that are from `v0.26`.
+
+    - Edit the [Grafana dashboard](../helmfile/charts/grafana-ops/files/welcome.md)
+    - Edit the [Opensearch dashboard](../helmfile/charts/opensearch/configurer/files/dashboards-resources/welcome.md)
+
 1. When you're done with QA, create a PR to the release branch and merge it.
 
 1. When the PR is merged switch to that branch and run:


### PR DESCRIPTION
**What this PR does / why we need it**:

Added a new 'What's new' section to the welcoming dashboards.

![Screenshot from 2022-10-14 09-09-47](https://user-images.githubusercontent.com/22236722/195784704-1054b6d4-b456-48ac-93e5-6c798ebea522.png)

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [X] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
