### PR TITLE
apps sc: removed legacy datasources from ops and user grafana

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -34,3 +34,5 @@
 
 - Prometheus recording rules for Rook.
 - Falco alerts in wc from prometheus. Users will get falco alerts via falco sidekick.
+- Legacy datasources from user-grafana: `prometheus-sc` and `prometheus-sc-reader`
+- Legacy datasources from grafana-ops: `prometheus-wc-reader`

--- a/helmfile/upstream/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
+++ b/helmfile/upstream/kube-prometheus-stack/templates/grafana/configmaps-datasources.yaml
@@ -15,6 +15,9 @@ metadata:
 data:
   datasource.yaml: |-
     apiVersion: 1
+    deleteDatasources:
+    - name: prometheus-wc-reader
+      orgId: 1
     datasources:
 {{- $scrapeInterval := .Values.grafana.sidecar.datasources.defaultDatasourceScrapeInterval | default .Values.prometheus.prometheusSpec.scrapeInterval | default "30s" }}
 {{- if .Values.grafana.sidecar.datasources.defaultDatasourceEnabled }}

--- a/helmfile/values/grafana-user.yaml.gotmpl
+++ b/helmfile/values/grafana-user.yaml.gotmpl
@@ -53,6 +53,11 @@ sidecar:
 datasources:
   datasources.yaml:
     apiVersion: 1
+    deleteDatasources:
+    - name: ck8s-metrics
+      orgId: 1
+    - name: prometheus-sc
+      orgId: 1
     datasources:
     {{- if and .Values.thanos.enabled .Values.thanos.query.enabled }}
     - name: "Service Cluster"

--- a/migration/v0.27.x-v0.28.x/upgrade-apps.md
+++ b/migration/v0.27.x-v0.28.x/upgrade-apps.md
@@ -27,3 +27,13 @@
     ```bash
     bin/ck8s apply {sc|wc}
     ```
+
+1. Removing the legacy datasources requires a pod restart.
+
+    a. check if the grafana pods have restarted (restart them if not):
+
+    ```bash
+    bin/ck8s ops kubectl sc get po -n monitoring -l app.kubernetes.io/name=grafana
+    ```
+
+    b. check in the UI if the legacy datasources were removed


### PR DESCRIPTION
**What this PR does / why we need it**: to remove the some old datasources from user-grafana

**Special notes for reviewer**:
- let me know if I should add the option to remove datasources in the configs
- the kube-prometheus-stack chart version that we use doesn't support `deleteDatasource`, we can do it after we upgrade the chart

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
