### PR TITLE
apps sc: Fix Harbor registry credentials

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -25,6 +25,7 @@
   - Separate network policies
   - Fixed replication egress rules, `core` and `jobservice`
 - Fixed harbor registry credentials template and htpasswd generation
+- Fixed checks in update-ips script to update Swift endpoints
 
 ### Added
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -24,6 +24,7 @@
   - Cleaned up `core` egress rule
   - Separate network policies
   - Fixed replication egress rules, `core` and `jobservice`
+- Fixed harbor registry credentials template and htpasswd generation
 
 ### Added
 

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -448,7 +448,7 @@ generate_secrets() {
     THANOS_INGRESS_PASS_HASH=$(htpasswd -bn "" "${THANOS_INGRESS_PASS}" | tr -d ':\n')
 
     HARBOR_REGISTRY_PASS=$(pwgen -cns 20 1)
-    HARBOR_REGISTRY_PASS_HTPASSWD=$(htpasswd -bn "harbor_registry_user" "${HARBOR_REGISTRY_PASS}" | tr -d '\n')
+    HARBOR_REGISTRY_PASS_HTPASSWD=$(htpasswd -bnB "harbor_registry_user" "${HARBOR_REGISTRY_PASS}" | tr -d '\n')
 
     yq4 --inplace ".grafana.password= \"$(pwgen -cns 20 1)\"" "${tmpfile}"
     yq4 --inplace ".grafana.clientSecret= \"$(pwgen -cns 20 1)\"" "${tmpfile}"

--- a/bin/update-ips.bash
+++ b/bin/update-ips.bash
@@ -244,8 +244,10 @@ fi
 
 ## Add Swift to sc config
 if [[ "${CHECK_CLUSTER}" =~ ^(sc|both)$ ]]; then
-    CHECK="$(yq_dig 'sc' '.harbor.persistence.type == "swift" or .thanos.objectStorage.type == "swift"' 'false')"
-    if [ "$CHECK" == "true" ]; then
+    CHECK_HARBOR="$(yq_dig 'sc' '.harbor.persistence.type' 'false')"
+    CHECK_THANOS="$(yq_dig 'sc' '.thanos.objectStorage.type' 'false')"
+
+    if [ "$CHECK_HARBOR" == "swift" ] || [ "$CHECK_THANOS" == "swift" ]; then
         SWIFT_ENDPOINT="$(yq_dig 'sc' '.objectStorage.swift.authUrl' '""' | sed 's/https\?:\/\///' | sed 's/[:\/].*//')"
         if [ -z "$SWIFT_ENDPOINT" ]; then
             log_error "No Swift endpoint found, check your sc-config.yaml"

--- a/helmfile/values/harbor.yaml.gotmpl
+++ b/helmfile/values/harbor.yaml.gotmpl
@@ -133,6 +133,7 @@ registry:
   affinity:     {{- toYaml .Values.harbor.registry.affinity | nindent 4 }}
   tolerations:  {{- toYaml .Values.harbor.tolerations | nindent 4 }}
   credentials:
+    password: {{ .Values.harbor.registryPassword }}
     htpasswdString: {{ .Values.harbor.registryPasswordHtpasswd }}
 
 notary:

--- a/migration/v0.27.x-v0.28.x/add-registry-credentials.sh
+++ b/migration/v0.27.x-v0.28.x/add-registry-credentials.sh
@@ -8,7 +8,7 @@ secret_config="${CK8S_CONFIG_PATH}/secrets.yaml"
 sops_config="${CK8S_CONFIG_PATH}/.sops.yaml"
 
 HARBOR_REGISTRY_PASS=$(pwgen -cns 20 1)
-HARBOR_REGISTRY_PASS_HTPASSWD=$(htpasswd -bn "harbor_registry_user" "${HARBOR_REGISTRY_PASS}" | tr -d '\n')
+HARBOR_REGISTRY_PASS_HTPASSWD=$(htpasswd -bnB "harbor_registry_user" "${HARBOR_REGISTRY_PASS}" | tr -d '\n')
 
 sops --config "${sops_config}" --set '["harbor"]["registryPassword"] "'"${HARBOR_REGISTRY_PASS}"'"' "${secret_config}"
 sops --config "${sops_config}" --set '["harbor"]["registryPasswordHtpasswd"] "'"${HARBOR_REGISTRY_PASS_HTPASSWD}"'"' "${secret_config}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the Harbor registry credentials which prevented it from authenticating.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
