### PR TITLE
apps sc: Fixed so registry doesn't restart each apply

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Used FQDN for services connecting from the workload cluster to the service cluster to prevent resolve timeouts
+- Added generation of registry password so that there's not a diff each time we run apply
 
 ### Added
 

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -417,10 +417,15 @@ generate_secrets() {
     THANOS_INGRESS_PASS=$(pwgen -cns 20 1)
     THANOS_INGRESS_PASS_HASH=$(htpasswd -bn "" "${THANOS_INGRESS_PASS}" | tr -d ':\n')
 
+    HARBOR_REGISTRY_PASS=$(pwgen -cns 20 1)
+    HARBOR_REGISTRY_PASS_HTPASSWD=$(htpasswd -bn "harbor_registry_user" "${HARBOR_REGISTRY_PASS}" | tr -d '\n')
+
     yq4 --inplace ".grafana.password= \"$(pwgen -cns 20 1)\"" "${tmpfile}"
     yq4 --inplace ".grafana.clientSecret= \"$(pwgen -cns 20 1)\"" "${tmpfile}"
     yq4 --inplace ".grafana.opsClientSecret= \"$(pwgen -cns 20 1)\"" "${tmpfile}"
     yq4 --inplace ".harbor.password= \"$(pwgen -cns 20 1)\"" "${tmpfile}"
+    yq4 --inplace ".harbor.registryPassword= \"${HARBOR_REGISTRY_PASS}\"" "${tmpfile}"
+    yq4 --inplace ".harbor.registryPasswordHtpasswd= \"${HARBOR_REGISTRY_PASS_HTPASSWD}\"" "${tmpfile}"
     yq4 --inplace ".harbor.internal.databasePassword= \"$(pwgen -cns 20 1)\"" "${tmpfile}"
     yq4 --inplace ".harbor.clientSecret= \"$(pwgen -cns 20 1)\"" "${tmpfile}"
     yq4 --inplace ".harbor.xsrf= \"$(pwgen -cns 32 1)\"" "${tmpfile}"

--- a/helmfile/values/harbor.yaml.gotmpl
+++ b/helmfile/values/harbor.yaml.gotmpl
@@ -132,6 +132,8 @@ registry:
   nodeSelector: {{- toYaml .Values.harbor.nodeSelector | nindent 4 }}
   affinity:     {{- toYaml .Values.harbor.registry.affinity | nindent 4 }}
   tolerations:  {{- toYaml .Values.harbor.tolerations | nindent 4 }}
+  credentials:
+    htpasswdString: {{ .Values.harbor.registryPasswordHtpasswd }}
 
 notary:
   server:

--- a/migration/v0.27.x-v0.28.x/add-registry-credentials.sh
+++ b/migration/v0.27.x-v0.28.x/add-registry-credentials.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+
+secret_config="${CK8S_CONFIG_PATH}/secrets.yaml"
+sops_config="${CK8S_CONFIG_PATH}/.sops.yaml"
+
+HARBOR_REGISTRY_PASS=$(pwgen -cns 20 1)
+HARBOR_REGISTRY_PASS_HTPASSWD=$(htpasswd -bn "harbor_registry_user" "${HARBOR_REGISTRY_PASS}" | tr -d '\n')
+
+sops --config "${sops_config}" --set '["harbor"]["registryPassword"] "'"${HARBOR_REGISTRY_PASS}"'"' "${secret_config}"
+sops --config "${sops_config}" --set '["harbor"]["registryPasswordHtpasswd"] "'"${HARBOR_REGISTRY_PASS_HTPASSWD}"'"' "${secret_config}"

--- a/migration/v0.27.x-v0.28.x/upgrade-apps.md
+++ b/migration/v0.27.x-v0.28.x/upgrade-apps.md
@@ -16,6 +16,12 @@
     ./migration/v0.27.x-v0.28.x/move-nginx-controller-service-annotation-to-map
     ```
 
+1. Add new harbor credentials
+
+    ```bash
+    ./migration/v0.27.x-v0.28.x/add-registry-credentials.sh
+    ```
+
 1. Upgrade applications:
 
     ```bash


### PR DESCRIPTION
**What this PR does / why we need it**:

While waiting for some other stuff I manage to find the root cause of this annoying issue.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
