### PR TITLE
apps: Disabled all collectors except textfile for cisbench exporter

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changed
 
 - Updated Rook alerts to the ones provided by Rook `v1.10.5`
+- Disabled all collectors for node-exporter in ciskubebench- and vulnerability-exporter except textcollector
+- Increased the default CPU limit for node-exporter in ciskubebench- and vulnerability-exporter
 
 ### Fixed
 

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -538,7 +538,7 @@ ciskubebenchExporter:
       cpu: 20m
       memory: 15Mi
     limits:
-      cpu: 40m
+      cpu: 100m
       memory: 30Mi
   tolerations: []
   affinity: {}

--- a/helmfile/charts/starboard/ciskubebench-exporter/templates/deployment.yaml
+++ b/helmfile/charts/starboard/ciskubebench-exporter/templates/deployment.yaml
@@ -28,7 +28,46 @@ spec:
         resources: {{- .Values.curlcronjob.resources | toYaml | nindent 10 }}
       - name: node-exporter
         image: prom/node-exporter:v1.0.1
-        args: ["--collector.textfile.directory=/textfile-collector", "--no-collector.arp", "--no-collector.bcache", "--no-collector.bonding", "--no-collector.conntrack", "--no-collector.cpu", "--no-collector.cpufreq", "--no-collector.diskstats", "--no-collector.edac", "--no-collector.entropy", "--no-collector.filefd", "--no-collector.filesystem", "--no-collector.hwmon", "--no-collector.infiniband", "--no-collector.ipvs", "--no-collector.loadavg", "--no-collector.mdadm", "--no-collector.meminfo", "--no-collector.netclass", "--no-collector.netdev", "--no-collector.nfs", "--no-collector.nfsd", "--no-collector.netstat", "--no-collector.pressure", "--no-collector.stat", "--no-collector.sockstat", "--no-collector.timex", "--no-collector.vmstat", "--no-collector.xfs", "--no-collector.zfs"]
+        args:
+          - --collector.textfile.directory=/textfile-collector
+          - --no-collector.arp
+          - --no-collector.bcache
+          - --no-collector.bonding
+          - --no-collector.conntrack
+          - --no-collector.cpu
+          - --no-collector.cpufreq
+          - --no-collector.diskstats
+          - --no-collector.edac
+          - --no-collector.entropy
+          - --no-collector.filefd
+          - --no-collector.filesystem
+          - --no-collector.hwmon
+          - --no-collector.infiniband
+          - --no-collector.ipvs
+          - --no-collector.loadavg
+          - --no-collector.mdadm
+          - --no-collector.meminfo
+          - --no-collector.netclass
+          - --no-collector.netdev
+          - --no-collector.nfs
+          - --no-collector.nfsd
+          - --no-collector.netstat
+          - --no-collector.pressure
+          - --no-collector.stat
+          - --no-collector.sockstat
+          - --no-collector.timex
+          - --no-collector.vmstat
+          - --no-collector.xfs
+          - --no-collector.zfs
+          - --no-collector.btrfs
+          - --no-collector.powersupplyclass
+          - --no-collector.rapl
+          - --no-collector.schedstat
+          - --no-collector.softnet
+          - --no-collector.thermal_zone
+          - --no-collector.time
+          - --no-collector.udp_queues
+          - --no-collector.uname
           # enabled collectors: textfile, time, uname
         ports:
         - containerPort: 9100

--- a/helmfile/charts/starboard/vulnerability-exporter/templates/deployment.yaml
+++ b/helmfile/charts/starboard/vulnerability-exporter/templates/deployment.yaml
@@ -28,7 +28,46 @@ spec:
         resources: {{- .Values.curlcronjob.resources | toYaml | nindent 10 }}
       - name: node-exporter
         image: prom/node-exporter:v1.0.1
-        args: ["--collector.textfile.directory=/textfile-collector", "--no-collector.arp", "--no-collector.bcache", "--no-collector.bonding", "--no-collector.conntrack", "--no-collector.cpu", "--no-collector.cpufreq", "--no-collector.diskstats", "--no-collector.edac", "--no-collector.entropy", "--no-collector.filefd", "--no-collector.filesystem", "--no-collector.hwmon", "--no-collector.infiniband", "--no-collector.ipvs", "--no-collector.loadavg", "--no-collector.mdadm", "--no-collector.meminfo", "--no-collector.netclass", "--no-collector.netdev", "--no-collector.nfs", "--no-collector.nfsd", "--no-collector.netstat", "--no-collector.pressure", "--no-collector.stat", "--no-collector.sockstat", "--no-collector.timex", "--no-collector.vmstat", "--no-collector.xfs", "--no-collector.zfs"]
+        args:
+          - --collector.textfile.directory=/textfile-collector
+          - --no-collector.arp
+          - --no-collector.bcache
+          - --no-collector.bonding
+          - --no-collector.conntrack
+          - --no-collector.cpu
+          - --no-collector.cpufreq
+          - --no-collector.diskstats
+          - --no-collector.edac
+          - --no-collector.entropy
+          - --no-collector.filefd
+          - --no-collector.filesystem
+          - --no-collector.hwmon
+          - --no-collector.infiniband
+          - --no-collector.ipvs
+          - --no-collector.loadavg
+          - --no-collector.mdadm
+          - --no-collector.meminfo
+          - --no-collector.netclass
+          - --no-collector.netdev
+          - --no-collector.nfs
+          - --no-collector.nfsd
+          - --no-collector.netstat
+          - --no-collector.pressure
+          - --no-collector.stat
+          - --no-collector.sockstat
+          - --no-collector.timex
+          - --no-collector.vmstat
+          - --no-collector.xfs
+          - --no-collector.zfs
+          - --no-collector.btrfs
+          - --no-collector.powersupplyclass
+          - --no-collector.rapl
+          - --no-collector.schedstat
+          - --no-collector.softnet
+          - --no-collector.thermal_zone
+          - --no-collector.time
+          - --no-collector.udp_queues
+          - --no-collector.uname
           # enabled collectors: textfile, time, uname
         ports:
         - containerPort: 9100


### PR DESCRIPTION
**What this PR does / why we need it**:

It just felt unnecessary for the node-exporter

## Before the fix

```
level=info ts=2022-11-23T15:12:47.920Z caller=node_exporter.go:177 msg="Starting node_exporter" version="(version=1.0.1, branch=HEAD, revision=3715be6ae899f2a9b9dbfd9c39f3e09a7bd4559f)"
level=info ts=2022-11-23T15:12:47.920Z caller=node_exporter.go:178 msg="Build context" build_context="(go=go1.14.4, user=root@1f76dbbcfa55, date=20200616-12:44:12)"
level=info ts=2022-11-23T15:12:47.920Z caller=node_exporter.go:105 msg="Enabled collectors"
level=info ts=2022-11-23T15:12:47.920Z caller=node_exporter.go:112 collector=btrfs
level=info ts=2022-11-23T15:12:47.920Z caller=node_exporter.go:112 collector=powersupplyclass
level=info ts=2022-11-23T15:12:47.920Z caller=node_exporter.go:112 collector=rapl
level=info ts=2022-11-23T15:12:47.921Z caller=node_exporter.go:112 collector=schedstat
level=info ts=2022-11-23T15:12:47.921Z caller=node_exporter.go:112 collector=softnet
level=info ts=2022-11-23T15:12:47.921Z caller=node_exporter.go:112 collector=textfile
level=info ts=2022-11-23T15:12:47.921Z caller=node_exporter.go:112 collector=thermal_zone
level=info ts=2022-11-23T15:12:47.921Z caller=node_exporter.go:112 collector=time
level=info ts=2022-11-23T15:12:47.921Z caller=node_exporter.go:112 collector=udp_queues
level=info ts=2022-11-23T15:12:47.921Z caller=node_exporter.go:112 collector=uname
level=info ts=2022-11-23T15:12:47.921Z caller=node_exporter.go:191 msg="Listening on" address=:9100
level=info ts=2022-11-23T15:12:47.921Z caller=tls_config.go:170 msg="TLS is disabled and it cannot be enabled on the fly." http2=false
```

## After the fix

```
level=info ts=2022-11-23T15:19:03.611Z caller=node_exporter.go:177 msg="Starting node_exporter" version="(version=1.0.1, branch=HEAD, revision=3715be6ae899f2a9b9dbfd9c39f3e09a7bd4559f)"
level=info ts=2022-11-23T15:19:03.611Z caller=node_exporter.go:178 msg="Build context" build_context="(go=go1.14.4, user=root@1f76dbbcfa55, date=20200616-12:44:12)"
level=info ts=2022-11-23T15:19:03.611Z caller=node_exporter.go:105 msg="Enabled collectors"
level=info ts=2022-11-23T15:19:03.611Z caller=node_exporter.go:112 collector=textfile
level=info ts=2022-11-23T15:19:03.611Z caller=node_exporter.go:191 msg="Listening on" address=:9100
level=info ts=2022-11-23T15:19:03.611Z caller=tls_config.go:170 msg="TLS is disabled and it cannot be enabled on the fly." http2=false
```

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
