### PR TITLE
apps: Add network policies for kube-system components

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -20,6 +20,7 @@
 - Starboard resources will now be removed when running the cleanup scripts - `scripts/clean-{sc,wc}.sh`.
 - Enabled the `rook-ceph` network policy in both `sc` and `wc` cluster.
 - Added templating for wc Velero bucket prefix.
+- Network policies for `csi-cinder`, `csi-upcloud`, `metrics-server` and `snapshot-controller`.
 
 ### Removed
 

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -132,10 +132,18 @@ set_storage_class() {
     case ${CK8S_CLOUD_PROVIDER} in
         safespring | citycloud | elastx)
             storage_class=cinder-csi
+
+            yq4 -i '.networkPolicies.kubeSystem.openstack.enabled = true' "${file}"
+            yq4 -i '.networkPolicies.kubeSystem.openstack.ips = ["set-me"]' "${file}"
+            yq4 -i '.networkPolicies.kubeSystem.openstack.ports = [5000,8774,8776]' "${file}" # Keystone, Nova, Cinder
             ;;
 
         upcloud)
             storage_class=upcloud-block-storage
+
+            yq4 -i '.networkPolicies.kubeSystem.upcloud.enabled = true' "${file}"
+            yq4 -i '.networkPolicies.kubeSystem.upcloud.ips = ["94.237.0.0/23"]' "${file}" # api.upcloud.com
+            yq4 -i '.networkPolicies.kubeSystem.upcloud.ports = [443]' "${file}"
             ;;
 
         exoscale|baremetal)

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -661,3 +661,6 @@ networkPolicies:
 
   rookCeph:
     enabled: true
+
+  kubeSystem:
+    enabled: true

--- a/helmfile/charts/networkpolicy-common/templates/kube-system/csi-cinder.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/kube-system/csi-cinder.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.kubeSystem.enabled .Values.kubeSystem.openstack.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "np.labels" . | nindent 4 }}
+  name: allow-csi-cinder-controller-plugin
+  namespace: kube-system
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app: csi-cinder-controllerplugin
+  ingress: []
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+    - to:
+        {{- range .Values.global.apiserver.ips }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.global.apiserver.port }}
+    - to:
+        {{- range .Values.kubeSystem.openstack.ips }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        {{- range .Values.kubeSystem.openstack.ports }}
+        - port: {{ . }}
+        {{- end }}
+{{- end }}

--- a/helmfile/charts/networkpolicy-common/templates/kube-system/csi-upcloud.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/kube-system/csi-upcloud.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.kubeSystem.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "np.labels" . | nindent 4 }}
+  name: allow-csi-upcloud-controller-plugin
+  namespace: kube-system
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app: csi-upcloud-controller
+  ingress: []
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+    - to:
+        {{- range .Values.global.apiserver.ips }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.global.apiserver.port }}
+    - to:
+        {{- range .Values.kubeSystem.upcloud.ips }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        {{- range .Values.kubeSystem.upcloud.ports }}
+        - port: {{ . }}
+        {{- end }}
+{{- end }}

--- a/helmfile/charts/networkpolicy-common/templates/kube-system/metrics-server.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/kube-system/metrics-server.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.kubeSystem.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "np.labels" . | nindent 4 }}
+  name: allow-metrics-server
+  namespace: kube-system
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: metrics-server
+  ingress:
+    - from:
+        {{- range .Values.global.apiserver.ips }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        - port: 8443
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+    - to:
+        {{- range .Values.global.apiserver.ips }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.global.apiserver.port }}
+    - to:
+        {{- range .Values.global.nodes.ips }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        - port: 10250
+{{- end }}

--- a/helmfile/charts/networkpolicy-common/templates/kube-system/snapshot-controller.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/kube-system/snapshot-controller.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.kubeSystem.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    {{- include "np.labels" . | nindent 4 }}
+  name: allow-snapshot-controller
+  namespace: kube-system
+spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  podSelector:
+    matchLabels:
+      app: snapshot-controller
+  ingress: []
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+    - to:
+        {{- range .Values.global.apiserver.ips }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.global.apiserver.port }}
+{{- end }}

--- a/helmfile/charts/networkpolicy-common/values.yaml
+++ b/helmfile/charts/networkpolicy-common/values.yaml
@@ -64,3 +64,22 @@ certManager:
 
 monitoring:
   enabled: true
+
+kubeSystem:
+  enabled: true
+
+  openstack:
+    enabled: false
+
+    ips:
+      - 0.0.0.0/0
+    ports:
+      - 443
+
+  upcloud:
+    enabled: false
+
+    ips:
+      - 0.0.0.0/0
+    ports:
+      - 443

--- a/helmfile/values/networkpolicy-common.yaml.gotmpl
+++ b/helmfile/values/networkpolicy-common.yaml.gotmpl
@@ -51,6 +51,7 @@ certManager:
     {{- end }}
   letsencrypt:
     ips: {{- toYaml .Values.networkPolicies.certManager.letsencrypt.ips | nindent 6 }}
+
 falco:
   enabled: {{ and .Values.falco.enabled .Values.networkPolicies.falco.enabled }}
   plugins:
@@ -59,3 +60,27 @@ falco:
 
 rookCeph:
   enabled: {{ .Values.networkPolicies.rookCeph.enabled }}
+
+kubeSystem:
+  enabled: {{ .Values.networkPolicies.kubeSystem.enabled }}
+
+  {{- if hasKey .Values.networkPolicies.kubeSystem "openstack" }}
+  {{- $openstack := .Values.networkPolicies.kubeSystem.openstack }}
+  openstack:
+    enabled: {{ $openstack.enabled }}
+
+    ips:
+      {{- toYaml $openstack.ips | nindent 6 }}
+    ports:
+      {{- toYaml $openstack.ports | nindent 6 }}
+
+  {{- else if hasKey .Values.networkPolicies.kubeSystem "upcloud" }}
+  {{- $upcloud := .Values.networkPolicies.kubeSystem.upcloud }}
+  upcloud:
+    enabled: {{ $upcloud.enabled }}
+
+    ips:
+      {{- toYaml $upcloud.ips | nindent 6 }}
+    ports:
+      {{- toYaml $upcloud.ports | nindent 6 }}
+  {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds netpols for kube-system components.

Let me know if I should rename the config key for `openstack` to `cinder`, though I felt like `openstack` was more fitting as it touches multiple components.
The ports `5000`, `8774`, and `8776` seem to be their default and matches across Cleura, Elastx, and Safespring.

**Which issue this PR fixes**:
Fixes #1134

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
