### PR TITLE
apps sc: increased cpu requests and limits for grafana

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -9,6 +9,7 @@
 - Increased the default CPU limit for node-exporter in ciskubebench- and vulnerability-exporter
 - Nginx controller service annotations are now defined as a map, previously just a single string.
 - Synced all grafana dashboards so that they use the same timezone, they all now use the default organization timezone.
+- Increased CPU requests and limits for Grafana sidecars
 
 ### Fixed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -98,10 +98,10 @@ user:
     sidecar:
       resources:
         requests:
-          cpu: 5m
+          cpu: 10m
           memory: 80Mi
         limits:
-          cpu: 10m
+          cpu: 50m
           memory: 100Mi
 
 harbor:
@@ -473,10 +473,10 @@ prometheus:
     sidecar:
       resources:
         requests:
-          cpu: 5m
+          cpu: 10m
           memory: 80Mi
         limits:
-          cpu: 10m
+          cpu: 50m
           memory: 100Mi
 dex:
   replicaCount: 2


### PR DESCRIPTION
**What this PR does / why we need it**: to speed up the startup of Grafana

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
