### PR TITLE
apps sc: Thanos configuration updates

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Release notes
 
+### Changed
+
+- Thanos Rulers now sends alerts to all Alertmanagers in an HA setup, sends requests directly to Queries, and are now accessible by Queries
+- Thanos components now use DNS SD to automatically find healthy replicas
+- Alerts can now be inspected in ops Grafana
+
 ### Fixed
 
 - The update-ips script can now fetch Calico Wireguard IPs

--- a/helmfile/charts/networkpolicy-service/templates/grafana/allow-grafana.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/grafana/allow-grafana.yaml
@@ -83,6 +83,8 @@ spec:
         - port: {{ $port }}
         {{- end }}
     - ports:
+      - protocol: TCP
+        port: 53
       - protocol: UDP
         port: 53
 {{- end }}

--- a/helmfile/charts/networkpolicy-service/templates/thanos/allow-thanos-query.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/thanos/allow-thanos-query.yaml
@@ -16,6 +16,9 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/component: query-frontend
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: ruler
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: monitoring
@@ -38,11 +41,16 @@ spec:
               app.kubernetes.io/component: receive
         - podSelector:
             matchLabels:
+              app.kubernetes.io/component: ruler
+        - podSelector:
+            matchLabels:
               app.kubernetes.io/component: storegateway
       ports:
         - port: 10901
           protocol: TCP
     - ports:
+      - protocol: TCP
+        port: 53
       - protocol: UDP
         port: 53
 {{- end }}

--- a/helmfile/charts/networkpolicy-service/templates/thanos/allow-thanos-ruler.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/thanos/allow-thanos-ruler.yaml
@@ -13,6 +13,13 @@ spec:
     - Egress
   ingress:
     - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: query
+      ports:
+        - port: 10901
+          protocol: TCP
+    - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: monitoring
@@ -26,7 +33,7 @@ spec:
     - to:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/component: query-frontend
+              app.kubernetes.io/component: query
       ports:
         - port: 10902
           protocol: TCP
@@ -50,6 +57,8 @@ spec:
         - port: {{ $port }}
         {{- end }}
     - ports:
+      - protocol: TCP
+        port: 53
       - protocol: UDP
         port: 53
 {{- end }}

--- a/helmfile/values/grafana-user.yaml.gotmpl
+++ b/helmfile/values/grafana-user.yaml.gotmpl
@@ -70,6 +70,7 @@ datasources:
       url: http://grafana-label-enforcer:9090
       jsonData:
         customQueryParameters: "tenant_id={{ .Values.global.clusterName }}"
+        manageAlerts: false
       version: 1
 
     {{- /*
@@ -88,6 +89,7 @@ datasources:
       version: 1
       jsonData:
         customQueryParameters: "tenant_id={{ first .Values.global.clustersMonitoring }}"
+        manageAlerts: false
     {{- else }}
     {{- range .Values.global.clustersMonitoring }}
     - name: "{{ . }}"
@@ -101,6 +103,7 @@ datasources:
       version: 1
       jsonData:
         customQueryParameters: "tenant_id={{ . }}"
+        manageAlerts: false
     {{- end }}
     {{- end }}
     {{- end }}

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -222,6 +222,8 @@ grafana:
     orgId: 1
     type: prometheus
     url: http://thanos-query-query-frontend.thanos:9090
+    jsonData:
+      prometheusType: Thanos
     version: 1
   - name: "Thanos SC Only"
     access: proxy
@@ -233,6 +235,7 @@ grafana:
     url: http://grafana-label-enforcer:9090
     jsonData:
       customQueryParameters: "tenant_id={{ .Values.global.clusterName }}"
+      manageAlerts: false
     version: 1
   {{- range .Values.global.clustersMonitoring }}
   - name: "Thanos {{ . }} only"
@@ -246,6 +249,7 @@ grafana:
     version: 1
     jsonData:
       customQueryParameters: "tenant_id={{ . }}"
+      manageAlerts: false
   {{- end }}
   {{- end }}
 

--- a/helmfile/values/thanos/query.yaml.gotmpl
+++ b/helmfile/values/thanos/query.yaml.gotmpl
@@ -5,16 +5,19 @@ query:
   replicaCount: {{ .Values.thanos.query.replicaCount }}
   topologySpreadConstraints: {{- toYaml .Values.thanos.query.topologySpreadConstraints | nindent 4 }}
 
+  service:
+    additionalHeadless: true
+
   extraFlags:
     - "--query.auto-downsampling"
 
   dnsDiscovery:
     enabled: false
+
   stores:
     - "thanos-receiver-storegateway:10901"
-    {{- range $i := until .Values.thanos.receiver.replicaCount }}
-    - "thanos-receiver-receive-{{ $i }}.thanos-receiver-receive-headless.thanos.svc.cluster.local:10901"
-    {{- end }}
+    - dnssrv+_grpc._tcp.thanos-receiver-receive-headless.thanos.svc
+    - dnssrv+_grpc._tcp.thanos-receiver-ruler-headless.thanos.svc
 
   replicaLabel:
     - replica

--- a/helmfile/values/thanos/receiver.yaml.gotmpl
+++ b/helmfile/values/thanos/receiver.yaml.gotmpl
@@ -84,6 +84,9 @@ ruler:
 
   resources: {{- toYaml .Values.thanos.ruler.resources | nindent 4 }}
 
+  service:
+    additionalHeadless: true
+
   persistence:
     enabled: {{ .Values.thanos.ruler.persistence.enabled }}
     size: {{ .Values.thanos.ruler.persistence.size }}
@@ -92,10 +95,10 @@ ruler:
   topologySpreadConstraints: {{- toYaml .Values.thanos.ruler.topologySpreadConstraints | nindent 4 }}
 
   alertmanagers:
-    - http://kube-prometheus-stack-alertmanager.monitoring:9093
+    - dnssrv+http://_web._tcp.alertmanager-operated.monitoring.svc.cluster.local
 
   queries:
-    - thanos-query-query-frontend:9090
+    - dnssrv+_http._tcp.thanos-query-query-headless.thanos.svc
 
   clusterName: {{ .Values.global.ck8sEnvironmentName }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This makes some changes to improve our setup, especially to make the Rulers access to metrics more redundant, and make it easier in dev environments to inspect alerts.

**Which issue this PR fixes**:

Part of #1205

**Special notes for reviewer**:

Inspection of alerts have been disabled in user Grafana.

We probably need to update more of the netpols to allow DNS with TCP to reduce potential resolve errors.

**Add a screenshot or an example to illustrate the proposed solution:**

![image](https://user-images.githubusercontent.com/58822152/215483554-cd60e291-b9e5-44bd-90c6-92ce83aead47.png)

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
