### PR TITLE
apps sc & wc: starboard operator scan-vulnerabilityreport fix

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -18,6 +18,7 @@
 - The test scripts can now always access the kubeconfig
 - The OpenSearch network policies now properly work with dedicated nodes and shapshots enabled
 - The `clean-sc` script now patches any pending challenges which would prevent the removal of certain namespaces
+- Increase memory limit to avoid OOMKilled in job starboard-operator/scan-vulnerabilityreport
 
 ### Updated
 

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -573,7 +573,14 @@ starboard:
       memory: 172Mi
   tolerations: []
   affinity: {}
-
+trivy:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100M
+    limits:
+      cpu: 500m
+      memory: null
 vulnerabilityExporter:
   # Will be disabled if starboard is disabled
   resources:

--- a/helmfile/values/starboard/starboard-operator.yaml.gotmpl
+++ b/helmfile/values/starboard/starboard-operator.yaml.gotmpl
@@ -48,3 +48,7 @@ tolerations:
 
 affinity:
 {{- toYaml .Values.starboard.affinity | nindent 2 }}
+
+trivy:
+  resources:
+{{- toYaml .Values.trivy.resources | nindent 4 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/elastisys/compliantkubernetes-apps/issues/1316

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1316

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
These errors all stem from the job "scan-vulnerabilityreport-*" not having enough resources to finish. 

OOMKilled -> EOF -> Reconciler error

Therefore, a solution is to increase the memory limit. Not sure this memory increase is needed permanently doe? Feels a lot like when we solved https://github.com/elastisys/compliantkubernetes-apps/pull/1347/files - a big buffer of sorts that needs to get released for a second.

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [x] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
