### PR TITLE
Upgrade grafana

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -11,7 +11,7 @@
 - Upgrade Velero helm chart to `v2.31.8`, which also upgrades Velero to `v1.9.2`.
 - Update the provider plugins to a supported version for the new Velero release
 - Upgraded Grafana helm chart to `v6.43.4`, which also upgrades the user-facing Grafana to `v9.2.3`.
-- Use Grafana tag `v9.2.3` in kube-prometheus-stack.
+- Use Grafana tag `9.2.3` in kube-prometheus-stack.
 
 ### Changed
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -10,8 +10,8 @@
 - Updated Falco Exporter chart to `0.9.0` upgrading Falco Exporter itself to `0.8.0`
 - Upgrade Velero helm chart to `v2.31.8`, which also upgrades Velero to `v1.9.2`.
 - Update the provider plugins to a supported version for the new Velero release
-- Upgraded Grafana helm chart to `v6.43.4`, which also upgrades the user-facing Grafana to `v9.2.3`.
-- Use Grafana tag `9.2.3` in kube-prometheus-stack.
+- Upgraded Grafana helm chart to `v6.43.4`.
+- Upgraded Grafana to version `9.2.4`.
 
 ### Changed
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -10,6 +10,8 @@
 - Updated Falco Exporter chart to `0.9.0` upgrading Falco Exporter itself to `0.8.0`
 - Upgrade Velero helm chart to `v2.31.8`, which also upgrades Velero to `v1.9.2`.
 - Update the provider plugins to a supported version for the new Velero release
+- Upgraded Grafana helm chart to `v6.43.4`, which also upgrades the user-facing Grafana to `v9.2.3`.
+- Use Grafana tag `v9.2.3` in kube-prometheus-stack.
 
 ### Changed
 

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -292,7 +292,7 @@ releases:
     app.kubernetes.io/instance: user-grafana
     app.kubernetes.io/name: grafana
   chart: ./upstream/grafana
-  version: 6.1.11
+  version: 6.43.4
   installed: {{ .Values.user.grafana.enabled }}
   values:
   - values/grafana-user.yaml.gotmpl

--- a/helmfile/upstream/grafana/Chart.yaml
+++ b/helmfile/upstream/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 8.2.3
+appVersion: 9.2.3
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png
@@ -19,4 +19,4 @@ name: grafana
 sources:
 - https://github.com/grafana/grafana
 type: application
-version: 6.17.2
+version: 6.43.4

--- a/helmfile/upstream/grafana/README.md
+++ b/helmfile/upstream/grafana/README.md
@@ -59,22 +59,24 @@ This version requires Helm >= 3.1.0.
 | `securityContext`                         | Deployment securityContext                    | `{"runAsUser": 472, "runAsGroup": 472, "fsGroup": 472}`  |
 | `priorityClassName`                       | Name of Priority Class to assign pods         | `nil`                                                   |
 | `image.repository`                        | Image repository                              | `grafana/grafana`                                       |
-| `image.tag`                               | Image tag (`Must be >= 5.0.0`)                | `8.0.3`                                                 |
-| `image.sha`                               | Image sha (optional)                          | `80c6d6ac633ba5ab3f722976fb1d9a138f87ca6a9934fcd26a5fc28cbde7dbfa` |
+| `image.tag`                               | Overrides the Grafana image tag whose default is the chart appVersion (`Must be >= 5.0.0`) | ``                                                      |
+| `image.sha`                               | Image sha (optional)                          | ``                                                      |
 | `image.pullPolicy`                        | Image pull policy                             | `IfNotPresent`                                          |
-| `image.pullSecrets`                       | Image pull secrets                            | `{}`                                                    |
+| `image.pullSecrets`                       | Image pull secrets (can be templated)         | `[]`                                                    |
 | `service.enabled`                         | Enable grafana service                        | `true`                                                  |
 | `service.type`                            | Kubernetes service type                       | `ClusterIP`                                             |
 | `service.port`                            | Kubernetes port where service is exposed      | `80`                                                    |
 | `service.portName`                        | Name of the port on the service               | `service`                                               |
+| `service.appProtocol`                     | Adds the appProtocol field to the service     | ``                                                      |
 | `service.targetPort`                      | Internal service is port                      | `3000`                                                  |
 | `service.nodePort`                        | Kubernetes service nodePort                   | `nil`                                                   |
-| `service.annotations`                     | Service annotations                           | `{}`                                                    |
+| `service.annotations`                     | Service annotations (can be templated)        | `{}`                                                    |
 | `service.labels`                          | Custom labels                                 | `{}`                                                    |
 | `service.clusterIP`                       | internal cluster service IP                   | `nil`                                                   |
 | `service.loadBalancerIP`                  | IP address to assign to load balancer (if supported) | `nil`                                            |
 | `service.loadBalancerSourceRanges`        | list of IP CIDRs allowed access to lb (if supported) | `[]`                                             |
 | `service.externalIPs`                     | service external IP addresses                 | `[]`                                                    |
+| `headlessService`                         | Create a headless service                     | `false`                                                 |
 | `extraExposePorts`                        | Additional service ports for sidecar containers| `[]`                                                   |
 | `hostAliases`                             | adds rules to the pod's /etc/hosts            | `[]`                                                    |
 | `ingress.enabled`                         | Enables Ingress                               | `false`                                                 |
@@ -97,12 +99,13 @@ This version requires Helm >= 3.1.0.
 | `persistence.enabled`                     | Use persistent volume to store data           | `false`                                                 |
 | `persistence.type`                        | Type of persistence (`pvc` or `statefulset`)  | `pvc`                                                   |
 | `persistence.size`                        | Size of persistent volume claim               | `10Gi`                                                  |
-| `persistence.existingClaim`               | Use an existing PVC to persist data           | `nil`                                                   |
+| `persistence.existingClaim`               | Use an existing PVC to persist data (can be templated) | `nil`                                          |
 | `persistence.storageClassName`            | Type of persistent volume claim               | `nil`                                                   |
 | `persistence.accessModes`                 | Persistence access modes                      | `[ReadWriteOnce]`                                       |
 | `persistence.annotations`                 | PersistentVolumeClaim annotations             | `{}`                                                    |
 | `persistence.finalizers`                  | PersistentVolumeClaim finalizers              | `[ "kubernetes.io/pvc-protection" ]`                    |
-| `persistence.subPath`                     | Mount a sub dir of the persistent volume      | `nil`                                                   |
+| `persistence.extraPvcLabels`              | Extra labels to apply to a PVC.               | `{}`                                                    |
+| `persistence.subPath`                     | Mount a sub dir of the persistent volume (can be templated) | `nil`                                     |
 | `persistence.inMemory.enabled`            | If persistence is not enabled, whether to mount the local storage in-memory to improve performance | `false`                                                   |
 | `persistence.inMemory.sizeLimit`          | SizeLimit for the in-memory local storage     | `nil`                                                   |
 | `initChownData.enabled`                   | If false, don't reset data ownership at startup | true                                                  |
@@ -113,16 +116,20 @@ This version requires Helm >= 3.1.0.
 | `initChownData.resources`                 | init-chown-data pod resource requests & limits | `{}`                                                   |
 | `schedulerName`                           | Alternate scheduler name                      | `nil`                                                   |
 | `env`                                     | Extra environment variables passed to pods    | `{}`                                                    |
-| `envValueFrom`                            | Environment variables from alternate sources. See the API docs on [EnvVarSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core) for format details.  | `{}` |
+| `envValueFrom`                            | Environment variables from alternate sources. See the API docs on [EnvVarSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core) for format details. Can be templated | `{}` |
 | `envFromSecret`                           | Name of a Kubernetes secret (must be manually created in the same namespace) containing values to be added to the environment. Can be templated | `""` |
+| `envFromSecrets`                          | List of Kubernetes secrets (must be manually created in the same namespace) containing values to be added to the environment. Can be templated | `[]` |
+| `envFromConfigMaps`                       | List of Kubernetes ConfigMaps (must be manually created in the same namespace) containing values to be added to the environment. Can be templated | `[]` |
 | `envRenderSecret`                         | Sensible environment variables passed to pods and stored as secret | `{}`                               |
 | `enableServiceLinks`                      | Inject Kubernetes services as environment variables. | `true`                                           |
 | `extraSecretMounts`                       | Additional grafana server secret mounts       | `[]`                                                    |
 | `extraVolumeMounts`                       | Additional grafana server volume mounts       | `[]`                                                    |
-| `extraConfigmapMounts`                    | Additional grafana server configMap volume mounts | `[]`                                                |
+| `createConfigmap`                         | Enable creating the grafana configmap         | `true`                                                  |
+| `extraConfigmapMounts`                    | Additional grafana server configMap volume mounts (values are templated) | `[]`                         |
 | `extraEmptyDirMounts`                     | Additional grafana server emptyDir volume mounts | `[]`                                                 |
 | `plugins`                                 | Plugins to be loaded along with Grafana       | `[]`                                                    |
 | `datasources`                             | Configure grafana datasources (passed through tpl) | `{}`                                               |
+| `alerting`                                | Configure grafana alerting (passed through tpl) | `{}`                                                  |
 | `notifiers`                               | Configure grafana notifiers                   | `{}`                                                    |
 | `dashboardProviders`                      | Configure grafana dashboard providers         | `{}`                                                    |
 | `dashboards`                              | Dashboards to import                          | `{}`                                                    |
@@ -136,12 +143,23 @@ This version requires Helm >= 3.1.0.
 | `podAnnotations`                          | Pod annotations                               | `{}`                                                    |
 | `podLabels`                               | Pod labels                                    | `{}`                                                    |
 | `podPortName`                             | Name of the grafana port on the pod           | `grafana`                                               |
+| `lifecycleHooks`                          | Lifecycle hooks for podStart and preStop [Example](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/#define-poststart-and-prestop-handlers)     | `{}`                                                    |
 | `sidecar.image.repository`                | Sidecar image repository                      | `quay.io/kiwigrid/k8s-sidecar`                          |
-| `sidecar.image.tag`                       | Sidecar image tag                             | `1.12.3`                                                |
+| `sidecar.image.tag`                       | Sidecar image tag                             | `1.19.2`                                                |
 | `sidecar.image.sha`                       | Sidecar image sha (optional)                  | `""`                                                    |
 | `sidecar.imagePullPolicy`                 | Sidecar image pull policy                     | `IfNotPresent`                                          |
 | `sidecar.resources`                       | Sidecar resources                             | `{}`                                                    |
-| `sidecar.enableUniqueFilenames`           | Sets the kiwigrid/k8s-sidecar UNIQUE_FILENAMES environment variable | `false`                           |
+| `sidecar.securityContext`                 | Sidecar securityContext                       | `{}`                                                    |
+| `sidecar.enableUniqueFilenames`           | Sets the kiwigrid/k8s-sidecar UNIQUE_FILENAMES environment variable. If set to `true` the sidecar will create unique filenames where duplicate data keys exist between ConfigMaps and/or Secrets within the same or multiple Namespaces. | `false`                           |
+| `sidecar.alerts.enabled`             | Enables the cluster wide search for alerts and adds/updates/deletes them in grafana |`false`       |
+| `sidecar.alerts.label`               | Label that config maps with alerts should have to be added | `grafana_alert`                               |
+| `sidecar.alerts.labelValue`          | Label value that config maps with alerts should have to be added | `""`                                |
+| `sidecar.alerts.searchNamespace`     | Namespaces list. If specified, the sidecar will search for alerts config-maps  inside these namespaces. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces. | `nil`                               |
+| `sidecar.alerts.watchMethod`         | Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds. | `WATCH` |
+| `sidecar.alerts.resource`            | Should the sidecar looks into secrets, configmaps or both. | `both`                               |
+| `sidecar.alerts.reloadURL`           | Full url of datasource configuration reload API endpoint, to invoke after a config-map change | `"http://localhost:3000/api/admin/provisioning/alerting/reload"` |
+| `sidecar.alerts.skipReload`          | Enabling this omits defining the REQ_URL and REQ_METHOD environment variables | `false` |
+| `sidecar.alerts.initDatasources`     | Set to true to deploy the datasource sidecar as an initContainer in addition to a container. This is needed if skipReload is true, to load any alerts defined at startup time. | `false` |
 | `sidecar.dashboards.enabled`              | Enables the cluster wide search for dashboards and adds/updates/deletes them in grafana | `false`       |
 | `sidecar.dashboards.SCProvider`           | Enables creation of sidecar provider          | `true`                                                  |
 | `sidecar.dashboards.provider.name`        | Unique name of the grafana provider           | `sidecarProvider`                                       |
@@ -154,30 +172,42 @@ This version requires Helm >= 3.1.0.
 | `sidecar.dashboards.watchMethod`          | Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds. | `WATCH` |
 | `sidecar.skipTlsVerify`                   | Set to true to skip tls verification for kube api calls | `nil`                                         |
 | `sidecar.dashboards.label`                | Label that config maps with dashboards should have to be added | `grafana_dashboard`                                |
-| `sidecar.dashboards.labelValue`                | Label value that config maps with dashboards should have to be added | `nil`                                |
+| `sidecar.dashboards.labelValue`                | Label value that config maps with dashboards should have to be added | `""`                                |
 | `sidecar.dashboards.folder`               | Folder in the pod that should hold the collected dashboards (unless `sidecar.dashboards.defaultFolderName` is set). This path will be mounted. | `/tmp/dashboards`    |
 | `sidecar.dashboards.folderAnnotation`     | The annotation the sidecar will look for in configmaps to override the destination folder for files | `nil`                                                  |
 | `sidecar.dashboards.defaultFolderName`    | The default folder name, it will create a subfolder under the `sidecar.dashboards.folder` and put dashboards in there instead | `nil`                                |
-| `sidecar.dashboards.searchNamespace`      | Namespaces list. If specified, the sidecar will search for dashboards config-maps  inside these namespaces.Otherwise the namespace in which the sidecar is running will be used.It's also possible to specify ALL to search in all namespaces. | `nil`                                |
+| `sidecar.dashboards.searchNamespace`      | Namespaces list. If specified, the sidecar will search for dashboards config-maps  inside these namespaces. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces. | `nil`                                |
+| `sidecar.dashboards.script`               | Absolute path to shell script to execute after a configmap got reloaded. | `nil`                                |
 | `sidecar.dashboards.resource`             | Should the sidecar looks into secrets, configmaps or both. | `both`                               |
+| `sidecar.dashboards.extraMounts`          | Additional dashboard sidecar volume mounts. | `[]`                               |
 | `sidecar.datasources.enabled`             | Enables the cluster wide search for datasources and adds/updates/deletes them in grafana |`false`       |
 | `sidecar.datasources.label`               | Label that config maps with datasources should have to be added | `grafana_datasource`                               |
-| `sidecar.datasources.labelValue`          | Label value that config maps with datasources should have to be added | `nil`                                |
-| `sidecar.datasources.searchNamespace`     | Namespaces list. If specified, the sidecar will search for datasources config-maps  inside these namespaces.Otherwise the namespace in which the sidecar is running will be used.It's also possible to specify ALL to search in all namespaces. | `nil`                               |
+| `sidecar.datasources.labelValue`          | Label value that config maps with datasources should have to be added | `""`                                |
+| `sidecar.datasources.searchNamespace`     | Namespaces list. If specified, the sidecar will search for datasources config-maps  inside these namespaces. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces. | `nil`                               |
+| `sidecar.datasources.watchMethod`         | Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds. | `WATCH` |
 | `sidecar.datasources.resource`            | Should the sidecar looks into secrets, configmaps or both. | `both`                               |
+| `sidecar.datasources.reloadURL`           | Full url of datasource configuration reload API endpoint, to invoke after a config-map change | `"http://localhost:3000/api/admin/provisioning/datasources/reload"` |
+| `sidecar.datasources.skipReload`          | Enabling this omits defining the REQ_URL and REQ_METHOD environment variables | `false` |
+| `sidecar.datasources.initDatasources`     | Set to true to deploy the datasource sidecar as an initContainer in addition to a container. This is needed if skipReload is true, to load any datasources defined at startup time. | `false` |
 | `sidecar.notifiers.enabled`               | Enables the cluster wide search for notifiers and adds/updates/deletes them in grafana | `false`        |
 | `sidecar.notifiers.label`                 | Label that config maps with notifiers should have to be added | `grafana_notifier`                               |
-| `sidecar.notifiers.searchNamespace`       | Namespaces list. If specified, the sidecar will search for notifiers config-maps (or secrets) inside these namespaces.Otherwise the namespace in which the sidecar is running will be used.It's also possible to specify ALL to search in all namespaces. | `nil`                               |
+| `sidecar.notifiers.labelValue`            | Label value that config maps with notifiers should have to be added | `""`                                |
+| `sidecar.notifiers.searchNamespace`       | Namespaces list. If specified, the sidecar will search for notifiers config-maps (or secrets) inside these namespaces. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces. | `nil`                               |
+| `sidecar.notifiers.watchMethod`           | Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds. | `WATCH` |
 | `sidecar.notifiers.resource`              | Should the sidecar looks into secrets, configmaps or both. | `both`                               |
+| `sidecar.notifiers.reloadURL`             | Full url of notifier configuration reload API endpoint, to invoke after a config-map change | `"http://localhost:3000/api/admin/provisioning/notifications/reload"` |
+| `sidecar.notifiers.skipReload`            | Enabling this omits defining the REQ_URL and REQ_METHOD environment variables | `false` |
+| `sidecar.notifiers.initNotifiers`         | Set to true to deploy the notifier sidecar as an initContainer in addition to a container. This is needed if skipReload is true, to load any notifiers defined at startup time. | `false` |
 | `smtp.existingSecret`                     | The name of an existing secret containing the SMTP credentials. | `""`                                  |
 | `smtp.userKey`                            | The key in the existing SMTP secret containing the username. | `"user"`                                 |
 | `smtp.passwordKey`                        | The key in the existing SMTP secret containing the password. | `"password"`                             |
-| `admin.existingSecret`                    | The name of an existing secret containing the admin credentials. | `""`                                 |
+| `admin.existingSecret`                    | The name of an existing secret containing the admin credentials (can be templated). | `""`                                 |
 | `admin.userKey`                           | The key in the existing admin secret containing the username. | `"admin-user"`                          |
 | `admin.passwordKey`                       | The key in the existing admin secret containing the password. | `"admin-password"`                      |
 | `serviceAccount.autoMount`                | Automount the service account token in the pod| `true`                                                  |
 | `serviceAccount.annotations`              | ServiceAccount annotations                    |                                                         |
 | `serviceAccount.create`                   | Create service account                        | `true`                                                  |
+| `serviceAccount.labels`                   | ServiceAccount labels                         | `{}`                                                    |
 | `serviceAccount.name`                     | Service account name to use, when empty will be set to created account if `serviceAccount.create` is set else to `default` | `` |
 | `serviceAccount.nameTest`                 | Service account name to use for test, when empty will be set to created account if `serviceAccount.create` is set else to `default` | `nil` |
 | `rbac.create`                             | Create and use RBAC resources                 | `true`                                                  |
@@ -222,14 +252,28 @@ This version requires Helm >= 3.1.0.
 | `imageRenderer.hostAliases`                | image-renderer deployment Host Aliases                                             | `[]`                             |
 | `imageRenderer.priorityClassName`          | image-renderer deployment priority class                                           | `''`                             |
 | `imageRenderer.service.enabled`            | Enable the image-renderer service                                                  | `true`                           |
-| `imageRenderer.service.portName`           | image-renderer service port name                                                   | `'http'`                         |
-| `imageRenderer.service.port`               | image-renderer service port used by both service and deployment                    | `8081`                           |
+| `imageRenderer.service.portName`           | image-renderer service port name                                                   | `http`                           |
+| `imageRenderer.service.port`               | image-renderer port used by deployment                                             | `8081`                           |
+| `imageRenderer.service.targetPort`         | image-renderer service port used by service                                        | `8081`                           |
+| `imageRenderer.appProtocol`                | Adds the appProtocol field to the service                                          | ``                               |
 | `imageRenderer.grafanaSubPath`             | Grafana sub path to use for image renderer callback url                            | `''`                             |
 | `imageRenderer.podPortName`                | name of the image-renderer port on the pod                                         | `http`                           |
 | `imageRenderer.revisionHistoryLimit`       | number of image-renderer replica sets to keep                                      | `10`                             |
-| `imageRenderer.networkPolicy.limitIngress` | Enable a NetworkPolicy to limit inbound traffic from only the created grafana pods  | `true`                           |
-| `imageRenderer.networkPolicy.limitEgress`  | Enable a NetworkPolicy to limit outbound traffic to only the created grafana pods   | `false`                          |
+| `imageRenderer.networkPolicy.limitIngress` | Enable a NetworkPolicy to limit inbound traffic from only the created grafana pods | `true`                           |
+| `imageRenderer.networkPolicy.limitEgress`  | Enable a NetworkPolicy to limit outbound traffic to only the created grafana pods  | `false`                          |
 | `imageRenderer.resources`                  | Set resource limits for image-renderer pdos                                        | `{}`                             |
+| `imageRenderer.nodeSelector`               | Node labels for pod assignment                | `{}`                                                    |
+| `imageRenderer.tolerations`                | Toleration labels for pod assignment          | `[]`                                                    |
+| `imageRenderer.affinity`                   | Affinity settings for pod assignment          | `{}`                                                    |
+| `networkPolicy.enabled`                    | Enable creation of NetworkPolicy resources.                                                                              | `false`             |
+| `networkPolicy.allowExternal`              | Don't require client label for connections                                                                               | `true`              |
+| `networkPolicy.explicitNamespacesSelector` | A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed                           | `{}`                |
+| `networkPolicy.ingress`                    | Enable the creation of an ingress network policy             | `true`    |
+| `networkPolicy.egress.enabled`             | Enable the creation of an egress network policy              | `false`   |
+| `networkPolicy.egress.ports`               | An array of ports to allow for the egress                    | `[]`    |
+| `enableKubeBackwardCompatibility`          | Enable backward compatibility of kubernetes where pod's defintion version below 1.13 doesn't have the enableServiceLinks option  | `false`     |
+
+
 
 ### Example ingress with path
 
@@ -250,7 +294,7 @@ ingress:
 ### Example of extraVolumeMounts
 
 Volume can be type persistentVolumeClaim or hostPath but not both at same time.
-If none existingClaim or hostPath argument is givent then type is emptyDir.
+If neither existingClaim or hostPath argument is given then type is emptyDir.
 
 ```yaml
 - extraVolumeMounts:
@@ -293,6 +337,14 @@ dashboards:
       gnetId: 2
       revision: 2
       datasource: Prometheus
+    loki-dashboard-quick-search:
+      gnetId: 12019
+      revision: 2
+      datasource:
+      - name: DS_PROMETHEUS
+        value: Prometheus
+      - name: DS_LOKI
+        value: Loki
     local-dashboard:
       url: https://raw.githubusercontent.com/user/repository/master/dashboards/dashboard.json
 ```
@@ -459,7 +511,7 @@ grafana.ini:
 
 ## How to securely reference secrets in grafana.ini
 
-This example uses Grafana uses [file providers](https://grafana.com/docs/grafana/latest/administration/configuration/#file-provider) for secret values and the `extraSecretMounts` configuration flag (Additional grafana server secret mounts) to mount the secrets.
+This example uses Grafana [file providers](https://grafana.com/docs/grafana/latest/administration/configuration/#file-provider) for secret values and the `extraSecretMounts` configuration flag (Additional grafana server secret mounts) to mount the secrets.
 
 In grafana.ini:
 
@@ -516,7 +568,7 @@ This example uses a CSI driver e.g. retrieving secrets using [Azure Key Vault Pr
 
 ## Image Renderer Plug-In
 
-This chart supports enabling [remote image rendering](https://github.com/grafana/grafana-image-renderer/blob/master/docs/remote_rendering_using_docker.md)
+This chart supports enabling [remote image rendering](https://github.com/grafana/grafana-image-renderer/blob/master/README.md#run-in-docker)
 
 ```yaml
 imageRenderer:
@@ -526,3 +578,23 @@ imageRenderer:
 ### Image Renderer NetworkPolicy
 
 By default the image-renderer pods will have a network policy which only allows ingress traffic from the created grafana instance
+
+### High Availability for unified alerting
+
+If you want to run Grafana in a high availability cluster you need to enable
+the headless service by setting `headlessService: true` in your `values.yaml`
+file.
+
+As next step you have to setup the `grafana.ini` in your `values.yaml` in a way
+that it will make use of the headless service to obtain all the IPs of the
+cluster. You should replace ``{{ Name }}`` with the name of your helm deployment.
+
+```yaml
+grafana.ini:
+  ...
+  unified_alerting:
+    enabled: true
+    ha_peers: {{ Name }}-headless:9094
+  alerting:
+    enabled: false
+```

--- a/helmfile/upstream/grafana/ci/with-affinity-values.yaml
+++ b/helmfile/upstream/grafana/ci/with-affinity-values.yaml
@@ -1,0 +1,16 @@
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: grafana-test
+              app.kubernetes.io/name: grafana
+          topologyKey: failure-domain.beta.kubernetes.io/zone
+        weight: 100
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: grafana-test
+            app.kubernetes.io/name: grafana
+        topologyKey: kubernetes.io/hostname

--- a/helmfile/upstream/grafana/ci/with-extraconfigmapmounts-values.yaml
+++ b/helmfile/upstream/grafana/ci/with-extraconfigmapmounts-values.yaml
@@ -1,0 +1,7 @@
+extraConfigmapMounts:
+  - name: '{{ template "grafana.fullname" . }}'
+    configMap: '{{ template "grafana.fullname" . }}'
+    mountPath: /var/lib/grafana/dashboards/test-dashboard.json
+    # This is not a realistic test, but for this we only care about extraConfigmapMounts not being empty and pointing to an existing ConfigMap
+    subPath: grafana.ini
+    readOnly: true

--- a/helmfile/upstream/grafana/ci/with-persistence.yaml
+++ b/helmfile/upstream/grafana/ci/with-persistence.yaml
@@ -1,0 +1,3 @@
+persistence:
+  type: pvc
+  enabled: true

--- a/helmfile/upstream/grafana/templates/_helpers.tpl
+++ b/helmfile/upstream/grafana/templates/_helpers.tpl
@@ -142,6 +142,17 @@ Return the appropriate apiVersion for ingress.
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for podDisruptionBudget.
+*/}}
+{{- define "grafana.podDisruptionBudget.apiVersion" -}}
+  {{- if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+    {{- print "policy/v1" -}}
+  {{- else -}}
+    {{- print "policy/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Return if ingress is stable.
 */}}
 {{- define "grafana.ingress.isStable" -}}

--- a/helmfile/upstream/grafana/templates/_pod.tpl
+++ b/helmfile/upstream/grafana/templates/_pod.tpl
@@ -1,22 +1,21 @@
-
 {{- define "grafana.pod" -}}
 {{- if .Values.schedulerName }}
 schedulerName: "{{ .Values.schedulerName }}"
 {{- end }}
 serviceAccountName: {{ template "grafana.serviceAccountName" . }}
 automountServiceAccountToken: {{ .Values.serviceAccount.autoMount }}
-{{- if .Values.securityContext }}
+{{- with .Values.securityContext }}
 securityContext:
-{{ toYaml .Values.securityContext | indent 2 }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- if .Values.hostAliases }}
+{{- with .Values.hostAliases }}
 hostAliases:
-{{ toYaml .Values.hostAliases | indent 2 }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- if .Values.priorityClassName }}
 priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
-{{- if ( or .Values.persistence.enabled .Values.dashboards .Values.sidecar.datasources.enabled .Values.sidecar.notifiers.enabled .Values.extraInitContainers) }}
+{{- if ( or .Values.persistence.enabled .Values.dashboards .Values.extraInitContainers (and .Values.sidecar.datasources.enabled .Values.sidecar.datasources.initDatasources) (and .Values.sidecar.notifiers.enabled .Values.sidecar.notifiers.initNotifiers)) }}
 initContainers:
 {{- end }}
 {{- if ( and .Values.persistence.enabled .Values.initChownData.enabled ) }}
@@ -27,17 +26,20 @@ initContainers:
     image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}"
     {{- end }}
     imagePullPolicy: {{ .Values.initChownData.image.pullPolicy }}
+    {{- with .Values.initChownData.securityContext }}
     securityContext:
-      runAsNonRoot: false
-      runAsUser: 0
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }}", "/var/lib/grafana"]
+    {{- with .Values.initChownData.resources }}
     resources:
-{{ toYaml .Values.initChownData.resources | indent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     volumeMounts:
       - name: storage
         mountPath: "/var/lib/grafana"
 {{- if .Values.persistence.subPath }}
-        subPath: {{ .Values.persistence.subPath }}
+        subPath: {{ tpl .Values.persistence.subPath . }}
 {{- end }}
 {{- end }}
 {{- if .Values.dashboards }}
@@ -50,13 +52,19 @@ initContainers:
     imagePullPolicy: {{ .Values.downloadDashboardsImage.pullPolicy }}
     command: ["/bin/sh"]
     args: [ "-c", "mkdir -p /var/lib/grafana/dashboards/default && /bin/sh -x /etc/grafana/download_dashboards.sh" ]
+    {{- with .Values.downloadDashboards.resources }}
     resources:
-{{ toYaml .Values.downloadDashboards.resources | indent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     env:
 {{- range $key, $value := .Values.downloadDashboards.env }}
       - name: "{{ $key }}"
         value: "{{ $value }}"
 {{- end }}
+    {{- with .Values.downloadDashboards.securityContext }}
+    securityContext:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- if .Values.downloadDashboards.envFromSecret }}
     envFrom:
       - secretRef:
@@ -69,7 +77,7 @@ initContainers:
       - name: storage
         mountPath: "/var/lib/grafana"
 {{- if .Values.persistence.subPath }}
-        subPath: {{ .Values.persistence.subPath }}
+        subPath: {{ tpl .Values.persistence.subPath . }}
 {{- end }}
     {{- range .Values.extraSecretMounts }}
       - name: {{ .name }}
@@ -77,8 +85,8 @@ initContainers:
         readOnly: {{ .readOnly }}
     {{- end }}
 {{- end }}
-{{- if .Values.sidecar.datasources.enabled }}
-  - name: {{ template "grafana.name" . }}-sc-datasources
+{{- if and .Values.sidecar.datasources.enabled .Values.sidecar.datasources.initDatasources }}
+  - name: {{ template "grafana.name" . }}-init-sc-datasources
     {{- if .Values.sidecar.image.sha }}
     image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -86,13 +94,25 @@ initContainers:
     {{- end }}
     imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
     env:
+      {{- range $key, $value := .Values.sidecar.datasources.env }}
+      - name: "{{ $key }}"
+        value: "{{ $value }}"
+      {{- end }}
+      {{- if .Values.sidecar.datasources.ignoreAlreadyProcessed }}
+      - name: IGNORE_ALREADY_PROCESSED
+        value: "true"
+      {{- end }}
       - name: METHOD
-        value: LIST
+        value: "LIST"
       - name: LABEL
         value: "{{ .Values.sidecar.datasources.label }}"
       {{- if .Values.sidecar.datasources.labelValue }}
       - name: LABEL_VALUE
         value: {{ quote .Values.sidecar.datasources.labelValue }}
+      {{- end }}
+      {{- if or .Values.sidecar.logLevel .Values.sidecar.datasources.logLevel }}
+      - name: LOG_LEVEL
+        value: {{ default .Values.sidecar.logLevel .Values.sidecar.datasources.logLevel }}
       {{- end }}
       - name: FOLDER
         value: "/etc/grafana/provisioning/datasources"
@@ -104,14 +124,395 @@ initContainers:
       {{- end }}
       {{- if .Values.sidecar.datasources.searchNamespace }}
       - name: NAMESPACE
-        value: "{{ .Values.sidecar.datasources.searchNamespace | join "," }}"
+        value: "{{ tpl (.Values.sidecar.datasources.searchNamespace | join ",") . }}"
       {{- end }}
       {{- if .Values.sidecar.skipTlsVerify }}
       - name: SKIP_TLS_VERIFY
         value: "{{ .Values.sidecar.skipTlsVerify }}"
       {{- end }}
+    {{- with .Values.sidecar.resources }}
     resources:
-{{ toYaml .Values.sidecar.resources | indent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.securityContext }}
+    securityContext:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    volumeMounts:
+      - name: sc-datasources-volume
+        mountPath: "/etc/grafana/provisioning/datasources"
+{{- end }}
+{{- if and .Values.sidecar.notifiers.enabled .Values.sidecar.notifiers.initNotifiers }}
+  - name: {{ template "grafana.name" . }}-init-sc-notifiers
+    {{- if .Values.sidecar.image.sha }}
+    image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
+    {{- else }}
+    image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
+    {{- end }}
+    imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    env:
+      {{- range $key, $value := .Values.sidecar.notifiers.env }}
+      - name: "{{ $key }}"
+        value: "{{ $value }}"
+      {{- end }}
+      {{- if .Values.sidecar.notifiers.ignoreAlreadyProcessed }}
+      - name: IGNORE_ALREADY_PROCESSED
+        value: "true"
+      {{- end }}
+      - name: METHOD
+        value: LIST
+      - name: LABEL
+        value: "{{ .Values.sidecar.notifiers.label }}"
+      {{- if .Values.sidecar.notifiers.labelValue }}
+      - name: LABEL_VALUE
+        value: {{ quote .Values.sidecar.notifiers.labelValue }}
+      {{- end }}
+      {{- if or .Values.sidecar.logLevel .Values.sidecar.notifiers.logLevel }}
+      - name: LOG_LEVEL
+        value: {{ default .Values.sidecar.logLevel .Values.sidecar.notifiers.logLevel }}
+      {{- end }}
+      - name: FOLDER
+        value: "/etc/grafana/provisioning/notifiers"
+      - name: RESOURCE
+        value: {{ quote .Values.sidecar.notifiers.resource }}
+      {{- if .Values.sidecar.enableUniqueFilenames }}
+      - name: UNIQUE_FILENAMES
+        value: "{{ .Values.sidecar.enableUniqueFilenames }}"
+      {{- end }}
+      {{- if .Values.sidecar.notifiers.searchNamespace }}
+      - name: NAMESPACE
+        value: "{{ tpl (.Values.sidecar.notifiers.searchNamespace | join ",") . }}"
+      {{- end }}
+      {{- if .Values.sidecar.skipTlsVerify }}
+      - name: SKIP_TLS_VERIFY
+        value: "{{ .Values.sidecar.skipTlsVerify }}"
+      {{- end }}
+    {{- with .Values.sidecar.livenessProbe }}
+    livenessProbe:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.readinessProbe }}
+    readinessProbe:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.securityContext }}
+    securityContext:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    volumeMounts:
+      - name: sc-notifiers-volume
+        mountPath: "/etc/grafana/provisioning/notifiers"
+{{- end}}
+{{- if .Values.extraInitContainers }}
+{{ tpl (toYaml .Values.extraInitContainers) . | indent 2 }}
+{{- end }}
+{{- if .Values.image.pullSecrets }}
+imagePullSecrets:
+{{- $root := . }}
+{{- range .Values.image.pullSecrets }}
+  - name: {{ tpl . $root }}
+{{- end}}
+{{- end }}
+{{- if not .Values.enableKubeBackwardCompatibility }}
+enableServiceLinks: {{ .Values.enableServiceLinks }}
+{{- end }}
+containers:
+{{- if .Values.sidecar.alerts.enabled }}
+  - name: {{ template "grafana.name" . }}-sc-alerts
+    {{- if .Values.sidecar.image.sha }}
+    image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
+    {{- else }}
+    image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
+    {{- end }}
+    imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    env:
+      {{- range $key, $value := .Values.sidecar.alerts.env }}
+      - name: "{{ $key }}"
+        value: "{{ $value }}"
+      {{- end }}
+      {{- if .Values.sidecar.alerts.ignoreAlreadyProcessed }}
+      - name: IGNORE_ALREADY_PROCESSED
+        value: "true"
+      {{- end }}
+      - name: METHOD
+        value: {{ .Values.sidecar.alerts.watchMethod }}
+      - name: LABEL
+        value: "{{ .Values.sidecar.alerts.label }}"
+      {{- with .Values.sidecar.alerts.labelValue }}
+      - name: LABEL_VALUE
+        value: {{ quote . }}
+      {{- end }}
+      {{- if or .Values.sidecar.logLevel .Values.sidecar.alerts.logLevel }}
+      - name: LOG_LEVEL
+        value: {{ default .Values.sidecar.logLevel .Values.sidecar.alerts.logLevel }}
+      {{- end }}
+      - name: FOLDER
+        value: "/etc/grafana/provisioning/alerting"
+      - name: RESOURCE
+        value: {{ quote .Values.sidecar.alerts.resource }}
+      {{- if .Values.sidecar.enableUniqueFilenames }}
+      - name: UNIQUE_FILENAMES
+        value: "{{ .Values.sidecar.enableUniqueFilenames }}"
+      {{- end }}
+            {{- with .Values.sidecar.alerts.searchNamespace }}
+      - name: NAMESPACE
+        value: {{ . | join "," | quote }}
+      {{- end }}
+      {{- with .Values.sidecar.alerts.skipTlsVerify }}
+      - name: SKIP_TLS_VERIFY
+        value: {{ quote . }}
+      {{- end }}
+      {{- with .Values.sidecar.alerts.script }}
+      - name: SCRIPT
+        value: {{ quote . }}
+      {{- end }}
+      {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      - name: REQ_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
+            key: {{ .Values.admin.userKey | default "admin-user" }}
+      {{- end }}
+      {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      - name: REQ_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
+            key: {{ .Values.admin.passwordKey | default "admin-password" }}
+      {{- end }}
+      {{- if not .Values.sidecar.alerts.skipReload }}
+      - name: REQ_URL
+        value: {{ .Values.sidecar.alerts.reloadURL }}
+      - name: REQ_METHOD
+        value: POST
+      {{- end }}
+      {{- if .Values.sidecar.alerts.watchServerTimeout }}
+      {{- if ne .Values.sidecar.alerts.watchMethod "WATCH" }}
+        {{- fail (printf "Cannot use .Values.sidecar.alerts.watchServerTimeout with .Values.sidecar.alerts.watchMethod %s" .Values.sidecar.alerts.watchMethod) }}
+      {{- end }}
+      - name: WATCH_SERVER_TIMEOUT
+        value: "{{ .Values.sidecar.alerts.watchServerTimeout }}"
+      {{- end }}
+      {{- if .Values.sidecar.alerts.watchClientTimeout }}
+      {{- if ne .Values.sidecar.alerts.watchMethod "WATCH" }}
+        {{- fail (printf "Cannot use .Values.sidecar.alerts.watchClientTimeout with .Values.sidecar.alerts.watchMethod %s" .Values.sidecar.alerts.watchMethod) }}
+      {{- end }}
+      - name: WATCH_CLIENT_TIMEOUT
+        value: "{{ .Values.sidecar.alerts.watchClientTimeout }}"
+      {{- end }}
+    {{- with .Values.sidecar.livenessProbe }}
+    livenessProbe:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.readinessProbe }}
+    readinessProbe:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.securityContext }}
+    securityContext:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    volumeMounts:
+      - name: sc-alerts-volume
+        mountPath: "/etc/grafana/provisioning/alerting"
+{{- end}}
+{{- if .Values.sidecar.dashboards.enabled }}
+  - name: {{ template "grafana.name" . }}-sc-dashboard
+    {{- if .Values.sidecar.image.sha }}
+    image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
+    {{- else }}
+    image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
+    {{- end }}
+    imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    env:
+      {{- range $key, $value := .Values.sidecar.dashboards.env }}
+      - name: "{{ $key }}"
+        value: "{{ $value }}"
+      {{- end }}
+      {{- if .Values.sidecar.dashboards.ignoreAlreadyProcessed }}
+      - name: IGNORE_ALREADY_PROCESSED
+        value: "true"
+      {{- end }}
+      - name: METHOD
+        value: {{ .Values.sidecar.dashboards.watchMethod }}
+      - name: LABEL
+        value: "{{ .Values.sidecar.dashboards.label }}"
+      {{- if .Values.sidecar.dashboards.labelValue }}
+      - name: LABEL_VALUE
+        value: {{ quote .Values.sidecar.dashboards.labelValue }}
+      {{- end }}
+      {{- if or .Values.sidecar.logLevel .Values.sidecar.dashboards.logLevel }}
+      - name: LOG_LEVEL
+        value: {{ default .Values.sidecar.logLevel .Values.sidecar.dashboards.logLevel }}
+      {{- end }}
+      - name: FOLDER
+        value: "{{ .Values.sidecar.dashboards.folder }}{{- with .Values.sidecar.dashboards.defaultFolderName }}/{{ . }}{{- end }}"
+      - name: RESOURCE
+        value: {{ quote .Values.sidecar.dashboards.resource }}
+      {{- if .Values.sidecar.enableUniqueFilenames }}
+      - name: UNIQUE_FILENAMES
+        value: "{{ .Values.sidecar.enableUniqueFilenames }}"
+      {{- end }}
+      {{- if .Values.sidecar.dashboards.searchNamespace }}
+      - name: NAMESPACE
+        value: "{{ tpl (.Values.sidecar.dashboards.searchNamespace | join ",") . }}"
+      {{- end }}
+      {{- if .Values.sidecar.skipTlsVerify }}
+      - name: SKIP_TLS_VERIFY
+        value: "{{ .Values.sidecar.skipTlsVerify }}"
+      {{- end }}
+      {{- if .Values.sidecar.dashboards.folderAnnotation }}
+      - name: FOLDER_ANNOTATION
+        value: "{{ .Values.sidecar.dashboards.folderAnnotation }}"
+      {{- end }}
+      {{- if .Values.sidecar.dashboards.script }}
+      - name: SCRIPT
+        value: "{{ .Values.sidecar.dashboards.script }}"
+      {{- end }}
+      {{- if .Values.sidecar.dashboards.watchServerTimeout }}
+      {{- if ne .Values.sidecar.dashboards.watchMethod "WATCH" }}
+        {{- fail (printf "Cannot use .Values.sidecar.dashboards.watchServerTimeout with .Values.sidecar.dashboards.watchMethod %s" .Values.sidecar.dashboards.watchMethod) }}
+      {{- end }}
+      - name: WATCH_SERVER_TIMEOUT
+        value: "{{ .Values.sidecar.dashboards.watchServerTimeout }}"
+      {{- end }}
+      {{- if .Values.sidecar.dashboards.watchClientTimeout }}
+      {{- if ne .Values.sidecar.dashboards.watchMethod "WATCH" }}
+        {{- fail (printf "Cannot use .Values.sidecar.dashboards.watchClientTimeout with .Values.sidecar.dashboards.watchMethod %s" .Values.sidecar.dashboards.watchMethod) }}
+      {{- end }}
+      - name: WATCH_CLIENT_TIMEOUT
+        value: "{{ .Values.sidecar.dashboards.watchClientTimeout }}"
+      {{- end }}
+    {{- with .Values.sidecar.livenessProbe }}
+    livenessProbe:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.readinessProbe }}
+    readinessProbe:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.securityContext }}
+    securityContext:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    volumeMounts:
+      - name: sc-dashboard-volume
+        mountPath: {{ .Values.sidecar.dashboards.folder | quote }}
+      {{- if .Values.sidecar.dashboards.extraMounts }}
+      {{- toYaml .Values.sidecar.dashboards.extraMounts | trim | nindent 6}}
+      {{- end }}
+{{- end}}
+{{- if .Values.sidecar.datasources.enabled }}
+  - name: {{ template "grafana.name" . }}-sc-datasources
+    {{- if .Values.sidecar.image.sha }}
+    image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
+    {{- else }}
+    image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}"
+    {{- end }}
+    imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+    env:
+      {{- range $key, $value := .Values.sidecar.datasources.env }}
+      - name: "{{ $key }}"
+        value: "{{ $value }}"
+      {{- end }}
+      {{- if .Values.sidecar.datasources.ignoreAlreadyProcessed }}
+      - name: IGNORE_ALREADY_PROCESSED
+        value: "true"
+      {{- end }}
+      - name: METHOD
+        value: {{ .Values.sidecar.datasources.watchMethod }}
+      - name: LABEL
+        value: "{{ .Values.sidecar.datasources.label }}"
+      {{- if .Values.sidecar.datasources.labelValue }}
+      - name: LABEL_VALUE
+        value: {{ quote .Values.sidecar.datasources.labelValue }}
+      {{- end }}
+      {{- if or .Values.sidecar.logLevel .Values.sidecar.datasources.logLevel }}
+      - name: LOG_LEVEL
+        value: {{ default .Values.sidecar.logLevel .Values.sidecar.datasources.logLevel }}
+      {{- end }}
+      - name: FOLDER
+        value: "/etc/grafana/provisioning/datasources"
+      - name: RESOURCE
+        value: {{ quote .Values.sidecar.datasources.resource }}
+      {{- if .Values.sidecar.enableUniqueFilenames }}
+      - name: UNIQUE_FILENAMES
+        value: "{{ .Values.sidecar.enableUniqueFilenames }}"
+      {{- end }}
+      {{- if .Values.sidecar.datasources.searchNamespace }}
+      - name: NAMESPACE
+        value: "{{ tpl (.Values.sidecar.datasources.searchNamespace | join ",") . }}"
+      {{- end }}
+      {{- if .Values.sidecar.skipTlsVerify }}
+      - name: SKIP_TLS_VERIFY
+        value: "{{ .Values.sidecar.skipTlsVerify }}"
+      {{- end }}
+      {{- if .Values.sidecar.datasources.script }}
+      - name: SCRIPT
+        value: "{{ .Values.sidecar.datasources.script }}"
+      {{- end }}
+      {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      - name: REQ_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
+            key: {{ .Values.admin.userKey | default "admin-user" }}
+      {{- end }}
+      {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      - name: REQ_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
+            key: {{ .Values.admin.passwordKey | default "admin-password" }}
+      {{- end }}
+      {{- if not .Values.sidecar.datasources.skipReload }}
+      - name: REQ_URL
+        value: {{ .Values.sidecar.datasources.reloadURL }}
+      - name: REQ_METHOD
+        value: POST
+      {{- end }}
+      {{- if .Values.sidecar.datasources.watchServerTimeout }}
+      {{- if ne .Values.sidecar.datasources.watchMethod "WATCH" }}
+        {{- fail (printf "Cannot use .Values.sidecar.datasources.watchServerTimeout with .Values.sidecar.datasources.watchMethod %s" .Values.sidecar.datasources.watchMethod) }}
+      {{- end }}
+      - name: WATCH_SERVER_TIMEOUT
+        value: "{{ .Values.sidecar.datasources.watchServerTimeout }}"
+      {{- end }}
+      {{- if .Values.sidecar.datasources.watchClientTimeout }}
+      {{- if ne .Values.sidecar.datasources.watchMethod "WATCH" }}
+        {{- fail (printf "Cannot use .Values.sidecar.datasources.watchClientTimeout with .Values.sidecar.datasources.watchMethod %s" .Values.sidecar.datasources.watchMethod) }}
+      {{- end }}
+      - name: WATCH_CLIENT_TIMEOUT
+        value: "{{ .Values.sidecar.datasources.watchClientTimeout }}"
+      {{- end }}
+    {{- with .Values.sidecar.livenessProbe }}
+    livenessProbe:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.readinessProbe }}
+    readinessProbe:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.securityContext }}
+    securityContext:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     volumeMounts:
       - name: sc-datasources-volume
         mountPath: "/etc/grafana/provisioning/datasources"
@@ -125,10 +526,26 @@ initContainers:
     {{- end }}
     imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
     env:
+      {{- range $key, $value := .Values.sidecar.notifiers.env }}
+      - name: "{{ $key }}"
+        value: "{{ $value }}"
+      {{- end }}
+      {{- if .Values.sidecar.notifiers.ignoreAlreadyProcessed }}
+      - name: IGNORE_ALREADY_PROCESSED
+        value: "true"
+      {{- end }}
       - name: METHOD
-        value: LIST
+        value: {{ .Values.sidecar.notifiers.watchMethod }}
       - name: LABEL
         value: "{{ .Values.sidecar.notifiers.label }}"
+      {{- if .Values.sidecar.notifiers.labelValue }}
+      - name: LABEL_VALUE
+        value: {{ quote .Values.sidecar.notifiers.labelValue }}
+      {{- end }}
+      {{- if or .Values.sidecar.logLevel .Values.sidecar.notifiers.logLevel }}
+      - name: LOG_LEVEL
+        value: {{ default .Values.sidecar.logLevel .Values.sidecar.notifiers.logLevel }}
+      {{- end }}
       - name: FOLDER
         value: "/etc/grafana/provisioning/notifiers"
       - name: RESOURCE
@@ -139,31 +556,72 @@ initContainers:
       {{- end }}
       {{- if .Values.sidecar.notifiers.searchNamespace }}
       - name: NAMESPACE
-        value: "{{ .Values.sidecar.notifiers.searchNamespace | join "," }}"
+        value: "{{ tpl (.Values.sidecar.notifiers.searchNamespace | join ",") . }}"
       {{- end }}
       {{- if .Values.sidecar.skipTlsVerify }}
       - name: SKIP_TLS_VERIFY
         value: "{{ .Values.sidecar.skipTlsVerify }}"
       {{- end }}
+      {{- if .Values.sidecar.notifiers.script }}
+      - name: SCRIPT
+        value: "{{ .Values.sidecar.notifiers.script }}"
+      {{- end }}
+      {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      - name: REQ_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
+            key: {{ .Values.admin.userKey | default "admin-user" }}
+      {{- end }}
+      {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      - name: REQ_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
+            key: {{ .Values.admin.passwordKey | default "admin-password" }}
+      {{- end }}
+      {{- if not .Values.sidecar.notifiers.skipReload }}
+      - name: REQ_URL
+        value: {{ .Values.sidecar.notifiers.reloadURL }}
+      - name: REQ_METHOD
+        value: POST
+      {{- end }}
+      {{- if .Values.sidecar.notifiers.watchServerTimeout }}
+      {{- if ne .Values.sidecar.notifiers.watchMethod "WATCH" }}
+        {{- fail (printf "Cannot use .Values.sidecar.notifiers.watchServerTimeout with .Values.sidecar.notifiers.watchMethod %s" .Values.sidecar.notifiers.watchMethod) }}
+      {{- end }}
+      - name: WATCH_SERVER_TIMEOUT
+        value: "{{ .Values.sidecar.notifiers.watchServerTimeout }}"
+      {{- end }}
+      {{- if .Values.sidecar.notifiers.watchClientTimeout }}
+      {{- if ne .Values.sidecar.notifiers.watchMethod "WATCH" }}
+        {{- fail (printf "Cannot use .Values.sidecar.notifiers.watchClientTimeout with .Values.sidecar.notifiers.watchMethod %s" .Values.sidecar.notifiers.watchMethod) }}
+      {{- end }}
+      - name: WATCH_CLIENT_TIMEOUT
+        value: "{{ .Values.sidecar.notifiers.watchClientTimeout }}"
+      {{- end }}
+    {{- with .Values.sidecar.livenessProbe }}
+    livenessProbe:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.readinessProbe }}
+    readinessProbe:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.resources }}
     resources:
-{{ toYaml .Values.sidecar.resources | indent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.securityContext }}
+    securityContext:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     volumeMounts:
       - name: sc-notifiers-volume
         mountPath: "/etc/grafana/provisioning/notifiers"
 {{- end}}
-{{- if .Values.extraInitContainers }}
-{{ toYaml .Values.extraInitContainers | indent 2 }}
-{{- end }}
-{{- if .Values.image.pullSecrets }}
-imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-  - name: {{ . }}
-{{- end}}
-{{- end }}
-enableServiceLinks: {{ .Values.enableServiceLinks }}
-containers:
-{{- if .Values.sidecar.dashboards.enabled }}
-  - name: {{ template "grafana.name" . }}-sc-dashboard
+{{- if .Values.sidecar.plugins.enabled }}
+  - name: {{ template "grafana.name" . }}-sc-plugins
     {{- if .Values.sidecar.image.sha }}
     image: "{{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}@sha256:{{ .Values.sidecar.image.sha }}"
     {{- else }}
@@ -171,57 +629,117 @@ containers:
     {{- end }}
     imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
     env:
+      {{- range $key, $value := .Values.sidecar.plugins.env }}
+      - name: "{{ $key }}"
+        value: "{{ $value }}"
+      {{- end }}
+      {{- if .Values.sidecar.plugins.ignoreAlreadyProcessed }}
+      - name: IGNORE_ALREADY_PROCESSED
+        value: "true"
+      {{- end }}
       - name: METHOD
-        value: {{ .Values.sidecar.dashboards.watchMethod }}
+        value: {{ .Values.sidecar.plugins.watchMethod }}
       - name: LABEL
-        value: "{{ .Values.sidecar.dashboards.label }}"
-      {{- if .Values.sidecar.dashboards.labelValue }}
+        value: "{{ .Values.sidecar.plugins.label }}"
+      {{- if .Values.sidecar.plugins.labelValue }}
       - name: LABEL_VALUE
-        value: {{ quote .Values.sidecar.dashboards.labelValue }}
+        value: {{ quote .Values.sidecar.plugins.labelValue }}
+      {{- end }}
+      {{- if or .Values.sidecar.logLevel .Values.sidecar.plugins.logLevel }}
+      - name: LOG_LEVEL
+        value: {{ default .Values.sidecar.logLevel .Values.sidecar.plugins.logLevel }}
       {{- end }}
       - name: FOLDER
-        value: "{{ .Values.sidecar.dashboards.folder }}{{- with .Values.sidecar.dashboards.defaultFolderName }}/{{ . }}{{- end }}"
+        value: "/etc/grafana/provisioning/plugins"
       - name: RESOURCE
-        value: {{ quote .Values.sidecar.dashboards.resource }}
+        value: {{ quote .Values.sidecar.plugins.resource }}
       {{- if .Values.sidecar.enableUniqueFilenames }}
       - name: UNIQUE_FILENAMES
         value: "{{ .Values.sidecar.enableUniqueFilenames }}"
       {{- end }}
-      {{- if .Values.sidecar.dashboards.searchNamespace }}
+      {{- if .Values.sidecar.plugins.searchNamespace }}
       - name: NAMESPACE
-        value: "{{ .Values.sidecar.dashboards.searchNamespace | join "," }}"
+        value: "{{ tpl (.Values.sidecar.plugins.searchNamespace | join ",") . }}"
+      {{- end }}
+      {{- if .Values.sidecar.plugins.script }}
+      - name: SCRIPT
+        value: "{{ .Values.sidecar.plugins.script }}"
       {{- end }}
       {{- if .Values.sidecar.skipTlsVerify }}
       - name: SKIP_TLS_VERIFY
         value: "{{ .Values.sidecar.skipTlsVerify }}"
       {{- end }}
-      {{- if .Values.sidecar.dashboards.folderAnnotation }}
-      - name: FOLDER_ANNOTATION
-        value: "{{ .Values.sidecar.dashboards.folderAnnotation }}"
+      {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      - name: REQ_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
+            key: {{ .Values.admin.userKey | default "admin-user" }}
       {{- end }}
+      {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      - name: REQ_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
+            key: {{ .Values.admin.passwordKey | default "admin-password" }}
+      {{- end }}
+      {{- if not .Values.sidecar.plugins.skipReload }}
+      - name: REQ_URL
+        value: {{ .Values.sidecar.plugins.reloadURL }}
+      - name: REQ_METHOD
+        value: POST
+      {{- end }}
+      {{- if .Values.sidecar.plugins.watchServerTimeout }}
+      {{- if ne .Values.sidecar.plugins.watchMethod "WATCH" }}
+        {{- fail (printf "Cannot use .Values.sidecar.plugins.watchServerTimeout with .Values.sidecar.plugins.watchMethod %s" .Values.sidecar.plugins.watchMethod) }}
+      {{- end }}
+      - name: WATCH_SERVER_TIMEOUT
+        value: "{{ .Values.sidecar.plugins.watchServerTimeout }}"
+      {{- end }}
+      {{- if .Values.sidecar.plugins.watchClientTimeout }}
+      {{- if ne .Values.sidecar.plugins.watchMethod "WATCH" }}
+        {{- fail (printf "Cannot use .Values.sidecar.plugins.watchClientTimeout with .Values.sidecar.plugins.watchMethod %s" .Values.sidecar.plugins.watchMethod) }}
+      {{- end }}
+      - name: WATCH_CLIENT_TIMEOUT
+        value: "{{ .Values.sidecar.plugins.watchClientTimeout }}"
+      {{- end }}
+    {{- with .Values.sidecar.livenessProbe }}
+    livenessProbe:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.readinessProbe }}
+    readinessProbe:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.resources }}
     resources:
-{{ toYaml .Values.sidecar.resources | indent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.sidecar.securityContext }}
+    securityContext:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     volumeMounts:
-      - name: sc-dashboard-volume
-        mountPath: {{ .Values.sidecar.dashboards.folder | quote }}
+      - name: sc-plugins-volume
+        mountPath: "/etc/grafana/provisioning/plugins"
 {{- end}}
   - name: {{ .Chart.Name }}
     {{- if .Values.image.sha }}
-    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}@sha256:{{ .Values.image.sha }}"
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}@sha256:{{ .Values.image.sha }}"
     {{- else }}
-    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
     {{- end }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
   {{- if .Values.command }}
     command:
     {{- range .Values.command }}
-      - {{ . }}
+      - {{ . | quote }}
     {{- end }}
   {{- end}}
-{{- if .Values.containerSecurityContext }}
+    {{- with .Values.containerSecurityContext }}
     securityContext:
-{{- toYaml .Values.containerSecurityContext | nindent 6 }}
-{{- end }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     volumeMounts:
       - name: config
         mountPath: "/etc/grafana/grafana.ini"
@@ -231,16 +749,17 @@ containers:
         mountPath: "/etc/grafana/ldap.toml"
         subPath: ldap.toml
       {{- end }}
+      {{- $root := . }}
       {{- range .Values.extraConfigmapMounts }}
-      - name: {{ .name }}
-        mountPath: {{ .mountPath }}
-        subPath: {{ .subPath | default "" }}
+      - name: {{ tpl .name $root }}
+        mountPath: {{ tpl .mountPath $root }}
+        subPath: {{ (tpl .subPath $root) | default "" }}
         readOnly: {{ .readOnly }}
       {{- end }}
       - name: storage
         mountPath: "/var/lib/grafana"
 {{- if .Values.persistence.subPath }}
-        subPath: {{ .Values.persistence.subPath }}
+        subPath: {{ tpl .Values.persistence.subPath . }}
 {{- end }}
 {{- if .Values.dashboards }}
 {{- range $provider, $dashboards := .Values.dashboards }}
@@ -273,6 +792,13 @@ containers:
         subPath: {{ . | quote }}
 {{- end }}
 {{- end }}
+{{- if .Values.alerting }}
+{{- range (keys .Values.alerting | sortAlpha) }}
+      - name: config
+        mountPath: "/etc/grafana/provisioning/alerting/{{ . }}"
+        subPath: {{ . | quote }}
+{{- end }}
+{{- end }}
 {{- if .Values.dashboardProviders }}
 {{- range (keys .Values.dashboardProviders | sortAlpha) }}
       - name: config
@@ -280,6 +806,10 @@ containers:
         subPath: {{ . | quote }}
 {{- end }}
 {{- end }}
+{{- with .Values.sidecar.alerts.enabled }}
+      - name: sc-alerts-volume
+        mountPath: "/etc/grafana/provisioning/alerting"
+{{- end}}
 {{- if .Values.sidecar.dashboards.enabled }}
       - name: sc-dashboard-volume
         mountPath: {{ .Values.sidecar.dashboards.folder | quote }}
@@ -292,6 +822,10 @@ containers:
 {{- if .Values.sidecar.datasources.enabled }}
       - name: sc-datasources-volume
         mountPath: "/etc/grafana/provisioning/datasources"
+{{- end}}
+{{- if .Values.sidecar.plugins.enabled }}
+      - name: sc-plugins-volume
+        mountPath: "/etc/grafana/provisioning/plugins"
 {{- end}}
 {{- if .Values.sidecar.notifiers.enabled }}
       - name: sc-notifiers-volume
@@ -314,25 +848,22 @@ containers:
         mountPath: {{ .mountPath }}
     {{- end }}
     ports:
-      - name: {{ .Values.service.portName }}
-        containerPort: {{ .Values.service.port }}
-        protocol: TCP
       - name: {{ .Values.podPortName }}
-        containerPort: 3000
+        containerPort: {{ .Values.service.targetPort }}
         protocol: TCP
     env:
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: GF_SECURITY_ADMIN_USER
         valueFrom:
           secretKeyRef:
-            name: {{ .Values.admin.existingSecret | default (include "grafana.fullname" .) }}
+            name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.userKey | default "admin-user" }}
       {{- end }}
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: GF_SECURITY_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:
-            name: {{ .Values.admin.existingSecret | default (include "grafana.fullname" .) }}
+            name: {{ (tpl .Values.admin.existingSecret .) | default (include "grafana.fullname" .) }}
             key: {{ .Values.admin.passwordKey | default "admin-password" }}
       {{- end }}
       {{- if .Values.plugins }}
@@ -354,12 +885,12 @@ containers:
             name: {{ .Values.smtp.existingSecret }}
             key: {{ .Values.smtp.passwordKey | default "password" }}
       {{- end }}
-      {{ if .Values.imageRenderer.enabled }}
+      {{- if .Values.imageRenderer.enabled }}
       - name: GF_RENDERING_SERVER_URL
         value: http://{{ template "grafana.fullname" . }}-image-renderer.{{ template "grafana.namespace" . }}:{{ .Values.imageRenderer.service.port }}/render
       - name: GF_RENDERING_CALLBACK_URL
-        value: http://{{ template "grafana.fullname" . }}.{{ template "grafana.namespace" . }}:{{ .Values.service.port }}/{{ .Values.imageRenderer.grafanaSubPath }}
-      {{ end }}
+        value: {{ .Values.imageRenderer.grafanaProtocol }}://{{ template "grafana.fullname" . }}.{{ template "grafana.namespace" . }}:{{ .Values.service.port }}/{{ .Values.imageRenderer.grafanaSubPath }}
+      {{- end }}
       - name: GF_PATHS_DATA
         value: {{ (get .Values "grafana.ini").paths.data }}
       - name: GF_PATHS_LOGS
@@ -371,13 +902,13 @@ containers:
     {{- range $key, $value := .Values.envValueFrom }}
       - name: {{ $key | quote }}
         valueFrom:
-{{ toYaml $value | indent 10 }}
+{{ tpl (toYaml $value) $ | indent 10 }}
     {{- end }}
 {{- range $key, $value := .Values.env }}
       - name: "{{ tpl $key $ }}"
         value: "{{ tpl (print $value) $ }}"
 {{- end }}
-    {{- if or .Values.envFromSecret (or .Values.envRenderSecret .Values.envFromSecrets) }}
+    {{- if or .Values.envFromSecret (or .Values.envRenderSecret .Values.envFromSecrets) .Values.envFromConfigMaps }}
     envFrom:
     {{- if .Values.envFromSecret }}
       - secretRef:
@@ -389,39 +920,62 @@ containers:
     {{- end }}
     {{- range .Values.envFromSecrets }}
       - secretRef:
-          name: {{ .name }}
+          name: {{ tpl .name $ }}
+          optional: {{ .optional | default false }}
+    {{- end }}
+    {{- range .Values.envFromConfigMaps }}
+      - configMapRef:
+          name: {{ tpl .name $ }}
           optional: {{ .optional | default false }}
     {{- end }}
     {{- end }}
+    {{- with .Values.livenessProbe }}
     livenessProbe:
-{{ toYaml .Values.livenessProbe | indent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.readinessProbe }}
     readinessProbe:
-{{ toYaml .Values.readinessProbe | indent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- if .Values.lifecycleHooks }}
+    lifecycle: {{ tpl (.Values.lifecycleHooks | toYaml) . | nindent 6 }}
+{{- end }}
+    {{- with .Values.resources }}
     resources:
-{{ toYaml .Values.resources | indent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- with .Values.extraContainers }}
 {{ tpl . $ | indent 2 }}
 {{- end }}
 {{- with .Values.nodeSelector }}
 nodeSelector:
-{{ toYaml . | indent 2 }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- $root := . }}
 {{- with .Values.affinity }}
 affinity:
-{{ toYaml . | indent 2 }}
+{{ tpl (toYaml .) $root | indent 2 }}
+{{- end }}
+{{- with .Values.topologySpreadConstraints }}
+topologySpreadConstraints:
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- with .Values.tolerations }}
 tolerations:
-{{ toYaml . | indent 2 }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 volumes:
   - name: config
     configMap:
       name: {{ template "grafana.fullname" . }}
+{{- $root := . }}
 {{- range .Values.extraConfigmapMounts }}
-  - name: {{ .name }}
+  - name: {{ tpl .name $root }}
     configMap:
-      name: {{ .configMap }}
+      name: {{ tpl .configMap $root }}
+      {{- if .items }}
+      items: {{ toYaml .items | nindent 6 }}
+      {{- end }}
 {{- end }}
   {{- if .Values.dashboards }}
     {{- range (keys .Values.dashboards | sortAlpha) }}
@@ -453,7 +1007,7 @@ volumes:
 {{- if and .Values.persistence.enabled (eq .Values.persistence.type "pvc") }}
   - name: storage
     persistentVolumeClaim:
-      claimName: {{ .Values.persistence.existingClaim | default (include "grafana.fullname" .) }}
+      claimName: {{ tpl (.Values.persistence.existingClaim | default (include "grafana.fullname" .)) . }}
 {{- else if and .Values.persistence.enabled (eq .Values.persistence.type "statefulset") }}
 # nothing
 {{- else }}
@@ -468,9 +1022,23 @@ volumes:
     emptyDir: {}
 {{- end -}}
 {{- end -}}
+{{- if .Values.sidecar.alerts.enabled }}
+  - name: sc-alerts-volume
+{{- if .Values.sidecar.alerts.sizeLimit }}
+    emptyDir:
+      sizeLimit: {{ .Values.sidecar.alerts.sizeLimit }}
+{{- else }}
+    emptyDir: {}
+{{- end -}}
+{{- end -}}
 {{- if .Values.sidecar.dashboards.enabled }}
   - name: sc-dashboard-volume
+{{- if .Values.sidecar.dashboards.sizeLimit }}
+    emptyDir:
+      sizeLimit: {{ .Values.sidecar.dashboards.sizeLimit }}
+{{- else }}
     emptyDir: {}
+{{- end -}}
 {{- if .Values.sidecar.dashboards.SCProvider }}
   - name: sc-dashboard-provider
     configMap:
@@ -479,11 +1047,30 @@ volumes:
 {{- end }}
 {{- if .Values.sidecar.datasources.enabled }}
   - name: sc-datasources-volume
+{{- if .Values.sidecar.datasources.sizeLimit }}
+    emptyDir:
+      sizeLimit: {{ .Values.sidecar.datasources.sizeLimit }}
+{{- else }}
     emptyDir: {}
+{{- end -}}
+{{- end -}}
+{{- if .Values.sidecar.plugins.enabled }}
+  - name: sc-plugins-volume
+{{- if .Values.sidecar.plugins.sizeLimit }}
+    emptyDir:
+      sizeLimit: {{ .Values.sidecar.plugins.sizeLimit }}
+{{- else }}
+    emptyDir: {}
+{{- end -}}
 {{- end -}}
 {{- if .Values.sidecar.notifiers.enabled }}
   - name: sc-notifiers-volume
+{{- if .Values.sidecar.notifiers.sizeLimit }}
+    emptyDir:
+      sizeLimit: {{ .Values.sidecar.notifiers.sizeLimit }}
+{{- else }}
     emptyDir: {}
+{{- end -}}
 {{- end -}}
 {{- range .Values.extraSecretMounts }}
 {{- if .secretName }}
@@ -491,6 +1078,9 @@ volumes:
     secret:
       secretName: {{ .secretName }}
       defaultMode: {{ .defaultMode }}
+      {{- if .items }}
+      items: {{ toYaml .items | nindent 6 }}
+      {{- end }}
 {{- else if .projected }}
   - name: {{ .name }}
     projected: {{- toYaml .projected | nindent 6 }}
@@ -507,6 +1097,10 @@ volumes:
     {{- else if .hostPath }}
     hostPath:
       path: {{ .hostPath }}
+    {{- else if .csi }}
+    csi:
+      data:
+        {{ toYaml .data | nindent 6 }}
     {{- else }}
     emptyDir: {}
     {{- end }}
@@ -516,6 +1110,6 @@ volumes:
     emptyDir: {}
 {{- end -}}
 {{- if .Values.extraContainerVolumes }}
-{{ toYaml .Values.extraContainerVolumes | indent 2 }}
+{{ tpl (toYaml .Values.extraContainerVolumes) . | indent 2 }}
 {{- end }}
 {{- end }}

--- a/helmfile/upstream/grafana/templates/clusterrole.yaml
+++ b/helmfile/upstream/grafana/templates/clusterrole.yaml
@@ -9,9 +9,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
   name: {{ template "grafana.fullname" . }}-clusterrole
-{{- if or .Values.sidecar.dashboards.enabled (or .Values.sidecar.datasources.enabled .Values.rbac.extraClusterRoleRules) }}
+{{- if or .Values.sidecar.dashboards.enabled (or .Values.rbac.extraClusterRoleRules (or .Values.sidecar.datasources.enabled .Values.sidecar.plugins.enabled)) }}
 rules:
-{{- if or .Values.sidecar.dashboards.enabled .Values.sidecar.datasources.enabled }}
+{{- if or .Values.sidecar.dashboards.enabled (or .Values.sidecar.datasources.enabled .Values.sidecar.plugins.enabled) }}
 - apiGroups: [""] # "" indicates the core API group
   resources: ["configmaps", "secrets"]
   verbs: ["get", "watch", "list"]

--- a/helmfile/upstream/grafana/templates/configmap-dashboard-provider.yaml
+++ b/helmfile/upstream/grafana/templates/configmap-dashboard-provider.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sidecar.dashboards.enabled }}
+{{- if and .Values.sidecar.dashboards.enabled .Values.sidecar.dashboards.SCProvider }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helmfile/upstream/grafana/templates/configmap.yaml
+++ b/helmfile/upstream/grafana/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.createConfigmap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,7 +15,19 @@ data:
   plugins: {{ join "," .Values.plugins }}
 {{- end }}
   grafana.ini: |
+{{- range $elem, $elemVal := index .Values "grafana.ini" }}
+    {{- if not (kindIs "map" $elemVal) }}
+    {{- if kindIs "invalid" $elemVal }}
+    {{ $elem }} =
+    {{- else if kindIs "string" $elemVal }}
+    {{ $elem }} = {{ tpl $elemVal $ }}
+    {{- else }}
+    {{ $elem }} = {{ $elemVal }}
+    {{- end }}
+    {{- end }}
+{{- end }}
 {{- range $key, $value := index .Values "grafana.ini" }}
+    {{- if kindIs "map" $value }}
     [{{ $key }}]
     {{- range $elem, $elemVal := $value }}
     {{- if kindIs "invalid" $elemVal }}
@@ -23,6 +36,7 @@ data:
     {{ $elem }} = {{ tpl $elemVal $ }}
     {{- else }}
     {{ $elem }} = {{ $elemVal }}
+    {{- end }}
     {{- end }}
     {{- end }}
 {{- end }}
@@ -39,6 +53,14 @@ data:
   {{- range $key, $value := .Values.notifiers }}
   {{ $key }}: |
 {{ toYaml $value | indent 4 }}
+  {{- end -}}
+{{- end -}}
+
+{{- if .Values.alerting }}
+{{ $root := . }}
+  {{- range $key, $value := .Values.alerting }}
+  {{ $key }}: |
+{{ tpl (toYaml $value | indent 4) $root }}
   {{- end -}}
 {{- end -}}
 
@@ -60,7 +82,7 @@ data:
         {{- end }}
       {{- end }}
     {{- end }}
-
+  {{ $dashboardProviders := .Values.dashboardProviders }}
   {{- range $provider, $dashboards := .Values.dashboards }}
     {{- range $key, $value := $dashboards }}
       {{- if (or (hasKey $value "gnetId") (hasKey $value "url")) }}
@@ -72,11 +94,41 @@ data:
         {{- if $value.token }}
     -H "Authorization: token {{ $value.token }}" \
         {{- end }}
+        {{- if $value.bearerToken }}
+    -H "Authorization: Bearer {{ $value.bearerToken }}" \
+        {{- end }}
+        {{- if $value.gitlabToken }}
+    -H "PRIVATE-TOKEN: {{ $value.gitlabToken }}" \
+        {{- end }}
     -H "Content-Type: application/json;charset=UTF-8" \
-      {{ end }}
-    {{- if $value.url -}}"{{ $value.url }}"{{- else -}}"https://grafana.com/api/dashboards/{{ $value.gnetId }}/revisions/{{- if $value.revision -}}{{ $value.revision }}{{- else -}}1{{- end -}}/download"{{- end -}}{{ if $value.datasource }} | sed '/-- .* --/! s/"datasource":.*,/"datasource": "{{ $value.datasource }}",/g'{{ end }}{{- if $value.b64content -}} | base64 -d {{- end -}} \
-    > "/var/lib/grafana/dashboards/{{ $provider }}/{{ $key }}.json"
       {{- end -}}
+    {{- $dpPath := "" -}}
+    {{- range $kd := (index $dashboardProviders "dashboardproviders.yaml").providers -}}
+      {{- if eq $kd.name $provider -}}
+      {{- $dpPath = $kd.options.path -}}
+      {{- end -}}
+    {{- end -}}
+    {{- if $value.url }}
+      "{{ $value.url }}" \
+    {{- else }}
+      "https://grafana.com/api/dashboards/{{ $value.gnetId }}/revisions/{{- if $value.revision -}}{{ $value.revision }}{{- else -}}1{{- end -}}/download" \
+    {{- end -}}
+    {{- if $value.datasource }}
+      {{- if kindIs "string" $value.datasource }}
+      | sed '/-- .* --/! s/"datasource":.*,/"datasource": "{{ $value.datasource }}",/g' \
+      {{- end -}}
+      {{- if kindIs "slice" $value.datasource -}}
+        {{- range $value.datasource }}
+          | sed '/-- .* --/! s/${{"{"}}{{ .name }}}/{{ .value }}/g' \
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+    {{- if $value.b64content }}
+      | base64 -d \
     {{- end }}
+    > "{{- if $dpPath -}}{{ $dpPath }}{{- else -}}/var/lib/grafana/dashboards/{{ $provider }}{{- end -}}/{{ $key }}.json"
+      {{ end }}
+    {{- end -}}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/helmfile/upstream/grafana/templates/dashboards-json-configmap.yaml
+++ b/helmfile/upstream/grafana/templates/dashboards-json-configmap.yaml
@@ -9,9 +9,6 @@ metadata:
   labels:
     {{- include "grafana.labels" $ | nindent 4 }}
     dashboard-provider: {{ $provider }}
-    {{- if $.Values.sidecar.dashboards.label }}
-    {{ $.Values.sidecar.dashboards.label }}: "1"
-    {{- end }}
 {{- if $dashboards }}
 data:
 {{- $dashboardFound := false }}

--- a/helmfile/upstream/grafana/templates/deployment.yaml
+++ b/helmfile/upstream/grafana/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if (or (not .Values.persistence.enabled) (eq .Values.persistence.type "pvc")) }}
+{{ if (and (not .Values.useStatefulSet) (or (not .Values.persistence.enabled) (eq .Values.persistence.type "pvc"))) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,7 +14,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
@@ -46,5 +46,5 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
-      {{- include "grafana.pod" . | nindent 6 }}
+      {{- include "grafana.pod" . | indent 6 }}
 {{- end }}

--- a/helmfile/upstream/grafana/templates/extra-manifests.yaml
+++ b/helmfile/upstream/grafana/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/helmfile/upstream/grafana/templates/headless-service.yaml
+++ b/helmfile/upstream/grafana/templates/headless-service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "statefulset")}}
+{{- if or .Values.headlessService (and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "statefulset"))}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,4 +15,8 @@ spec:
   selector:
     {{- include "grafana.selectorLabels" . | nindent 4 }}
   type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 3000
+    targetPort: {{ .Values.service.targetPort }}
 {{- end }}

--- a/helmfile/upstream/grafana/templates/hpa.yaml
+++ b/helmfile/upstream/grafana/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "grafana.fullname" . }}
+  namespace: {{ template "grafana.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ template "grafana.name" . }}
     helm.sh/chart: {{ template "grafana.chart" . }}
@@ -11,7 +12,11 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
+    {{- if eq .Values.persistence.type "statefulset" }}
+    kind: StatefulSet
+    {{- else }}
     kind: Deployment
+    {{- end }}
     name: {{ template "grafana.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}

--- a/helmfile/upstream/grafana/templates/image-renderer-deployment.yaml
+++ b/helmfile/upstream/grafana/templates/image-renderer-deployment.yaml
@@ -6,37 +6,37 @@ metadata:
   namespace: {{ template "grafana.namespace" . }}
   labels:
     {{- include "grafana.imageRenderer.labels" . | nindent 4 }}
-{{- if .Values.imageRenderer.labels }}
-{{ toYaml .Values.imageRenderer.labels | indent 4 }}
-{{- end }}
-{{- with .Values.imageRenderer.annotations }}
+    {{- if .Values.imageRenderer.labels }}
+    {{ toYaml .Values.imageRenderer.labels | indent 4 }}
+    {{- end }}
+  {{- with .Values.imageRenderer.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.imageRenderer.replicas }}
   revisionHistoryLimit: {{ .Values.imageRenderer.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "grafana.imageRenderer.selectorLabels" . | nindent 6 }}
-{{- with .Values.imageRenderer.deploymentStrategy }}
+
+  {{- with .Values.imageRenderer.deploymentStrategy }}
   strategy:
-{{ toYaml . | trim | indent 4 }}
-{{- end }}
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:
         {{- include "grafana.imageRenderer.selectorLabels" . | nindent 8 }}
-{{- with .Values.imageRenderer.podLabels }}
-{{ toYaml . | indent 8 }}
-{{- end }}
+        {{- with .Values.imageRenderer.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-{{- with .Values.imageRenderer.podAnnotations }}
-{{ toYaml . | indent 8 }}
-{{- end }}
+        {{- with .Values.imageRenderer.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
-
       {{- if .Values.imageRenderer.schedulerName }}
       schedulerName: "{{ .Values.imageRenderer.schedulerName }}"
       {{- end }}
@@ -56,8 +56,9 @@ spec:
       {{- end }}
       {{- if .Values.imageRenderer.image.pullSecrets }}
       imagePullSecrets:
+      {{- $root := . }}
       {{- range .Values.imageRenderer.image.pullSecrets }}
-        - name: {{ . }}
+        - name: {{ tpl . $root }}
       {{- end}}
       {{- end }}
       containers:
@@ -76,7 +77,7 @@ spec:
         {{- end}}
           ports:
             - name: {{ .Values.imageRenderer.service.portName }}
-              containerPort: {{ .Values.imageRenderer.service.port }}
+              containerPort: {{ .Values.imageRenderer.service.targetPort }}
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -84,34 +85,34 @@ spec:
               port: {{ .Values.imageRenderer.service.portName }}
           env:
             - name: HTTP_PORT
-              value: {{ .Values.imageRenderer.service.port | quote }}
+              value: {{ .Values.imageRenderer.service.targetPort | quote }}
           {{- range $key, $value := .Values.imageRenderer.env }}
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
           {{- end }}
+          {{- with .Values.imageRenderer.containerSecurityContext }}
           securityContext:
-            capabilities:
-              drop: ['all']
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /tmp
               name: image-renderer-tmpfs
-      {{- with .Values.imageRenderer.resources }}
+          {{- with .Values.imageRenderer.resources }}
           resources:
-{{ toYaml . | indent 12 }}
-      {{- end }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.imageRenderer.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- $root := . }}
       {{- with .Values.imageRenderer.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
+        {{- tpl (toYaml .) $root | nindent 8 }}
       {{- end }}
       {{- with .Values.imageRenderer.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
         - name: image-renderer-tmpfs

--- a/helmfile/upstream/grafana/templates/image-renderer-network-policy.yaml
+++ b/helmfile/upstream/grafana/templates/image-renderer-network-policy.yaml
@@ -19,7 +19,7 @@ spec:
     - Ingress
   ingress:
     - ports:
-        - port: {{ .Values.imageRenderer.service.port }}
+        - port: {{ .Values.imageRenderer.service.targetPort }}
           protocol: TCP
       from:
         - namespaceSelector:
@@ -64,10 +64,7 @@ spec:
         - port: {{ .Values.service.port }}
           protocol: TCP
       to:
-        - namespaceSelector:
-            matchLabels:
-              name: {{ template "grafana.namespace" . }}
-          podSelector:
+        - podSelector:
             matchLabels:
               {{- include "grafana.selectorLabels" . | nindent 14 }}
               {{- if .Values.podLabels }}

--- a/helmfile/upstream/grafana/templates/image-renderer-service.yaml
+++ b/helmfile/upstream/grafana/templates/image-renderer-service.yaml
@@ -24,6 +24,9 @@ spec:
       port: {{ .Values.imageRenderer.service.port }}
       protocol: TCP
       targetPort: {{ .Values.imageRenderer.service.targetPort }}
+      {{- if .Values.imageRenderer.appProtocol }}
+      appProtocol: {{ .Values.imageRenderer.appProtocol }}
+      {{- end }}
   selector:
     {{- include "grafana.imageRenderer.selectorLabels" . | nindent 4 }}
 {{ end }}

--- a/helmfile/upstream/grafana/templates/networkpolicy.yaml
+++ b/helmfile/upstream/grafana/templates/networkpolicy.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "grafana.fullname" . }}
+  namespace: {{ template "grafana.namespace" . }}
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  policyTypes:
+    {{- if .Values.networkPolicy.ingress }}
+    - Ingress
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  podSelector:
+    matchLabels:
+    {{- include "grafana.selectorLabels" . | nindent 6 }}
+
+  {{- if .Values.networkPolicy.egress.enabled }}
+  egress:
+    - ports:
+        {{ .Values.networkPolicy.egress.ports | toJson }}
+  {{- end }}
+  {{- if .Values.networkPolicy.ingress }}
+  ingress:
+    - ports:
+      - port: {{ .Values.service.targetPort }}
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ template "grafana.fullname" . }}-client: "true"
+        {{- with .Values.networkPolicy.explicitNamespacesSelector }}
+        - namespaceSelector:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+        - podSelector:
+            matchLabels:
+              {{- include "grafana.labels" . | nindent 14 }}
+              role: read
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/helmfile/upstream/grafana/templates/poddisruptionbudget.yaml
+++ b/helmfile/upstream/grafana/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "grafana.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "grafana.fullname" . }}

--- a/helmfile/upstream/grafana/templates/podsecuritypolicy.yaml
+++ b/helmfile/upstream/grafana/templates/podsecuritypolicy.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -46,4 +47,5 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}

--- a/helmfile/upstream/grafana/templates/pvc.yaml
+++ b/helmfile/upstream/grafana/templates/pvc.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ template "grafana.namespace" . }}
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
+    {{- with .Values.persistence.extraPvcLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.persistence.annotations  }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/helmfile/upstream/grafana/templates/role.yaml
+++ b/helmfile/upstream/grafana/templates/role.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- if or .Values.rbac.pspEnabled (and .Values.rbac.namespaced (or .Values.sidecar.dashboards.enabled (or .Values.sidecar.datasources.enabled .Values.rbac.extraRoleRules))) }}
+{{- if or .Values.rbac.pspEnabled (and .Values.rbac.namespaced (or .Values.sidecar.dashboards.enabled (or .Values.sidecar.datasources.enabled (or .Values.sidecar.plugins.enabled .Values.rbac.extraRoleRules)))) }}
 rules:
 {{- if .Values.rbac.pspEnabled }}
 - apiGroups:      ['extensions']
@@ -18,7 +18,7 @@ rules:
   verbs:          ['use']
   resourceNames:  [{{ template "grafana.fullname" . }}]
 {{- end }}
-{{- if and .Values.rbac.namespaced (or .Values.sidecar.dashboards.enabled .Values.sidecar.datasources.enabled) }}
+{{- if and .Values.rbac.namespaced (or .Values.sidecar.dashboards.enabled (or .Values.sidecar.datasources.enabled .Values.sidecar.plugins.enabled)) }}
 - apiGroups: [""] # "" indicates the core API group
   resources: ["configmaps", "secrets"]
   verbs: ["get", "watch", "list"]

--- a/helmfile/upstream/grafana/templates/secret.yaml
+++ b/helmfile/upstream/grafana/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (or (and (not .Values.admin.existingSecret) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD)) (and .Values.ldap.enabled (not .Values.ldap.existingSecret))) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+{{- if or (and (not .Values.admin.existingSecret) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION)) (and .Values.ldap.enabled (not .Values.ldap.existingSecret)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 type: Opaque
 data:
-  {{- if and (not .Values.admin.existingSecret) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) }}
+  {{- if and (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) (not .Values.admin.existingSecret) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) }}
   admin-user: {{ .Values.adminUser | b64enc | quote }}
   {{- if .Values.adminPassword }}
   admin-password: {{ .Values.adminPassword | b64enc | quote }}

--- a/helmfile/upstream/grafana/templates/service.yaml
+++ b/helmfile/upstream/grafana/templates/service.yaml
@@ -9,9 +9,10 @@ metadata:
 {{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
+{{- $root := . }}
 {{- with .Values.service.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
+{{ tpl (toYaml . | indent 4) $root }}
 {{- end }}
 spec:
 {{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
@@ -40,12 +41,15 @@ spec:
       port: {{ .Values.service.port }}
       protocol: TCP
       targetPort: {{ .Values.service.targetPort }}
-{{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      {{- if .Values.service.appProtocol }}
+      appProtocol: {{ .Values.service.appProtocol }}
+      {{- end }}
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{.Values.service.nodePort}}
-{{ end }}
-  {{- if .Values.extraExposePorts }}
-  {{- tpl (toYaml .Values.extraExposePorts) . | indent 4 }}
-  {{- end }}
+      {{ end }}
+      {{- if .Values.extraExposePorts }}
+      {{- tpl (toYaml .Values.extraExposePorts) . | nindent 4 }}
+      {{- end }}
   selector:
     {{- include "grafana.selectorLabels" . | nindent 4 }}
 {{ end }}

--- a/helmfile/upstream/grafana/templates/serviceaccount.yaml
+++ b/helmfile/upstream/grafana/templates/serviceaccount.yaml
@@ -4,9 +4,13 @@ kind: ServiceAccount
 metadata:
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- $root := . }}
 {{- with .Values.serviceAccount.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
+{{ tpl (toYaml . | indent 4) $root }}
 {{- end }}
   name: {{ template "grafana.serviceAccountName" . }}
   namespace: {{ template "grafana.namespace" . }}

--- a/helmfile/upstream/grafana/templates/servicemonitor.yaml
+++ b/helmfile/upstream/grafana/templates/servicemonitor.yaml
@@ -5,7 +5,9 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana.fullname" . }}
   {{- if .Values.serviceMonitor.namespace }}
-  namespace: {{ .Values.serviceMonitor.namespace }}
+  namespace: {{ tpl .Values.serviceMonitor.namespace . }}
+  {{- else }}
+  namespace: {{ template "grafana.namespace" . }}
   {{- end }}
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
@@ -14,12 +16,14 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-  - interval: {{ .Values.serviceMonitor.interval }}
-    {{- if .Values.serviceMonitor.scrapeTimeout }}
-    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+  - port: {{ .Values.service.portName }}
+    {{- with .Values.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
     {{- end }}
     honorLabels: true
-    port: {{ .Values.service.portName }}
     path: {{ .Values.serviceMonitor.path }}
     scheme: {{ .Values.serviceMonitor.scheme }}
     {{- if .Values.serviceMonitor.tlsConfig }}
@@ -36,5 +40,5 @@ spec:
       {{- include "grafana.selectorLabels" . | nindent 8 }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ template "grafana.namespace" . }}
 {{- end }}

--- a/helmfile/upstream/grafana/templates/statefulset.yaml
+++ b/helmfile/upstream/grafana/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "statefulset")}}
+{{- if (or (.Values.useStatefulSet) (and .Values.persistence.enabled (not .Values.persistence.existingClaim) (eq .Values.persistence.type "statefulset")))}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -35,6 +35,7 @@ spec:
 {{- end }}
     spec:
       {{- include "grafana.pod" . | nindent 6 }}
+  {{- if .Values.persistence.enabled}}
   volumeClaimTemplates:
   - metadata:
       name: storage
@@ -49,4 +50,5 @@ spec:
         matchLabels:
 {{ toYaml . | indent 10 }}
       {{- end }}
+  {{- end }}
 {{- end }}

--- a/helmfile/upstream/grafana/templates/tests/test-configmap.yaml
+++ b/helmfile/upstream/grafana/templates/tests/test-configmap.yaml
@@ -4,6 +4,9 @@ kind: ConfigMap
 metadata:
   name: {{ template "grafana.fullname" . }}-test
   namespace: {{ template "grafana.namespace" . }}
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
 data:
@@ -11,7 +14,7 @@ data:
     @test "Test Health" {
       url="http://{{ template "grafana.fullname" . }}/api/health"
 
-      code=$(wget --server-response --spider --timeout 10 --tries 1 ${url} 2>&1 | awk '/^  HTTP/{print $2}')
+      code=$(wget --server-response --spider --timeout 90 --tries 10 ${url} 2>&1 | awk '/^  HTTP/{print $2}')
       [ "$code" == "200" ]
     }
 {{- end }}

--- a/helmfile/upstream/grafana/templates/tests/test-podsecuritypolicy.yaml
+++ b/helmfile/upstream/grafana/templates/tests/test-podsecuritypolicy.yaml
@@ -1,8 +1,12 @@
 {{- if and .Values.testFramework.enabled .Values.rbac.pspEnabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "grafana.fullname" . }}-test
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
 spec:
@@ -26,4 +30,5 @@ spec:
   - projected
   - csi
   - secret
+{{- end }}
 {{- end }}

--- a/helmfile/upstream/grafana/templates/tests/test-role.yaml
+++ b/helmfile/upstream/grafana/templates/tests/test-role.yaml
@@ -4,6 +4,9 @@ kind: Role
 metadata:
   name: {{ template "grafana.fullname" . }}-test
   namespace: {{ template "grafana.namespace" . }}
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
 rules:

--- a/helmfile/upstream/grafana/templates/tests/test-rolebinding.yaml
+++ b/helmfile/upstream/grafana/templates/tests/test-rolebinding.yaml
@@ -4,6 +4,9 @@ kind: RoleBinding
 metadata:
   name: {{ template "grafana.fullname" . }}-test
   namespace: {{ template "grafana.namespace" . }}
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
 roleRef:

--- a/helmfile/upstream/grafana/templates/tests/test-serviceaccount.yaml
+++ b/helmfile/upstream/grafana/templates/tests/test-serviceaccount.yaml
@@ -6,4 +6,7 @@ metadata:
     {{- include "grafana.labels" . | nindent 4 }}
   name: {{ template "grafana.serviceAccountNameTest" . }}
   namespace: {{ template "grafana.namespace" . }}
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 {{- end }}

--- a/helmfile/upstream/grafana/templates/tests/test.yaml
+++ b/helmfile/upstream/grafana/templates/tests/test.yaml
@@ -7,25 +7,28 @@ metadata:
     {{- include "grafana.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   namespace: {{ template "grafana.namespace" . }}
 spec:
   serviceAccountName: {{ template "grafana.serviceAccountNameTest" . }}
   {{- if .Values.testFramework.securityContext }}
   securityContext: {{ toYaml .Values.testFramework.securityContext | nindent 4 }}
   {{- end }}
+  {{- $root := . }}
   {{- if .Values.image.pullSecrets }}
   imagePullSecrets:
   {{- range .Values.image.pullSecrets }}
-    - name: {{ . }}
+    - name: {{ tpl . $root }}
   {{- end}}
   {{- end }}
   {{- with .Values.nodeSelector }}
   nodeSelector:
 {{ toYaml . | indent 4 }}
   {{- end }}
+  {{- $root := . }}
   {{- with .Values.affinity }}
   affinity:
-{{ toYaml . | indent 4 }}
+{{ tpl (toYaml .) $root | indent 4 }}
   {{- end }}
   {{- with .Values.tolerations }}
   tolerations:

--- a/helmfile/upstream/grafana/values.yaml
+++ b/helmfile/upstream/grafana/values.yaml
@@ -17,11 +17,17 @@ serviceAccount:
   create: true
   name:
   nameTest:
+  ## ServiceAccount labels.
+  labels: {}
+## Service account annotations. Can be templated.
 #  annotations:
 #    eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here
   autoMount: true
 
 replicas: 1
+
+## Create a headless service for the deployment
+headlessService: false
 
 ## Create HorizontalPodAutoscaler object for deployment type
 #
@@ -70,13 +76,15 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 8.2.3
+  # Overrides the Grafana image tag whose default is the chart appVersion
+  tag: ""
   sha: ""
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## Can be templated.
   ##
   # pullSecrets:
   #   - myRegistrKeySecretName
@@ -96,6 +104,11 @@ securityContext:
 containerSecurityContext:
   {}
 
+# Enable creating the grafana configmap
+createConfigmap: true
+
+# Extra configmaps to mount in grafana pods
+# Values are templated.
 extraConfigmapMounts: []
   # - name: certs-configmap
   #   mountPath: /etc/grafana/ssl/
@@ -117,7 +130,7 @@ extraLabels: {}
 
 downloadDashboardsImage:
   repository: curlimages/curl
-  tag: 7.73.0
+  tag: 7.85.0
   sha: ""
   pullPolicy: IfNotPresent
 
@@ -125,6 +138,7 @@ downloadDashboards:
   env: {}
   envFromSecret: ""
   resources: {}
+  securityContext: {}
 
 ## Pod Annotations
 # podAnnotations: {}
@@ -147,9 +161,12 @@ service:
   port: 80
   targetPort: 3000
     # targetPort: 4181 To be used with a proxy extraContainer
+  ## Service annotations. Can be templated.
   annotations: {}
   labels: {}
   portName: service
+  # Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
+  appProtocol: ""
 
 serviceMonitor:
   ## If true, a ServiceMonitor CRD is created for a prometheus operator
@@ -233,11 +250,19 @@ nodeSelector: {}
 ##
 tolerations: []
 
-## Affinity for pod assignment
+## Affinity for pod assignment (evaluated as template)
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ##
 affinity: {}
 
+## Topology Spread Constraints
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+##
+topologySpreadConstraints: []
+
+## Additional init containers (evaluated as template)
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+##
 extraInitContainers: []
 
 ## Enable an Specify container in extraContainers. This is meant to allow adding an authentication proxy to a grafana pod
@@ -280,8 +305,12 @@ persistence:
   finalizers:
     - kubernetes.io/pvc-protection
   # selectorLabels: {}
+  ## Sub-directory of the PV to mount. Can be templated.
   # subPath: ""
+  ## Name of an existing PVC. Can be templated.
   # existingClaim:
+  ## Extra labels to apply to a PVC.
+  extraPvcLabels: {}
 
   ## If persistence is not enabled, this allows to mount the
   ## local storage in-memory to improve performance
@@ -296,7 +325,7 @@ persistence:
 
 initChownData:
   ## If false, data ownership will not be reset at startup
-  ## This allows the prometheus-server to be run with an arbitrary user
+  ## This allows the grafana-server to be run with an arbitrary user
   ##
   enabled: true
 
@@ -318,6 +347,9 @@ initChownData:
   #  requests:
   #    cpu: 100m
   #    memory: 128Mi
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 0
 
 
 # Administrator credentials when not using an existing secret (see below)
@@ -326,6 +358,7 @@ adminUser: admin
 
 # Use an existing secret for the admin user.
 admin:
+  ## Name of the secret. Can be templated.
   existingSecret: ""
   userKey: admin-user
   passwordKey: admin-password
@@ -366,8 +399,8 @@ admin:
 
 env: {}
 
-## "valueFrom" environment variable references that will be added to deployment pods
-## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core
+## "valueFrom" environment variable references that will be added to deployment pods. Name is templated.
+## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvarsource-v1-core
 ## Renders in container spec as:
 ##   env:
 ##     ...
@@ -375,6 +408,10 @@ env: {}
 ##       valueFrom:
 ##         <value rendered as YAML>
 envValueFrom: {}
+  #  ENV_NAME:
+  #    configMapKeyRef:
+  #      name: configmap-name
+  #      key: value_key
 
 ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
 ## This can be useful for auth tokens, etc. Value is templated.
@@ -386,8 +423,17 @@ envRenderSecret: {}
 
 ## The names of secrets in the same kubernetes namespace which contain values to be added to the environment
 ## Each entry should contain a name key, and can optionally specify whether the secret must be defined with an optional key.
+## Name is templated.
 envFromSecrets: []
 ## - name: secret-name
+##   optional: true
+
+## The names of conifgmaps in the same kubernetes namespace which contain values to be added to the environment
+## Each entry should contain a name key, and can optionally specify whether the configmap must be defined with an optional key.
+## Name is templated.
+## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmapenvsource-v1-core
+envFromConfigMaps: []
+## - name: configmap-name
 ##   optional: true
 
 # Inject Kubernetes services as environment variables.
@@ -438,6 +484,19 @@ extraVolumeMounts: []
   #   mountPath: /mnt/volume1
   #   readOnly: true
   #   hostPath: /usr/shared/
+  # - name: grafana-secrets
+  #   csi: true
+  #   data:
+  #     driver: secrets-store.csi.k8s.io
+  #     readOnly: true
+  #     volumeAttributes:
+  #       secretProviderClass: "grafana-env-spc"
+
+## Container Lifecycle Hooks. Execute a specific bash command or make an HTTP request
+lifecycleHooks: {}
+  # postStart:
+  #   exec:
+  #     command: []
 
 ## Pass the plugins you want installed as a list.
 ##
@@ -465,6 +524,71 @@ datasources: {}
 #      jsonData:
 #        authType: default
 #        defaultRegion: us-east-1
+
+## Configure grafana alerting (can be templated)
+## ref: http://docs.grafana.org/administration/provisioning/#alerting
+##
+alerting: {}
+  # rules.yaml:
+  #   apiVersion: 1
+  #   groups:
+  #     - orgId: 1
+  #       name: '{{ .Chart.Name }}_my_rule_group'
+  #       folder: my_first_folder
+  #       interval: 60s
+  #       rules:
+  #         - uid: my_id_1
+  #           title: my_first_rule
+  #           condition: A
+  #           data:
+  #             - refId: A
+  #               datasourceUid: '-100'
+  #               model:
+  #                 conditions:
+  #                   - evaluator:
+  #                       params:
+  #                         - 3
+  #                       type: gt
+  #                     operator:
+  #                       type: and
+  #                     query:
+  #                       params:
+  #                         - A
+  #                     reducer:
+  #                       type: last
+  #                     type: query
+  #                 datasource:
+  #                   type: __expr__
+  #                   uid: '-100'
+  #                 expression: 1==0
+  #                 intervalMs: 1000
+  #                 maxDataPoints: 43200
+  #                 refId: A
+  #                 type: math
+  #           dashboardUid: my_dashboard
+  #           panelId: 123
+  #           noDataState: Alerting
+  #           for: 60s
+  #           annotations:
+  #             some_key: some_value
+  #           labels:
+  #             team: sre_team_1
+  # contactpoints.yaml:
+  #   apiVersion: 1
+  #   contactPoints:
+  #     - orgId: 1
+  #       name: cp_1
+  #       receivers:
+  #         - uid: first_uid
+  #           type: pagerduty
+  #           settings:
+  #             integrationKey: XXX
+  #             severity: critical
+  #             class: ping failure
+  #             component: Grafana
+  #             group: app-stack
+  #             summary: |
+  #               {{ `{{ template "default.message" . }}` }}
 
 ## Configure notifiers
 ## ref: http://docs.grafana.org/administration/provisioning/#alert-notification-channels
@@ -526,6 +650,12 @@ dashboards: {}
   #     url: https://example.com/repository/test-b64.json
   #     token: ''
   #     b64content: true
+  #   local-dashboard-gitlab:
+  #     url: https://example.com/repository/test-gitlab.json
+  #     gitlabToken: ''
+  #   local-dashboard-bitbucket:
+  #     url: https://example.com/repository/test-bitbucket.json
+  #     bearerToken: ''
 
 ## Reference to external ConfigMap per provider. Use provider name as key and ConfigMap name as value.
 ## A provider dashboards must be defined either by external ConfigMaps or in values.yaml, not in both.
@@ -554,6 +684,8 @@ grafana.ini:
     mode: console
   grafana_net:
     url: https://grafana.net
+  server:
+    domain: "{{ if (and .Values.ingress.enabled .Values.ingress.hosts) }}{{ .Values.ingress.hosts | first }}{{ else }}''{{ end }}"
 ## grafana Authentication can be enabled with the following values on grafana.ini
  # server:
       # The full public facing url you use in browser, used for redirects and emails
@@ -615,7 +747,7 @@ smtp:
 sidecar:
   image:
     repository: quay.io/kiwigrid/k8s-sidecar
-    tag: 1.14.2
+    tag: 1.19.2
     sha: ""
   imagePullPolicy: IfNotPresent
   resources: {}
@@ -625,16 +757,65 @@ sidecar:
 #   requests:
 #     cpu: 50m
 #     memory: 50Mi
+  securityContext: {}
   # skipTlsVerify Set to true to skip tls verification for kube api calls
   # skipTlsVerify: true
   enableUniqueFilenames: false
+  readinessProbe: {}
+  livenessProbe: {}
+  # Log level default for all sidecars. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL. Defaults to INFO
+  # logLevel: INFO
+  alerts:
+    enabled: false
+    # Additional environment variables for the alerts sidecar
+    env: {}
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
+    # label that the configmaps with alert are marked with
+    label: grafana_alert
+    # value of label that the configmaps with alert are set to
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
+    # If specified, the sidecar will search for alert config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # Endpoint to send request to reload alerts
+    reloadURL: "http://localhost:3000/api/admin/provisioning/alerting/reload"
+    # Absolute path to shell script to execute after a alert got reloaded
+    script: null
+    skipReload: false
+    # Deploy the alert sidecar as an initContainer in addition to a container.
+    # Sets the size limit of the alert sidecar emptyDir volume
+    sizeLimit: {}
   dashboards:
     enabled: false
+    # Additional environment variables for the dashboards sidecar
+    env: {}
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
     SCProvider: true
     # label that the configmaps with dashboards are marked with
     label: grafana_dashboard
     # value of label that the configmaps with dashboards are set to
-    labelValue: null
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
     # folder in the pod that should hold the collected dashboards (unless `defaultFolderName` is set)
     folder: /tmp/dashboards
     # The default folder name, it will create a subfolder under the `folder` and put dashboards in there instead
@@ -643,11 +824,25 @@ sidecar:
     # Otherwise the namespace in which the sidecar is running will be used.
     # It's also possible to specify ALL to search in all namespaces.
     searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
     # search in configmap, secret or both
     resource: both
     # If specified, the sidecar will look for annotation with this name to create folder and put graph here.
     # You can use this parameter together with `provider.foldersFromFilesStructure`to annotate configmaps and create folder structure.
     folderAnnotation: null
+    # Absolute path to shell script to execute after a configmap got reloaded
+    script: null
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
     # provider configuration that lets grafana manage the dashboards
     provider:
       # name of the provider, should be unique
@@ -664,28 +859,130 @@ sidecar:
       allowUiUpdates: false
       # allow Grafana to replicate dashboard structure from filesystem
       foldersFromFilesStructure: false
+    # Additional dashboard sidecar volume mounts
+    extraMounts: []
+    # Sets the size limit of the dashboard sidecar emptyDir volume
+    sizeLimit: {}
   datasources:
     enabled: false
+    # Additional environment variables for the datasourcessidecar
+    env: {}
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
     # label that the configmaps with datasources are marked with
     label: grafana_datasource
     # value of label that the configmaps with datasources are set to
-    labelValue: null
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
     # If specified, the sidecar will search for datasource config-maps inside this namespace.
     # Otherwise the namespace in which the sidecar is running will be used.
     # It's also possible to specify ALL to search in all namespaces
     searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
     # search in configmap, secret or both
     resource: both
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # Endpoint to send request to reload datasources
+    reloadURL: "http://localhost:3000/api/admin/provisioning/datasources/reload"
+    # Absolute path to shell script to execute after a datasource got reloaded
+    script: null
+    skipReload: false
+    # Deploy the datasource sidecar as an initContainer in addition to a container.
+    # This is needed if skipReload is true, to load any datasources defined at startup time.
+    initDatasources: false
+    # Sets the size limit of the datasource sidecar emptyDir volume
+    sizeLimit: {}
+  plugins:
+    enabled: false
+    # Additional environment variables for the plugins sidecar
+    env: {}
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
+    # label that the configmaps with plugins are marked with
+    label: grafana_plugin
+    # value of label that the configmaps with plugins are set to
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
+    # If specified, the sidecar will search for plugin config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # Endpoint to send request to reload plugins
+    reloadURL: "http://localhost:3000/api/admin/provisioning/plugins/reload"
+    # Absolute path to shell script to execute after a plugin got reloaded
+    script: null
+    skipReload: false
+    # Deploy the datasource sidecar as an initContainer in addition to a container.
+    # This is needed if skipReload is true, to load any plugins defined at startup time.
+    initPlugins: false
+    # Sets the size limit of the plugin sidecar emptyDir volume
+    sizeLimit: {}
   notifiers:
     enabled: false
+    # Additional environment variables for the notifierssidecar
+    env: {}
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
     # label that the configmaps with notifiers are marked with
     label: grafana_notifier
+    # value of label that the configmaps with notifiers are set to
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
     # If specified, the sidecar will search for notifier config-maps inside this namespace.
     # Otherwise the namespace in which the sidecar is running will be used.
     # It's also possible to specify ALL to search in all namespaces
     searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
     # search in configmap, secret or both
     resource: both
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # Endpoint to send request to reload notifiers
+    reloadURL: "http://localhost:3000/api/admin/provisioning/notifications/reload"
+    # Absolute path to shell script to execute after a notifier got reloaded
+    script: null
+    skipReload: false
+    # Deploy the notifier sidecar as an initContainer in addition to a container.
+    # This is needed if skipReload is true, to load any notifiers defined at startup time.
+    initNotifiers: false
+    # Sets the size limit of the notifier sidecar emptyDir volume
+    sizeLimit: {}
 
 ## Override the deployment namespace
 ##
@@ -697,6 +994,7 @@ revisionHistoryLimit: 10
 
 ## Add a seperate remote image renderer deployment/service
 imageRenderer:
+  deploymentStrategy: {}
   # Enable the image-renderer deployment & service
   enabled: false
   replicas: 1
@@ -714,10 +1012,17 @@ imageRenderer:
     HTTP_HOST: "0.0.0.0"
     # RENDERING_ARGS: --no-sandbox,--disable-gpu,--window-size=1280x758
     # RENDERING_MODE: clustered
+    # IGNORE_HTTPS_ERRORS: true
   # image-renderer deployment serviceAccount
   serviceAccountName: ""
   # image-renderer deployment securityContext
   securityContext: {}
+  # image-renderer deployment container securityContext
+  containerSecurityContext:
+    capabilities:
+      drop: ['ALL']
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
   # image-renderer deployment Host Aliases
   hostAliases: []
   # image-renderer deployment priority class
@@ -730,6 +1035,10 @@ imageRenderer:
     # image-renderer service port used by both service and deployment
     port: 8081
     targetPort: 8081
+    # Adds the appProtocol field to the image-renderer service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
+    appProtocol: ""
+  # If https is enabled in Grafana, this needs to be set as 'https' to correctly configure the callback used in Grafana
+  grafanaProtocol: http
   # In case a sub_path is used this needs to be added to the image renderer callback
   grafanaSubPath: ""
   # name of the image-renderer port on the pod
@@ -748,3 +1057,86 @@ imageRenderer:
 #   requests:
 #     cpu: 50m
 #     memory: 50Mi
+  ## Node labels for pod assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  #
+  nodeSelector: {}
+
+  ## Tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Affinity for pod assignment (evaluated as template)
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+
+networkPolicy:
+  ## @param networkPolicy.enabled Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
+  ##
+  enabled: false
+  ## @param networkPolicy.allowExternal Don't require client label for connections
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to  grafana port defined.
+  ## When true, grafana will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  ingress: true
+  ## @param networkPolicy.ingress When true enables the creation
+  ## an ingress network policy
+  ##
+  allowExternal: true
+  ## @param networkPolicy.explicitNamespacesSelector A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed
+  ## If explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
+  ## and that match other criteria, the ones that have the good label, can reach the grafana.
+  ## But sometimes, we want the grafana to be accessible to clients from other namespaces, in this case, we can use this
+  ## LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
+  ##
+  ## Example:
+  ## explicitNamespacesSelector:
+  ##   matchLabels:
+  ##     role: frontend
+  ##   matchExpressions:
+  ##    - {key: role, operator: In, values: [frontend]}
+  ##
+  explicitNamespacesSelector: {}
+  ##
+  ##
+  ##
+  ##
+  ##
+  ##
+  egress:
+    ## @param networkPolicy.egress.enabled When enabled, an egress network policy will be
+    ## created allowing grafana to connect to external data sources from kubernetes cluster.
+    enabled: false
+    ##
+    ## @param networkPolicy.egress.ports Add individual ports to be allowed by the egress
+    ports: []
+    ## Add ports to the egress by specifying - port: <port number>
+    ## E.X.
+    ## ports:
+      ## - port: 80
+      ## - port: 443
+  ##
+  ##
+  ##
+  ##
+  ##
+  ##
+
+# Enable backward compatibility of kubernetes where version below 1.13 doesn't have the enableServiceLinks option
+enableKubeBackwardCompatibility: false
+useStatefulSet: false
+# Create a dynamic manifests via values:
+extraObjects: []
+  # - apiVersion: "kubernetes-client.io/v1"
+  #   kind: ExternalSecret
+  #   metadata:
+  #     name: grafana-secrets
+  #   spec:
+  #     backendType: gcpSecretsManager
+  #     data:
+  #       - key: grafana-admin-password
+  #         name: adminPassword

--- a/helmfile/values/grafana-user.yaml.gotmpl
+++ b/helmfile/values/grafana-user.yaml.gotmpl
@@ -2,7 +2,7 @@ adminPassword: {{ .Values.user.grafanaPassword }}
 
 image:
   repository: grafana/grafana
-  tag: 8.4.7
+
 testFramework:
   enabled: false
 

--- a/helmfile/values/grafana-user.yaml.gotmpl
+++ b/helmfile/values/grafana-user.yaml.gotmpl
@@ -2,6 +2,7 @@ adminPassword: {{ .Values.user.grafanaPassword }}
 
 image:
   repository: grafana/grafana
+  tag: 9.2.4
 
 testFramework:
   enabled: false

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -142,7 +142,7 @@ kubeScheduler:
 
 grafana:
   image:
-    tag: 8.4.7
+    tag: 9.2.3
 
   testFramework:
     enabled: false

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -142,7 +142,7 @@ kubeScheduler:
 
 grafana:
   image:
-    tag: 9.2.3
+    tag: 9.2.4
 
   testFramework:
     enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrades the grafana helm chart sed for user-grafana.
Bumped the grafana tag in the kube-prometheus-stack to the same version as is delivered by the upstream grafana chart.

**Which issue this PR fixes**:

Fixes #1018 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

These are the biggest changes that upgrading will do (user-grafana).
 The domain setting is new, but according to the [docs](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#domain) it is not needed for us.
I have tested and I did not find any problems in ops grafana where it is not set.

```diff
monitoring, user-grafana, ConfigMap (v1) has changed:
  # Source: grafana/templates/configmap.yaml
  apiVersion: v1
  kind: ConfigMap
  data:
    grafana.ini: |
      [server]
+     domain = grafana.olle-dev.a1ck.io
      root_url = https://grafana.olle-dev.a1ck.io
      [users]
      viewers_can_edit = true

monitoring, user-grafana, Deployment (apps) has changed:
  # Source: grafana/templates/deployment.yaml
  apiVersion: apps/v1
  kind: Deployment
  spec:
    template:
+     spec:      
+           image: "quay.io/kiwigrid/k8s-sidecar:1.19.2"
            imagePullPolicy: IfNotPresent
            env:
              - name: METHOD
-               value: 
+               value: WATCH
```

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [x] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
