### PR TITLE
apps sc: support for opensearch static users

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -5,6 +5,8 @@
 - Enable rook-ceph network polices by default for exoscale
 - Troubleshooting scripts for HNC
 - Tests for Groups RBAC
+- the possibility to add static users for opensearch
+
 ### Fixed
 
 - The update-ips script can now fetch Calico Wireguard IPs

--- a/config/secrets/sc-secrets.yaml
+++ b/config/secrets/sc-secrets.yaml
@@ -51,6 +51,17 @@ opensearch:
   curatorPassword: somelongsecret
   snapshotterPassword: somelongsecret
   metricsExporterPassword: somelongsecret
+  extraUsers: []
+  #    - username: static-user
+  #      definition:
+  #        password: somelongsecret
+  #        opendistro_security_roles:
+  #        - kibana_user #make sure the role exists or is created using extraRoles
+  #        backend_role:
+  #        - backed_role
+  #        attributes:
+  #          attribute1: value1
+  #          attribute2: value2
 kubeapiMetricsPassword: somelongsecret
 alerts:
   slack:

--- a/helmfile/values/opensearch/configurer.yaml.gotmpl
+++ b/helmfile/values/opensearch/configurer.yaml.gotmpl
@@ -76,6 +76,9 @@ config:
         password: {{ .Values.opensearch.metricsExporterPassword }}
         opendistro_security_roles:
         - metrics_exporter
+  {{- if .Values.opensearch.extraUsers }}
+    {{- toYaml .Values.opensearch.extraUsers | nindent 4 }}
+  {{- end }}
 
     roles:
     - role_name: log_forwarder


### PR DESCRIPTION
**What this PR does / why we need it**: to enable static users in opensearch

**Which issue this PR fixes**: fixes #1067

**Add a screenshot or an example to illustrate the proposed solution:**
1. `GET _plugins/_security/api/internalusers`
```
{
  "static-user2" : {
    "hash" : "",
    "reserved" : false,
    "hidden" : false,
    "backend_roles" : [
      "backed_role2"
    ],
    "attributes" : {
      "foo" : "boo",
      "red" : "blue"
    },
    "opendistro_security_roles" : [
      "kibana_user"
    ],
    "static" : false
  },
  "static-user" : {
    "hash" : "",
    "reserved" : false,
    "hidden" : false,
    "backend_roles" : [
      "backed_role"
    ],
    "attributes" : {
      "green" : "yellow",
      "too" : "roo"
    },
    "opendistro_security_roles" : [
      "kibana_user"
    ],
    "static" : false
  },

```


2. I disabled SSO and I could successfully login to opensearch dashboard

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).