### PR TITLE
apps:enable quotes to allow rclone to be scheduled every x minutes

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -39,6 +39,7 @@
   In this image `fluent-plugin-kubernetes_metadata_filter` has been downgraded to version `2.13.0`, which still includes the de_dot functionality that was removed in the prior tag of the image.
 - Fixed harbor network policies
 - Fixed update-ips script to handle ports for S3 endpoints
+- Rclone can now be configured to run every x minutes/hours/days/week/month/year.
 
 ### Added
 - Option to configure alerts for growing indices in OpenSearch

--- a/helmfile/charts/rclone-sync/templates/cronjob.yaml
+++ b/helmfile/charts/rclone-sync/templates/cronjob.yaml
@@ -9,7 +9,7 @@ metadata:
     component: {{ $.Chart.Name }}-{{ .source }}
 spec:
   {{- if hasKey . "schedule" }}
-  schedule: {{ .schedule }}
+  schedule: {{ .schedule | quote }}
   {{- else }}
   schedule: {{ $.Values.defaultSchedule }}
   {{- end }}

--- a/helmfile/values/rclone-sync.yaml.gotmpl
+++ b/helmfile/values/rclone-sync.yaml.gotmpl
@@ -71,7 +71,7 @@ buckets:
     destination: {{ .source }}
     {{- end }}
     {{- if hasKey . "schedule" }}
-    schedule: {{ .schedule }}
+    schedule: {{ .schedule | quote }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Enable quotes to allow rclone to be schedulled every x minnutes

**What this PR does / why we need it**:

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
