### PR TITLE
apps sc: fixed templating when monitoring multiple workload clusters

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Used FQDN for services connecting from the workload cluster to the service cluster to prevent resolve timeouts
 - Added generation of registry password so that there's not a diff each time we run apply
+- Fixed a templating error which occurs when more than one workload cluster is specified under the `global.clustersMonitoring` in the `sc-config.yaml`
 
 ### Added
 

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -44,11 +44,11 @@ alertmanager:
         receiver: 'null'
         {{ end }}
       {{ if not .Values.user.alertmanager.enabled }}
+      {{- range .Values.global.clustersMonitoring }}
       - match:
           # TODO: it would be nice to do this some other way.
           # The workload_cluster does not have an alertmanager, send to null.
           alertname: AlertmanagerDown
-          {{- range .Values.global.clustersMonitoring }}
           cluster: {{ . }}
         receiver: 'null'
       - match:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue with templating that occurs when multiple workload clusters are specified in the `sc-config.yaml` under the `global.clustersMonitoring` field. This makes it possible to distinguish metrics between different workload clusters.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
