### PR TITLE
tests sc: fix thanos ruler and query tests

### DIFF
--- a/pipeline/test/services/service-cluster/testPrometheusTargets.sh
+++ b/pipeline/test/services/service-cluster/testPrometheusTargets.sh
@@ -53,11 +53,11 @@ if [[ "${enable_thanos}" == "true" ]] && [[ "${enable_thanos_service_monitor}" =
     )
 fi
 if [[ "${enable_thanos}" == "true" ]] && [[ "${enable_thanos_service_monitor}" == "true" ]] && [[ "${enable_thanos_ruler}" == "true" ]]; then
-    scTargets+=("serviceMonitor/thanos/thanos-receiver-ruler/0 2")
+    scTargets+=("serviceMonitor/thanos/thanos-receiver-ruler/0 4")
 fi
 if [[ "${enable_thanos}" == "true" ]] && [[ "${enable_thanos_service_monitor}" == "true" ]] && [[ "${enable_thanos_query}" == "true" ]]; then
     scTargets+=(
-        "serviceMonitor/thanos/thanos-query-query/0 1"
+        "serviceMonitor/thanos/thanos-query-query/0 2"
         "serviceMonitor/thanos/thanos-query-query-frontend/0 1"
     )
 fi


### PR DESCRIPTION
**What this PR does / why we need it**: the test sc was failing when checking service monitor for thanos ruler and query:

> serviceMonitor/thanos/thanos-receiver-ruler/0	❌
> serviceMonitor/thanos/thanos-query-query/0	❌

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).