### PR TITLE
apps: missing np for rook-ceph

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,10 +1,8 @@
 ### Release notes
 
-### Changed
+### Added
 
-- Thanos Rulers now sends alerts to all Alertmanagers in an HA setup, sends requests directly to Queries, and are now accessible by Queries
-- Thanos components now use DNS SD to automatically find healthy replicas
-- Alerts can now be inspected in ops Grafana
+- Enable rook-ceph network polices by default for exoscale
 
 ### Fixed
 
@@ -14,7 +12,13 @@
 ### Updated
 
 - The NetworkPolicy Dashboard have been updated to be more clear
+
 ### Changed
 
+- Thanos Rulers now sends alerts to all Alertmanagers in an HA setup, sends requests directly to Queries, and are now accessible by Queries
+- Thanos components now use DNS SD to automatically find healthy replicas
+- Alerts can now be inspected in ops Grafana
 - Updated metrics-server chart to 0.6.2 which upgrades metrics-server to 3.8.3
 - Allow the creation of arbitrary network-policy in wc
+- Network polices
+  - Added missing network policy for rook-ceph-csi-detect-version for rook-ceph v1.10

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -148,6 +148,8 @@ set_storage_class() {
 
         exoscale|baremetal)
             storage_class=rook-ceph-block
+
+            yq4 -i '.networkPolicies.rookCeph.enabled = true' "${file}"
             ;;
         aws)
             storage_class=ebs-gp2

--- a/helmfile/charts/networkpolicy-common/templates/rook-ceph/csi-detect-version.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/rook-ceph/csi-detect-version.yaml
@@ -1,0 +1,22 @@
+{{ if .Values.rookCeph.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-rook-ceph-csi-detect-version
+  namespace: rook-ceph
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      app: rook-ceph-csi-detect-version
+  egress:
+    - to:
+        {{- range $ip := .Values.global.apiserver.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.global.apiserver.port }}
+          protocol: TCP
+{{- end }}

--- a/helmfile/charts/networkpolicy-common/templates/rook-ceph/csi-rbdplugin-provisioner.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/rook-ceph/csi-rbdplugin-provisioner.yaml
@@ -37,4 +37,13 @@ spec:
           endPort: 7300
         - port: 9283
           protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app: rook-ceph-mon
+      ports:
+        - port: 3300
+          protocol: TCP
+        - port: 6789
+          protocol: TCP
 {{- end }}

--- a/helmfile/charts/networkpolicy-common/templates/rook-ceph/mon.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/rook-ceph/mon.yaml
@@ -42,6 +42,15 @@ spec:
           protocol: TCP
         - port: 7000
           protocol: TCP
+    - from:
+        - podSelector:
+            matchLabels:
+              app: csi-rbdplugin-provisioner
+      ports:
+        - port: 3300
+          protocol: TCP
+        - port: 6789
+          protocol: TCP
   egress:
     - to:
         - podSelector:


### PR DESCRIPTION
**What this PR does / why we need it**:

Add missing np for rook-ceph-csi-detect-version

**Which issue this PR fixes**: fixes #1329 

Definition of Done

- [x] the network policies are fixed for the new rook-ceph version and regular ops changes can be performed without issues
- [x] enable rook network policy only for exoscale environments in the apps init.sh script
- [x] the network policies should support the latest and older versions of rook, see [rook](https://github.com/elastisys/compliantkubernetes-kubespray/tree/main/rook?rgh-link-date=2022-12-13T14%3A03%3A42Z)
- [x] Also, with rook network policies enabled seems that we cannot create any PVCs, see this [pipeline run](https://github.com/elastisys/compliantkubernetes-apps/actions/runs/3702298246/jobs/6272466621).

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
