### PR TITLE
all: add removal of starboard resource in cleanup scripts

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Added
 
+- Starboard resources will now be removed when running the cleanup scripts - `scripts/clean-{sc,wc}.sh`.
+
 ### Removed
 
 - Prometheus recording rules for Rook.

--- a/scripts/clean-sc.sh
+++ b/scripts/clean-sc.sh
@@ -61,3 +61,23 @@ if [ -n "$PROM_CRDS" ]; then
     # We definitely want word splitting here.
     "${here}/.././bin/ck8s" ops kubectl sc delete crds $PROM_CRDS
 fi
+
+# Starboard specific removal
+STAR_CRDS=$(
+    "${here}/.././bin/ck8s" ops \
+        kubectl sc api-resources \
+        --api-group=aquasecurity.github.io \
+        -o name
+    )
+
+# Delete CRs
+for cr in $STAR_CRDS; do
+    "${here}/.././bin/ck8s" ops kubectl sc delete "$cr" --all --all-namespaces
+done
+
+# Delete CRDs
+if [ -n "$STAR_CRDS" ]; then
+    # shellcheck disable=SC2086
+    # We definitely want word splitting here.
+    "${here}/.././bin/ck8s" ops kubectl sc delete crds $STAR_CRDS
+fi

--- a/scripts/clean-wc.sh
+++ b/scripts/clean-wc.sh
@@ -70,3 +70,23 @@ if [ -n "$PROM_CRDS" ]; then
     # We definitely want word splitting here.
     "${here}/.././bin/ck8s" ops kubectl wc delete crds $PROM_CRDS
 fi
+
+# Starboard specific removal
+STAR_CRDS=$(
+    "${here}/.././bin/ck8s" ops \
+        kubectl wc api-resources \
+        --api-group=aquasecurity.github.io \
+        -o name
+    )
+
+# Delete CRs
+for cr in $STAR_CRDS; do
+    "${here}/.././bin/ck8s" ops kubectl wc delete "$cr" --all --all-namespaces
+done
+
+# Delete CRDs
+if [ -n "$STAR_CRDS" ]; then
+    # shellcheck disable=SC2086
+    # We definitely want word splitting here.
+    "${here}/.././bin/ck8s" ops kubectl wc delete crds $STAR_CRDS
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
fixes #892 

**Public facing documentation PR** *(if applicable)*

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
