### PR TITLE
script: Fix cleanup script to remove PVCs instead of PVs

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -41,6 +41,7 @@
 - Fixed harbor network policies
 - Fixed update-ips script to handle ports for S3 endpoints
 - Rclone can now be configured to run every x minutes/hours/days/week/month/year.
+- Cleanup scripts now delete PVCs instead of PVs to let the cloud controller manager handle the volume lifecycle
 
 ### Added
 - Option to configure alerts for growing indices in OpenSearch

--- a/scripts/clean-sc.sh
+++ b/scripts/clean-sc.sh
@@ -25,8 +25,8 @@ here="$(dirname "$(readlink -f "$0")")"
 # Clean up cert-manager namespace
 "${here}/.././bin/ck8s" ops kubectl sc delete ns cert-manager
 
-# Remove any lingering persistent volumes
-"${here}/.././bin/ck8s" ops kubectl sc delete pv --all
+# Remove any lingering persistent volume claims
+"${here}/.././bin/ck8s" ops kubectl sc delete pvc -A --all
 
 # Velero-specific removal: https://velero.io/docs/v1.5/uninstalling/
 "${here}/.././bin/ck8s" ops kubectl sc delete namespace/velero clusterrolebinding/velero

--- a/scripts/clean-wc.sh
+++ b/scripts/clean-wc.sh
@@ -34,8 +34,8 @@ here="$(dirname "$(readlink -f "$0")")"
 # Clean up cert-manager namespace
 "${here}/.././bin/ck8s" ops kubectl wc delete ns cert-manager
 
-# Remove any lingering persistent volumes
-"${here}/.././bin/ck8s" ops kubectl wc delete pv --all
+# Remove any lingering persistent volume claims
+"${here}/.././bin/ck8s" ops kubectl wc delete pvc -A --all
 
 # Velero-specific removal: https://velero.io/docs/v1.5/uninstalling/
 "${here}/.././bin/ck8s" ops kubectl wc delete namespace/velero clusterrolebinding/velero


### PR DESCRIPTION
**What this PR does / why we need it**:
Else CCM might not delete the volume.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
