### PR TITLE
docs: Add migration steps for kured upgrade

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -23,3 +23,4 @@
 - Allow the creation of arbitrary network-policy in wc
 - Network polices
   - Added missing network policy for rook-ceph-csi-detect-version for rook-ceph v1.10
+- Upgraded the kured helm chart to `4.4.1` which upgrades the app version to `1.12.1`

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -31,7 +31,7 @@ releases:
   labels:
     app: kured
   chart: ./upstream/kured
-  version: 2.11.2
+  version: 4.4.1
   installed: {{ .Values.kured.enabled }}
   values:
   - values/kured.yaml.gotmpl

--- a/helmfile/charts/networkpolicy-common/templates/kured/allow.yaml
+++ b/helmfile/charts/networkpolicy-common/templates/kured/allow.yaml
@@ -12,7 +12,7 @@ spec:
     - Egress
   podSelector:
     matchLabels:
-      app: kured
+      app.kubernetes.io/name: kured
   ingress:
     - from: {{ toYaml .Values.global.prometheusSelector | nindent 8 }}
       ports:

--- a/helmfile/upstream/kured/Chart.yaml
+++ b/helmfile/upstream/kured/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.9.1
+appVersion: 1.12.1
 description: A Helm chart for kured
-home: https://github.com/weaveworks/kured
-icon: https://raw.githubusercontent.com/weaveworks/kured/main/img/logo.png
+home: https://github.com/kubereboot/kured
+icon: https://raw.githubusercontent.com/kubereboot/website/main/static/img/kured.png
 maintainers:
 - email: christian.kotzbauer@gmail.com
   name: ckotzbauer
@@ -10,5 +10,5 @@ maintainers:
   name: davidkarlsen
 name: kured
 sources:
-- https://github.com/weaveworks/kured
-version: 2.11.2
+- https://github.com/kubereboot/kured
+version: 4.4.1

--- a/helmfile/upstream/kured/README.md
+++ b/helmfile/upstream/kured/README.md
@@ -9,8 +9,8 @@ This chart installs the "Kubernetes Reboot Daemon" using the Helm Package Manage
 ## Installing the Chart
 To install the chart with the release name `my-release`:
 ```bash
-$ helm repo add kured https://weaveworks.github.io/kured
-$ helm install my-release kured/kured
+$ helm repo add kubereboot https://kubereboot.github.io/charts
+$ helm install my-release kubereboot/kured
 ```
 
 ## Uninstalling the Chart
@@ -21,81 +21,116 @@ $ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Upgrade Notes
+
+### From 3.x to 4.x
+
+We have migrated the code and its release artifacts (helm charts, docker images, manifests) to an
+independent organisation named kubereboot. To migrate to 4.x, please adapt your helm repositories.
+
+### From 2.x to 3.x
+
+The Helm chart labels have been realigned to conform with the [standard labels](https://helm.sh/docs/chart_best_practices/labels/#standard-labels) in the current Helm Chart Best Practices guide, so this upgrade will fail unless the DaemonSet is deleted and recreated. The only way that Helm supports delete and recreate is by uninstalling, so please uninstall the Kured Helm chart before installing again with `v3.x`.
+
+If you use any GitOps tool, please check and understand how to do a reinstall beforehand.
+
+Supposing users want to enable metrics and use a `ServiceMonitor` with the `kube-prometheus-stack` chart's default `prometheus` instance. Starting with a chart that has values:
+
+```
+metrics:
+  create: true
+  labels:
+    release: kube-prometheus-stack
+```
+
+A "ServiceMonitor" needs a "release" label to be discovered by the Prometheus-Operator with the default configuration of `kube-prometheus-stack` and this chart (in the prior `v2.x` chart) already sets a `release` label hardcoded. This is changed by applying the best-practise labels in the chart `v3.x`. Now the user can decide which `release` label-value should be used.
+
+With this update, it's more readily possible to make use of the Kured chart with `kube-prometheus-stack`'s default `ServiceMonitor` selector configuration.
 
 ## Migrate from stable Helm-Chart
+
+### From 1.x to 2.x
+
 The following changes have been made compared to the stable chart:
 - **[BREAKING CHANGE]** The `autolock` feature was removed. Use `configuration.startTime` and `configuration.endTime` instead.
 - Role inconsistencies have been fixed (allowed verbs for modifying the `DaemonSet`, apiGroup of `PodSecurityPolicy`)
 - Added support for affinities.
 - Configuration of cli-flags can be made through a `configuration` object.
 - Added optional `Service` and `ServiceMonitor` support for metrics endpoint.
-
+- Previously static Slack channel, hook URL and username values are now made dynamic using `tpl` function.
 
 ## Configuration
 
-| Config                  | Description                                                                 | Default                    |
-| ------                  | -----------                                                                 | -------                    |
-| `image.repository`      | Image repository                                                            | `weaveworks/kured` |
-| `image.tag`             | Image tag                                                                   | `1.9.1`                    |
-| `image.pullPolicy`      | Image pull policy                                                           | `IfNotPresent`             |
-| `image.pullSecrets`     | Image pull secrets                                                          | `[]`                       |
-| `updateStrategy`        | Daemonset update strategy                                                   | `RollingUpdate`            |
-| `maxUnavailable`        | The max pods unavailable during a rolling update                            | `1`                        |
-| `podAnnotations`        | Annotations to apply to pods (eg to add Prometheus annotations)             | `{}`                       |
-| `dsAnnotations`         | Annotations to apply to the kured DaemonSet                                 | `{}`                       |
-| `extraArgs`             | Extra arguments to pass to `/usr/bin/kured`. See below.                     | `{}`                       |
-| `extraEnvVars`          | Array of environment variables to pass to the daemonset.                    | `{}`                       |
-| `configuration.lockTtl` | cli-parameter `--lock-ttl`                                                  | `0`                       |
-| `configuration.lockReleaseDelay` | cli-parameter `--lock-release-delay`                               | `0`                       |
-| `configuration.alertFilterRegexp` | cli-parameter `--alert-filter-regexp`                             | `""`                       |
-| `configuration.alertFiringOnly` | cli-parameter `--alert-firing-only`                                 | `false`                   |
-| `configuration.blockingPodSelector` | Array of selectors for multiple cli-parameters `--blocking-pod-selector` | `[]`             |
-| `configuration.endTime` | cli-parameter `--end-time`                                                  | `""`                      |
-| `configuration.lockAnnotation` | cli-parameter `--lock-annotation`                                    | `""`                      |
-| `configuration.period` | cli-parameter `--period`                                                     | `""`                      |
-| `configuration.forceReboot` | cli-parameter `--force-reboot`                                          | `false`                   |
-| `configuration.drainGracePeriod` | cli-parameter `--drain-grace-period`                               | `""`                      |
-| `configuration.drainTimeout` | cli-parameter `--drain-timeout`                                        | `""`                      |
-| `configuration.skipWaitForDeleteTimeout` | cli-parameter `--skip-wait-for-delete-timeout`             | `""`                      |
-| `configuration.prometheusUrl` | cli-parameter `--prometheus-url`                                      | `""`                      |
-| `configuration.rebootDays` | Array of days for multiple cli-parameters `--reboot-days`                | `[]`                      |
-| `configuration.rebootSentinel` | cli-parameter `--reboot-sentinel`                                    | `""`                      |
-| `configuration.rebootSentinelCommand` | cli-parameter `--reboot-sentinel-command`                     | `""`                      |
-| `configuration.rebootCommand` | cli-parameter `--reboot-command`                                      | `""`                      |
-| `configuration.rebootDelay` | cli-parameter `--reboot-delay`                                          | `""`                      |
-| `configuration.slackChannel` | cli-parameter `--slack-channel`                                        | `""`                      |
-| `configuration.slackHookUrl` | cli-parameter `--slack-hook-url`                                       | `""`                      |
-| `configuration.slackUsername` | cli-parameter `--slack-username`                                      | `""`                      |
-| `configuration.notifyUrl` | cli-parameter `--notify-url`                                              | `""`                      |
-| `configuration.messageTemplateDrain` | cli-parameter `--message-template-drain`                       | `""`                      |
-| `configuration.messageTemplateReboot` | cli-parameter `--message-template-reboot`                     | `""`                      |
-| `configuration.startTime` | cli-parameter `--start-time`                                              | `""`                      |
-| `configuration.timeZone` | cli-parameter `--time-zone`                                                | `""`                      |
-| `configuration.annotateNodes` | cli-parameter `--annotate-nodes`                                      | `false`                   |
-| `configuration.logFormat` | cli-parameter `--log-format`                                              | `"text"`                  |
-| `configuration.preferNoScheduleTaint` | Taint name applied during pending node reboot                 | `""`                   |
-| `rbac.create`           | Create RBAC roles                                                           | `true`                     |
-| `serviceAccount.create` | Create a service account                                                    | `true`                     |
-| `serviceAccount.name`   | Service account name to create (or use if `serviceAccount.create` is false) | (chart fullname)           |
-| `podSecurityPolicy.create` | Create podSecurityPolicy                                                 | `false`                     |
-| `resources`             | Resources requests and limits.                                              | `{}`                       |
-| `metrics.create`        | Create a ServiceMonitor for prometheus-operator                             | `false`                    |
-| `metrics.namespace`     | The namespace to create the ServiceMonitor in                               | `""`                    |
-| `metrics.labels`        | Additional labels for the ServiceMonitor                                    | `{}`                    |
-| `metrics.interval`      | Interval prometheus should scrape the endpoint                              | `60s`                   |
-| `metrics.scrapeTimeout` | A custom scrapeTimeout for prometheus                                       | `""`                    |
-| `service.create`        | Create a Service for the metrics endpoint                                   | `false`                    |
-| `service.name  `        | Service name for the metrics endpoint                                       | `""`                       |
-| `service.port`          | Port of the service to expose                                               | `8080`                     |
-| `service.annotations`   | Annotations to apply to the service (eg to add Prometheus annotations)      | `{}`                       |
-| `podLabels`             | Additional labels for pods (e.g. CostCenter=IT)                             | `{}`                       |
-| `priorityClassName`     | Priority Class to be used by the pods                                       | `""`                       |
-| `tolerations`           | Tolerations to apply to the daemonset (eg to allow running on master)       | `[{"key": "node-role.kubernetes.io/master", "effect": "NoSchedule"}]`|
-| `affinity`              | Affinity for the daemonset (ie, restrict which nodes kured runs on)         | `{}`                       |
-| `nodeSelector`          | Node Selector for the daemonset (ie, restrict which nodes kured runs on)    | `{}`                       |
-| `volumeMounts`          | Maps of volumes mount to mount                                              | `{}`                       |
-| `volumes`               | Maps of volumes to mount                                                    | `{}`                       |
-See https://github.com/weaveworks/kured#configuration for values (not contained in the `configuration` object) for `extraArgs`. Note that
+| Config                                  | Description                                                                 | Default                   |
+| ------                                  | -----------                                                                 | -------                   |
+| `image.repository`                      | Image repository                                                            | `ghcr.io/kubereboot/kured`|
+| `image.tag`                             | Image tag                                                                   | `1.12.1`                  |
+| `image.pullPolicy`                      | Image pull policy                                                           | `IfNotPresent`            |
+| `image.pullSecrets`                     | Image pull secrets                                                          | `[]`                      |
+| `updateStrategy`                        | Daemonset update strategy                                                   | `RollingUpdate`           |
+| `maxUnavailable`                        | The max pods unavailable during a rolling update                            | `1`                       |
+| `podAnnotations`                        | Annotations to apply to pods (eg to add Prometheus annotations)             | `{}`                      |
+| `dsAnnotations`                         | Annotations to apply to the kured DaemonSet                                 | `{}`                      |
+| `extraArgs`                             | Extra arguments to pass to `/usr/bin/kured`. See below.                     | `{}`                      |
+| `extraEnvVars`                          | Array of environment variables to pass to the daemonset.                    | `{}`                      |
+| `configuration.lockTtl`                 | cli-parameter `--lock-ttl`                                                  | `0`                       |
+| `configuration.lockReleaseDelay`        | cli-parameter `--lock-release-delay`                                        | `0`                       |
+| `configuration.alertFilterRegexp`       | cli-parameter `--alert-filter-regexp`                                       | `""`                      |
+| `configuration.alertFiringOnly`         | cli-parameter `--alert-firing-only`                                         | `false`                   |
+| `configuration.blockingPodSelector`     | Array of selectors for multiple cli-parameters `--blocking-pod-selector`    | `[]`                      |
+| `configuration.endTime`                 | cli-parameter `--end-time`                                                  | `""`                      |
+| `configuration.lockAnnotation`          | cli-parameter `--lock-annotation`                                           | `""`                      |
+| `configuration.period`                  | cli-parameter `--period`                                                    | `""`                      |
+| `configuration.forceReboot`             | cli-parameter `--force-reboot`                                              | `false`                   |
+| `configuration.drainGracePeriod`        | cli-parameter `--drain-grace-period`                                        | `""`                      |
+| `configuration.drainTimeout`            | cli-parameter `--drain-timeout`                                             | `""`                      |
+| `configuration.skipWaitForDeleteTimeout` | cli-parameter `--skip-wait-for-delete-timeout`                             | `""`                      |
+| `configuration.prometheusUrl`           | cli-parameter `--prometheus-url`                                            | `""`                      |
+| `configuration.rebootDays`              | Array of days for multiple cli-parameters `--reboot-days`                   | `[]`                      |
+| `configuration.rebootSentinel`          | cli-parameter `--reboot-sentinel`                                           | `""`                      |
+| `configuration.rebootSentinelCommand`   | cli-parameter `--reboot-sentinel-command`                                   | `""`                      |
+| `configuration.rebootCommand`           | cli-parameter `--reboot-command`                                            | `""`                      |
+| `configuration.rebootDelay`             | cli-parameter `--reboot-delay`                                              | `""`                      |
+| `configuration.slackChannel`            | cli-parameter `--slack-channel`. Passed through `tpl`                       | `""`                      |
+| `configuration.slackHookUrl`            | cli-parameter `--slack-hook-url`. Passed through `tpl`                      | `""`                      |
+| `configuration.slackUsername`           | cli-parameter `--slack-username`. Passed through `tpl`                      | `""`                      |
+| `configuration.notifyUrl`               | cli-parameter `--notify-url`                                                | `""`                      |
+| `configuration.messageTemplateDrain`    | cli-parameter `--message-template-drain`                                    | `""`                      |
+| `configuration.messageTemplateReboot`   | cli-parameter `--message-template-reboot`                                   | `""`                      |
+| `configuration.messageTemplateUncordon` | cli-parameter `--message-template-uncordon`                                 | `""`                      |
+| `configuration.startTime`               | cli-parameter `--start-time`                                                | `""`                      |
+| `configuration.timeZone`                | cli-parameter `--time-zone`                                                 | `""`                      |
+| `configuration.annotateNodes`           | cli-parameter `--annotate-nodes`                                            | `false`                   |
+| `configuration.logFormat`               | cli-parameter `--log-format`                                                | `"text"`                  |
+| `configuration.preferNoScheduleTaint`   | Taint name applied during pending node reboot                               | `""`                      |
+| `configuration.preRebootNodeLabels`     | Array of key-value-pairs to add to nodes before cordoning for multiple cli-parameters `--pre-reboot-node-labels`   | `[]` |
+| `configuration.postRebootNodeLabels`    | Array of key-value-pairs to add to nodes after uncordoning for multiple cli-parameters `--post-reboot-node-labels` | `[]` |
+| `rbac.create`                           | Create RBAC roles                                                           | `true`                    |
+| `serviceAccount.create`                 | Create a service account                                                    | `true`                    |
+| `serviceAccount.name`                   | Service account name to create (or use if `serviceAccount.create` is false) | (chart fullname)          |
+| `podSecurityPolicy.create`              | Create podSecurityPolicy                                                    | `false`                   |
+| `containerSecurityContext.privileged `  | Enables `privileged` in container-specific security context                 | `true`                    |
+| `containerSecurityContext.allowPrivilegeEscalation`| Enables `allowPrivilegeEscalation` in container-specific security context. If not set it won't be configured. |  |
+| `resources`             | Resources requests and limits.                                                              | `{}`                      |
+| `metrics.create`        | Create a ServiceMonitor for prometheus-operator                                             | `false`                   |
+| `metrics.namespace`     | The namespace to create the ServiceMonitor in                                               | `""`                      |
+| `metrics.labels`        | Additional labels for the ServiceMonitor                                                    | `{}`                      |
+| `metrics.interval`      | Interval prometheus should scrape the endpoint                                              | `60s`                     |
+| `metrics.scrapeTimeout` | A custom scrapeTimeout for prometheus                                                       | `""`                      |
+| `service.create`        | Create a Service for the metrics endpoint                                                   | `false`                   |
+| `service.name  `        | Service name for the metrics endpoint                                                       | `""`                      |
+| `service.port`          | Port of the service to expose                                                               | `8080`                    |
+| `service.annotations`   | Annotations to apply to the service (eg to add Prometheus annotations)                      | `{}`                      |
+| `podLabels`             | Additional labels for pods (e.g. CostCenter=IT)                                             | `{}`                      |
+| `priorityClassName`     | Priority Class to be used by the pods                                                       | `""`                      |
+| `tolerations`           | Tolerations to apply to the daemonset (eg to allow running on master)                       | `[{"key": "node-role.kubernetes.io/control-plane", "effect": "NoSchedule"}]` for Kubernetes 1.24.0 and greater, otherwise `[{"key": "node-role.kubernetes.io/master", "effect": "NoSchedule"}]`|
+| `affinity`              | Affinity for the daemonset (ie, restrict which nodes kured runs on)                         | `{}`                      |
+| `hostNetwork`           | Pod uses the host network instead of the cluster network                                    | `true`                    |
+| `nodeSelector`          | Node Selector for the daemonset (ie, restrict which nodes kured runs on)                    | `{}`                      |
+| `volumeMounts`          | Maps of volumes mount to mount                                                              | `{}`                      |
+| `volumes`               | Maps of volumes to mount                                                                    | `{}`                      |
+| `initContainers`        | Define initContainers for DaemonSet                                                         | `{}`                      |
+See https://github.com/kubereboot/kured#configuration for values (not contained in the `configuration` object) for `extraArgs`. Note that
 ```yaml
 extraArgs:
   foo: 1
@@ -106,7 +141,7 @@ becomes `/usr/bin/kured ... --foo=1 --bar-baz=2`.
 
 ## Prometheus Metrics
 
-Kured exposes a single prometheus metric indicating whether a reboot is required or not (see [kured docs](https://github.com/weaveworks/kured#prometheus-metrics)) for details.
+Kured exposes a single prometheus metric indicating whether a reboot is required or not (see [kured docs](https://github.com/kubereboot/kured#prometheus-metrics)) for details.
 
 #### Prometheus-Operator
 

--- a/helmfile/upstream/kured/templates/NOTES.txt
+++ b/helmfile/upstream/kured/templates/NOTES.txt
@@ -1,3 +1,3 @@
 Kured will check for /var/run/reboot-required, and reboot nodes when needed.
 
-See https://github.com/weaveworks/kured/ for details.
+See https://github.com/kubereboot/kured/ for details.

--- a/helmfile/upstream/kured/templates/_helpers.tpl
+++ b/helmfile/upstream/kured/templates/_helpers.tpl
@@ -57,16 +57,16 @@ Return the appropriate apiVersion for podsecuritypolicy.
 Returns a set of labels applied to each resource.
 */}}
 {{- define "kured.labels" -}}
-app: {{ template "kured.name" . }}
-chart: {{ template "kured.chart" . }}
-release: {{ .Release.Name }}
-heritage: {{ .Release.Service }}
+app.kubernetes.io/name: {{ template "kured.name" . }}
+helm.sh/chart: {{ template "kured.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
 Returns a set of matchLabels applied.
 */}}
 {{- define "kured.matchLabels" -}}
-app: {{ template "kured.name" . }}
-release: {{ .Release.Name }}
+app.kubernetes.io/name: {{ template "kured.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}

--- a/helmfile/upstream/kured/templates/daemonset.yaml
+++ b/helmfile/upstream/kured/templates/daemonset.yaml
@@ -36,6 +36,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "kured.serviceAccountName" . }}
+      hostNetwork: {{ .Values.hostNetwork }}
       hostPID: true
       restartPolicy: Always
       {{- with .Values.image.pullSecrets }}
@@ -45,12 +46,18 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+      {{- if .Values.initContainers }}
+          {{- with .Values.initContainers }}
+      initContainers:
+{{ toYaml . | indent 8 }}
+          {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            privileged: true # Give permission to nsenter /proc/1/ns/mnt
+{{ toYaml .Values.containerSecurityContext | indent 12 }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           command:
@@ -92,13 +99,19 @@ spec:
             - --drain-timeout={{ .Values.configuration.drainTimeout }}
           {{- end }}
           {{- if .Values.configuration.skipWaitForDeleteTimeout }}
-             - --skip-wait-for-delete-timeout={{ .Values.configuration.skipWaitForDeleteTimeout }}
+            - --skip-wait-for-delete-timeout={{ .Values.configuration.skipWaitForDeleteTimeout }}
           {{- end }}
           {{- if .Values.configuration.prometheusUrl }}
             - --prometheus-url={{ .Values.configuration.prometheusUrl }}
           {{- end }}
           {{- range .Values.configuration.rebootDays }}
             - --reboot-days={{ . }}
+          {{- end }}
+          {{- range .Values.configuration.preRebootNodeLabels }}
+            - --pre-reboot-node-labels={{ . }}
+          {{- end }}
+          {{- range .Values.configuration.postRebootNodeLabels }}
+            - --post-reboot-node-labels={{ . }}
           {{- end }}
           {{- if .Values.configuration.rebootSentinel }}
             - --reboot-sentinel={{ .Values.configuration.rebootSentinel }}
@@ -113,13 +126,13 @@ spec:
             - --reboot-delay={{ .Values.configuration.rebootDelay }}
           {{- end }}
           {{- if .Values.configuration.slackChannel }}
-            - --slack-channel={{ .Values.configuration.slackChannel }}
+            - --slack-channel={{ tpl .Values.configuration.slackChannel . }}
           {{- end }}
           {{- if .Values.configuration.slackHookUrl }}
-            - --slack-hook-url={{ .Values.configuration.slackHookUrl }}
+            - --slack-hook-url={{ tpl .Values.configuration.slackHookUrl . }}
           {{- end }}
           {{- if .Values.configuration.slackUsername }}
-            - --slack-username={{ .Values.configuration.slackUsername }}
+            - --slack-username={{ tpl .Values.configuration.slackUsername . }}
           {{- end }}
           {{- if .Values.configuration.notifyUrl }}
             - --notify-url={{ .Values.configuration.notifyUrl }}
@@ -129,6 +142,9 @@ spec:
           {{- end }}
           {{- if .Values.configuration.messageTemplateReboot }}
             - --message-template-reboot={{ .Values.configuration.messageTemplateReboot }}
+          {{- end }}
+          {{- if .Values.configuration.messageTemplateUncordon }}
+            - --message-template-uncordon={{ .Values.configuration.messageTemplateUncordon }}
           {{- end }}
           {{- if .Values.configuration.startTime }}
             - --start-time={{ .Values.configuration.startTime }}
@@ -169,9 +185,16 @@ spec:
             {{- if .Values.extraEnvVars }}
               {{ toYaml .Values.extraEnvVars | nindent 12 }}
             {{- end }}
-      {{- with .Values.tolerations }}
       tolerations:
+      {{- if .Values.tolerations }}
+          {{- with .Values.tolerations }}
 {{ toYaml . | indent 8 }}
+          {{- end }}
+      {{- else }}
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helmfile/upstream/kured/values.minikube.yaml
+++ b/helmfile/upstream/kured/values.minikube.yaml
@@ -3,29 +3,32 @@ image:
   tag: latest
 
 configuration:
-  # annotationTtl: 0          # force clean annotation after this amount of time (default 0, disabled)
-  # alertFilterRegexp: ""     # alert names to ignore when checking for active alerts
-  # alertFiringOnly: false     # only consider firing alerts when checking for active alerts
-  # blockingPodSelector: []   # label selector identifying pods whose presence should prevent reboots
-  # endTime: ""               # only reboot before this time of day (default "23:59")
-  # lockAnnotation: ""        # annotation in which to record locking node (default "weave.works/kured-node-lock")
-  period: "1m"                # reboot check period (default 1h0m0s)
-  # forceReboot: false        # force a reboot even if the drain fails or times out (default: false)
-  # drainGracePeriod: ""      # time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used (default: -1)
-  # drainTimeout: ""          # timeout after which the drain is aborted (default: 0, infinite time)
+  # annotationTtl: 0              # force clean annotation after this amount of time (default 0, disabled)
+  # alertFilterRegexp: ""         # alert names to ignore when checking for active alerts
+  # alertFiringOnly: false        # only consider firing alerts when checking for active alerts
+  # blockingPodSelector: []       # label selector identifying pods whose presence should prevent reboots
+  # endTime: ""                   # only reboot before this time of day (default "23:59")
+  # lockAnnotation: ""            # annotation in which to record locking node (default "weave.works/kured-node-lock")
+  period: "1m"                    # reboot check period (default 1h0m0s)
+  # forceReboot: false            # force a reboot even if the drain fails or times out (default: false)
+  # drainGracePeriod: ""          # time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used (default: -1)
+  # drainTimeout: ""              # timeout after which the drain is aborted (default: 0, infinite time)
   # skipWaitForDeleteTimeout: ""  # when time is greater than zero, skip waiting for the pods whose deletion timestamp is older than N seconds while draining a node (default: 0)
-  # prometheusUrl: ""         # Prometheus instance to probe for active alerts
-  # rebootDays: []            # only reboot on these days (default [su,mo,tu,we,th,fr,sa])
-  # rebootSentinel: ""        # path to file whose existence signals need to reboot (default "/var/run/reboot-required")
-  # rebootSentinelCommand: ""  # command for which a successful run signals need to reboot (default ""). If non-empty, sentinel file will be ignored.
-  # slackChannel: ""          # slack channel for reboot notfications
-  # slackHookUrl: ""          # slack hook URL for reboot notfications
-  # slackUsername: ""         # slack username for reboot notfications (default "kured")
-  # notifyUrl: ""             # notification URL with the syntax as follows: https://containrrr.dev/shoutrrr/services/overview/
-  # messageTemplateDrain: ""  # slack message template when notifying about a node being drained (default "Draining node %s")
-  # messageTemplateReboot: "" # slack message template when notifying about a node being rebooted (default "Rebooted node %s")
-  # startTime: ""             # only reboot after this time of day (default "0:00")
-  # timeZone: ""              # time-zone to use (valid zones from "time" golang package)
-  # annotateNodes: false      # enable 'weave.works/kured-reboot-in-progress' and 'weave.works/kured-most-recent-reboot-needed' node annotations to signify kured reboot operations
-  # lockReleaseDelay: "5m"    # hold lock after reboot by this amount of time (default 0, disabled)
-  # logFormat: "text"         # log format specified as text or json, defaults to text
+  # prometheusUrl: ""             # Prometheus instance to probe for active alerts
+  # rebootDays: []                # only reboot on these days (default [su,mo,tu,we,th,fr,sa])
+  # rebootSentinel: ""            # path to file whose existence signals need to reboot (default "/var/run/reboot-required")
+  # rebootSentinelCommand: ""     # command for which a successful run signals need to reboot (default ""). If non-empty, sentinel file will be ignored.
+  # slackChannel: ""              # slack channel for reboot notfications
+  # slackHookUrl: ""              # slack hook URL for reboot notfications
+  # slackUsername: ""             # slack username for reboot notfications (default "kured")
+  # notifyUrl: ""                 # notification URL with the syntax as follows: https://containrrr.dev/shoutrrr/services/overview/
+  # messageTemplateDrain: ""      # slack message template when notifying about a node being drained (default "Draining node %s")
+  # messageTemplateReboot: ""     # slack message template when notifying about a node being rebooted (default "Rebooted node %s")
+  # messageTemplateUncordon: ""   # slack message template when notifying about a node being drained (default "Node %s rebooted & uncordoned successfully!")
+  # startTime: ""                 # only reboot after this time of day (default "0:00")
+  # timeZone: ""                  # time-zone to use (valid zones from "time" golang package)
+  # annotateNodes: false          # enable 'weave.works/kured-reboot-in-progress' and 'weave.works/kured-most-recent-reboot-needed' node annotations to signify kured reboot operations
+  # lockReleaseDelay: "5m"        # hold lock after reboot by this amount of time (default 0, disabled)
+  # logFormat: "text"             # log format specified as text or json, defaults to text
+  # preRebootNodeLabels: []       # labels to add to nodes before cordoning (default [])
+  # postRebootNodeLabels: []      # labels to add to nodes after uncordoning (default [])

--- a/helmfile/upstream/kured/values.yaml
+++ b/helmfile/upstream/kured/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: weaveworks/kured
+  repository: ghcr.io/kubereboot/kured
   tag: ""  # will default to the appVersion in Chart.yaml
   pullPolicy: IfNotPresent
   pullSecrets: []
@@ -23,35 +23,39 @@ extraEnvVars:
 #    value: 123
 
 configuration:
-  lockTtl: 0                 # force clean annotation after this amount of time (default 0, disabled)
-  alertFilterRegexp: ""      # alert names to ignore when checking for active alerts
-  alertFiringOnly: false     # only consider firing alerts when checking for active alerts
-  blockingPodSelector: []    # label selector identifying pods whose presence should prevent reboots
-  endTime: ""                # only reboot before this time of day (default "23:59")
-  lockAnnotation: ""         # annotation in which to record locking node (default "weave.works/kured-node-lock")
-  period: ""                 # reboot check period (default 1h0m0s)
-  forceReboot: false         # force a reboot even if the drain fails or times out (default: false)
-  drainGracePeriod: ""       # time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used (default: -1)
-  drainTimeout: ""           # timeout after which the drain is aborted (default: 0, infinite time)
+  lockTtl: 0                    # force clean annotation after this amount of time (default 0, disabled)
+  alertFilterRegexp: ""         # alert names to ignore when checking for active alerts
+  alertFiringOnly: false        # only consider firing alerts when checking for active alerts
+  blockingPodSelector: []       # label selector identifying pods whose presence should prevent reboots
+  endTime: ""                   # only reboot before this time of day (default "23:59")
+  lockAnnotation: ""            # annotation in which to record locking node (default "weave.works/kured-node-lock")
+  period: ""                    # reboot check period (default 1h0m0s)
+  forceReboot: false            # force a reboot even if the drain fails or times out (default: false)
+  drainGracePeriod: ""          # time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used (default: -1)
+  drainTimeout: ""              # timeout after which the drain is aborted (default: 0, infinite time)
   skipWaitForDeleteTimeout: ""  # when time is greater than zero, skip waiting for the pods whose deletion timestamp is older than N seconds while draining a node (default: 0)
-  prometheusUrl: ""          # Prometheus instance to probe for active alerts
-  rebootDays: []             # only reboot on these days (default [su,mo,tu,we,th,fr,sa])
-  rebootSentinel: ""         # path to file whose existence signals need to reboot (default "/var/run/reboot-required")
-  rebootSentinelCommand: ""  # command for which a successful run signals need to reboot (default ""). If non-empty, sentinel file will be ignored.
+  prometheusUrl: ""             # Prometheus instance to probe for active alerts
+  rebootDays: []                # only reboot on these days (default [su,mo,tu,we,th,fr,sa])
+  rebootSentinel: ""            # path to file whose existence signals need to reboot (default "/var/run/reboot-required")
+  rebootSentinelCommand: ""     # command for which a successful run signals need to reboot (default ""). If non-empty, sentinel file will be ignored.
   rebootCommand: "/bin/systemctl reboot"  # command to run when a reboot is required by the sentinel
-  rebootDelay: ""            # add a delay after drain finishes but before the reboot command is issued
-  slackChannel: ""           # slack channel for reboot notfications
-  slackHookUrl: ""           # slack hook URL for reboot notfications
-  slackUsername: ""          # slack username for reboot notfications (default "kured")
-  notifyUrl: ""              # notification URL with the syntax as follows: https://containrrr.dev/shoutrrr/services/overview/
-  messageTemplateDrain: ""   # slack message template when notifying about a node being drained (default "Draining node %s")
-  messageTemplateReboot: ""  # slack message template when notifying about a node being rebooted (default "Rebooted node %s")
-  startTime: ""              # only reboot after this time of day (default "0:00")
-  timeZone: ""               # time-zone to use (valid zones from "time" golang package)
-  annotateNodes: false       # enable 'weave.works/kured-reboot-in-progress' and 'weave.works/kured-most-recent-reboot-needed' node annotations to signify kured reboot operations
-  lockReleaseDelay: 0        # hold lock after reboot by this amount of time (default 0, disabled)
-  preferNoScheduleTaint: ""  # Taint name applied during pending node reboot (to prevent receiving additional pods from other rebooting nodes). Disabled by default. Set e.g. to "weave.works/kured-node-reboot" to enable tainting.
-  logFormat: "text"          # log format specified as text or json, defaults to text
+  rebootDelay: ""               # add a delay after drain finishes but before the reboot command is issued
+  slackChannel: ""              # slack channel for reboot notifications
+  slackHookUrl: ""              # slack hook URL for reboot notifications
+  slackUsername: ""             # slack username for reboot notifications (default "kured")
+  notifyUrl: ""                 # notification URL with the syntax as follows: https://containrrr.dev/shoutrrr/services/overview/
+  messageTemplateDrain: ""      # slack message template when notifying about a node being drained (default "Draining node %s")
+  messageTemplateReboot: ""     # slack message template when notifying about a node being rebooted (default "Rebooted node %s")
+  messageTemplateUncordon: ""   # slack message template when notifying about a node being uncordoned (default "Node %s rebooted & uncordoned successfully!")
+  startTime: ""                 # only reboot after this time of day (default "0:00")
+  timeZone: ""                  # time-zone to use (valid zones from "time" golang package)
+  annotateNodes: false          # enable 'weave.works/kured-reboot-in-progress' and 'weave.works/kured-most-recent-reboot-needed' node annotations to signify kured reboot operations
+  lockReleaseDelay: 0           # hold lock after reboot by this amount of time (default 0, disabled)
+  preferNoScheduleTaint: ""     # Taint name applied during pending node reboot (to prevent receiving additional pods from other rebooting nodes). Disabled by default. Set e.g. to "weave.works/kured-node-reboot" to enable tainting.
+  logFormat: "text"             # log format specified as text or json, defaults to text
+  preRebootNodeLabels: []       # labels to add to nodes before cordoning (default [])
+  postRebootNodeLabels: []      # labels to add to nodes after uncordoning (default [])
+
 
 rbac:
   create: true
@@ -63,7 +67,13 @@ serviceAccount:
 podSecurityPolicy:
   create: false
 
+containerSecurityContext:
+  privileged: true  # Give permission to nsenter /proc/1/ns/mnt
+#  allowPrivilegeEscalation: true # Needed when using defaultAllowPrivilegedEscalation: false in psp
+
 resources: {}
+
+hostNetwork: true
 
 metrics:
   create: false
@@ -83,9 +93,7 @@ podLabels: {}
 
 priorityClassName: ""
 
-tolerations:
-  - key: node-role.kubernetes.io/master
-    effect: NoSchedule
+tolerations: []
 
 affinity: {}
 
@@ -94,3 +102,5 @@ nodeSelector: {}
 volumeMounts: []
 
 volumes: []
+
+initContainers: {}

--- a/helmfile/values/kured.yaml.gotmpl
+++ b/helmfile/values/kured.yaml.gotmpl
@@ -35,3 +35,5 @@ slack:
   channel: {{ .Values.kured.notification.slack.channel }}
   botToken: {{ .Values.kured.slack.botToken }}
 {{- end }}
+
+hostNetwork: false

--- a/migration/v0.28.x-v0.29.x/upgrade-apps.md
+++ b/migration/v0.28.x-v0.29.x/upgrade-apps.md
@@ -14,6 +14,12 @@
 
     This will remove the old metrics-server components from the clusters.
 
+1. Before upgrading, destroy `kured` in sc & wc
+    ```bash
+    ./bin/ck8s ops helmfile sc -l app=kured destroy
+    ./bin/ck8s ops helmfile wc -l app=kured destroy
+    ```
+
 1. Upgrade applications:
 
     ```bash


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds migration steps for kured upgrade that were missing for the original PR.
**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
