### PR TITLE
apps sc: Renamed ElasticSearch dashboard

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -25,6 +25,8 @@
 - Upgraded the Starboard-operator helm chart to `0.10.11` which upgrades the app version to `0.15.11`
 - Upgrade Gatekeeper helm chart to `v3.11.0`, which also upgrades Gatekeeper to `v3.11.0`
 - Updated Gatekeeper Dashboard to new one from upstream
+- Renamed the ElasticSearch Dashboard to Opensearch in Grafana
+- Changed release name for `prometheus-elasticsearch-exporter` to `prometheus-opensearch-exporter`
 
 ### Changed
 

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -458,6 +458,7 @@ releases:
 # prometheus-elasticsearch-exporter
 - name: prometheus-elasticsearch-exporter
   namespace: opensearch-system
+  installed: false
   labels:
     app: prometheus-elasticsearch-exporter
     group: opensearch
@@ -467,6 +468,20 @@ releases:
   - opensearch-system/opensearch-configurer
   values:
   - values/prometheus-elasticsearch-exporter.yaml.gotmpl
+
+# prometheus-opensearch-exporter
+- name: prometheus-opensearch-exporter
+  namespace: opensearch-system
+  installed: true
+  labels:
+    app: prometheus-opensearch-exporter
+    group: opensearch
+  chart: ./upstream/prometheus-elasticsearch-exporter
+  version: 4.11.0
+  needs:
+  - opensearch-system/opensearch-configurer
+  values:
+  - values/prometheus-opensearch-exporter.yaml.gotmpl
 
 # Harbor
 - name: harbor-certs

--- a/helmfile/charts/grafana-ops/dashboards/opensearch-dashboard.json
+++ b/helmfile/charts/grafana-ops/dashboards/opensearch-dashboard.json
@@ -6736,8 +6736,7 @@
   "schemaVersion": 30,
   "style": "dark",
   "tags": [
-    "elasticsearch",
-    "App"
+    "opensearch"
   ],
   "templating": {
     "list": [
@@ -6964,6 +6963,6 @@
     ]
   },
   "timezone": "",
-  "title": "ElasticSearch",
+  "title": "OpenSearch",
   "version": 1
 }

--- a/helmfile/values/prometheus-opensearch-exporter.yaml.gotmpl
+++ b/helmfile/values/prometheus-opensearch-exporter.yaml.gotmpl
@@ -35,3 +35,5 @@ tolerations: {{- toYaml .Values.opensearch.exporter.tolerations | nindent 2 }}
 
 podSecurityPolicies:
   enabled: true
+
+fullnameOverride: "prometheus-opensearch-exporter"

--- a/pipeline/test/services/service-cluster/testPodsReady.sh
+++ b/pipeline/test/services/service-cluster/testPodsReady.sh
@@ -39,7 +39,7 @@ deployments=(
     "monitoring kube-prometheus-stack-grafana"
     "monitoring kube-prometheus-stack-kube-state-metrics"
     "monitoring prometheus-blackbox-exporter"
-    "opensearch-system prometheus-elasticsearch-exporter"
+    "opensearch-system prometheus-opensearch-exporter"
     "opensearch-system opensearch-dashboards"
 )
 if "${enable_harbor}"; then

--- a/pipeline/test/services/service-cluster/testPrometheusTargets.sh
+++ b/pipeline/test/services/service-cluster/testPrometheusTargets.sh
@@ -28,7 +28,7 @@ echo "=================================="
 # "monitoring/kube-prometheus-stack-kube-etcd/0 1"
 # "monitoring/kube-prometheus-stack-kube-proxy/0 1"
 scTargets=(
-    "serviceMonitor/opensearch-system/prometheus-elasticsearch-exporter/0 1"
+    "serviceMonitor/opensearch-system/prometheus-opensearch-exporter/0 1"
     "serviceMonitor/monitoring/prometheus-blackbox-exporter-user-api-server/0 1"
     "serviceMonitor/monitoring/prometheus-blackbox-exporter-dex/0 1"
     "serviceMonitor/monitoring/prometheus-blackbox-exporter-grafana/0 1"


### PR DESCRIPTION
**What this PR does / why we need it**:
apps sc: Renamed ElasticSearch dashboard
**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1382 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
