### PR TITLE
pipeline: re-enable it and use kubespray v2.20.0

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -1,9 +1,9 @@
 name: End-to-end
 
-#on:
-#  schedule:
-#  # Run at 4 and 10 GMT, basically "early morning" and "lunch"
-#  - cron: "0 4,10 * * *"
+on:
+  schedule:
+  # Run at 4 and 10 GMT, basically "early morning" and "lunch"
+  - cron: "0 4,10 * * *"
 
 jobs:
 
@@ -91,7 +91,7 @@ jobs:
         args: route53 change-resource-record-sets --hosted-zone-id Z2STJRQSJO5PZ0 --change-batch file://apps/pipeline/config/exoscale/dns-${{ matrix.cluster }}.json
 
     - name: Run kubespray
-      uses: docker://quay.io/kubespray/kubespray:v2.19.0
+      uses: docker://quay.io/kubespray/kubespray:v2.20.0
       env:
         ANSIBLE_CONFIG: ./compliantkubernetes-kubespray/kubespray/ansible.cfg
       with:


### PR DESCRIPTION
**What this PR does / why we need it**: re-enable the pipeline and use v2.20.0 for kubespray

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).