### PR TITLE
pipeline: fix missing dependency

### DIFF
--- a/helmfile/charts/networkpolicy-common/templates/cert-manager/startupapicheck.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/cert-manager/startupapicheck.yaml
@@ -1,0 +1,22 @@
+{{ if .Values.certManager.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cert-manager-startupapicheck
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: startupapicheck
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        {{- range $IP := .Values.global.apiserver.ips }}
+        - ipBlock:
+            cidr: {{ $IP }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.global.apiserver.port }}
+{{- end }}

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -5,14 +5,14 @@ RUN  apt-get update && \
      add-apt-repository ppa:git-core/ppa && \
      apt-get update && \
      apt-get install -y \
-         python3-pip make git wget \
+         python3-pip make git wget dnsutils \
          unzip ssh gettext-base \
          jq pwgen curl apache2-utils \
          net-tools iputils-ping && \
      rm -rf /var/lib/apt/lists/*
 
 # Kubectl
-ENV KUBECTL_VERSION "v1.22.6"
+ENV KUBECTL_VERSION "v1.24.4"
 RUN wget "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl

--- a/pipeline/config/exoscale/common-config.yaml
+++ b/pipeline/config/exoscale/common-config.yaml
@@ -29,23 +29,20 @@ monitoring:
     enabled: true
 networkPolicies:
   global:
+    objectStorage:
+      ips:
+        - 0.0.0.0/0
+      ports:
+        - 443
     scIngress:
       ips:
-        - "0.0.0.0/0"
+        - 0.0.0.0/0
     wcIngress:
       ips:
-        - "0.0.0.0/0"
-    objectStorage:
-      ips: # ips to s3 service
-      - "0.0.0.0/0"
-      ports: # ports to s3 service
-      - 443
+        - 0.0.0.0/0
+    externalLoadBalancer: true
+    ingressUsingHostNetwork: true
   certManager:
-    enabled: true
     letsencrypt:
       ips:
-        - "0.0.0.0/0"
-  ingressNginx:
-    enabled: true
-    ingressOverride:
-      enabled: true
+        - 0.0.0.0/0

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -40,33 +40,28 @@ prometheus:
 networkPolicies:
   global:
     scApiserver:
-      ips: # usualy private ip of control-plane nodes
-        - "0.0.0.0/0"
+      ips:
+        - 0.0.0.0/0
     scNodes:
-      ips: # ip of all nodes in the cluster for internal communication
-        - "0.0.0.0/0"
-    externalLoadBalancer: true
+      ips:
+        - 0.0.0.0/0
   harbor:
     jobservice:
       ips:
-        - "0.0.0.0/0"
+        - 0.0.0.0/0
     trivy:
       ips:
-        - "0.0.0.0/0"
+        - 0.0.0.0/0
   monitoring:
     grafana:
-      externalDashboardProvider: # loading dashboards from grafana website
+      externalDashboardProvider:
         ips:
-          - "0.0.0.0/0"
+          - 0.0.0.0/0
     alertmanager:
-      alertReceivers: # alert receiver, e.g. slack or opsgenie
+      alertReceivers:
         ips:
-          - "0.0.0.0/0"
+          - 0.0.0.0/0
   opensearch:
     plugins:
       ips:
-        - "0.0.0.0/0"
-  ingressNginx:
-    ingressOverride:
-      ips:
-      - "0.0.0.0/0"
+        - 0.0.0.0/0

--- a/pipeline/config/exoscale/wc-config.yaml
+++ b/pipeline/config/exoscale/wc-config.yaml
@@ -17,10 +17,10 @@ networkPolicies:
   global:
     wcApiserver:
       ips:
-        - "0.0.0.0/0"
+        - 0.0.0.0/0
     wcNodes:
       ips:
-        - "0.0.0.0/0"
+        - 0.0.0.0/0
   ingressNginx:
     ingressOverride:
       ips:


### PR DESCRIPTION
**What this PR does / why we need it**: 
- the cert-manager helm chart included a job that checks if the [webhook is available](https://github.com/elastisys/compliantkubernetes-apps/blob/main/helmfile/upstream/cert-manager/values.yaml#L445:L453). In a new installation the helm chart will fail because this job doesn't have a network policy defined. I added the necessary networkpolicy for this job to run.
- not necessary, but I added `dnsutils` in the pipeline docker image to be able to run [update-ips.bash](https://github.com/elastisys/compliantkubernetes-apps/blob/main/bin/update-ips.bash)

**Alternatives:**
- disable the startupapicheck job

**Special notes for reviewer**:
Green pipeline: https://github.com/elastisys/compliantkubernetes-apps/actions/runs/3362027852

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

