### PR TITLE
apps: nginx controller service annotations now a map

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -7,6 +7,7 @@
 - Updated Rook alerts to the ones provided by Rook `v1.10.5`
 - Disabled all collectors for node-exporter in ciskubebench- and vulnerability-exporter except textcollector
 - Increased the default CPU limit for node-exporter in ciskubebench- and vulnerability-exporter
+- Nginx controller service annotations are now defined as a map, previously just a single string.
 
 ### Fixed
 

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -324,7 +324,7 @@ ingressNginx:
 
       ## Annotations to add to service
       ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-      annotations: set-me
+      annotations: {}
 
       ## Whitelist IP address for octavia loadbalancer
       ## ref: https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#restrict-access-for-loadbalancer-service

--- a/helmfile/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile/values/ingress-nginx.yaml.gotmpl
@@ -102,8 +102,7 @@ controller:
     {{ if .Values.ingressNginx.controller.service.enabled }}
     enabled: true
     type: {{ .Values.ingressNginx.controller.service.type }}
-    annotations:
-    {{- .Values.ingressNginx.controller.service.annotations | nindent 6 }}
+    annotations: {{- toYaml .Values.ingressNginx.controller.service.annotations | nindent 6 }}
     loadBalancerSourceRanges: {{- toYaml .Values.ingressNginx.controller.service.loadBalancerSourceRanges | nindent 6 }}
     {{ else }}
     enabled: false

--- a/migration/v0.27.x-v0.28.x/move-nginx-controller-service-annotation-to-map.sh
+++ b/migration/v0.27.x-v0.28.x/move-nginx-controller-service-annotation-to-map.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?"CK8S_CONFIG_PATH is unset"}"
+
+config_common="$CK8S_CONFIG_PATH/common-config.yaml"
+config_sc="$CK8S_CONFIG_PATH/sc-config.yaml"
+config_wc="$CK8S_CONFIG_PATH/wc-config.yaml"
+
+annotation_string_to_map() {
+    annotation=$(yq4 '.ingressNginx.controller.service.annotations' "${1}")
+    if [[ "${annotation}" == "null" ]]; then
+        echo "info: .ingressNginx.controller.service.annotations missing from ${1}, skipping."
+    else
+        echo "info: Converting annotations to map for ${1}"
+
+        key=$(echo "${annotation}" | yq4 'keys | .[]')
+        value=$(echo "${annotation}" | yq4 '.[]')
+
+        yq4 -i 'del(.ingressNginx.controller.service.annotations)' "${1}"
+        yq4 -i ".ingressNginx.controller.service.annotations.\"${key}\" = \"${value}\"" "${1}"
+    fi
+}
+
+annotation_string_to_map "${config_common}"
+annotation_string_to_map "${config_sc}"
+annotation_string_to_map "${config_wc}"

--- a/migration/v0.27.x-v0.28.x/upgrade-apps.md
+++ b/migration/v0.27.x-v0.28.x/upgrade-apps.md
@@ -1,0 +1,23 @@
+# Upgrade v0.27.x to v0.28.x
+
+## Steps
+
+1. Update apps configuration:
+
+    This will take a backup into `backups/` before modifying any files.
+
+    ```bash
+    bin/ck8s init
+    ```
+
+1. Migrate nginx service annotations from a string to a map
+
+    ```
+    ./migration/v0.27.x-v0.28.x/move-nginx-controller-service-annotation-to-map
+    ```
+
+1. Upgrade applications:
+
+    ```bash
+    bin/ck8s apply {sc|wc}
+    ```


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow us to set multiple annotations for Ingres controller service with a map. Currently it only supports a single string. 

**Which issue this PR fixes**: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
