### PR TITLE
bin: fix destinationObjectStorage ips

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -10,10 +10,10 @@
 ### Fixed
 
 - The update-ips script can now fetch Calico Wireguard IPs
+- The update-ips script can now fetch object storage sync destination IPs
 - The test scripts can now always access the kubeconfig
 - The OpenSearch network policies now properly work with dedicated nodes and shapshots enabled
 - The `clean-sc` script now patches any pending challenges which would prevent the removal of certain namespaces
-
 
 ### Updated
 


### PR DESCRIPTION
**What this PR does / why we need it**: when sync to a different S3 bucket is enabled the update-ips script is throwing an error without adding the destination IP in the sc-config.yaml:
`[ck8s] No ips for s3-region.provider.com:8080 was found`

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

