### PR TITLE
apps: Added falco rules for redis

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -11,6 +11,7 @@
 - Support for extracting and storing audit logs with Fluentd
 - Compaction for logs stored directly in object store by Fluentd
 - New 'Log review overview' Opensearch dashboard
+- Added falco rules to ignore redis operator related alerts.
 
 ### Fixed
 

--- a/helmfile/values/falco.yaml.gotmpl
+++ b/helmfile/values/falco.yaml.gotmpl
@@ -109,6 +109,43 @@ customRules:
             container.image.repository=docker.io/elastisys/curl-jq and k8s.pod.name startswith opensearch-
           )
         )
+    - macro: user_known_non_sudo_setuid_conditions
+      condition: (
+          user.name=root or
+          (k8s.pod.name startswith 'rfr-' and container.image.repository=docker.io/library/redis and (
+              proc.cmdline='sh -c redis-cli -h $(hostname) ping' or
+              proc.cmdline='xargs -0 sh -c' or
+              proc.cmdline='hostname' or
+              (proc.cmdline='hostname -i' and proc.pname='sh') or
+              (proc.cmdline='sh -c redis-cli info replication | grep role | tr -d "\\r" | tr -d "\\n"\n' and (proc.pname='xargs' or proc.pname='sh')) or
+              (proc.cmdline='sh -c redis-cli info replication | grep master_sync_in_progress:1 | tr -d "\\r" | tr -d "\\n"\n' and (proc.pname='xargs' or proc.pname='sh')) or
+              (proc.cmdline='sh -c redis-cli info replication | grep master_host:127.0.0.1 | tr -d "\\r" | tr -d "\\n"\n' and (proc.pname='xargs' or proc.pname='sh')) or
+              (proc.cmdline='grep role' and (proc.pname='xargs' or proc.pname='sh')) or
+              (proc.cmdline='grep master_sync_in_progress:1' and (proc.pname='xargs' or proc.pname='sh')) or
+              (proc.cmdline='grep master_host:127.0.0.1' and (proc.pname='xargs' or proc.pname='sh')) or
+              (proc.cmdline='tr -d \\n' and (proc.pname='xargs' or proc.pname='sh')) or
+              (proc.cmdline='tr -d \\r' and (proc.pname='xargs' or proc.pname='sh')) or
+              (proc.cmdline='tr -d \\"' and (proc.pname='xargs' or proc.pname='sh')) or
+              proc.cmdline='tr ,  ' or
+              proc.cmdline='cut -d  -f1' or
+              (proc.cmdline='sleep 5' and proc.pname='sh') or
+              proc.cmdline='sh -c sleep 5 && redis-server /redis/redis.conf' or
+              proc.cmdline='sh /redis-readiness/ready.sh' or
+              proc.cmdline='sh /redis-shutdown/shutdown.sh'
+            )
+          ) or (
+            k8s.pod.name startswith 'rfs-' and (
+              (container.image.repository=docker.io/library/redis and (
+                  proc.cmdline='sh -c redis-cli -h $(hostname) -p 26379 ping' or
+                  proc.cmdline='hostname' or
+                  proc.cmdline='cp /redis/sentinel.conf /redis-writable/sentinel.conf'
+                )
+              ) or (
+                container.image.repository=quay.io/oliver006/redis_exporter and proc.cmdline='redis_exporter -redis.addr redis://localhost:26379'
+              )
+            )
+          )
+        )
 
 falcosidekick:
   enabled: {{ .Values.falco.alerts.enabled }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Since we don't want to get alerts for redis we need to add some exceptions for it.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
