### PR TITLE
apps-sc/wc: Adding network-policy rook-ceph

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Added
 
 - Starboard resources will now be removed when running the cleanup scripts - `scripts/clean-{sc,wc}.sh`.
+- Enabled the `rook-ceph` network policy in both `sc` and `wc` cluster.
 
 ### Removed
 

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -653,3 +653,6 @@ networkPolicies:
         - set-me
       ports:
         - 443
+
+  rookCeph:
+    enabled: true

--- a/helmfile/charts/networkpolicy-common/templates/rook-ceph/ceph-tools.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/rook-ceph/ceph-tools.yaml
@@ -1,0 +1,43 @@
+{{ if .Values.rookCeph.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-rook-ceph-tools
+  namespace: rook-ceph
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app: rook-ceph-tools
+  egress:
+    - to:
+        {{- range $ip := .Values.global.apiserver.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.global.apiserver.port }}
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-mgr
+      ports:
+        - port: 6800
+          protocol: TCP
+          endPort: 7300
+        - port: 9283
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-mon
+      ports:
+        - port: 6789
+          protocol: TCP
+        - port: 3300
+          protocol: TCP
+        - port: 7000
+          protocol: TCP
+{{- end }}

--- a/helmfile/charts/networkpolicy-common/templates/rook-ceph/csi-rbdplugin-provisioner.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/rook-ceph/csi-rbdplugin-provisioner.yaml
@@ -1,0 +1,40 @@
+{{ if .Values.rookCeph.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-rook-ceph-csi-rbdplugin-provisioner
+  namespace: rook-ceph
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app: csi-rbdplugin-provisioner
+  egress:
+    - to:
+        {{- range $ip := .Values.global.apiserver.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.global.apiserver.port }}
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-osd
+      ports:
+        - port: 6800
+          protocol: TCP
+          endPort: 7300
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-mgr
+      ports:
+        - port: 6800
+          protocol: TCP
+          endPort: 7300
+        - port: 9283
+          protocol: TCP
+{{- end }}

--- a/helmfile/charts/networkpolicy-common/templates/rook-ceph/default-deny.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/rook-ceph/default-deny.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.rookCeph.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: rook-ceph-default-deny-all
+  namespace: rook-ceph
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+{{- end }}

--- a/helmfile/charts/networkpolicy-common/templates/rook-ceph/detect-version.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/rook-ceph/detect-version.yaml
@@ -1,0 +1,22 @@
+{{ if .Values.rookCeph.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-rook-ceph-detect-version
+  namespace: rook-ceph
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app: rook-ceph-detect-version
+  egress:
+    - to:
+        {{- range $ip := .Values.global.apiserver.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.global.apiserver.port }}
+          protocol: TCP
+{{- end }}

--- a/helmfile/charts/networkpolicy-common/templates/rook-ceph/mgr.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/rook-ceph/mgr.yaml
@@ -1,0 +1,69 @@
+{{ if .Values.rookCeph.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-rook-ceph-mgr
+  namespace: rook-ceph
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app: rook-ceph-mgr
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-operator
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-tools
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-mon
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-osd
+        {{- range $ip := .Values.global.nodes.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+        - podSelector:
+            matchLabels:
+              app: csi-rbdplugin-provisioner
+      ports:
+        - port: 6800
+          protocol: TCP
+          endPort: 7300
+        - port: 9283
+          protocol: TCP
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-osd
+      ports:
+        - port: 6800
+          protocol: TCP
+          endPort: 7300
+    - to:
+        {{- range $ip := .Values.global.apiserver.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.global.apiserver.port }}
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-mon
+      ports:
+        - port: 6789
+          protocol: TCP
+        - port: 3300
+          protocol: TCP
+        - port: 7000
+          protocol: TCP
+{{- end }}

--- a/helmfile/charts/networkpolicy-common/templates/rook-ceph/mon.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/rook-ceph/mon.yaml
@@ -1,0 +1,83 @@
+{{ if .Values.rookCeph.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-rook-ceph-mon
+  namespace: rook-ceph
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app: rook-ceph-mon
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-mon
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-operator
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-osd
+        {{- range $ip := .Values.global.nodes.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-mgr
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-tools
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-osd-prepare
+      ports:
+        - port: 6789
+          protocol: TCP
+        - port: 3300
+          protocol: TCP
+        - port: 7000
+          protocol: TCP
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-mgr
+      ports:
+        - port: 6800
+          protocol: TCP
+          endPort: 7300
+        - port: 9283
+          protocol: TCP
+    - to:
+        {{- range $ip := .Values.global.apiserver.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.global.apiserver.port }}
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-osd
+      ports:
+        - port: 6800
+          protocol: TCP
+          endPort: 7300
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-mon
+      ports:
+        - port: 6789
+          protocol: TCP
+        - port: 3300
+          protocol: TCP
+        - port: 7000
+          protocol: TCP
+{{- end }}

--- a/helmfile/charts/networkpolicy-common/templates/rook-ceph/operator.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/rook-ceph/operator.yaml
@@ -1,0 +1,51 @@
+{{ if .Values.rookCeph.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-rook-ceph-operator
+  namespace: rook-ceph
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app: rook-ceph-operator
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-mon
+      ports:
+        - port: 6789
+          protocol: TCP
+        - port: 3300
+          protocol: TCP
+        - port: 7000
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-mgr
+      ports:
+        - port: 6800
+          protocol: TCP
+          endPort: 7300
+        - port: 9283
+          protocol: TCP
+    - to:
+        {{- range $ip := .Values.global.apiserver.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.global.apiserver.port }}
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-osd
+      ports:
+        - port: 6800
+          protocol: TCP
+          endPort: 7300
+{{- end }}

--- a/helmfile/charts/networkpolicy-common/templates/rook-ceph/osd-prepare.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/rook-ceph/osd-prepare.yaml
@@ -1,0 +1,41 @@
+{{ if .Values.rookCeph.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-rook-ceph-osd-prepare
+  namespace: rook-ceph
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app: rook-ceph-osd-prepare
+  egress:
+    - to:
+        {{- range $ip := .Values.global.apiserver.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.global.apiserver.port }}
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-osd
+      ports:
+        - port: 6800
+          protocol: TCP
+          endPort: 7300
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-mon
+      ports:
+        - port: 6789
+          protocol: TCP
+        - port: 3300
+          protocol: TCP
+        - port: 7000
+          protocol: TCP
+{{- end }}

--- a/helmfile/charts/networkpolicy-common/templates/rook-ceph/osd.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/rook-ceph/osd.yaml
@@ -1,0 +1,74 @@
+{{ if .Values.rookCeph.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-rook-ceph-osd
+  namespace: rook-ceph
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app: rook-ceph-osd
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-osd
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-mgr
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-operator
+        - podSelector:
+            matchLabels:
+              app: csi-rbdplugin-provisioner
+        {{- range $ip := .Values.global.nodes.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        - port: 6800
+          protocol: TCP
+          endPort: 7300
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-mgr
+      ports:
+        - port: 6800
+          protocol: TCP
+          endPort: 7300
+        - port: 9283
+          protocol: TCP
+    - to:
+        {{- range $ip := .Values.global.apiserver.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.global.apiserver.port }}
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-mon
+      ports:
+        - port: 6789
+          protocol: TCP
+        - port: 3300
+          protocol: TCP
+        - port: 7000
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-osd
+      ports:
+        - port: 6800
+          protocol: TCP
+          endPort: 7300
+{{- end }}

--- a/helmfile/values/networkpolicy-common.yaml.gotmpl
+++ b/helmfile/values/networkpolicy-common.yaml.gotmpl
@@ -53,3 +53,6 @@ certManager:
     ips: {{- toYaml .Values.networkPolicies.certManager.letsencrypt.ips | nindent 6 }}
 falco:
   enabled: {{ and .Values.falco.enabled .Values.networkPolicies.falco.enabled }}
+
+rookCeph:
+  enabled: {{ .Values.networkPolicies.rookCeph.enabled }}


### PR DESCRIPTION
**What this PR does / why we need it**: apps-sc/wc: Adding network-policy rook-ceph in sc and wc cluster 

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1135 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

1) Please read more details on the Github issue - https://github.com/elastisys/compliantkubernetes-apps/issues/1135 

**Add a screenshot or an example to illustrate the proposed solution:**
![image](https://user-images.githubusercontent.com/75951259/201395439-a36f48e9-e0c8-4a07-9d3c-9a3ad8ab1939.png)

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
