### PR TITLE
Aarnq/thanos swift support

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -22,6 +22,7 @@
 - Made dex ID Token expiration time configurable
 - Made dex tokens expiry times configurable
 - Excluded the `gatekeeper-system` namespace from velero backups in the workload cluster.
+- Moved Harbor Swift configuration to `objectStorage.swift` to use the same as for Thanos.
 
 ### Fixed
 
@@ -34,6 +35,7 @@
 - Fixed inevitable mapping conflicts in Opensearch by updating `elastisys/fluentd` to use image tag `v3.4.0-ck8s4`.
   In this image `fluent-plugin-kubernetes_metadata_filter` has been downgraded to version `2.13.0`, which still includes the de_dot functionality that was removed in the prior tag of the image.
 - Fixed harbor network policies
+- Fixed update-ips script to handle ports for S3 endpoints
 
 ### Added
 - Option to configure alerts for growing indices in OpenSearch
@@ -49,6 +51,7 @@
 - Network policies for s3-exporter
 - New section in the welcoming dashboards, displaying the most relevant features and changes for the user added in the last two releases.
 - Network policies for ingress-nginx and cert-manager
+- Added support for running Thanos on Swift
 
 ### Removed
 

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -279,15 +279,15 @@ set_harbor_config() {
             persistence_type=swift
             disable_redirect=true
 
-            yq4 --inplace '.harbor.persistence.swift.identityApiVersion = 3' "${file}"
-            yq4 --inplace '.harbor.persistence.swift.authURL = "set-me"' "${file}"
-            yq4 --inplace '.harbor.persistence.swift.regionName = "set-me"' "${file}"
-            yq4 --inplace '.harbor.persistence.swift.projectDomainName = "set-me"' "${file}"
-            yq4 --inplace '.harbor.persistence.swift.userDomainName = "set-me"' "${file}"
-            yq4 --inplace '.harbor.persistence.swift.projectName = "set-me"' "${file}"
-            yq4 --inplace '.harbor.persistence.swift.projectID = "set-me"' "${file}"
-            yq4 --inplace '.harbor.persistence.swift.tenantName = "set-me"' "${file}"
-            yq4 --inplace '.harbor.persistence.swift.authVersion = 3' "${file}"
+            yq4 --inplace '.objectStorage.swift.authVersion = 0' "${file}"
+            yq4 --inplace '.objectStorage.swift.authUrl = "set-me"' "${file}"
+            yq4 --inplace '.objectStorage.swift.region = "set-me"' "${file}"
+            yq4 --inplace '.objectStorage.swift.domainId = "set-me"' "${file}"
+            yq4 --inplace '.objectStorage.swift.domainName = "set-me-or-domainId"' "${file}"
+            yq4 --inplace '.objectStorage.swift.projectDomainId = "set-me"' "${file}"
+            yq4 --inplace '.objectStorage.swift.projectDomainName = "set-me-or-projectDomainId"' "${file}"
+            yq4 --inplace '.objectStorage.swift.projectId = "set-me"' "${file}"
+            yq4 --inplace '.objectStorage.swift.projectName = "set-me"' "${file}"
             ;;
 
         baremetal)

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -62,11 +62,11 @@ storageClasses:
 ## Object storage configuration for backups.
 objectStorage:
   ## Options are 's3', 'gcs', or 'none'
-  ## If 'none', remember to disable backups (velero)
-  # If "none", remember to disable features that depend on object storage:
-  #   all backups (velero, harbor, opensearch), sc logs (fluentd)
-  #   Also set harbor persistence to "filesystem" or "swift"
-  # Otherwise configure the features to match this type.
+  ## If "none", remember to disable features that depend on object storage:
+  ##   All backups (Velero, Harbor, OpenSearch), SC logs (Fluentd)
+  ##   Long term metrics with Thanos.
+  ##   Also set Harbor persistence to "filesystem" or "swift"
+  ## Otherwise configure the features to match this type.
   type: set-me
   # gcs:
   #   project: set-me

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -9,6 +9,19 @@ global:
     - ${CK8S_ENVIRONMENT_NAME}-wc
 
 objectStorage:
+  ## Swift can be enabled seperately for Harbor and Thanos only.
+  # swift:
+  #   authVersion: 0 # auto detect
+  #   authUrl: set-me
+  #   region: set-me
+  #   domainId: set-me
+  #   domainName: set-me
+  #   projectDomainId: set-me
+  #   projectDomainName: set-me
+  #   projectId: set-me
+  #   projectName: set-me
+  #   segmentsContainerSuffix: "+segments" # same as s3api
+
   buckets:
     harbor: ${CK8S_ENVIRONMENT_NAME}-harbor
     opensearch: ${CK8S_ENVIRONMENT_NAME}-opensearch
@@ -674,6 +687,11 @@ thanos:
     serviceMonitor:
       enabled: true
 
+  objectStorage:
+    # Available options "s3" or "swift", defaults to "objectStorage.type" when empty
+    # Configure the storage credentials in the global "objectStorage"
+    type: ""
+
 opensearch:
   # 'subdomain' and 'indexPerNamespace' is set in common-config.yaml
 
@@ -1086,6 +1104,11 @@ networkPolicies:
 #     egress: {}
 # ---
   global:
+    objectStorageSwift:
+      ips:
+        - set-me-if-enabled
+      ports:
+        - set-me-if-enabled
     scApiserver:
       # usualy private ip of control-plane nodes
       ips:

--- a/config/secrets/sc-secrets.yaml
+++ b/config/secrets/sc-secrets.yaml
@@ -5,6 +5,9 @@ objectStorage: {}
   # s3:
   #   accessKey: "set-me"
   #   secretKey: "set-me"
+  # swift:
+  #   username: set-me
+  #   password: set-me
   #
   # # If backup sync is enabled
   # sync:
@@ -31,10 +34,6 @@ harbor:
     databasePassword: somelongsecret
   # external:
   #   databasePassword: set-me # password for external database user
-  # persistence:
-  #   swift:
-  #     username: "set-me"
-  #     password: "set-me"
 thanos:
   receiver:
     basic_auth:

--- a/helmfile/values/harbor.yaml.gotmpl
+++ b/helmfile/values/harbor.yaml.gotmpl
@@ -59,16 +59,22 @@ persistence:
     filesystem:
       rootdirectory: /storage
     {{ else if eq .Values.harbor.persistence.type "swift" }}
+    {{- $swift := .Values.objectStorage | getOrNil "swift" | required "Swift enabled for Harbor but not configured!" }}
     type: swift
     swift:
-      authurl: {{ .Values.harbor.persistence.swift.authURL }}/v3
-      username: {{ .Values.harbor.persistence.swift.username }}
-      password: {{ .Values.harbor.persistence.swift.password }}
+      authversion: {{ $swift.authVersion }}
+      authurl: {{ $swift.authUrl }}
+      region: {{ $swift.region }}
       container: {{ .Values.objectStorage.buckets.harbor }}
-      region: {{ .Values.harbor.persistence.swift.regionName }}
-      authversion: {{ .Values.harbor.persistence.swift.authVersion }}
-      tenant: {{ .Values.harbor.persistence.swift.tenantName }}
-      domain: {{ .Values.harbor.persistence.swift.projectDomainName }}
+      {{- if hasKey $swift "domainId" }}
+      domainid: {{ $swift.domainId }}
+      {{- else if hasKey $swift "domainName" }}
+      domain: {{ $swift.domainName }}
+      {{- end }}
+      username: {{ $swift.username | quote }}
+      password: {{ $swift.password | quote }}
+      tenantid: {{ $swift.projectId }}
+      tenant: {{ $swift.projectName }}
     {{ else if eq .Values.harbor.persistence.type "objectStorage" }}
     {{ if eq .Values.objectStorage.type "s3" }}
     type: s3

--- a/helmfile/values/service-cluster-networkpolicy.yaml.gotmpl
+++ b/helmfile/values/service-cluster-networkpolicy.yaml.gotmpl
@@ -14,8 +14,16 @@ global:
   wcIngress:
     ips: {{- toYaml .Values.networkPolicies.global.wcIngress.ips | nindent 6 }}
   objectStorage:
-    ips: {{- toYaml .Values.networkPolicies.global.objectStorage.ips | nindent 6 }}
-    ports: {{- toYaml .Values.networkPolicies.global.objectStorage.ports | nindent 6 }}
+    ips:
+      {{- toYaml .Values.networkPolicies.global.objectStorage.ips | nindent 6 }}
+      {{- if or (eq .Values.harbor.persistence.type "swift") (eq .Values.harbor.persistence.type "swift") }}
+      {{- toYaml .Values.networkPolicies.global.objectStorageSwift.ips | nindent 6 }}
+      {{- end }}
+    ports:
+      {{- toYaml .Values.networkPolicies.global.objectStorage.ports | nindent 6 }}
+      {{- if or (eq .Values.harbor.persistence.type "swift") (eq .Values.harbor.persistence.type "swift") }}
+      {{- toYaml .Values.networkPolicies.global.objectStorageSwift.ports | nindent 6 }}
+      {{- end }}
   externalLoadBalancer: {{ .Values.networkPolicies.global.externalLoadBalancer }}
   ingressUsingHostNetwork: {{ .Values.ingressNginx.controller.useHostPort }}
 

--- a/helmfile/values/thanos/objectstorage-secret.yaml.gotmpl
+++ b/helmfile/values/thanos/objectstorage-secret.yaml.gotmpl
@@ -1,7 +1,3 @@
-{{ if not (eq .Values.objectStorage.type "s3") }}
-{{ fail "\nERROR: Thanos requires s3 object storage, see Values.objectStorage.type" }}
-{{ end }}
-
 query:
   enabled: false
 
@@ -9,7 +5,13 @@ queryFrontend:
   enabled: false
 
 objstoreConfig: |-
-  {{- if eq .Values.objectStorage.type "s3" }}
+  {{- $type := default .Values.objectStorage.type .Values.thanos.objectStorage.type }}
+
+  {{- if and (ne $type "s3") (ne $type "swift") }}
+  {{- fail "\nERROR: Thanos requires either S3 or Swift object storage, see Values.objectStorage.type" }}
+  {{- end }}
+
+  {{- if eq $type "s3" }}
   type: s3
   config:
     bucket: {{ .Values.objectStorage.buckets.thanos }}
@@ -17,4 +19,31 @@ objstoreConfig: |-
     access_key: {{ .Values.objectStorage.s3.accessKey }}
     secret_key: {{ .Values.objectStorage.s3.secretKey }}
     region: {{ .Values.objectStorage.s3.region }}
+
+  {{- else if eq $type "swift" }}
+  {{- $swift := .Values.objectStorage | getOrNil "swift" | required "Swift enabled for Thanos but not configured!" }}
+  type: swift
+  config:
+    auth_version: {{ $swift.authVersion }}
+    auth_url: {{ $swift.authUrl }}
+    {{- if hasKey $swift "region" }}
+    region_name: {{ $swift.region }}
+    {{- end }}
+    container_name: {{ .Values.objectStorage.buckets.thanos }}
+    large_object_segments_container_name: {{ printf "%s%s" .Values.objectStorage.buckets.thanos $swift.segmentsContainerSuffix }}
+    large_object_chunk_size: 1073741824
+    {{- if hasKey $swift "domainId" }}
+    domain_id: {{ $swift.domainId }}
+    {{- else if hasKey $swift "domainName" }}
+    domain_name: {{ $swift.domainName }}
+    {{- end }}
+    username: {{ $swift.username | quote }}
+    password: {{ $swift.password | quote }}
+    {{- if hasKey $swift "projectDomainId" }}
+    project_domain_id: {{ $swift.projectDomainId }}
+    {{- else if hasKey $swift "projectDomainName" }}
+    project_domain_name: {{ $swift.projectDomainName }}
+    {{- end }}
+    project_id: {{ $swift.projectId }}
+    project_name: {{ $swift.projectName }}
   {{- end }}

--- a/migration/v0.26.x-v0.27.x/migrate-swift.sh
+++ b/migration/v0.26.x-v0.27.x/migrate-swift.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?"CK8S_CONFIG_PATH is unset"}"
+
+default_common="$CK8S_CONFIG_PATH/defaults/common-config.yaml"
+default_sc="$CK8S_CONFIG_PATH/defaults/sc-config.yaml"
+config_common="$CK8S_CONFIG_PATH/common-config.yaml"
+config_sc="$CK8S_CONFIG_PATH/sc-config.yaml"
+secrets="$CK8S_CONFIG_PATH/secrets.yaml"
+
+configs=( "$default_common" "$default_sc" "$config_common" "$config_sc" )
+
+if [ ! -f "$secrets" ]; then
+  echo "err: $secrets not found" >&2
+  exit 1
+fi
+
+for config in "${configs[@]}"; do
+  if [ ! -f "$config" ]; then
+    echo "err: $config not found" >&2
+    exit 1
+  fi
+done
+
+merge="$(yq4 ea "explode(.) as \$config ireduce ({}; . * \$config)" "${configs[@]}")"
+
+if [ "$(echo "$merge" | yq4 '.harbor.persistence.type')" != "swift" ]; then
+  echo "skip: swift not enabled for harbor"
+  exit 0
+fi
+
+echo "info: moving values harbor.persistence.swift to objectStorage.swift"
+move_value() {
+  value="$(echo "$merge" | yq4 ".$1 // \"unset\"")"
+  if [ "$value" = "unset" ]; then
+    echo "- skip: move $1 to $2"
+  else
+    echo "- info: move $1 to $2"
+    yq4 -i ".$2 = \"$value\" | del(.$1)" "$config_sc"
+  fi
+}
+
+move_value "harbor.persistence.swift.authVersion" "objectStorage.swift.authVersion"
+move_value "harbor.persistence.swift.authURL" "objectStorage.swift.authUrl"
+move_value "harbor.persistence.swift.regionName" "objectStorage.swift.region"
+move_value "harbor.persistence.swift.userDomainName" "objectStorage.swift.domainName"
+move_value "harbor.persistence.swift.projectDomainName" "objectStorage.swift.projectDomainName"
+move_value "harbor.persistence.swift.projectID" "objectStorage.swift.projectId"
+move_value "harbor.persistence.swift.tenantName" "objectStorage.swift.projectName"
+
+if [ "$(echo "$merge" | yq4 '.harbor.persistence.swift // "unset"')" != "unset" ]; then
+  echo "- info: clear harbor.persistence.swift"
+  yq4 -i 'del(.harbor.persistence.swift)' "$config_sc"
+fi
+
+authUrl="$(echo "$merge" | yq4 '.objectStorage.swift.authUrl // "unset"')"
+if [ -n "${authUrl##*/v3}" ]; then
+  echo "- info: appending '/v3' to objectStorage.swift.authUrl"
+  yq4 -i '.objectStorage.swift.authUrl = .objectStorage.swift.authUrl + "/v3"' "$config_sc"
+fi
+
+echo "info: moving secrets harbor.persistence.swift to objectStorage.swift"
+if [ "$(sops --config "$CK8S_CONFIG_PATH/.sops.yaml" -d "$secrets" | yq4 '.harbor.persistence.swift // "unset"')" = "unset" ]; then
+  echo "- skip: move secrets harbor.persistence.swift to objectStorage.swift"
+else
+  echo "- info: move secrets harbor.persistence.swift to objectStorage.swift"
+  sops --config "$CK8S_CONFIG_PATH/.sops.yaml" -d "$secrets" \
+    | yq4 '.objectStorage.swift = .harbor.persistence.swift | del(.harbor.persistence)' \
+    | sops --input-type yaml --config "$CK8S_CONFIG_PATH/.sops.yaml" --output-type yaml -e /dev/stdin \
+    > "${secrets}2" \
+    && mv "${secrets}2" "${secrets}"
+fi

--- a/migration/v0.26.x-v0.27.x/upgrade-apps.md
+++ b/migration/v0.26.x-v0.27.x/upgrade-apps.md
@@ -10,6 +10,12 @@
     bin/ck8s init
     ```
 
+1. *When using Harbor on Swift:* Migrate Swift configuration.
+
+    ```bash
+    ./migration/v0.26.x-v0.27.x/migrate-swift.sh
+    ```
+
 1. *IMPORTANT* If you are using any Dex connector of type `google` and you haven't added a service account then you'll need to change it to a type `oidc`
 
     This can be done by adding the following line to the `config` part in the connector


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Swift support for Thanos, and I updated the way we set it for Harbor to be more up to date and understandable.

**Which issue this PR fixes**:
Fixes #1200

**Special notes for reviewer**:
~~I still have some network policy issues to deal with.~~
And I created a PR upstream to enable auth with application credentials.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
