### PR TITLE
tests: Add troubleshooting script for certificates/ingresses

### DIFF
--- a/bin/ck8s
+++ b/bin/ck8s
@@ -70,7 +70,7 @@ case "${1}" in
         ;;
     test)
         [[ "${2}" =~ ^(wc|sc)$ ]] || usage
-        "${here}/test.bash" "${2}"
+        "${here}/test.bash" "${@:2}"
         ;;
     dry-run)
         [[ "${2}" =~ ^(wc|sc)$ ]] || usage

--- a/bin/test.bash
+++ b/bin/test.bash
@@ -11,6 +11,11 @@ source "${here}/common.bash"
 # shellcheck source=pipeline/test/services/service-cluster/testOpensearch.sh
 source "${pipeline_path}/test/services/service-cluster/testOpensearch.sh"
 
+# shellcheck source=pipeline/test/services/service-cluster/testCertManager.sh
+source "${pipeline_path}/test/services/service-cluster/testCertManager.sh"
+# shellcheck source=pipeline/test/services/workload-cluster/testCertManager.sh
+source "${pipeline_path}/test/services/workload-cluster/testCertManager.sh"
+
 test_apps_sc() {
     log_info "Testing service cluster"
 
@@ -25,14 +30,23 @@ test_apps_wc() {
         "${pipeline_path}/test/services/test-wc.sh" "${config[config_file_wc]}"
 }
 
-function sc_help(){
-    printf "%s\n" "[Usage]: test sc [target] [ARGUMENTS]";
-    printf "%s\n" "List of targets:";
-    printf "\t%-23s %s\n" "opensearch" "Open search checks";
-    printf "\t%-23s %s\n" "fluentd" "Fluentd checks";
-    printf "\t%-23s %s\n" "opensearch-dashboards" "Opensearch dashboards checks";
-    printf "%s\n" "[NOTE] If no target is specified, the tests will go through all of them.";
-    exit 0;
+function sc_help() {
+    printf "%s\n" "[Usage]: test sc [target] [ARGUMENTS]"
+    printf "%s\n" "List of targets:"
+    printf "\t%-23s %s\n" "opensearch" "Open search checks"
+    printf "\t%-23s %s\n" "fluentd" "Fluentd checks"
+    printf "\t%-23s %s\n" "opensearch-dashboards" "Opensearch dashboards checks"
+    printf "\t%-23s %s\n" "cert-manager" "Cert Manager checks"
+    printf "%s\n" "[NOTE] If no target is specified, the tests will go through all of them."
+    exit 0
+}
+
+function wc_help() {
+    printf "%s\n" "[Usage]: test wc [target] [ARGUMENTS]"
+    printf "%s\n" "List of targets:"
+    printf "\t%-23s %s\n" "cert-manager" "Cert Manager checks"
+    printf "%s\n" "[NOTE] If no target is specified, the tests will go through all of them."
+    exit 0
 }
 
 function sc() {
@@ -40,48 +54,72 @@ function sc() {
         test_apps_sc
     else
         case ${1} in
-            opensearch )
-                sc_opensearch_checks "${@:2}";
+        opensearch)
+            sc_opensearch_checks "${@:2}"
             ;;
-            --help )
-              sc_help
+        cert-manager)
+            sc_cert_manager_checks "${@:2}"
             ;;
-            * )
-                echo "unknown command: $1";
-                sc_help 1;
-                exit 1;
+        --help)
+            sc_help
+            ;;
+        *)
+            echo "unknown command: $1"
+            sc_help 1
+            exit 1
             ;;
         esac
     fi
-    exit 0;
+    exit 0
 }
 
-function main_help(){
-    echo list of commands:
-    printf "%-23s %s\n" "help" "show help menu and commands";
-    printf "%-23s %s\n" "sc" "Run sc checks";
-    printf "%-23s %s\n" "wc" "Run wc checks";
-
-    exit "${1:-0}";
-}
-
-function main(){
+function wc() {
     if [[ ${#} == 0 ]]; then
-        main_help 0;
+        test_apps_wc
+    else
+        case ${1} in
+        cert-manager)
+            wc_cert_manager_checks "${@:2}"
+            ;;
+        --help)
+            wc_help
+            ;;
+        *)
+            echo "unknown command: $1"
+            wc_help 1
+            exit 1
+            ;;
+        esac
+    fi
+    exit 0
+}
+
+function main_help() {
+    echo list of commands:
+    printf "%-23s %s\n" "help" "show help menu and commands"
+    printf "%-23s %s\n" "sc" "Run sc checks"
+    printf "%-23s %s\n" "wc" "Run wc checks"
+
+    exit "${1:-0}"
+}
+
+function main() {
+    if [[ ${#} == 0 ]]; then
+        main_help 0
     fi
 
     case ${1} in
-        sc )
-            config_load "$1";
-            with_kubeconfig "${config[kube_config_sc]}" \
-              "$1" "${@:2}";
+    sc)
+        config_load "$1"
+        with_kubeconfig "${config[kube_config_sc]}" \
+            "$1" "${@:2}"
         ;;
-        wc )
-            config_load "$1";
-            with_kubeconfig "${config[kube_config_wc]}" \
-              "$1" "${@:2}";
+    wc)
+        config_load "$1"
+        with_kubeconfig "${config[kube_config_wc]}" \
+            "$1" "${@:2}"
         ;;
     esac
 }
 
-main "$@";
+main "$@"

--- a/bin/test.bash
+++ b/bin/test.bash
@@ -8,6 +8,8 @@ set -eu -o pipefail
 here="$(dirname "$(readlink -f "$0")")"
 # shellcheck source=bin/common.bash
 source "${here}/common.bash"
+# shellcheck source=pipeline/test/services/service-cluster/testOpensearch.sh
+source "${pipeline_path}/test/services/service-cluster/testOpensearch.sh"
 
 test_apps_sc() {
     log_info "Testing service cluster"
@@ -23,17 +25,63 @@ test_apps_wc() {
         "${pipeline_path}/test/services/test-wc.sh" "${config[config_file_wc]}"
 }
 
-#
-# ENTRYPOINT
-#
+function sc_help(){
+    printf "%s\n" "[Usage]: test sc [target] [ARGUMENTS]";
+    printf "%s\n" "List of targets:";
+    printf "\t%-23s %s\n" "opensearch" "Open search checks";
+    printf "\t%-23s %s\n" "fluentd" "Fluentd checks";
+    printf "\t%-23s %s\n" "opensearch-dashboards" "Opensearch dashboards checks";
+    printf "%s\n" "[NOTE] If no target is specified, the tests will go through all of them.";
+    exit 0;
+}
 
-config_load "$1"
-if [[ $1 == "wc" ]]; then
-    test_apps_wc
-elif [[ $1 == "sc" ]]; then
-    test_apps_sc
-else
-    echo "ERROR:  [$1] is an invalid argument:"
-    echo "usage:   ck8s test <wc|sc>. "
-    exit 1
-fi
+function sc() {
+    if [[ ${#} == 0 ]]; then
+        test_apps_sc
+    else
+        case ${1} in
+            opensearch )
+                sc_opensearch_checks "${@:2}";
+            ;;
+            --help )
+              sc_help
+            ;;
+            * )
+                echo "unknown command: $1";
+                sc_help 1;
+                exit 1;
+            ;;
+        esac
+    fi
+    exit 0;
+}
+
+function main_help(){
+    echo list of commands:
+    printf "%-23s %s\n" "help" "show help menu and commands";
+    printf "%-23s %s\n" "sc" "Run sc checks";
+    printf "%-23s %s\n" "wc" "Run wc checks";
+
+    exit "${1:-0}";
+}
+
+function main(){
+    if [[ ${#} == 0 ]]; then
+        main_help 0;
+    fi
+
+    case ${1} in
+        sc )
+            config_load "$1";
+            with_kubeconfig "${config[kube_config_sc]}" \
+              "$1" "${@:2}";
+        ;;
+        wc )
+            config_load "$1";
+            with_kubeconfig "${config[kube_config_wc]}" \
+              "$1" "${@:2}";
+        ;;
+    esac
+}
+
+main "$@";

--- a/pipeline/test/services/funcs.sh
+++ b/pipeline/test/services/funcs.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+PIPELINE=${PIPELINE:-false}
 if [ -z "$PIPELINE" ]
 then
     RETRY_COUNT=6

--- a/pipeline/test/services/service-cluster/testCertManager.sh
+++ b/pipeline/test/services/service-cluster/testCertManager.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+# (return 0 2>/dev/null) && sourced=1 || sourced=0
+
+INNER_SCRIPTS_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+# shellcheck source=bin/common.bash
+source "${INNER_SCRIPTS_PATH}/../funcs.sh"
+
+function sc_certmanager_check_help() {
+    printf "%s\n" "[Usage]: test sc cert-manager [ARGUMENT]"
+    printf "\t%-25s %s\n" "--cluster-issuers" "Check cluster issuers"
+    printf "\t%-25s %s\n" "--certificates" "Check cluster certificates"
+    printf "\t%-25s %s\n" "--challenges" "Check challenges"
+    printf "%s\n" "[NOTE] If no argument is specified, it will go over all of them."
+
+    exit 0
+}
+
+function sc_cert_manager_checks() {
+    if [[ ${#} == 0 ]]; then
+        echo "Running all checks ..."
+        check_sc_certmanager_cluster_issuers
+        check_sc_certmanager_apps_certificates
+        check_sc_certmanager_challenges
+        exit 0
+    fi
+    while [[ ${#} -gt 0 ]]; do
+        case ${1} in
+        --cluster-issuers)
+            check_sc_certmanager_cluster_issuers
+            ;;
+        --certificates)
+            check_sc_certmanager_apps_certificates
+            ;;
+        --challenges)
+            check_sc_certmanager_challenges
+            ;;
+        --help)
+            sc_certmanager_check_help
+            ;;
+        esac
+        shift
+    done
+}
+
+function check_sc_certmanager_cluster_issuers() {
+    echo -ne "Checking cert manager cluster issuers ... "
+    no_error=true
+    debug_msg=""
+
+    clusterIssuers=("letsencrypt-prod" "letsencrypt-staging")
+
+    for clusterIssuer in "${clusterIssuers[@]}"; do
+        if kubectl get ClusterIssuer "$clusterIssuer" &>/dev/null; then
+            jsonData=$(kubectl get ClusterIssuer "$clusterIssuer" -ojson)
+            cluster_issuer_status=$(echo "$jsonData" | jq -r '.status.conditions[] | select(.type=="Ready") | .status')
+            if [[ "$cluster_issuer_status" == "True" ]]; then
+                IFS='-' read -ra data <<<"$clusterIssuer"
+                readarray custom_solvers < <(yq4 e -o=j -I=0 ".issuers.${data[0]}.${data[1]}.solvers[]" "${config['config_file_sc']}")
+                if ! [ ${#custom_solvers[@]} -eq 0 ]; then
+                    for custom_solver in "${custom_solvers[@]}"; do
+                        challenge_solver=$(echo "$custom_solver" | jq ". | del( .selector ) | keys[] ")
+                        solver_exist=$(kubectl get ClusterIssuer "$clusterIssuer" -oyaml | yq4 e -o=j -I=0 ".spec.acme.solvers[].$challenge_solver")
+                        if [[ $solver_exist == "null" ]]; then
+                            no_error=false
+                            debug_msg+="[ERROR] Missing custom solver : $challenge_solver for Cluster Issuer : $clusterIssuer\n"
+                        fi
+                    done
+                fi
+
+            else
+                no_error=false
+                debug_msg+="[ERROR] ClusterIssuer $clusterIssuer is not ready\n"
+            fi
+
+        else
+            no_error=false
+            debug_msg+="[ERROR] ClusterIssuer $clusterIssuer does not exist\n"
+        fi
+    done
+
+    if $no_error; then
+        echo "success ✔"
+        echo -e "[DEBUG] All ClusterIssuer resources are present and ready, with correct solvers"
+    else
+        echo "failure ❌"
+        echo -e "$debug_msg"
+    fi
+}
+
+function check_sc_certmanager_apps_certificates() {
+    echo -ne "Checking cert manager for Apps Certificates ... "
+    no_error=true
+    debug_msg=""
+
+    certificates=(
+        "dex dex-tls"
+        "opensearch-system opensearch-admin"
+        "opensearch-system opensearch-ca"
+        "opensearch-system opensearch-dashboards-ingress-cert"
+        "opensearch-system opensearch-http"
+        "opensearch-system opensearch-ingress-cert"
+        "opensearch-system opensearch-transport"
+    )
+
+    enable_harbor=$(yq4 -e '.harbor.enabled' "${config['config_file_sc']}" 2>/dev/null)
+    enable_thanos=$(yq4 -e '.thanos.enabled' "${config['config_file_sc']}" 2>/dev/null)
+    enable_user_grafana=$(yq4 -e '.user.grafana.enabled' "${config['config_file_sc']}" 2>/dev/null)
+
+    if "${enable_harbor}"; then
+        certificates+=(
+            "harbor harbor-core-cert"
+            "harbor harbor-notary-cert"
+            "harbor harbor-core-ingress-cert"
+            "harbor harbor-notary-ingress-cert"
+        )
+    fi
+
+    if "${enable_user_grafana}"; then
+        certificates+=(
+            "monitoring grafana-ops-general-tls"
+            "monitoring user-grafana-tls"
+        )
+    fi
+
+    if "${enable_thanos}"; then
+        thanos_subdomain=$(yq4 -e '.thanos.receiver.subdomain' "${config['config_file_sc']}")
+        opsDomain=$(yq4 -e '.global.opsDomain' "${config['config_file_sc']}")
+        certificates+=(
+            "thanos $thanos_subdomain.$opsDomain-tls"
+        )
+    fi
+
+    for cert in "${certificates[@]}"; do
+        read -r -a arr <<<"$cert"
+        namespace="${arr[0]}"
+        name="${arr[1]}"
+        if kubectl get "Certificate" -n "$namespace" "$name" &>/dev/null; then
+            certificate_data=$(kubectl get "Certificate" -n "$namespace" "$name" -ojson)
+            cert_renewal_time=$(echo "$certificate_data" | jq -r ".status.renewalTime")
+            cert_expiry_time=$(echo "$certificate_data" | jq -r ".status.notAfter")
+            cert_status=$(echo "$certificate_data" | jq -r ".status.conditions[] | select(.type==\"Ready\") | .status")
+            cert_status_message=$(echo "$certificate_data" | jq -r ".status.conditions[] | select(.type==\"Ready\") | .message")
+            if [[ "$cert_status" != "True" ]]; then
+                no_error=false
+                debug_msg+="[ERROR] $cert_status_message \n"
+            else
+                now_date=$(date +%s)
+                expiry_date=$(date -d "$cert_expiry_time" +%s)
+                renew_date=$(date -d "$cert_renewal_time" +%s)
+                ((expiry_diff = (expiry_date - now_date) / 86400))
+                ((renew_diff = (renew_date - now_date) / 86400))
+                if [[ $expiry_diff -lt 1 ]]; then
+                    no_error=false
+                    debug_msg+="[ERROR] $name will expire in less than $expiry_diff day(s)\n"
+                else
+                    debug_msg+="[DEBUG] Certificate: $name is Ready, will expire in $expiry_diff day(s), will be renewed in $renew_diff day(s)\n"
+                fi
+            fi
+        else
+            no_error=false
+            debug_msg+="[ERROR]: Missing certificate : $name in namespace $namespace\n"
+        fi
+    done
+
+    if $no_error; then
+        echo "success ✔"
+        echo -e "$debug_msg"
+    else
+        echo "failure ❌"
+        echo -e "$debug_msg"
+    fi
+}
+
+function check_sc_certmanager_challenges() {
+    echo -ne "Checking cert manager Challenges ... "
+    no_error=true
+    debug_msg=""
+
+    challenges_data=$(kubectl get challenges -A -ojson)
+
+    readarray -t pending_challenges < <(jq -c '.items[] | select(.status.state=="pending")' <<<"$challenges_data")
+
+    if ! [[ $(echo "$challenges_data" | jq '.items | length') -eq 0 ]]; then
+        if [[ ${#pending_challenges[@]} != 0 ]]; then
+            no_error=false
+            debug_msg+="[ERROR] There are some pending challenges\n"
+            for pending_challenge in "${pending_challenges[@]}"; do
+                challenge_name=$(echo "$pending_challenge" | jq -r ".metadata.name")
+                challenge_namespace=$(echo "$pending_challenge" | jq -r ".metadata.namespace")
+                pending_reason=$(echo "$pending_challenge" | jq -r ".status.reason")
+                debug_msg+="Challenge $challenge_name in the $challenge_namespace namepsace is pending because : $pending_reason\n"
+            done
+        fi
+    fi
+
+    orders_data=$(kubectl get orders -A -ojson)
+
+    if ! [[ $(echo "$orders_data" | jq '.items | length') -eq 0 ]]; then
+        readarray -t errored_orders < <(jq -c '.items[] | select(.status.state=="errored")' <<<"$orders_data")
+
+        if [[ ${#errored_orders[@]} != 0 ]]; then
+            no_error=false
+            debug_msg+="[ERROR] There some errored orders\n"
+            for errored_order in "${errored_orders[@]}"; do
+                order_name=$(echo "$errored_order" | jq -r ".metadata.name")
+                order_namespace=$(echo "$errored_order" | jq -r ".metadata.namespace")
+                errored_reason=$(echo "$errored_order" | jq -r ".status.reason")
+                debug_msg+="Order $order_name in the $order_namespace namepsace is errored because : $errored_reason\n"
+            done
+        fi
+    fi
+
+    if $no_error; then
+        echo "success ✔"
+        echo -e "[DEBUG] There are no pending challenges, or errored orders"
+    else
+        echo "failure ❌"
+        echo -e "$debug_msg"
+    fi
+}

--- a/pipeline/test/services/service-cluster/testOpensearch.sh
+++ b/pipeline/test/services/service-cluster/testOpensearch.sh
@@ -1,0 +1,403 @@
+#!/bin/bash
+# (return 0 2>/dev/null) && sourced=1 || sourced=0
+
+INNER_SCRIPTS_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+# shellcheck source=bin/common.bash
+source "${INNER_SCRIPTS_PATH}/../funcs.sh"
+
+pushd "${CK8S_CONFIG_PATH}" || exit
+adminPassword=$(sops -d secrets.yaml | yq4 '.opensearch.adminPassword')
+fluentdPassword=$(sops -d secrets.yaml | yq4 '.opensearch.fluentdPassword')
+opsDomain=$(yq4 '.global.opsDomain' common-config.yaml)
+popd || exit
+
+
+function opensearch_check_help(){
+    printf "%s\n" "[Usage]: test sc opensearch [ARGUMENT]";
+    printf "\t%-25s %s\n" "--cluster-health" "Get cluster health";
+    printf "\t%-25s %s\n" "--snapshot-status" "Check snapshot status";
+    printf "\t%-25s %s\n" "--breakers" "Check if circuit breakers have been triggered";
+    printf "\t%-25s %s\n" "--indices" "Check if there are any missing indices";
+    printf "\t%-25s %s\n" "--aliases" "Check if each aliase has a write index";
+    printf "\t%-25s %s\n" "--mappings" "Check mappings/fields count & limit";
+    printf "\t%-25s %s\n" "--user-roles" "Check configured user roles";
+    printf "\t%-25s %s\n" "--ism" "Check ISM";
+    printf "\t%-25s %s\n" "--object-store-access" "Check object store access";
+    printf "\t%-25s %s\n" "--fluentd" "Check that fluentd can connect to opensearch";
+    printf "%s\n" "[NOTE] If no argument is specified, it will go over all of them.";
+
+    exit 0;
+}
+
+function sc_opensearch_checks(){
+    if [[ ${#} == 0 ]]; then
+        check_opensearch_cluster_health
+        check_opensearch_snapshots_status
+        check_opensearch_breakers
+        check_opensearch_indices
+        check_opensearch_aliases
+        check_opensearch_mappings
+        check_opensearch_user_roles
+        check_opensearch_ism
+        check_object_store_access
+        check_fluentd_connection
+        exit 0
+    fi
+    while [[ ${#} -gt  0 ]]; do
+      case ${1} in
+          --cluster-health )
+              check_opensearch_cluster_health
+          ;;
+          --snapshot-status )
+              check_opensearch_snapshots_status
+          ;;
+          --breakers )
+              check_opensearch_breakers
+          ;;
+          --indices )
+              check_opensearch_indices
+          ;;
+          --aliases )
+              check_opensearch_aliases
+          ;;
+          --mappings )
+              check_opensearch_mappings
+          ;;
+          --user-roles )
+              check_opensearch_user_roles
+          ;;
+          --ism )
+              check_opensearch_ism
+          ;;
+          --object-store-access )
+              check_object_store_access;
+          ;;
+          --fluentd )
+              check_fluentd_connection;
+          ;;
+          --help )
+            opensearch_check_help
+          ;;
+      esac
+      shift
+    done
+}
+
+check_opensearch_cluster_health() {
+  echo -ne "Checking if opensearch cluster is healthy ... "
+  cluster_health=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_cluster/health")
+  status=$(echo "$cluster_health" | jq -r '.status')
+  if [[ $status != "green" ]]; then
+    echo -e "failure ❌";
+    echo "$cluster_health" | jq
+  else
+    echo -e "success ✔";
+  fi
+}
+
+check_opensearch_snapshots_status(){
+  echo -ne "Checking opensearch snapshots status ... "
+  no_error=true
+  debug_msg=""
+  repo_name=$(yq4 -e '.opensearch.snapshot.repository' "${config['config_file_sc']}")
+  repo_exists_status=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_snapshot/${repo_name}" | jq "select(.error)")
+  if [[ -z "$repo_exists_status" ]]; then
+    if kubectl get "cronjob" -n "opensearch-system" "opensearch-backup" &> /dev/null
+    then
+        snapshots=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_cat/snapshots/${repo_name}")
+        failed=$(echo "$snapshots" | grep 'FAILED' || true)
+        partial=$(echo "$snapshots" | grep 'PARTIAL' || true)
+        if [[ "$failed" != "" ]]; then
+          no_error=false
+          debug_msg+="[ERROR] We found some failed snapshots: \n $failed\n"
+        fi
+
+        if [[ "$partial" != "" ]]; then
+          no_error=false
+          debug_msg+="[WARNING] We found some partial snapshots: \n $partial\n"
+        fi
+
+        IFS=$'\n' readarray -t data < <(awk '{ print $1 " " $2 " " $3}' <<< "$snapshots")
+        IFS=" " read -ra last_snapshot <<< "${data[-1]}"
+
+        now_epoch=$(date +%s)
+        last_snapshot_epoch=${last_snapshot[2]}
+        ((diff=now_epoch-last_snapshot_epoch))
+
+          if [[ $diff -gt 86400 ]]; then
+            no_error=false
+            debug_msg+="[ERROR] The snapshot has been created for more than 24 hours, with a status: ${last_snapshot[1]}\n"
+          else
+            debug_msg+="[WARNING] The latest snapshot has been created within 24 hours, with a status: ${last_snapshot[1]}\n"
+          fi
+    else
+        no_error=false
+        debug_msg+="[ERROR] opensearch-backup cronjob doesn't exist\n"
+    fi
+  else
+    no_error=false
+    debug_msg=$(echo -e "$repo_exists_status" | jq)
+  fi
+
+  if $no_error; then
+    echo "success ✔"
+    echo "[DEBUG] All snapshots are either completed or in progress"
+  else
+    echo "failure ❌";
+    echo -e "$debug_msg"
+  fi
+}
+
+check_opensearch_indices(){
+  echo -ne "Checking opensearch indices status ... "
+  debug_msg=""
+  no_error=true
+
+  for index in 'other' 'kubernetes' 'kubeaudit' 'authlog'; do
+    res=$(curl -w "%{http_code}"  -o /dev/null -ksIL -u admin:"${adminPassword}" -X HEAD "https://opensearch.${opsDomain}/${index}")
+    if [[ $res != "200" ]]; then
+      debug_msg+="[ERROR] Missing index : ${index}\n"
+      no_error=false
+    fi
+  done
+
+  if $no_error; then
+    echo "success ✔"
+    echo -e "[DEBUG] All indices are present"
+  else
+      echo "failure ❌";
+      echo -e "$debug_msg"
+  fi
+}
+
+check_opensearch_breakers(){
+  echo -ne "Checking opensearch breakers ... "
+  breakers_data=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_nodes/_all/stats/breaker")
+  no_error=true
+  debug_msg=""
+  nodes_data=$(echo "$breakers_data" | jq ".nodes")
+  readarray -t nodes < <(jq -c 'to_entries[]' <<< "$nodes_data")
+
+  for node in "${nodes[@]}"; do
+    node_name=$(jq '.key' <<< "$node")
+    readarray -t breakers < <(jq -c '.value.breakers | to_entries[]' <<< "$node")
+    for breaker in "${breakers[@]}"; do
+      tripped=$(jq ".value.tripped" <<< "$breaker")
+      name=$(jq ".key" <<< "$breaker")
+      if [[ $tripped == "1" ]]; then
+        no_error=false
+        debug_msg+="[DEBUG] A circuit breaker : $name has been triggered for node: $node_name\n"
+      fi
+    done
+  done
+
+  if $no_error; then
+    echo "success ✔"
+    echo "[DEBUG] None of the circuit breakers has been triggered"
+  else
+    echo "failure ❌";
+    echo -e "$debug_msg"
+  fi
+
+}
+
+check_opensearch_aliases(){
+  echo -ne "Checking opensearch aliases indices mapping ... "
+  no_error=true
+  debug_msg=""
+
+  curl -sk -o /tmp/response -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_cat/aliases"
+
+  aliases=$(awk '{print $1}' < /tmp/response)
+  aliases_arr=("$aliases")
+
+  uniq_aliases=$(echo "${aliases_arr[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+  for alias in $uniq_aliases; do
+    if ! [[ $alias =~ ^[\.*] ]]; then
+
+      alias_data=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_alias/${alias}")
+      is_write_index="$(echo "$alias_data" | jq ".[].aliases.$alias.is_write_index | select(. == true)")"
+      if [[ "$is_write_index" == "" ]]; then
+        no_error=false
+        debug_msg+="[DEBUG] Alias : $alias has no write index \n"
+      fi
+
+    fi
+  done
+
+  if $no_error; then
+    echo "success ✔"
+    echo "[DEBUG] All aliases have write indices associated with them"
+  else
+    echo "failure ❌";
+    echo -e "$debug_msg"
+  fi
+
+}
+
+check_opensearch_mappings(){
+  echo -ne "Checking opensearch mappings/fields ... "
+  no_error=true
+  debug_msg="INDEX\t\t\t#FIELDS\tLIMIT\n"
+  debug_msg+="------------------------------------------------\n"
+
+  indices_data=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_cat/indices" | awk '{print $3}' | tr '\n' ' ')
+  IFS=' ' read -ra indices <<< "$indices_data"
+  for index in "${indices[@]}"; do
+    fields_limit=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/${index}/_settings" | jq -r ".[\"${index}\"].settings.index.mapping.total_fields.limit")
+    fields_count=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/${index}/_field_caps?fields=*" | jq -r ".fields | keys | length")
+
+    if [[ $fields_limit != "null" ]] && [[ $fields_count -gt $fields_limit ]]; then
+      no_error=false
+    fi
+    debug_msg+="${index}\t\t\t${fields_count}\t${fields_limit}\n"
+  done
+
+  if $no_error; then
+    echo "success ✔"
+    echo "[DEBUG] Fields limit has not been reached yet"
+    echo -e "$debug_msg"
+  else
+    echo "failure ❌";
+    echo "[DEBUG] Some fields limit have been crossed"
+    echo -e "$debug_msg"
+  fi
+}
+
+check_opensearch_user_roles(){
+  echo -ne "checking user roles mappings ... "
+  no_error=true
+  debug_msg=""
+
+  readarray configuredMappings < <(yq4 e -o=j -I=0 '.opensearch.extraRoleMappings[]' "${config['config_file_sc']}")
+
+  rolesmapping=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_plugins/_security/api/rolesmapping")
+
+  for roleMapping in "${configuredMappings[@]}"; do
+    configured_mapping_name=$(echo "$roleMapping" | yq4 e '.mapping_name' -)
+    configured_users=$(echo "$roleMapping" | yq4 e '.definition.users[]' -)
+    res=$(echo "$rolesmapping" | jq ".$configured_mapping_name")
+    if [[ $res != "null" ]]; then
+      users=$(echo "$rolesmapping" | jq -r ".$configured_mapping_name.users[]")
+      if [[ "$users" != "$configured_users" ]]; then
+        no_error=false
+        debug_msg+="[ERROR] Missing users < ${configured_users//$'\n'/ }> != < $users >, for role mapping: $configured_mapping_name \n"
+      fi
+    else
+        no_error=false
+        debug_msg+="[ERROR] Missing role mapping_name ${roleMapping} \n"
+    fi
+  done
+
+  if $no_error; then
+    echo "success ✔"
+    echo "[DEBUG] User roles are configured correctly"
+  else
+    echo "failure ❌";
+    echo -ne "$debug_msg"
+  fi
+}
+
+check_opensearch_ism(){
+  echo -ne "Checking opensearch Index State Management ... "
+  no_error=true
+  debug_msg=""
+
+  default_policies_enabled=$(yq4 -e '.opensearch.ism.defaultPolicies' "${config['config_file_sc']}")
+  if [[ $default_policies_enabled == "true" ]]; then
+    default_policies=("kubernetes" "kubeaudit" "authlog" "other")
+    for policy in "${default_policies[@]}"; do
+      res=$(curl -w "%{http_code}" -o /dev/null -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_plugins/_ism/policies/${policy}")
+      if [[ $res != "200" ]]; then
+        no_error=false
+        debug_msg+="[ERROR] Missing default policy : ${policy}\n"
+      fi
+    done
+  fi
+
+  # additional_policies=$(yq4 -e '.opensearch.ism.additionalPolicies | keys' "${config['config_file_sc']}")
+  readarray -t additional_policies < <(yq4 e -o=j -I=0 '.opensearch.ism.additionalPolicies | keys' "${config['config_file_sc']}")
+
+  additional_policies=("${additional_policies//,/ }")
+  additional_policies=("${additional_policies##[}")
+  additional_policies=("${additional_policies%]}")
+  # additional_policies=($additional_policies)
+  read -ra additional_policies <<< "${additional_policies[@]}"
+
+  for policy in "${additional_policies[@]}"; do
+    policy_name=$(echo "$policy" | awk -F'.' '{print $1}' | tr '"' ' ')
+    res=$(curl -w "%{http_code}" -o /dev/null -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_plugins/_ism/policies/${policy_name}")
+    if [[ $res != "200" ]]; then
+      no_error=false
+      debug_msg+="[ERROR] Missing additional policy : ${policy_name}\n"
+    fi
+  done
+
+  if $no_error; then
+    echo "success ✔"
+    echo -e "[DEBUG] There are no missing default policies or additional policies"
+  else
+    echo "failure ❌";
+    echo -e "$debug_msg"
+  fi
+}
+
+check_object_store_access(){
+  echo -ne "Checking opensearch snapshot bucket access... "
+  no_error=true
+  debug_msg=""
+  EX_NOTFOUND=12
+  EX_OK=0
+  EX_ACCESSDENIED=77
+  EX_CONFIG=78
+  snapshot_bucket=$(yq4 -e '.objectStorage.buckets.opensearch' "${config['config_file_sc']}")
+
+  command=$(s3cmd --config <(sops -d "${CK8S_CONFIG_PATH}"/.state/s3cfg.ini) ls s3://"${snapshot_bucket}" > /dev/null 2>&1 ;echo $?)
+  if [[ ${command} -eq $EX_OK ]]; then
+    debug_msg="[DEBUG] Snapshot bucket ${snapshot_bucket} exist and can be accessed"
+  elif [[ ${command} -eq $EX_NOTFOUND ]]; then
+    no_error=false
+    debug_msg="[ERROR] S3 error: 404 (NoSuchBucket): The specified bucket ${snapshot_bucket} does not exist."
+  elif [[ ${command} -eq $EX_ACCESSDENIED ]]; then
+    no_error=false
+    debug_msg="[ERROR] S3 error: Insufficient permissions to perform the operation on S3"
+  elif [[ ${command} -eq $EX_CONFIG ]]; then
+    no_error=false
+    debug_msg="[ERROR] S3 error: Configuration file error"
+  else
+    no_error=false
+    debug_msg="[ERROR] An error happened, please try again"
+  fi
+
+  if $no_error; then
+    echo "success ✔"
+    echo -e "$debug_msg"
+  else
+    echo "failure ❌";
+    echo -e "$debug_msg"
+  fi
+}
+
+check_fluentd_connection(){
+  echo -ne "Checking if fluentd can connect to opensearch... "
+  no_error=true
+  debug_msg=""
+
+
+  res=$(curl -w "%{http_code}"  -o /dev/null -ksIL -u fluentd:"${fluentdPassword}" -X HEAD "https://opensearch.${opsDomain}/")
+  if [[ $res != "200" ]]; then
+    debug_msg+="[ERROR] $res : Fluentd cannot connect to opensearch.\nPlease check your credentials"
+    no_error=false
+  fi
+
+
+  if $no_error; then
+    echo "success ✔"
+    echo -e "[DEBUG] Fluentd is able to connect to Opensearch"
+  else
+    echo "failure ❌";
+    echo -e "$debug_msg"
+  fi
+
+}

--- a/pipeline/test/services/service-cluster/testOpensearch.sh
+++ b/pipeline/test/services/service-cluster/testOpensearch.sh
@@ -11,25 +11,24 @@ fluentdPassword=$(sops -d secrets.yaml | yq4 '.opensearch.fluentdPassword')
 opsDomain=$(yq4 '.global.opsDomain' common-config.yaml)
 popd || exit
 
+function opensearch_check_help() {
+    printf "%s\n" "[Usage]: test sc opensearch [ARGUMENT]"
+    printf "\t%-25s %s\n" "--cluster-health" "Get cluster health"
+    printf "\t%-25s %s\n" "--snapshot-status" "Check snapshot status"
+    printf "\t%-25s %s\n" "--breakers" "Check if circuit breakers have been triggered"
+    printf "\t%-25s %s\n" "--indices" "Check if there are any missing indices"
+    printf "\t%-25s %s\n" "--aliases" "Check if each aliase has a write index"
+    printf "\t%-25s %s\n" "--mappings" "Check mappings/fields count & limit"
+    printf "\t%-25s %s\n" "--user-roles" "Check configured user roles"
+    printf "\t%-25s %s\n" "--ism" "Check ISM"
+    printf "\t%-25s %s\n" "--object-store-access" "Check object store access"
+    printf "\t%-25s %s\n" "--fluentd" "Check that fluentd can connect to opensearch"
+    printf "%s\n" "[NOTE] If no argument is specified, it will go over all of them."
 
-function opensearch_check_help(){
-    printf "%s\n" "[Usage]: test sc opensearch [ARGUMENT]";
-    printf "\t%-25s %s\n" "--cluster-health" "Get cluster health";
-    printf "\t%-25s %s\n" "--snapshot-status" "Check snapshot status";
-    printf "\t%-25s %s\n" "--breakers" "Check if circuit breakers have been triggered";
-    printf "\t%-25s %s\n" "--indices" "Check if there are any missing indices";
-    printf "\t%-25s %s\n" "--aliases" "Check if each aliase has a write index";
-    printf "\t%-25s %s\n" "--mappings" "Check mappings/fields count & limit";
-    printf "\t%-25s %s\n" "--user-roles" "Check configured user roles";
-    printf "\t%-25s %s\n" "--ism" "Check ISM";
-    printf "\t%-25s %s\n" "--object-store-access" "Check object store access";
-    printf "\t%-25s %s\n" "--fluentd" "Check that fluentd can connect to opensearch";
-    printf "%s\n" "[NOTE] If no argument is specified, it will go over all of them.";
-
-    exit 0;
+    exit 0
 }
 
-function sc_opensearch_checks(){
+function sc_opensearch_checks() {
     if [[ ${#} == 0 ]]; then
         check_opensearch_cluster_health
         check_opensearch_snapshots_status
@@ -43,365 +42,385 @@ function sc_opensearch_checks(){
         check_fluentd_connection
         exit 0
     fi
-    while [[ ${#} -gt  0 ]]; do
-      case ${1} in
-          --cluster-health )
-              check_opensearch_cluster_health
-          ;;
-          --snapshot-status )
-              check_opensearch_snapshots_status
-          ;;
-          --breakers )
-              check_opensearch_breakers
-          ;;
-          --indices )
-              check_opensearch_indices
-          ;;
-          --aliases )
-              check_opensearch_aliases
-          ;;
-          --mappings )
-              check_opensearch_mappings
-          ;;
-          --user-roles )
-              check_opensearch_user_roles
-          ;;
-          --ism )
-              check_opensearch_ism
-          ;;
-          --object-store-access )
-              check_object_store_access;
-          ;;
-          --fluentd )
-              check_fluentd_connection;
-          ;;
-          --help )
+    while [[ ${#} -gt 0 ]]; do
+        case ${1} in
+        --cluster-health)
+            check_opensearch_cluster_health
+            ;;
+        --snapshot-status)
+            check_opensearch_snapshots_status
+            ;;
+        --breakers)
+            check_opensearch_breakers
+            ;;
+        --indices)
+            check_opensearch_indices
+            ;;
+        --aliases)
+            check_opensearch_aliases
+            ;;
+        --mappings)
+            check_opensearch_mappings
+            ;;
+        --user-roles)
+            check_opensearch_user_roles
+            ;;
+        --ism)
+            check_opensearch_ism
+            ;;
+        --object-store-access)
+            check_object_store_access
+            ;;
+        --fluentd)
+            check_fluentd_connection
+            ;;
+        --help)
             opensearch_check_help
-          ;;
-      esac
-      shift
+            ;;
+        esac
+        shift
     done
 }
 
 check_opensearch_cluster_health() {
-  echo -ne "Checking if opensearch cluster is healthy ... "
-  cluster_health=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_cluster/health")
-  status=$(echo "$cluster_health" | jq -r '.status')
-  if [[ $status != "green" ]]; then
-    echo -e "failure ❌";
-    echo "$cluster_health" | jq
-  else
-    echo -e "success ✔";
-  fi
+    echo -ne "Checking if opensearch cluster is healthy ... "
+    cluster_health=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_cluster/health")
+    status=$(echo "$cluster_health" | jq -r '.status')
+    if [[ $status != "green" ]]; then
+        echo -e "failure ❌"
+        echo "$cluster_health" | jq
+    else
+        echo -e "success ✔"
+    fi
 }
 
-check_opensearch_snapshots_status(){
-  echo -ne "Checking opensearch snapshots status ... "
-  no_error=true
-  debug_msg=""
-  repo_name=$(yq4 -e '.opensearch.snapshot.repository' "${config['config_file_sc']}")
-  repo_exists_status=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_snapshot/${repo_name}" | jq "select(.error)")
-  if [[ -z "$repo_exists_status" ]]; then
-    if kubectl get "cronjob" -n "opensearch-system" "opensearch-backup" &> /dev/null
-    then
-        snapshots=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_cat/snapshots/${repo_name}")
-        failed=$(echo "$snapshots" | grep 'FAILED' || true)
-        partial=$(echo "$snapshots" | grep 'PARTIAL' || true)
-        if [[ "$failed" != "" ]]; then
-          no_error=false
-          debug_msg+="[ERROR] We found some failed snapshots: \n $failed\n"
-        fi
+check_opensearch_snapshots_status() {
+    echo -ne "Checking opensearch snapshots status ... "
+    no_error=true
+    debug_msg=""
+    repo_name=$(yq4 -e '.opensearch.snapshot.repository' "${config['config_file_sc']}")
+    repo_exists_status=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_snapshot/${repo_name}" | jq "select(.error)")
+    if [[ -z "$repo_exists_status" ]]; then
+        if kubectl get "cronjob" -n "opensearch-system" "opensearch-backup" &>/dev/null; then
+            snapshots=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_cat/snapshots/${repo_name}")
+            failed=$(echo "$snapshots" | grep 'FAILED' || true)
+            partial=$(echo "$snapshots" | grep 'PARTIAL' || true)
+            if [[ "$failed" != "" ]]; then
+                no_error=false
+                debug_msg+="[ERROR] We found some failed snapshots: \n $failed\n"
+            fi
 
-        if [[ "$partial" != "" ]]; then
-          no_error=false
-          debug_msg+="[WARNING] We found some partial snapshots: \n $partial\n"
-        fi
+            if [[ "$partial" != "" ]]; then
+                no_error=false
+                debug_msg+="[WARNING] We found some partial snapshots: \n $partial\n"
+            fi
 
-        IFS=$'\n' readarray -t data < <(awk '{ print $1 " " $2 " " $3}' <<< "$snapshots")
-        IFS=" " read -ra last_snapshot <<< "${data[-1]}"
+            IFS=$'\n' readarray -t data < <(awk '{ print $1 " " $2 " " $3}' <<<"$snapshots")
+            IFS=" " read -ra last_snapshot <<<"${data[-1]}"
 
-        now_epoch=$(date +%s)
-        last_snapshot_epoch=${last_snapshot[2]}
-        ((diff=now_epoch-last_snapshot_epoch))
+            now_epoch=$(date +%s)
+            last_snapshot_epoch=${last_snapshot[2]}
+            ((diff = now_epoch - last_snapshot_epoch))
 
-          if [[ $diff -gt 86400 ]]; then
+            if [[ $diff -gt 86400 ]]; then
+                no_error=false
+                debug_msg+="[ERROR] The snapshot has been created for more than 24 hours, with a status: ${last_snapshot[1]}\n"
+            else
+                debug_msg+="[WARNING] The latest snapshot has been created within 24 hours, with a status: ${last_snapshot[1]}\n"
+            fi
+        else
             no_error=false
-            debug_msg+="[ERROR] The snapshot has been created for more than 24 hours, with a status: ${last_snapshot[1]}\n"
-          else
-            debug_msg+="[WARNING] The latest snapshot has been created within 24 hours, with a status: ${last_snapshot[1]}\n"
-          fi
+            debug_msg+="[ERROR] opensearch-backup cronjob doesn't exist\n"
+        fi
     else
         no_error=false
-        debug_msg+="[ERROR] opensearch-backup cronjob doesn't exist\n"
+        debug_msg=$(echo -e "$repo_exists_status" | jq)
     fi
-  else
-    no_error=false
-    debug_msg=$(echo -e "$repo_exists_status" | jq)
-  fi
 
-<<<<<<< HEAD
-=======
-
->>>>>>> 661f291 (tests: Add troubleshooting script for opensearch checks)
-  if $no_error; then
-    echo "success ✔"
-    echo "[DEBUG] All snapshots are either completed or in progress"
-  else
-    echo "failure ❌";
-    echo -e "$debug_msg"
-  fi
+    if $no_error; then
+        echo "success ✔"
+        echo "[DEBUG] All snapshots are either completed or in progress"
+    else
+        echo "failure ❌"
+        echo -e "$debug_msg"
+    fi
 }
 
-check_opensearch_indices(){
-  echo -ne "Checking opensearch indices status ... "
-  debug_msg=""
-  no_error=true
+check_opensearch_indices() {
+    echo -ne "Checking opensearch indices status ... "
+    debug_msg=""
+    no_error=true
 
-  for index in 'other' 'kubernetes' 'kubeaudit' 'authlog'; do
-    res=$(curl -w "%{http_code}"  -o /dev/null -ksIL -u admin:"${adminPassword}" -X HEAD "https://opensearch.${opsDomain}/${index}")
-    if [[ $res != "200" ]]; then
-      debug_msg+="[ERROR] Missing index : ${index}\n"
-      no_error=false
-    fi
-  done
-
-  if $no_error; then
-    echo "success ✔"
-    echo -e "[DEBUG] All indices are present"
-  else
-      echo "failure ❌";
-      echo -e "$debug_msg"
-  fi
-}
-
-check_opensearch_breakers(){
-  echo -ne "Checking opensearch breakers ... "
-  breakers_data=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_nodes/_all/stats/breaker")
-  no_error=true
-  debug_msg=""
-  nodes_data=$(echo "$breakers_data" | jq ".nodes")
-  readarray -t nodes < <(jq -c 'to_entries[]' <<< "$nodes_data")
-
-  for node in "${nodes[@]}"; do
-    node_name=$(jq '.key' <<< "$node")
-    readarray -t breakers < <(jq -c '.value.breakers | to_entries[]' <<< "$node")
-    for breaker in "${breakers[@]}"; do
-      tripped=$(jq ".value.tripped" <<< "$breaker")
-      name=$(jq ".key" <<< "$breaker")
-      if [[ $tripped == "1" ]]; then
-        no_error=false
-        debug_msg+="[DEBUG] A circuit breaker : $name has been triggered for node: $node_name\n"
-      fi
+    for index in 'other' 'kubernetes' 'kubeaudit' 'authlog'; do
+        res=$(curl -w "%{http_code}" -o /dev/null -ksIL -u admin:"${adminPassword}" -X HEAD "https://opensearch.${opsDomain}/${index}")
+        if [[ $res != "200" ]]; then
+            debug_msg+="[ERROR] Missing index : ${index}\n"
+            no_error=false
+        fi
     done
-  done
 
-  if $no_error; then
-    echo "success ✔"
-    echo "[DEBUG] None of the circuit breakers has been triggered"
-  else
-    echo "failure ❌";
-    echo -e "$debug_msg"
-  fi
-
-}
-
-check_opensearch_aliases(){
-  echo -ne "Checking opensearch aliases indices mapping ... "
-  no_error=true
-  debug_msg=""
-
-  curl -sk -o /tmp/response -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_cat/aliases"
-
-  aliases=$(awk '{print $1}' < /tmp/response)
-  aliases_arr=("$aliases")
-
-  uniq_aliases=$(echo "${aliases_arr[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
-
-  for alias in $uniq_aliases; do
-    if ! [[ $alias =~ ^[\.*] ]]; then
-
-      alias_data=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_alias/${alias}")
-      is_write_index="$(echo "$alias_data" | jq ".[].aliases.$alias.is_write_index | select(. == true)")"
-      if [[ "$is_write_index" == "" ]]; then
-        no_error=false
-        debug_msg+="[DEBUG] Alias : $alias has no write index \n"
-      fi
-
+    if $no_error; then
+        echo "success ✔"
+        echo -e "[DEBUG] All indices are present"
+    else
+        echo "failure ❌"
+        echo -e "$debug_msg"
     fi
-  done
-
-  if $no_error; then
-    echo "success ✔"
-    echo "[DEBUG] All aliases have write indices associated with them"
-  else
-    echo "failure ❌";
-    echo -e "$debug_msg"
-  fi
-
 }
 
-check_opensearch_mappings(){
-  echo -ne "Checking opensearch mappings/fields ... "
-  no_error=true
-  debug_msg="INDEX\t\t\t#FIELDS\tLIMIT\n"
-  debug_msg+="------------------------------------------------\n"
+check_opensearch_breakers() {
+    echo -ne "Checking opensearch breakers ... "
+    breakers_data=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_nodes/_all/stats/breaker")
+    no_error=true
+    debug_msg=""
+    nodes_data=$(echo "$breakers_data" | jq ".nodes")
+    readarray -t nodes < <(jq -c 'to_entries[]' <<<"$nodes_data")
 
-  indices_data=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_cat/indices" | awk '{print $3}' | tr '\n' ' ')
-  IFS=' ' read -ra indices <<< "$indices_data"
-  for index in "${indices[@]}"; do
-    fields_limit=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/${index}/_settings" | jq -r ".[\"${index}\"].settings.index.mapping.total_fields.limit")
-    fields_count=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/${index}/_field_caps?fields=*" | jq -r ".fields | keys | length")
+    for node in "${nodes[@]}"; do
+        node_name=$(jq '.key' <<<"$node")
+        readarray -t breakers < <(jq -c '.value.breakers | to_entries[]' <<<"$node")
+        for breaker in "${breakers[@]}"; do
+            tripped=$(jq ".value.tripped" <<<"$breaker")
+            name=$(jq ".key" <<<"$breaker")
+            if [[ $tripped == "1" ]]; then
+                no_error=false
+                debug_msg+="[DEBUG] A circuit breaker : $name has been triggered for node: $node_name\n"
+            fi
+        done
+    done
 
-    if [[ $fields_limit != "null" ]] && [[ $fields_count -gt $fields_limit ]]; then
-      no_error=false
+    if $no_error; then
+        echo "success ✔"
+        echo "[DEBUG] None of the circuit breakers has been triggered"
+    else
+        echo "failure ❌"
+        echo -e "$debug_msg"
     fi
-    debug_msg+="${index}\t\t\t${fields_count}\t${fields_limit}\n"
-  done
 
-  if $no_error; then
-    echo "success ✔"
-    echo "[DEBUG] Fields limit has not been reached yet"
-    echo -e "$debug_msg"
-  else
-    echo "failure ❌";
-    echo "[DEBUG] Some fields limit have been crossed"
-    echo -e "$debug_msg"
-  fi
 }
 
-check_opensearch_user_roles(){
-  echo -ne "checking user roles mappings ... "
-  no_error=true
-  debug_msg=""
+check_opensearch_aliases() {
+    echo -ne "Checking opensearch aliases indices mapping ... "
+    no_error=true
+    debug_msg=""
 
-  readarray configuredMappings < <(yq4 e -o=j -I=0 '.opensearch.extraRoleMappings[]' "${config['config_file_sc']}")
+    curl -sk -o /tmp/response -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_cat/aliases"
 
-  rolesmapping=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_plugins/_security/api/rolesmapping")
+    aliases=$(awk '{print $1}' </tmp/response)
+    aliases_arr=("$aliases")
 
-  for roleMapping in "${configuredMappings[@]}"; do
-    configured_mapping_name=$(echo "$roleMapping" | yq4 e '.mapping_name' -)
-    configured_users=$(echo "$roleMapping" | yq4 e '.definition.users[]' -)
-    res=$(echo "$rolesmapping" | jq ".$configured_mapping_name")
-    if [[ $res != "null" ]]; then
-      users=$(echo "$rolesmapping" | jq -r ".$configured_mapping_name.users[]")
-      if [[ "$users" != "$configured_users" ]]; then
+    uniq_aliases=$(echo "${aliases_arr[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+    for alias in $uniq_aliases; do
+        if ! [[ $alias =~ ^[\.*] ]]; then
+
+            alias_data=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_alias/${alias}")
+            is_write_index="$(echo "$alias_data" | jq ".[].aliases.$alias.is_write_index | select(. == true)")"
+            if [[ "$is_write_index" == "" ]]; then
+                no_error=false
+                debug_msg+="[DEBUG] Alias : $alias has no write index \n"
+            fi
+
+        fi
+    done
+
+    if $no_error; then
+        echo "success ✔"
+        echo "[DEBUG] All aliases have write indices associated with them"
+    else
+        echo "failure ❌"
+        echo -e "$debug_msg"
+    fi
+
+}
+
+check_opensearch_mappings() {
+    echo -ne "Checking opensearch mappings/fields ... "
+    no_error=true
+    debug_msg="INDEX\t\t\t#FIELDS\tLIMIT\n"
+    debug_msg+="------------------------------------------------\n"
+
+    indices_data=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_cat/indices" | awk '{print $3}' | tr '\n' ' ')
+    IFS=' ' read -ra indices <<<"$indices_data"
+    for index in "${indices[@]}"; do
+        fields_limit=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/${index}/_settings" | jq -r ".[\"${index}\"].settings.index.mapping.total_fields.limit")
+        fields_count=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/${index}/_field_caps?fields=*" | jq -r ".fields | keys | length")
+
+        if [[ $fields_limit != "null" ]] && [[ $fields_count -gt $fields_limit ]]; then
+            no_error=false
+        fi
+        debug_msg+="${index}\t\t\t${fields_count}\t${fields_limit}\n"
+    done
+
+    if $no_error; then
+        echo "success ✔"
+        echo "[DEBUG] Fields limit has not been reached yet"
+        echo -e "$debug_msg"
+    else
+        echo "failure ❌"
+        echo "[DEBUG] Some fields limit have been crossed"
+        echo -e "$debug_msg"
+    fi
+}
+
+check_opensearch_user_roles() {
+    echo -ne "checking user roles mappings ... "
+    no_error=true
+    debug_msg=""
+
+    readarray configuredMappings < <(yq4 e -o=j -I=0 '.opensearch.extraRoleMappings[]' "${config['config_file_sc']}")
+
+    rolesmapping=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_plugins/_security/api/rolesmapping")
+
+    for roleMapping in "${configuredMappings[@]}"; do
+        configured_mapping_name=$(echo "$roleMapping" | yq4 e '.mapping_name' -)
+        configured_users=$(echo "$roleMapping" | yq4 e '.definition.users[]' -)
+        res=$(echo "$rolesmapping" | jq ".$configured_mapping_name")
+        if [[ $res != "null" ]]; then
+            users=$(echo "$rolesmapping" | jq -r ".$configured_mapping_name.users[]")
+            if [[ "$users" != "$configured_users" ]]; then
+                no_error=false
+                debug_msg+="[ERROR] Missing users < ${configured_users//$'\n'/ }> != < $users >, for role mapping: $configured_mapping_name \n"
+            fi
+        else
+            no_error=false
+            debug_msg+="[ERROR] Missing role mapping_name ${roleMapping} \n"
+        fi
+    done
+
+    if $no_error; then
+        echo "success ✔"
+        echo "[DEBUG] User roles are configured correctly"
+    else
+        echo "failure ❌"
+        echo -ne "$debug_msg"
+    fi
+}
+
+check_opensearch_ism() {
+    echo -ne "Checking opensearch Index State Management ... "
+    no_error=true
+    debug_msg=""
+
+    default_policies_enabled=$(yq4 -e '.opensearch.ism.defaultPolicies' "${config['config_file_sc']}")
+    if [[ $default_policies_enabled == "true" ]]; then
+        default_policies=("kubernetes" "kubeaudit" "authlog" "other")
+        for policy in "${default_policies[@]}"; do
+            res=$(curl -w "%{http_code}" -o /dev/null -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_plugins/_ism/policies/${policy}")
+            if [[ $res != "200" ]]; then
+                no_error=false
+                debug_msg+="[ERROR] Missing default policy : ${policy}\n"
+            fi
+        done
+    fi
+
+    # additional_policies=$(yq4 -e '.opensearch.ism.additionalPolicies | keys' "${config['config_file_sc']}")
+    readarray -t additional_policies < <(yq4 e -o=j -I=0 '.opensearch.ism.additionalPolicies | keys' "${config['config_file_sc']}")
+
+    additional_policies=("${additional_policies//,/ }")
+    additional_policies=("${additional_policies##[}")
+    additional_policies=("${additional_policies%]}")
+    # additional_policies=($additional_policies)
+    read -ra additional_policies <<<"${additional_policies[@]}"
+
+    for policy in "${additional_policies[@]}"; do
+        policy_name=$(echo "$policy" | awk -F'.' '{print $1}' | tr '"' ' ')
+        res=$(curl -w "%{http_code}" -o /dev/null -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_plugins/_ism/policies/${policy_name}")
+        if [[ $res != "200" ]]; then
+            no_error=false
+            debug_msg+="[ERROR] Missing additional policy : ${policy_name}\n"
+        fi
+    done
+
+    indices_data=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_cat/indices" | awk '{print $3}' | tr '\n' ' ')
+    IFS=' ' read -ra indices <<<"$indices_data"
+
+    for index in "${indices[@]}"; do
+        index_data=$(curl -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/$index")
+        index_alias=$(echo "$index_data" | jq -r ".\"$index\".settings.index.plugins.index_state_management.rollover_alias")
+        is_write_index=$(echo "$index_data" | jq -r ".\"$index\".aliases.$index_alias.is_write_index")
+
+        if [[ "$is_write_index" == "true" ]]; then
+            rollover_age_days=$(yq4 -e '.opensearch.ism.rolloverAgeDays' "${config['config_file_sc']}")
+            epoch_now=$(date +%s)
+            index_creation_date=$(echo "$index_data" | jq -r ".\"$index\".settings.index.creation_date")
+
+            index_creation_date_seconds=$(echo "scale=3; $index_creation_date/1000" | bc)
+            rollover_diff=$(echo "scale=3; ($epoch_now-$index_creation_date_seconds)/86400" | bc | awk '{printf "%f", $0}')
+            if (($(echo "$rollover_diff > $rollover_age_days" | bc -l))); then
+                no_error=false
+                echo -e "[ERROR]The write index : $index is old and has not been rolled over as expected\n"
+            fi
+
+        fi
+    done
+
+    if $no_error; then
+        echo "success ✔"
+        echo -e "[DEBUG] There are no missing default/additional policies"
+        echo -e "[DEBUG] All write indices are rolled over as expected"
+    else
+        echo "failure ❌"
+        echo -e "$debug_msg"
+    fi
+}
+
+check_object_store_access() {
+    echo -ne "Checking opensearch snapshot bucket access... "
+    no_error=true
+    debug_msg=""
+    EX_NOTFOUND=12
+    EX_OK=0
+    EX_ACCESSDENIED=77
+    EX_CONFIG=78
+    snapshot_bucket=$(yq4 -e '.objectStorage.buckets.opensearch' "${config['config_file_sc']}")
+
+    command=$(
+        s3cmd --config <(sops -d "${CK8S_CONFIG_PATH}"/.state/s3cfg.ini) ls s3://"${snapshot_bucket}" >/dev/null 2>&1
+        echo $?
+    )
+    if [[ ${command} -eq $EX_OK ]]; then
+        debug_msg="[DEBUG] Snapshot bucket ${snapshot_bucket} exist and can be accessed"
+    elif [[ ${command} -eq $EX_NOTFOUND ]]; then
         no_error=false
-        debug_msg+="[ERROR] Missing users < ${configured_users//$'\n'/ }> != < $users >, for role mapping: $configured_mapping_name \n"
-      fi
+        debug_msg="[ERROR] S3 error: 404 (NoSuchBucket): The specified bucket ${snapshot_bucket} does not exist."
+    elif [[ ${command} -eq $EX_ACCESSDENIED ]]; then
+        no_error=false
+        debug_msg="[ERROR] S3 error: Insufficient permissions to perform the operation on S3"
+    elif [[ ${command} -eq $EX_CONFIG ]]; then
+        no_error=false
+        debug_msg="[ERROR] S3 error: Configuration file error"
     else
         no_error=false
-        debug_msg+="[ERROR] Missing role mapping_name ${roleMapping} \n"
+        debug_msg="[ERROR] An error happened, please try again"
     fi
-  done
 
-  if $no_error; then
-    echo "success ✔"
-    echo "[DEBUG] User roles are configured correctly"
-  else
-    echo "failure ❌";
-    echo -ne "$debug_msg"
-  fi
+    if $no_error; then
+        echo "success ✔"
+        echo -e "$debug_msg"
+    else
+        echo "failure ❌"
+        echo -e "$debug_msg"
+    fi
 }
 
-check_opensearch_ism(){
-  echo -ne "Checking opensearch Index State Management ... "
-  no_error=true
-  debug_msg=""
+check_fluentd_connection() {
+    echo -ne "Checking if fluentd can connect to opensearch... "
+    no_error=true
+    debug_msg=""
 
-  default_policies_enabled=$(yq4 -e '.opensearch.ism.defaultPolicies' "${config['config_file_sc']}")
-  if [[ $default_policies_enabled == "true" ]]; then
-    default_policies=("kubernetes" "kubeaudit" "authlog" "other")
-    for policy in "${default_policies[@]}"; do
-      res=$(curl -w "%{http_code}" -o /dev/null -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_plugins/_ism/policies/${policy}")
-      if [[ $res != "200" ]]; then
-        no_error=false
-        debug_msg+="[ERROR] Missing default policy : ${policy}\n"
-      fi
-    done
-  fi
-
-  # additional_policies=$(yq4 -e '.opensearch.ism.additionalPolicies | keys' "${config['config_file_sc']}")
-  readarray -t additional_policies < <(yq4 e -o=j -I=0 '.opensearch.ism.additionalPolicies | keys' "${config['config_file_sc']}")
-
-  additional_policies=("${additional_policies//,/ }")
-  additional_policies=("${additional_policies##[}")
-  additional_policies=("${additional_policies%]}")
-  # additional_policies=($additional_policies)
-  read -ra additional_policies <<< "${additional_policies[@]}"
-
-  for policy in "${additional_policies[@]}"; do
-    policy_name=$(echo "$policy" | awk -F'.' '{print $1}' | tr '"' ' ')
-    res=$(curl -w "%{http_code}" -o /dev/null -sk -u admin:"${adminPassword}" -X GET "https://opensearch.${opsDomain}/_plugins/_ism/policies/${policy_name}")
+    res=$(curl -w "%{http_code}" -o /dev/null -ksIL -u fluentd:"${fluentdPassword}" -X HEAD "https://opensearch.${opsDomain}/")
     if [[ $res != "200" ]]; then
-      no_error=false
-      debug_msg+="[ERROR] Missing additional policy : ${policy_name}\n"
+        debug_msg+="[ERROR] $res : Fluentd cannot connect to opensearch.\nPlease check your credentials"
+        no_error=false
     fi
-  done
 
-  if $no_error; then
-    echo "success ✔"
-    echo -e "[DEBUG] There are no missing default policies or additional policies"
-  else
-    echo "failure ❌";
-    echo -e "$debug_msg"
-  fi
-}
-
-check_object_store_access(){
-  echo -ne "Checking opensearch snapshot bucket access... "
-  no_error=true
-  debug_msg=""
-  EX_NOTFOUND=12
-  EX_OK=0
-  EX_ACCESSDENIED=77
-  EX_CONFIG=78
-  snapshot_bucket=$(yq4 -e '.objectStorage.buckets.opensearch' "${config['config_file_sc']}")
-
-  command=$(s3cmd --config <(sops -d "${CK8S_CONFIG_PATH}"/.state/s3cfg.ini) ls s3://"${snapshot_bucket}" > /dev/null 2>&1 ;echo $?)
-  if [[ ${command} -eq $EX_OK ]]; then
-    debug_msg="[DEBUG] Snapshot bucket ${snapshot_bucket} exist and can be accessed"
-  elif [[ ${command} -eq $EX_NOTFOUND ]]; then
-    no_error=false
-    debug_msg="[ERROR] S3 error: 404 (NoSuchBucket): The specified bucket ${snapshot_bucket} does not exist."
-  elif [[ ${command} -eq $EX_ACCESSDENIED ]]; then
-    no_error=false
-    debug_msg="[ERROR] S3 error: Insufficient permissions to perform the operation on S3"
-  elif [[ ${command} -eq $EX_CONFIG ]]; then
-    no_error=false
-    debug_msg="[ERROR] S3 error: Configuration file error"
-  else
-    no_error=false
-    debug_msg="[ERROR] An error happened, please try again"
-  fi
-
-  if $no_error; then
-    echo "success ✔"
-    echo -e "$debug_msg"
-  else
-    echo "failure ❌";
-    echo -e "$debug_msg"
-  fi
-}
-
-check_fluentd_connection(){
-  echo -ne "Checking if fluentd can connect to opensearch... "
-  no_error=true
-  debug_msg=""
-
-
-  res=$(curl -w "%{http_code}"  -o /dev/null -ksIL -u fluentd:"${fluentdPassword}" -X HEAD "https://opensearch.${opsDomain}/")
-  if [[ $res != "200" ]]; then
-    debug_msg+="[ERROR] $res : Fluentd cannot connect to opensearch.\nPlease check your credentials"
-    no_error=false
-  fi
-
-
-  if $no_error; then
-    echo "success ✔"
-    echo -e "[DEBUG] Fluentd is able to connect to Opensearch"
-  else
-    echo "failure ❌";
-    echo -e "$debug_msg"
-  fi
+    if $no_error; then
+        echo "success ✔"
+        echo -e "[DEBUG] Fluentd is able to connect to Opensearch"
+    else
+        echo "failure ❌"
+        echo -e "$debug_msg"
+    fi
 
 }

--- a/pipeline/test/services/service-cluster/testOpensearch.sh
+++ b/pipeline/test/services/service-cluster/testOpensearch.sh
@@ -139,6 +139,10 @@ check_opensearch_snapshots_status(){
     debug_msg=$(echo -e "$repo_exists_status" | jq)
   fi
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> 661f291 (tests: Add troubleshooting script for opensearch checks)
   if $no_error; then
     echo "success ✔"
     echo "[DEBUG] All snapshots are either completed or in progress"

--- a/pipeline/test/services/workload-cluster/testCertManager.sh
+++ b/pipeline/test/services/workload-cluster/testCertManager.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# (return 0 2>/dev/null) && sourced=1 || sourced=0
+
+INNER_SCRIPTS_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+# shellcheck source=bin/common.bash
+source "${INNER_SCRIPTS_PATH}/../funcs.sh"
+
+function wc_certmanager_check_help() {
+    printf "%s\n" "[Usage]: test wc cert-manager [ARGUMENT]"
+    printf "\t%-25s %s\n" "--cluster-issuers" "Check cluster issuers"
+    printf "\t%-25s %s\n" "--certificates" "Check cluster certificates"
+    printf "\t%-25s %s\n" "--challenges" "Check challenges"
+    printf "%s\n" "[NOTE] If no argument is specified, it will go over all of them."
+
+    exit 0
+}
+
+function wc_cert_manager_checks() {
+    if [[ ${#} == 0 ]]; then
+        echo "Running all checks ..."
+        check_wc_certmanager_cluster_issuers
+        check_wc_certmanager_apps_certificates
+        check_wc_certmanager_challenges
+        exit 0
+    fi
+    while [[ ${#} -gt 0 ]]; do
+        case ${1} in
+        --cluster-issuers)
+            check_wc_certmanager_cluster_issuers
+            ;;
+        --certificates)
+            check_wc_certmanager_apps_certificates
+            ;;
+        --challenges)
+            check_wc_certmanager_challenges
+            ;;
+        --help)
+            wc_certmanager_check_help
+            ;;
+        esac
+        shift
+    done
+}
+
+function check_wc_certmanager_cluster_issuers() {
+    echo -ne "Checking cert manager cluster issuers ... "
+    no_error=true
+    debug_msg=""
+
+    clusterIssuers=("letsencrypt-prod" "letsencrypt-staging")
+
+    for clusterIssuer in "${clusterIssuers[@]}"; do
+        if kubectl get ClusterIssuer "$clusterIssuer" &>/dev/null; then
+            jsonData=$(kubectl get ClusterIssuer "$clusterIssuer" -ojson)
+            cluster_issuer_status=$(echo "$jsonData" | jq -r '.status.conditions[] | select(.type=="Ready") | .status')
+            if [[ "$cluster_issuer_status" == "True" ]]; then
+                IFS='-' read -ra data <<<"$clusterIssuer"
+                readarray custom_solvers < <(yq4 e -o=j -I=0 ".issuers.${data[0]}.${data[1]}.solvers[]" "${config['config_file_wc']}")
+                if ! [ ${#custom_solvers[@]} -eq 0 ]; then
+                    for custom_solver in "${custom_solvers[@]}"; do
+                        challenge_solver=$(echo "$custom_solver" | jq ". | del( .selector ) | keys[] ")
+                        solver_exist=$(kubectl get ClusterIssuer "$clusterIssuer" -oyaml | yq4 e -o=j -I=0 ".spec.acme.solvers[].$challenge_solver")
+                        if [[ $solver_exist == "null" ]]; then
+                            no_error=false
+                            debug_msg+="[ERROR] Missing custom solver : $challenge_solver for Cluster Issuer : $clusterIssuer\n"
+                        fi
+                    done
+                fi
+
+            else
+                no_error=false
+                debug_msg+="[ERROR] ClusterIssuer $clusterIssuer is not ready\n"
+            fi
+
+        else
+            no_error=false
+            debug_msg+="[ERROR] ClusterIssuer $clusterIssuer does not exist\n"
+        fi
+    done
+
+    if $no_error; then
+        echo "success ✔"
+        echo -e "[DEBUG] All ClusterIssuer resources are present and ready, with correct solvers"
+    else
+        echo "failure ❌"
+        echo -e "$debug_msg"
+    fi
+}
+
+function check_wc_certmanager_apps_certificates() {
+    echo -ne "Checking cert manager for Certificates ... "
+    no_error=true
+    debug_msg=""
+
+    certificates=()
+
+    enable_hnc=$(yq4 -e '.hnc.enabled' "${config['config_file_wc']}" 2>/dev/null)
+
+    if "${enable_hnc}"; then
+        certificates+=(
+            "hnc-system hnc-webhook-server-cert"
+        )
+    fi
+
+    for cert in "${certificates[@]}"; do
+        read -r -a arr <<<"$cert"
+        namespace="${arr[0]}"
+        name="${arr[1]}"
+        if kubectl get "Certificate" -n "$namespace" "$name" &>/dev/null; then
+            certificate_data=$(kubectl get "Certificate" -n "$namespace" "$name" -ojson)
+            cert_renewal_time=$(echo "$certificate_data" | jq -r ".status.renewalTime")
+            cert_expiry_time=$(echo "$certificate_data" | jq -r ".status.notAfter")
+            cert_status=$(echo "$certificate_data" | jq -r ".status.conditions[] | select(.type==\"Ready\") | .status")
+            cert_status_message=$(echo "$certificate_data" | jq -r ".status.conditions[] | select(.type==\"Ready\") | .message")
+            if [[ "$cert_status" != "True" ]]; then
+                no_error=false
+                debug_msg+="[ERROR] $cert_status_message \n"
+            else
+                now_date=$(date +%s)
+                expiry_date=$(date -d "$cert_expiry_time" +%s)
+                renew_date=$(date -d "$cert_renewal_time" +%s)
+                ((expiry_diff = (expiry_date - now_date) / 86400))
+                ((renew_diff = (renew_date - now_date) / 86400))
+                if [[ $expiry_diff -lt 1 ]]; then
+                    no_error=false
+                    debug_msg+="[ERROR] $name will expire in less than $expiry_diff day(s)\n"
+                else
+                    debug_msg+="[DEBUG] Certificate: $name is Ready, will expire in $expiry_diff day(s), will be renewed in $renew_diff day(s)\n"
+                fi
+            fi
+        else
+            no_error=false
+            debug_msg+="[ERROR]: Missing certificate : $name in namespace $namespace\n"
+        fi
+    done
+
+    if $no_error; then
+        echo "success ✔"
+        echo -e "$debug_msg"
+    else
+        echo "failure ❌"
+        echo -e "$debug_msg"
+    fi
+}
+
+function check_wc_certmanager_challenges() {
+    echo -ne "Checking cert manager Challenges ... "
+    no_error=true
+    debug_msg=""
+
+    challenges_data=$(kubectl get challenges -A -ojson)
+
+    readarray -t pending_challenges < <(jq -c '.items[] | select(.status.state=="pending")' <<<"$challenges_data")
+
+    if ! [[ $(echo "$challenges_data" | jq '.items | length') -eq 0 ]]; then
+        if [[ ${#pending_challenges[@]} != 0 ]]; then
+            no_error=false
+            debug_msg+="[ERROR] There are some pending challenges\n"
+            for pending_challenge in "${pending_challenges[@]}"; do
+                challenge_name=$(echo "$pending_challenge" | jq -r ".metadata.name")
+                challenge_namespace=$(echo "$pending_challenge" | jq -r ".metadata.namespace")
+                pending_reason=$(echo "$pending_challenge" | jq -r ".status.reason")
+                debug_msg+="Challenge $challenge_name in the $challenge_namespace namepsace is pending because : $pending_reason\n"
+            done
+        fi
+    fi
+
+    orders_data=$(kubectl get orders -A -ojson)
+
+    if ! [[ $(echo "$orders_data" | jq '.items | length') -eq 0 ]]; then
+        readarray -t errored_orders < <(jq -c '.items[] | select(.status.state=="errored")' <<<"$orders_data")
+
+        if [[ ${#errored_orders[@]} != 0 ]]; then
+            no_error=false
+            debug_msg+="[ERROR] There some errored orders\n"
+            for errored_order in "${errored_orders[@]}"; do
+                order_name=$(echo "$errored_order" | jq -r ".metadata.name")
+                order_namespace=$(echo "$errored_order" | jq -r ".metadata.namespace")
+                errored_reason=$(echo "$errored_order" | jq -r ".status.reason")
+                debug_msg+="Order $order_name in the $order_namespace namepsace is errored because : $errored_reason\n"
+            done
+        fi
+    fi
+
+    if $no_error; then
+        echo "success ✔"
+        echo -e "[DEBUG] There are no pending challenges, or errored orders"
+    else
+        echo "failure ❌"
+        echo -e "$debug_msg"
+    fi
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Compliant Kubernetes needs more troubleshooting scripts to help operators quickly figure out faults in an environment.
We need checks for the status for the certificates and ingresses so we can assert that they work as they should.

**Which issue this PR fixes** : fixes #1190 
