### PR TITLE
pipeline: upgrade terraform

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -78,14 +78,23 @@ jobs:
         ssh-keygen -q -t rsa -N "" -f apps/pipeline/config/exoscale/id_rsa
         sed -i "s!PUBLIC_SSH_KEY_HERE!$(cat apps/pipeline/config/exoscale/id_rsa.pub)!g" apps/pipeline/config/exoscale/pipeline-${{ matrix.cluster }}-config/default.tfvars
     - name: Init terraform
-      uses: docker://hashicorp/terraform:0.14.7
+      uses: docker://hashicorp/terraform:1.2.9
       with:
-        args: init compliantkubernetes-kubespray/kubespray/contrib/terraform/exoscale
+        args: -chdir="/github/workspace/compliantkubernetes-kubespray/kubespray/contrib/terraform/exoscale" init
     # Note: This container doesn't run bash, so we cannot use env vars in the arguments
     - name: Run terraform
-      uses: docker://hashicorp/terraform:0.14.7
+      continue-on-error: true
+      id: runterraform0
+      uses: docker://hashicorp/terraform:1.2.9
       with:
-        args: apply -auto-approve -var-file apps/pipeline/config/exoscale/pipeline-${{ matrix.cluster }}-config/default.tfvars -state apps/pipeline/config/exoscale/pipeline-${{ matrix.cluster }}-config/terraform.tfstate compliantkubernetes-kubespray/kubespray/contrib/terraform/exoscale
+        args: -chdir="/github/workspace/compliantkubernetes-kubespray/kubespray/contrib/terraform/exoscale" apply -auto-approve -var-file /github/workspace/apps/pipeline/config/exoscale/pipeline-${{ matrix.cluster }}-config/default.tfvars -state /github/workspace/apps/pipeline/config/exoscale/pipeline-${{ matrix.cluster }}-config/terraform.tfstate
+
+    - name: Run terraform - retry 1
+      id: runterraform1
+      if: steps.runterraform0.outcome=='failure'
+      uses: docker://hashicorp/terraform:1.2.9
+      with:
+        args: -chdir="/github/workspace/compliantkubernetes-kubespray/kubespray/contrib/terraform/exoscale" apply -auto-approve -var-file /github/workspace/apps/pipeline/config/exoscale/pipeline-${{ matrix.cluster }}-config/default.tfvars -state /github/workspace/apps/pipeline/config/exoscale/pipeline-${{ matrix.cluster }}-config/terraform.tfstate
 
     - name: Prepare DNS
       if: matrix.cluster == 'sc'
@@ -106,6 +115,17 @@ jobs:
         args: route53 change-resource-record-sets --hosted-zone-id Z2STJRQSJO5PZ0 --change-batch file://apps/pipeline/config/exoscale/dns-${{ matrix.cluster }}.json
 
     - name: Run kubespray
+      continue-on-error: true
+      id: runkubespray0
+      uses: docker://quay.io/kubespray/kubespray:v2.20.0
+      env:
+        ANSIBLE_CONFIG: ./compliantkubernetes-kubespray/kubespray/ansible.cfg
+      with:
+        args: /bin/bash -c "cd compliantkubernetes-kubespray/kubespray && ansible-playbook -i ../../$CK8S_CONFIG_PATH/pipeline-${{ matrix.cluster }}-config/inventory.ini --private-key ../../$CK8S_CONFIG_PATH/id_rsa --become --become-user=root cluster.yml"
+
+    - name: Run kubespray - retry 1
+      id: runkubespray1
+      if: steps.runkubespray0.outcome=='failure'
       uses: docker://quay.io/kubespray/kubespray:v2.20.0
       env:
         ANSIBLE_CONFIG: ./compliantkubernetes-kubespray/kubespray/ansible.cfg
@@ -211,10 +231,20 @@ jobs:
         path: ./events
 
     - name: Destroy terraform
+      continue-on-error: true
+      id: destroyterraform0
       if: always()
-      uses: docker://hashicorp/terraform:0.14.7
+      uses: docker://hashicorp/terraform:1.2.9
       with:
-        args: destroy -auto-approve -var-file apps/pipeline/config/exoscale/pipeline-${{ matrix.cluster }}-config/default.tfvars -state apps/pipeline/config/exoscale/pipeline-${{ matrix.cluster }}-config/terraform.tfstate compliantkubernetes-kubespray/kubespray/contrib/terraform/exoscale
+        args: -chdir="/github/workspace/compliantkubernetes-kubespray/kubespray/contrib/terraform/exoscale" destroy -auto-approve -var-file /github/workspace/apps/pipeline/config/exoscale/pipeline-${{ matrix.cluster }}-config/default.tfvars -state /github/workspace/apps/pipeline/config/exoscale/pipeline-${{ matrix.cluster }}-config/terraform.tfstate
+
+    - name: Destroy terraform - retry 1
+      id: destroyterraform1
+      if: always() && steps.destroyterraform0.outcome=='failure'
+      uses: docker://hashicorp/terraform:1.2.9
+      with:
+        args: -chdir="/github/workspace/compliantkubernetes-kubespray/kubespray/contrib/terraform/exoscale" destroy -auto-approve -var-file /github/workspace/apps/pipeline/config/exoscale/pipeline-${{ matrix.cluster }}-config/default.tfvars -state /github/workspace/apps/pipeline/config/exoscale/pipeline-${{ matrix.cluster }}-config/terraform.tfstate
+
 
     - name: Prepare DNS cleanup
       if: always() && (matrix.cluster == 'sc')

--- a/pipeline/config/exoscale/pipeline-sc-config/default.tfvars
+++ b/pipeline/config/exoscale/pipeline-sc-config/default.tfvars
@@ -1,7 +1,7 @@
 prefix = "pipeline-sc"
 zone   = "ch-gva-2"
 
-inventory_file = "apps/pipeline/config/exoscale/pipeline-sc-config/inventory.ini"
+inventory_file = "/github/workspace/apps/pipeline/config/exoscale/pipeline-sc-config/inventory.ini"
 
 ssh_public_keys = [
   # Put your public SSH key here

--- a/pipeline/config/exoscale/pipeline-sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
+++ b/pipeline/config/exoscale/pipeline-sc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
@@ -100,3 +100,24 @@ container_manager: containerd
 kubelet_config_extra_args:
   imageGCHighThresholdPercent: 75
   imageGCLowThresholdPercent: 70
+
+calico_ipip_mode: 'Always'
+calico_vxlan_mode: 'Never'
+calico_network_backend: 'bird'
+
+kube_profiling: false
+kube_scheduler_bind_address: 127.0.0.1
+kube_kubeadm_scheduler_extra_args:
+  profiling: false
+
+kube_controller_manager_bind_address: 127.0.0.1
+
+kubelet_secure_addresses: >-
+  {%- for host in groups['kube_control_plane'] -%}
+    {{ hostvars[host]['ip'] | default(fallback_ips[host]) }}{{ ' ' if not loop.last else '' }}
+  {%- endfor -%}
+
+containerd_version: 1.6.12
+containerd_archive_checksums:
+  amd64:
+    1.6.12: a56c39795fd0d0ee356b4099a4dfa34689779f61afc858ef84c765c63e983a7d

--- a/pipeline/config/exoscale/pipeline-wc-config/default.tfvars
+++ b/pipeline/config/exoscale/pipeline-wc-config/default.tfvars
@@ -1,7 +1,7 @@
 prefix = "pipeline-wc"
 zone   = "ch-gva-2"
 
-inventory_file = "apps/pipeline/config/exoscale/pipeline-wc-config/inventory.ini"
+inventory_file = "/github/workspace/apps/pipeline/config/exoscale/pipeline-wc-config/inventory.ini"
 
 ssh_public_keys = [
   # Put your public SSH key here

--- a/pipeline/config/exoscale/pipeline-wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
+++ b/pipeline/config/exoscale/pipeline-wc-config/group_vars/k8s_cluster/ck8s-k8s-cluster.yaml
@@ -100,3 +100,24 @@ container_manager: containerd
 kubelet_config_extra_args:
   imageGCHighThresholdPercent: 75
   imageGCLowThresholdPercent: 70
+
+calico_ipip_mode: 'Always'
+calico_vxlan_mode: 'Never'
+calico_network_backend: 'bird'
+
+kube_profiling: false
+kube_scheduler_bind_address: 127.0.0.1
+kube_kubeadm_scheduler_extra_args:
+  profiling: false
+
+kube_controller_manager_bind_address: 127.0.0.1
+
+kubelet_secure_addresses: >-
+  {%- for host in groups['kube_control_plane'] -%}
+    {{ hostvars[host]['ip'] | default(fallback_ips[host]) }}{{ ' ' if not loop.last else '' }}
+  {%- endfor -%}
+
+containerd_version: 1.6.12
+containerd_archive_checksums:
+  amd64:
+    1.6.12: a56c39795fd0d0ee356b4099a4dfa34689779f61afc858ef84c765c63e983a7d


### PR DESCRIPTION
**What this PR does / why we need it**: to upgrade the terraform version and implement a retry strategy for the terraform and kubespray steps

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1079 

**Special notes for reviewer**:
- [green pipeline 1](https://github.com/elastisys/compliantkubernetes-apps/actions/runs/3931622349)
- [green pipeline 2](https://github.com/elastisys/compliantkubernetes-apps/actions/runs/3937226277)

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
