### PR TITLE
apps wc: stuck ingesting ingress-nginx logs

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix `KubeletDown` alert rule, did previously not alert if a kubelet was missing.
 - Add permissions to the `alerting_full_access` role in Opensearch to be able to view notification channels.
 - Fixed network policies for when internal traffic to the ingress is not short circuted by kube-proxy
+- `fluent-plugin-record-modifier` was added to our image `ghcr.io/elastisys/fluentd:v3.4.0-ck8s5` to prevent mapping errors from happening
 
 ### Added
 

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -254,6 +254,7 @@ fluentd:
   ## Users can specify additional plugins and config in the respective configmaps:
   ## 'fluentd-extra-plugins', and 'fluentd-extra-config'.
   user:
+
     resources:
       limits:
         cpu: 500m

--- a/helmfile/values/fluentd-user.yaml.gotmpl
+++ b/helmfile/values/fluentd-user.yaml.gotmpl
@@ -5,8 +5,8 @@ tolerations:  {{- toYaml .Values.fluentd.user.tolerations | nindent 2  }}
 
 image:
   # This is our own fork-image(https://github.com/elastisys/fluentd-elasticsearch). This can later be replaces with the original image(https://github.com/monotek/fluentd-elasticsearch) when our changes is merged.
-  repository: elastisys/fluentd
-  tag: v3.4.0-ck8s4
+  repository: ghcr.io/elastisys/fluentd
+  tag: v3.4.0-ck8s5
 
 elasticsearch:
   scheme: https
@@ -129,6 +129,11 @@ extraConfigMaps:
         expression /^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
       </parse>
     </source>
+
+    <filter **>
+       @type record_modifier
+       char_encoding utf-8:utf-8
+    </filter>
 
     # Detect exceptions in the log output and forward them as one log entry.
     <match raw.kubernetes.**>

--- a/helmfile/values/fluentd-wc.yaml.gotmpl
+++ b/helmfile/values/fluentd-wc.yaml.gotmpl
@@ -5,8 +5,8 @@ tolerations:  {{- toYaml .Values.fluentd.tolerations | nindent 2  }}
 
 image:
   # This is our own fork-image(https://github.com/elastisys/fluentd-elasticsearch). This can later be replaces with the original image(https://github.com/monotek/fluentd-elasticsearch) when our changes is merged.
-  repository: elastisys/fluentd
-  tag: v3.4.0-ck8s4
+  repository: ghcr.io/elastisys/fluentd
+  tag: v3.4.0-ck8s5
 
 elasticsearch:
   scheme: https
@@ -130,6 +130,11 @@ extraConfigMaps:
         expression /^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$/
       </parse>
     </source>
+
+    <filter **>
+       @type record_modifier
+       char_encoding utf-8:utf-8
+    </filter>
 
   containers.input.conf: |-
     #This config is taken from a default config that we have disabled


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/elastisys/compliantkubernetes-apps/issues/1317

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1317

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
This is a solution that at least seems to work. Is it perfect? Not sure. Removing the limits of the pod may not be needed to stop the error from happening in the first place but it seems to be needed to get rid of it in practice when it have been going on for a long time.

**Add a screenshot or an example to illustrate the proposed solution:**
![Screenshot from 2023-01-02 09-57-35](https://user-images.githubusercontent.com/80628178/210210956-69d4a753-bbfa-488a-a2e4-5430d06d428e.png)

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
