### PR TITLE
Patch 0.26.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Compliant Kubernetes changelog
 <!-- BEGIN TOC -->
+- [v0.26.3](#v0263---2022-10-31)
 - [v0.26.2](#v0262---2022-10-18)
 - [v0.26.1](#v0261---2022-10-05)
 - [v0.26.0](#v0260---2022-09-19)
@@ -30,6 +31,19 @@
 - [v0.6.0](#v060---2020-10-16)
 - [v0.5.0](#v050---2020-08-06)
 <!-- END TOC -->
+
+-------------------------------------------------
+## v0.26.3 - 2022-10-31
+
+### Release notes
+
+### Changed
+
+- Excluded the `gatekeeper-system` namespace from velero backups in the workload cluster.
+
+### Fixed
+
+- Harbor backup is now pointed to the correct service to make backups from
 
 -------------------------------------------------
 ## v0.26.2 - 2022-10-18

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,9 +1,0 @@
-### Release notes
-
-### Changed
-
-- Excluded the `gatekeeper-system` namespace from velero backups in the workload cluster.
-
-### Fixed
-
-- Harbor backup is now pointed to the correct service to make backups from

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,5 @@
+### Release notes
+
+### Fixed
+
+- Harbor backup is now pointed to the correct service to make backups from

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Release notes
 
+### Changed
+
+- Excluded the `gatekeeper-system` namespace from velero backups in the workload cluster.
+
 ### Fixed
 
 - Harbor backup is now pointed to the correct service to make backups from

--- a/helmfile/charts/harbor/harbor-backup/values.yaml
+++ b/helmfile/charts/harbor/harbor-backup/values.yaml
@@ -1,4 +1,4 @@
-pgHostname: harbor-harbor-database
+pgHostname: harbor-database
 dbPassword: ""
 retentionDays: 7
 schedule: "0 0 * * *"

--- a/helmfile/values/velero-wc.yaml.gotmpl
+++ b/helmfile/values/velero-wc.yaml.gotmpl
@@ -109,6 +109,7 @@ schedules:
         - redis-system
         - rook-ceph
         - velero
+        - gatekeeper-system
       ttl: {{ .Values.velero.retentionPeriod }}
       labelSelector:
         matchExpressions:


### PR DESCRIPTION
**What this PR does / why we need it**: Patch release v0.26.3

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
