### PR TITLE
bin: changed init script to enable proxy protocol for elastx and cleura

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -9,6 +9,7 @@
 - Increased the default CPU limit for node-exporter in ciskubebench- and vulnerability-exporter
 - Nginx controller service annotations are now defined as a map, previously just a single string.
 - Synced all grafana dashboards so that they use the same timezone, they all now use the default organization timezone.
+- Changed init script to enable proxy-protocol for elastx and cleura clouds
 
 ### Fixed
 

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -204,11 +204,11 @@ set_nginx_config() {
             ;;
 
         citycloud | elastx)
-            use_proxy_protocol=false
+            use_proxy_protocol=true
             use_host_port=false
             service_enabled=true
             service_type=LoadBalancer
-            service_annotations=''
+            service_annotations='loadbalancer.openstack.org/proxy-protocol: true'
             ;;
 
         aws)


### PR DESCRIPTION
**What this PR does / why we need it**:

Since we decided to change this internally we should also update this repo.

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [X] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
