### PR TITLE
apps: Fix ingress-nginx controller netpol

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -44,6 +44,7 @@
 - Rclone can now be configured to run every x minutes/hours/days/week/month/year.
 - Cleanup scripts now delete PVCs instead of PVs to let the cloud controller manager handle the volume lifecycle
 - Fixed issue with the update-ips script to fail to parse port
+- Fixed ingress-nginx controller network policy for loadbalancer service and thanos remote write
 
 ### Added
 - Option to configure alerts for growing indices in OpenSearch

--- a/helmfile/charts/networkpolicy-service/templates/ingress-nginx/controller.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/ingress-nginx/controller.yaml
@@ -18,6 +18,11 @@ spec:
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
+      {{- else if not (or .Values.global.externalLoadBalancer .Values.global.ingressUsingHostNetwork) }}
+        {{- range $IP := .Values.global.scNodes.ips }}
+        - ipBlock:
+            cidr: {{ $IP }}
+        {{- end }}
       {{- else }}
         {{- range $IP := .Values.global.scIngress.ips }}
         - ipBlock:
@@ -33,7 +38,7 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: monitoring
-        - podSelector:
+          podSelector:
             matchLabels:
               app.kubernetes.io/instance: kube-prometheus-stack-prometheus
       ports:
@@ -43,6 +48,13 @@ spec:
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus-blackbox-exporter
+              app.kubernetes.io/instance: prometheus-blackbox-exporter
       ports:
         - protocol: TCP
           port: 8443 ## admission
@@ -150,7 +162,8 @@ spec:
             matchLabels:
               app.kubernetes.io/component: receive-distributor
       ports:
-        - port: 10902
+        - port: 10902 # HTTP API
+        - port: 19291 # Remote Write
     - to:
         - podSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy-workload/templates/ingress-nginx/controller.yaml
+++ b/helmfile/charts/networkpolicy-workload/templates/ingress-nginx/controller.yaml
@@ -18,6 +18,11 @@ spec:
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
+      {{- else if not (or .Values.global.externalLoadBalancer .Values.global.ingressUsingHostNetwork) }}
+        {{- range $IP := .Values.global.wcNodes.ips }}
+        - ipBlock:
+            cidr: {{ $IP }}
+        {{- end }}
       {{- else }}
         {{- range $IP := .Values.global.wcIngress.ips }}
         - ipBlock:
@@ -43,6 +48,13 @@ spec:
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus-blackbox-exporter
+              app.kubernetes.io/instance: prometheus-blackbox-exporter
       ports:
         - protocol: TCP
           port: 8443


### PR DESCRIPTION
**What this PR does / why we need it**:
It was missing ingress for blackbox-exporter and egress for thanos-receiver-distributor remote write.
There is still something that is blocked going into ingress-nginx.
And in the setup with service type loadbalancer we need to add node IPs for the ingress into ingress-nginx as it will only see node and tunnel IPs.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
