### PR TITLE
bin: Test scripts can now always access the kubeconfig

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -2,3 +2,4 @@
 ### Fixed
 
 - The update-ips script can now fetch Calico Wireguard IPs
+- The test scripts can now always access the kubeconfig

--- a/bin/ck8s
+++ b/bin/ck8s
@@ -70,7 +70,7 @@ case "${1}" in
         ;;
     test)
         [[ "${2}" =~ ^(wc|sc)$ ]] || usage
-        "${here}/test.bash" "${@:2}"
+        with_kubeconfig "${config["kube_config_${2}"]}" "${here}/test.bash" "${@:2}"
         ;;
     dry-run)
         [[ "${2}" =~ ^(wc|sc)$ ]] || usage

--- a/bin/test.bash
+++ b/bin/test.bash
@@ -23,15 +23,13 @@ source "${pipeline_path}/test/services/workload-cluster/testIngress.sh"
 test_apps_sc() {
     log_info "Testing service cluster"
 
-    with_kubeconfig "${config[kube_config_sc]}" \
-        "${pipeline_path}/test/services/test-sc.sh" "${config[config_file_sc]}"
+    "${pipeline_path}/test/services/test-sc.sh" "${config[config_file_sc]}"
 }
 
 test_apps_wc() {
     log_info "Testing workload cluster"
 
-    with_kubeconfig "${config[kube_config_wc]}" \
-        "${pipeline_path}/test/services/test-wc.sh" "${config[config_file_wc]}"
+    "${pipeline_path}/test/services/test-wc.sh" "${config[config_file_wc]}"
 }
 
 function sc_help() {
@@ -121,13 +119,11 @@ function main() {
     case ${1} in
     sc)
         config_load "$1"
-        with_kubeconfig "${config[kube_config_sc]}" \
-            "$1" "${@:2}"
+        "$1" "${@:2}"
         ;;
     wc)
         config_load "$1"
-        with_kubeconfig "${config[kube_config_wc]}" \
-            "$1" "${@:2}"
+        "$1" "${@:2}"
         ;;
     esac
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Since some of the tests now run with functions instead of separate scripts we need to change where we expose the kubeconfig.

**Special notes for reviewer**:

Will fix the issue in the pipeline.
We should reconsider how we manage the kubeconfig in our scripts.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
