### PR TITLE
bin: Added patching of pending challenges with finalizers

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - The update-ips script can now fetch Calico Wireguard IPs
 - The test scripts can now always access the kubeconfig
+- The `clean-sc` script now patches any pending challenges which would prevent the removal of certain namespaces
 
 ### Updated
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In certain situations cert-manager Challenges gets stuck in a pending state with a finalizer which would prevent certain namespaces such as monitoring and harbor from terminating after running the `clean-sc.sh` script. This PR solves this issue.

**Which issue this PR fixes:**

fixes [#1396](https://github.com/elastisys/compliantkubernetes-apps/issues/1396)

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Note** that I have not been able to fully replicate the situation described in the issue, but it has been tested that you can run the script without getting an error and that it can patch a Challenge, removing any finalizers.

The solution uses `kubectl patch` in this case, but a shorter version that should also work is turning any remaining challenges into json and replacing the finalizers with `jq` and then applying the changes. This approach is a bit shorter, e.g:
```bash
CHALLENGES="${here}/.././bin/ck8s" ops kubectl sc get challenge -A
if [ -n "$CHALLENGES" ]; then
    "${here}/.././bin/ck8s" ops kubectl sc get challenge -A -o json | jq '.items[].metadata.finalizers = null' | kubectl apply -f -
fi
```
Any feedback on preference between using the patch or the json approach is appreciated.

Also note that this PR only adds patching for the service cluster clean script. The same should apply for the workload cluster clean script.

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [X] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
