### PR TITLE
apps sc: made dex id token expiration time configurable

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -18,6 +18,8 @@
 - Gatekeeper audits every 10 min instead of 1 min
 - Gatekeeper audit only looks at the resource types mentioned in constraints, instead of all resource types
 - Set backoffLimit for rclone-jobs to 0.
+- Made dex ID Token expiration time configurable
+- Made dex tokens expiry times configurable
 
 ### Fixed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -495,6 +495,14 @@ dex:
       whenUnsatisfiable: DoNotSchedule
   affinity: {}
   nodeSelector: {}
+  expiry:
+    deviceRequests: "5m"
+    signingKeys: "6h"
+    idToken: "24h"
+    refreshTokens:
+      reuseInterval: "3s"
+      validIfNotUsedFor: "2160h" # 90 days
+      absoluteLifetime: "3960h" # 165 days
   google:
     # Enables extra config needed to enable google connector to fetch group info.
     # When this is enabled the SASecretName needs to be set.

--- a/helmfile/values/dex.yaml.gotmpl
+++ b/helmfile/values/dex.yaml.gotmpl
@@ -28,6 +28,14 @@ volumes:
 {{- end }}
 
 config:
+  expiry:
+    deviceRequests: {{ .Values.dex.expiry.deviceRequests }}
+    signingKeys: {{ .Values.dex.expiry.signingKeys }}
+    idTokens: {{ .Values.dex.expiry.idToken }}
+    refreshTokens:
+      reuseInterval: {{ .Values.dex.expiry.refreshTokens.reuseInterval }}
+      validIfNotUsedFor: {{ .Values.dex.expiry.refreshTokens.validIfNotUsedFor }}
+      absoluteLifetime: {{ .Values.dex.expiry.refreshTokens.absoluteLifetime }}
   storage:
     type: kubernetes
     config:


### PR DESCRIPTION
**What this PR does / why we need it**:

Made dex id token expiration time configurable

Tested setting it to `1m`, then `5m` and then `24h` in my cluster and it worked as expected

**Which issue this PR fixes** : fixes #1242

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [X] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
