### PR TITLE
release: updated the docs for v0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Compliant Kubernetes changelog
 <!-- BEGIN TOC -->
+- [v0.27.1](#v0271---2023-01-16)
 - [v0.27.0](#v0270---2022-11-17)
 - [v0.26.0](#v0260---2022-09-19)
 - [v0.25.0](#v0250---2022-08-25)
@@ -29,6 +30,24 @@
 - [v0.6.0](#v060---2020-10-16)
 - [v0.5.0](#v050---2020-08-06)
 <!-- END TOC -->
+
+-------------------------------------------------
+## v0.27.1 - 2023-01-16
+
+### Fixed
+
+- Fixed harbor restore network policy to allow all egress for the restore job.
+- `fluent-plugin-record-modifier` was added to our image `ghcr.io/elastisys/fluentd:v3.4.0-ck8s5` to prevent mapping errors from happening
+- Added generation of registry password so that there's not a diff each time we run apply
+- Fixed network policies for when internal traffic to the ingress is not short circuted by kube-proxy
+- Fixed Harbor network policies
+  - Cleaned up `core` egress rule
+  - Separate network policies
+  - Fixed replication egress rules, `core` and `jobservice`
+
+### Removed
+
+- Falco alerts in wc from prometheus. Users will get falco alerts via falco sidekick.
 
 -------------------------------------------------
 ## v0.27.0 - 2022-11-17

--- a/migration/v0.26.x-v0.27.x/upgrade-apps.md
+++ b/migration/v0.26.x-v0.27.x/upgrade-apps.md
@@ -109,6 +109,28 @@
     ./bin/ck8s ops helmfile wc -l app=falco -l app=falco-exporter destroy
     ./bin/ck8s ops helmfile sc -l app=falco -l app=falco-exporter destroy
     ```
+1. If you are upgrading from v0.26.x to v0.27.1 apply this steps:
+
+   1. Add new harbor credentials
+
+       ```bash
+       ./migration/v0.27.x-v0.28.x/add-registry-credentials.sh
+       ```
+
+   1. Migrate harbor jobservice port to ports (array)
+
+       ```bash
+       ./migration/v0.27.x-v0.28.x/move-harbor-jobservice-port-to-ports.sh
+       ```
+
+   1. Up date the IPs for harbor replication in `$CK8S_CONFIG_PATH/sc-config.yaml`
+
+       ```yaml
+         harbor:
+           registries:
+             ips:
+               - "set-me"
+       ```
 
 1. Upgrade applications:
 

--- a/migration/v0.27.0-v0.27.1/upgrade-apps.md
+++ b/migration/v0.27.0-v0.27.1/upgrade-apps.md
@@ -1,0 +1,38 @@
+# Upgrade v0.27.0 to v0.27.1
+
+## Steps
+
+1. Update apps configuration:
+
+    This will take a backup into `backups/` before modifying any files.
+
+    ```bash
+    bin/ck8s init
+    ```
+
+1. Add new harbor credentials
+
+    ```bash
+    ./migration/v0.27.x-v0.28.x/add-registry-credentials.sh
+    ```
+
+1. Migrate harbor jobservice port to ports (array)
+
+    ```bash
+    ./migration/v0.27.x-v0.28.x/move-harbor-jobservice-port-to-ports.sh
+    ```
+
+1. Up date the IPs for harbor replication in `$CK8S_CONFIG_PATH/sc-config.yaml`
+
+    ```yaml
+      harbor:
+        registries:
+          ips:
+            - "set-me"
+    ```
+
+
+1. Upgrade applications:
+
+    ```bash
+    bin/ck8s apply {sc|wc}


### PR DESCRIPTION
**What this PR does / why we need it**: to update main branch with the patch release v0.27.1 instructions

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).