### PR TITLE
apps sc: Fix OpenSearch netpol for dedicated nodes

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - The update-ips script can now fetch Calico Wireguard IPs
 - The test scripts can now always access the kubeconfig
+- The OpenSearch network policies now properly work with dedicated nodes and shapshots enabled
 
 ### Updated
 

--- a/helmfile/charts/networkpolicy-service/templates/opensearch/client.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/opensearch/client.yaml
@@ -57,6 +57,16 @@ spec:
       ports:
         - port: 9300
     - to:
+        {{- range $ip := .Values.global.objectStorage.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        {{- range $port := .Values.global.objectStorage.ports }}
+        - protocol: TCP
+          port: {{ $port }}
+        {{- end }}
+    - to:
         {{- range $ip := .Values.opensearch.plugins.ips }}
         - ipBlock:
             cidr: {{ $ip }}

--- a/helmfile/charts/networkpolicy-service/templates/opensearch/data.yaml
+++ b/helmfile/charts/networkpolicy-service/templates/opensearch/data.yaml
@@ -39,6 +39,16 @@ spec:
       ports:
         - port: 9300
     - to:
+        {{- range $ip := .Values.global.objectStorage.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        {{- range $port := .Values.global.objectStorage.ports }}
+        - protocol: TCP
+          port: {{ $port }}
+        {{- end }}
+    - to:
         {{- range $ip := .Values.opensearch.plugins.ips }}
         - ipBlock:
             cidr: {{ $ip }}


### PR DESCRIPTION
**What this PR does / why we need it**:
So they can now reach the snapshot repository as well.

**Which issue this PR fixes**: 
fixes #1410

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
~~I'm not really able to test but would dedicated client nodes access S3 directly as well?~~ There is good reason to assume they may so I added that as well.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
