### PR TITLE
apps wc: Use FQDN when connecting to service cluster

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Used FQDN for services connecting from the workload cluster to the service cluster to prevent resolve timeouts
+
 ### Added
 
 ### Removed

--- a/helmfile/values/fluentd-user.yaml.gotmpl
+++ b/helmfile/values/fluentd-user.yaml.gotmpl
@@ -15,7 +15,7 @@ elasticsearch:
     enabled: true
     user: fluentd
     password: null
-  hosts: ["{{ .Values.opensearch.subdomain }}.{{ .Values.global.opsDomain  }}"]
+  hosts: ["{{ .Values.opensearch.subdomain }}.{{ .Values.global.opsDomain  }}."]
   sslVerify: {{ .Values.global.verifyTls }}
   logLevel: "info"
   reloadOnFailure: true

--- a/helmfile/values/fluentd-wc.yaml.gotmpl
+++ b/helmfile/values/fluentd-wc.yaml.gotmpl
@@ -15,7 +15,7 @@ elasticsearch:
     enabled: true
     user: fluentd
     password: null
-  hosts: ["{{ .Values.opensearch.subdomain }}.{{ .Values.global.opsDomain  }}"]
+  hosts: ["{{ .Values.opensearch.subdomain }}.{{ .Values.global.opsDomain  }}."]
   sslVerify: {{ .Values.global.verifyTls }}
   logLevel: "info"
   reloadOnFailure: true

--- a/helmfile/values/kube-prometheus-stack-wc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-wc.yaml.gotmpl
@@ -64,7 +64,7 @@ prometheus:
 
     {{- if and .Values.thanos.enabled .Values.thanos.receiver.enabled }}
     remoteWrite:
-    - url: https://{{ .Values.thanos.receiver.subdomain }}.{{ .Values.global.opsDomain }}/api/v1/receive
+    - url: https://{{ .Values.thanos.receiver.subdomain }}.{{ .Values.global.opsDomain }}./api/v1/receive
       tlsConfig:
         insecureSkipVerify: {{ not .Values.global.verifyTls }}
       headers:


### PR DESCRIPTION
**What this PR does / why we need it**:
To prevent scenarios with resolve timeouts, which we've seen most frequently with fluentd.

**Which issue this PR fixes**:
Fixes #1314

**Special notes for reviewer**:
All seem to be working fine, I'll monitor and see if fluentd still presents resolve issues.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
