### PR TITLE
tests: Add troubleshooting script for user access & sub namespaces

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Added
 
 - Enable rook-ceph network polices by default for exoscale
-
+- Troubleshooting scripts for HNC
+- Tests for Groups RBAC
 ### Fixed
 
 - The update-ips script can now fetch Calico Wireguard IPs

--- a/bin/test.bash
+++ b/bin/test.bash
@@ -10,7 +10,6 @@ here="$(dirname "$(readlink -f "$0")")"
 source "${here}/common.bash"
 # shellcheck source=pipeline/test/services/service-cluster/testOpensearch.sh
 source "${pipeline_path}/test/services/service-cluster/testOpensearch.sh"
-
 # shellcheck source=pipeline/test/services/service-cluster/testCertManager.sh
 source "${pipeline_path}/test/services/service-cluster/testCertManager.sh"
 # shellcheck source=pipeline/test/services/workload-cluster/testCertManager.sh
@@ -19,6 +18,8 @@ source "${pipeline_path}/test/services/workload-cluster/testCertManager.sh"
 source "${pipeline_path}/test/services/service-cluster/testIngress.sh"
 # shellcheck source=pipeline/test/services/workload-cluster/testIngress.sh
 source "${pipeline_path}/test/services/workload-cluster/testIngress.sh"
+# shellcheck source=pipeline/test/services/workload-cluster/testHNC.sh
+source "${pipeline_path}/test/services/workload-cluster/testHNC.sh"
 
 test_apps_sc() {
     log_info "Testing service cluster"
@@ -47,6 +48,7 @@ function wc_help() {
     printf "%s\n" "List of targets:"
     printf "\t%-23s %s\n" "cert-manager" "Cert Manager checks"
     printf "\t%-23s %s\n" "ingress" "Ingress checks"
+    printf "\t%-23s %s\n" "hnc" "HNC checks"
     printf "%s\n" "[NOTE] If no target is specified, the default wc apps tests will be executed."
     exit 0
 }
@@ -65,7 +67,7 @@ function sc() {
         ingress)
             sc_ingress_checks "${@:2}"
             ;;
-        --help)
+        --help | -h)
             sc_help
             ;;
         *)
@@ -89,7 +91,10 @@ function wc() {
         ingress)
             wc_ingress_checks "${@:2}"
             ;;
-        --help)
+        hnc)
+            wc_hnc_checks "${@:2}"
+            ;;
+        --help | -h)
             wc_help
             ;;
         *)

--- a/pipeline/test/services/workload-cluster/testHNC.sh
+++ b/pipeline/test/services/workload-cluster/testHNC.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# (return 0 2>/dev/null) && sourced=1 || sourced=0
+
+INNER_SCRIPTS_PATH="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+# shellcheck source=bin/common.bash
+source "${INNER_SCRIPTS_PATH}/../funcs.sh"
+
+function wc_hnc_check_help() {
+    printf "%s\n" "[Usage]: test wc hnc [ARGUMENT]"
+    printf "\t%-25s %s\n" "--subns-anchors" "Check that users can create sub namespace anchors and remove them"
+    printf "\t%-25s %s\n" "--system-namespaces" "Check that no system namespace is labelled by HNC"
+    printf "%s\n" "[NOTE] If no argument is specified, it will go over all of them."
+
+    exit 0
+}
+
+function wc_hnc_checks() {
+    if [[ ${#} == 0 ]]; then
+        echo "Running all checks ..."
+        check_wc_hnc_creation_removal
+        check_wc_hnc_system_namespaces
+        exit 0
+    fi
+    while [[ ${#} -gt 0 ]]; do
+        case ${1} in
+        --subns-anchors)
+            check_wc_hnc_creation_removal
+            ;;
+        --system-namespaces)
+            check_wc_hnc_system_namespaces
+            ;;
+        --help)
+            wc_hnc_check_help
+            ;;
+        esac
+        shift
+    done
+}
+
+function check_wc_hnc_creation_removal() {
+    echo -ne "Checking that users can create/delete sub namespaces ... "
+    no_error=true
+    debug_msg=""
+
+    user_namespaces=$(yq4 -e '.user.namespaces[]' "${config['config_file_wc']}")
+    user_admin_users=$(yq4 -e '.user.adminUsers[]' "${config['config_file_wc']}")
+
+    VERBS=(
+        create
+        delete
+        patch
+        update
+    )
+
+    CK8S_NAMESPACES=(
+        cert-manager
+        default
+        falco
+        fluentd
+        kube-system
+        monitoring
+        ingress-nginx
+        velero
+    )
+
+    for user in ${user_admin_users}; do
+        for namespace in ${user_namespaces}; do
+            for verb in "${VERBS[@]}"; do
+                if ! kubectl auth can-i "$verb" "subns" -n "$namespace" --as "$user" >/dev/null 2>&1; then
+                    no_error=false
+                    debug_msg+="[ERROR] $user cannot $verb sub namespace under $namespace namespace\n"
+                fi
+            done
+        done
+    done
+
+    for user in ${user_admin_users}; do
+        for namespace in "${CK8S_NAMESPACES[@]}"; do
+            for verb in "${VERBS[@]}"; do
+                if kubectl auth can-i "$verb" "subns" -n "$namespace" --as "$user" >/dev/null 2>&1; then
+                    no_error=false
+                    debug_msg+="[ERROR] $user can $verb subnamespace anchors under $namespace namespace\n"
+                fi
+            done
+        done
+    done
+
+    if $no_error; then
+        echo "success ✔"
+        echo -e "[DEBUG] Users are able to create/delete subnamespaces anchors"
+    else
+        echo "failure ❌"
+        echo -e "$debug_msg"
+    fi
+}
+
+function check_wc_hnc_system_namespaces() {
+    echo -ne "Checking that system namespaces are not labelled by HNC ... "
+    no_error=true
+    debug_msg=""
+
+    CK8S_NAMESPACES=(
+        cert-manager
+        falco
+        fluentd
+        kube-system
+        monitoring
+        ingress-nginx
+        velero
+    )
+
+    for namespace in "${CK8S_NAMESPACES[@]}"; do
+        hnc_label_exists=$(kubectl get ns "$namespace" -ojson | jq -r '.metadata.labels | .["hnc.x-k8s.io/included-namespace"]')
+        if [[ "$hnc_label_exists" == "true" ]]; then
+            no_error=false
+            debug_msg+="[ERROR] The $namespace namespace is labelled by HNC\n"
+        fi
+    done
+
+    if $no_error; then
+        echo "success ✔"
+        echo -e "[DEBUG] No system namespace is labelled by HNC"
+    else
+        echo "failure ❌"
+        echo -e "$debug_msg"
+    fi
+}

--- a/pipeline/test/services/workload-cluster/testUserRbac.sh
+++ b/pipeline/test/services/workload-cluster/testUserRbac.sh
@@ -54,13 +54,67 @@ function testCannotUserDo {
     fi
 }
 
+# Args:
+#   1. verb
+#   2. resource
+#   3. namespace
+#   4. group
+function testCanGroupDoInNamespace {
+    echo -n "$4 $1 $2 in $3"
+    if kubectl auth can-i "$1" "$2" -n "$3" --as "tester" --as-group "$4" > /dev/null 2>&1;
+    then echo -e "\tauthorized ✔"; SUCCESSES=$((SUCCESSES+1))
+    else
+        echo -e "\tnot authorized ❌"; FAILURES=$((FAILURES+1))
+    fi
+}
+
+# Args:
+#   1. verb
+#   2. resource
+#   3. group
+function testCanGroupDo {
+    echo -n -e "$3 $1 $2"
+    if kubectl auth can-i "$1" "$2" --as "tester" --as-group "$3" > /dev/null 2>&1;
+    then echo -e "\tauthorized ✔"; SUCCESSES=$((SUCCESSES+1))
+    else
+        echo -e "\tnot authorized ❌"; FAILURES=$((FAILURES+1))
+    fi
+}
+
+# Args:
+#   1. verb
+#   2. resource
+#   3. namespace
+#   4. group
+function testCannotGroupDoInNamespace {
+    echo -n "$4 $1 $2 in $3"
+    if kubectl auth can-i "$1" "$2" -n "$3" --as "tester" --as-group "$4" > /dev/null 2>&1;
+    then echo -e "\tauthorized ❌"; FAILURES=$((FAILURES+1))
+    else
+        echo -e "\tnot authorized ✔"; SUCCESSES=$((SUCCESSES+1))
+    fi
+}
+
+# Args:
+#   1. verb
+#   2. resource
+#   3. group
+function testCannotGroupDo {
+    echo -n -e "$3 $1 $2"
+    if kubectl auth can-i "$1" "$2" --as "tester" --as-group "$3" > /dev/null 2>&1;
+    then echo -e "\tauthorized ❌"; FAILURES=$((FAILURES+1))
+    else
+        echo -e "\tnot authorized ✔"; SUCCESSES=$((SUCCESSES+1))
+    fi
+}
+
 echo
 echo
 echo "Testing user RBAC"
 echo "====================="
 
-user_namespaces=$(yq4 '.user.namespaces.[]' "$CONFIG_FILE")
-user_admin_users=$(yq4 '.user.adminUsers.[]' "$CONFIG_FILE")
+user_namespaces=$(yq4 '.user.namespaces[]' "$CONFIG_FILE")
+user_admin_users=$(yq4 '.user.adminUsers[]' "$CONFIG_FILE")
 
 for user in ${user_admin_users}; do
     testCanUserDo "get" "node" "$user"
@@ -182,6 +236,140 @@ then
         for resource in "${ALERTMANAGER_ROLEBINDING_RESOURCES[@]}"; do
             for verb in "${ALERTMANAGER_ROLEBINDING_VERBS[@]}"; do
                 testCanUserDoInNamespace "$verb" "$resource" "monitoring" "$user"
+            done
+        done
+    done
+fi
+
+echo
+echo
+echo "Testing group RBAC"
+echo "====================="
+
+
+user_namespaces=$(yq4 '.user.namespaces[]' "$CONFIG_FILE")
+user_admin_groups=$(yq4 '.user.adminGroups[]' "$CONFIG_FILE")
+
+for group in ${user_admin_groups}; do
+    testCanGroupDo "get" "node" "$group"
+    testCanGroupDo "get" "namespace" "$group"
+    testCannotGroupDo "drain" "node" "$group"
+    testCannotGroupDo "create" "namespace" "$group"
+done
+
+VERBS=(
+    create
+    delete
+)
+RESOURCES=(
+    deployments
+)
+
+for group in ${user_admin_groups}; do
+    for namespace in ${user_namespaces}; do
+        for resource in "${RESOURCES[@]}"; do
+            for verb in "${VERBS[@]}"; do
+                testCanGroupDoInNamespace "$verb" "$resource" "$namespace" "$group"
+            done
+        done
+    done
+done
+
+VERBS=(
+    create
+    delete
+    patch
+    update
+)
+RESOURCES=(
+    deployments
+    daemonset
+    statefulset
+    secrets
+)
+CK8S_NAMESPACES=(
+    cert-manager
+    default
+    falco
+    fluentd
+    kube-system
+    monitoring
+    ingress-nginx
+    velero
+)
+
+for group in ${user_admin_groups}; do
+    for namespace in "${CK8S_NAMESPACES[@]}"; do
+        for resource in "${RESOURCES[@]}"; do
+            for verb in "${VERBS[@]}"; do
+                testCannotGroupDoInNamespace "$verb" "$resource" "$namespace" "$group"
+            done
+        done
+    done
+done
+
+FLUENTD_VERBS=(
+    patch
+)
+FLUENTD_RESOURCES=(
+    configmaps/fluentd-extra-config
+    configmaps/fluentd-extra-plugins
+)
+
+for group in ${user_admin_groups}; do
+    for resource in "${FLUENTD_RESOURCES[@]}"; do
+        for verb in "${FLUENTD_VERBS[@]}"; do
+            testCanGroupDoInNamespace "$verb" "$resource" "fluentd" "$group"
+        done
+    done
+done
+
+if [[ $ENABLE_USER_ALERTMANAGER == "true" ]]
+then
+    ALERTMANAGER_SECRET_VERBS=(
+        update
+    )
+    ALERTMANAGER_SECRET_RESOURCES=(
+        secret/alertmanager-alertmanager
+        secret/user-alertmanager-auth
+    )
+
+    for group in ${user_admin_groups}; do
+        for resource in "${ALERTMANAGER_SECRET_RESOURCES[@]}"; do
+            for verb in "${ALERTMANAGER_SECRET_VERBS[@]}"; do
+                testCanGroupDoInNamespace "$verb" "$resource" "monitoring" "$group"
+            done
+        done
+    done
+
+    ALERTMANAGER_SECRET_VERBS=(
+        create
+        delete
+    )
+    ALERTMANAGER_SECRET_RESOURCES=(
+        secret/alertmanager-alertmanager
+        secret/user-alertmanager-auth
+    )
+
+    for group in ${user_admin_groups}; do
+        for resource in "${ALERTMANAGER_SECRET_RESOURCES[@]}"; do
+            for verb in "${ALERTMANAGER_SECRET_VERBS[@]}"; do
+                testCannotGroupDoInNamespace "$verb" "$resource" "monitoring" "$group"
+            done
+        done
+    done
+
+    ALERTMANAGER_ROLEBINDING_VERBS=(
+        create
+    )
+    ALERTMANAGER_ROLEBINDING_RESOURCES=(
+        rolebinding/alertmanager-configurer
+    )
+
+    for group in ${user_admin_groups}; do
+        for resource in "${ALERTMANAGER_ROLEBINDING_RESOURCES[@]}"; do
+            for verb in "${ALERTMANAGER_ROLEBINDING_VERBS[@]}"; do
+                testCanGroupDoInNamespace "$verb" "$resource" "monitoring" "$group"
             done
         done
     done


### PR DESCRIPTION
**What this PR does / why we need it**:

Compliant Kubernetes needs more troubleshooting scripts to help operators quickly figure out faults in an environment.
We could use some checks for user access and namespaces so we can quickly assert that they work as they should.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1198 

