### PR TITLE
apps sc: fixed k8s cluster status grafana dashboard

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -20,6 +20,7 @@
 - Bumped backup-postgres image to use tag `1.2.0`, which includes newer versions of the postgresql client
 - Fixed Test User RBAC
 - Fixed the shifted comment after running init
+- Kubernetes cluster status Grafana dashboard not loading data for some panels
 
 ### Added
 

--- a/helmfile/charts/grafana-ops/dashboards/kubernetesstatus-dashboard.json
+++ b/helmfile/charts/grafana-ops/dashboards/kubernetesstatus-dashboard.json
@@ -1314,7 +1314,6 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
       "fieldConfig": {
@@ -1388,10 +1387,6 @@
       "pluginVersion": "8.0.5",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
           "exemplar": false,
           "expr": "sum by (node, cluster) (kube_pod_container_resource_requests{cluster=~\"$cluster\", node=~\"$node\", namespace=~\"$namespace\", resource=\"cpu\"} and on (pod, namespace, cluster) kube_pod_status_phase{phase=\"Running\", cluster=~\"$cluster\", namespace=~\"$namespace\"} == 1 ) / sum by (node, cluster) (kube_node_status_allocatable{cluster=~\"$cluster\", node=~\"$node\", resource=\"cpu\"})",
           "interval": "",
@@ -1404,7 +1399,6 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
       "fieldConfig": {
@@ -1478,10 +1472,6 @@
       "pluginVersion": "8.0.5",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
           "exemplar": true,
           "expr": "sum by (node, cluster) (kube_pod_container_resource_requests{cluster=~\"$cluster\", namespace=~\"$namespace\", node=~\"$node\", resource=\"memory\"} and on (pod, namespace, cluster) kube_pod_status_phase{phase=\"Running\", cluster=~\"$cluster\", namespace=~\"$namespace\"} == 1) / sum by (node, cluster) (kube_node_status_allocatable{cluster=~\"$cluster\", node=~\"$node\", resource=\"memory\"})",
           "interval": "",
@@ -1494,7 +1484,6 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
       "fieldConfig": {
@@ -1567,10 +1556,6 @@
       "pluginVersion": "8.0.5",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
           "exemplar": true,
           "expr": "sum by (node, cluster) (kube_pod_container_resource_limits{cluster=~\"$cluster\", namespace=~\"$namespace\", node=~\"$node\", resource=\"cpu\"} and on (pod, namespace, cluster) kube_pod_status_phase{phase=\"Running\", cluster=~\"$cluster\", namespace=~\"$namespace\"} == 1 ) / sum by (node, cluster) (kube_node_status_allocatable{cluster=~\"$cluster\", node=~\"$node\", resource=\"cpu\"})",
           "interval": "",
@@ -1583,7 +1568,6 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
       "fieldConfig": {
@@ -1656,10 +1640,6 @@
       "pluginVersion": "8.0.5",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
           "exemplar": true,
           "expr": "sum by (node, cluster) (kube_pod_container_resource_limits{cluster=~\"$cluster\", namespace=~\"$namespace\", node=~\"$node\", resource=\"memory\"} and on (pod, namespace, cluster) kube_pod_status_phase{phase=\"Running\", cluster=~\"$cluster\", namespace=~\"$namespace\"} == 1) / sum by (node, cluster) (kube_node_status_allocatable{cluster=~\"$cluster\", node=~\"$node\", resource=\"memory\"})",
           "interval": "",
@@ -1672,7 +1652,6 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
       "fieldConfig": {
@@ -1751,10 +1730,6 @@
       "pluginVersion": "8.0.5",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
           "exemplar": true,
           "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=~\"$cluster\", node=~\"$node\", namespace=~\"$namespace\"}) by (pod, cluster) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=~\"$cluster\", node=~\"$node\", namespace=~\"$namespace\"}) by (pod, cluster)",
           "hide": false,
@@ -1769,7 +1744,6 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
       "fieldConfig": {
@@ -1848,10 +1822,6 @@
       "pluginVersion": "8.0.5",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
           "exemplar": false,
           "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=~\"$cluster\", node=~\"$node\", namespace=~\"$namespace\", container!=\"\"}) by (pod, cluster) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=~\"$cluster\", node=~\"$node\", namespace=~\"$namespace\"}) by (pod, cluster)",
           "hide": false,


### PR DESCRIPTION
**What this PR does / why we need it**: fixed the k8s cluster status Grafana dashboard not loading data for some panels 

**Add a screenshot or an example to illustrate the proposed solution:**
![image](https://user-images.githubusercontent.com/77267293/195790951-5faa4479-5d6f-4698-94ea-e448ab5c968e.png)

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
