### PR TITLE
apps: disable rook network policies by default

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -19,8 +19,8 @@
 ### Added
 
 - Starboard resources will now be removed when running the cleanup scripts - `scripts/clean-{sc,wc}.sh`.
-- Enabled the `rook-ceph` network policy in both `sc` and `wc` cluster.
 - Added templating for wc Velero bucket prefix.
+- Network policies for `rook-ceph` (disabled by default).
 - Network policies for `csi-cinder`, `csi-upcloud`, `metrics-server` and `snapshot-controller`.
 - Added alert for less kubelets than nodes in the cluster.
 

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -660,7 +660,7 @@ networkPolicies:
         - 443
 
   rookCeph:
-    enabled: true
+    enabled: false
 
   kubeSystem:
     enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**: rook network policies should be enabled only on env that are using rook-ceph. I propose to disabled them in the default configs.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
