### PR TITLE
release: migration steps fix

### DIFF
--- a/migration/v0.26.x-v0.27.x/upgrade-apps.md
+++ b/migration/v0.26.x-v0.27.x/upgrade-apps.md
@@ -32,6 +32,12 @@
             clientSecret: examplesecret
     ```
 
+1. Upgrade the `workload-cluster-np` with the new changes, before applying the common-np chart:
+
+    ```bash
+    ./bin/ck8s ops helmfile wc -f helmfile -l app=workload-cluster-np -i apply
+    ```
+
 1. Upgrade applications:
 
     ```bash


### PR DESCRIPTION
**What this PR does / why we need it**: to fix an issue while upgrading from apps v0.26 to v0.27

**Special notes for reviewer**:

>   Error: rendered manifests contain a resource that already exists. Unable to continue with install: NetworkPolicy "allow-cert-manager-resolver" in namespace "staging" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name" must equal "common-np": current value is "workload-cluster-np

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
