### PR TITLE
apps wc: move excluded namespaces to configs

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -8,13 +8,13 @@
 - Updated dex chart to `v0.12.0` which upgraded dex to `v2.35.1`
 - Updated Falco chart to `2.2.0` upgrading Falco itself to `0.33.0` and Falco Sidekick to `2.26.0`
 - Updated Falco Exporter chart to `0.9.0` upgrading Falco Exporter itself to `0.8.0`
+- Upgrade Velero helm chart to `v2.31.8`, which also upgrades Velero to `v1.9.2`.
+- Update the provider plugins to a supported version for the new Velero release
 
 ### Changed
 
 - Lowered the default retention age for kubernetes logs in the prod flavor down to 30 days
 - Changed grafana's communication with dex to use internal service
-- Upgrade Velero helm chart to `v2.31.8`, which also upgrades Velero to `v1.9.2`.
-- Update the provider plugins to a supported version for the new Velero release
 - Added support for anchors and aliases in override configs, not tested with merge aliases/tags
 - Changed the default limit for diskLimit alert, from 66 to 75
 - Changed some default resource requests and limits for multiple components
@@ -27,6 +27,7 @@
 - Moved Harbor Swift configuration to `objectStorage.swift` to use the same as for Thanos.
 - Rewritten Falco overrides to use user editable macros with is used by upstream configuration.
 - User alertmanager is now enabled by default.
+- Moved the excluded namespace for velero and hnc from templates to configs.
 
 ### Fixed
 

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -102,13 +102,50 @@ opa:
     tags:
      - latest
 
+velero:
+  ## Excluded namespaces
+  excludedNamespaces:
+    - cert-manager
+    - falco
+    - fluentd
+    - hnc-system
+    - ingress-nginx
+    - kube-node-lease
+    - kube-public
+    - kube-system
+    - kured
+    - monitoring
+    - rook-ceph
+    - velero
+    - gatekeeper-system
+
+  ## Extra excluded namespace, here we should add the namespaces that are more likely to change
+  excludedExtraNamespaces: []
+
 ## Hierarchical namespace controller configuration, enable in common-config.yaml
 hnc:
   ## Included namespaces, empty string will include all
   includedNamespacesRegex: ""
 
-  ## Excluded namespaces, system namespaces are excluded by default in addition to this list
-  excludedNamespaces: []
+  ## Excluded namespaces
+  excludedNamespaces:
+    - alertmanager
+    - cert-manager
+    - falco
+    - fluentd
+    - hnc-system
+    - ingress-nginx
+    - kube-node-lease
+    - kube-public
+    - kube-system
+    - kured
+    - monitoring
+    - rook-ceph
+    - velero
+    - gatekeeper-system
+
+  ## Extra excluded namespace, here we should add the namespaces that are more likely to change
+  excludedExtraNamespaces: []
 
   ## Annotations that will be stripped from propagated objects
   unpropagatedAnnotations: []

--- a/helmfile/values/hnc.yaml.gotmpl
+++ b/helmfile/values/hnc.yaml.gotmpl
@@ -1,23 +1,10 @@
 includedNamespacesRegex: {{ .Values.hnc.includedNamespacesRegex }}
 
 excludedNamespaces:
-  - alertmanager
-  - cert-manager
-  - falco
-  - fluentd
-  - hnc-system
-  - ingress-nginx
-  - kube-node-lease
-  - kube-public
-  - kube-system
-  - kured
-  - monitoring
-  - postgres-system
-  - rabbitmq-system
-  - redis-system
-  - rook-ceph
-  - velero
   {{- with .Values.hnc.excludedNamespaces }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.hnc.excludedExtraNamespaces }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
 

--- a/helmfile/values/velero-wc.yaml.gotmpl
+++ b/helmfile/values/velero-wc.yaml.gotmpl
@@ -94,22 +94,12 @@ schedules:
     template:
       storageLocation: default
       excludedNamespaces:
-        - cert-manager
-        - falco
-        - fluentd
-        - hnc-system
-        - ingress-nginx
-        - kube-node-lease
-        - kube-public
-        - kube-system
-        - kured
-        - monitoring
-        - postgres-system
-        - rabbitmq-system
-        - redis-system
-        - rook-ceph
-        - velero
-        - gatekeeper-system
+        {{- with .Values.velero.excludedNamespaces }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.velero.excludedExtraNamespaces }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       ttl: {{ .Values.velero.retentionPeriod }}
       labelSelector:
         matchExpressions:

--- a/migration/v0.26.x-v0.27.x/add-extra-excluded-namespaces.sh
+++ b/migration/v0.26.x-v0.27.x/add-extra-excluded-namespaces.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
+wc_config="${CK8S_CONFIG_PATH}/wc-config.yaml"
+
+add_values_to() {
+    echo "adding additional services namespaces to $1 in $3"
+    yq4 -i "$1 = $2" "$3"
+}
+
+if [[ ! -f "$wc_config" ]]; then
+    echo "$wc_config does not exist, skipping."
+else
+   add_values_to '.velero.excludedExtraNamespaces' '["postgres-system","rabbitmq-system","redis-system","argocd-system","jaeger-system"]' "$wc_config"
+   add_values_to '.hnc.excludedExtraNamespaces' '["postgres-system","rabbitmq-system","redis-system","argocd-system","jaeger-system"]' "$wc_config"
+fi

--- a/migration/v0.26.x-v0.27.x/upgrade-apps.md
+++ b/migration/v0.26.x-v0.27.x/upgrade-apps.md
@@ -16,6 +16,13 @@
     ./migration/v0.26.x-v0.27.x/migrate-swift.sh
     ```
 
+1. Adding the additional services namespaces in `$CK8S_CONFIG_PATH/wc-config.yaml`
+
+    ```bash
+    ./migration/v0.26.x-v0.27.x/add-extra-excluded-namespaces.sh
+    ```
+    > **_NOTE:_** remove the namespaces that are not managed from `$CK8S_CONFIG_PATH/wc-config.yaml`
+
 1. *IMPORTANT* If you are using any Dex connector of type `google` and you haven't added a service account then you'll need to change it to a type `oidc`
 
     This can be done by adding the following line to the `config` part in the connector


### PR DESCRIPTION
**What this PR does / why we need it**: to move the excluded namespaces to configs

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1159 

**Special notes for reviewer**:
My proposal is:
- to keep the more "static" namespaces in defaults wc-config.yaml under `velero|hnc.excludedNamespaces`
- to add the more "fluid" namespaces in the overwrite wc-config.yaml under `velero|hnc.excludedExtraNamespaces`, to add and remove them more easily

**Add a screenshot or an example to illustrate the proposed solution:**
![hnc_namespaces](https://user-images.githubusercontent.com/77267293/199528816-38318b06-7c31-44f8-973d-c25c00f62ecf.png)
![velero_namespace](https://user-images.githubusercontent.com/77267293/199528843-f0188217-b8f9-4ee9-b587-92de2560d212.png)


**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
