### PR TITLE
apps wc: Update Gatekeeper default enforcements

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -44,6 +44,10 @@
   - This have changed the deployment for Fluentd considerably and users must ensure that their custom filter continues to work as expected
 - Retention for logs stored directly in object store have been reworked
 - Updated alertmanager network policy to allow ingress traffic from user pods.
+- Gatekeeper default enforcements have been changed for certain policies
+  - Disallow latest tag default is now `deny`, was `dryrun`
+  - Require trusted image registry default is now `warn`, was `deny`
+  - Require network policies default is now `warn`, was `deny`
 
 ### Removed
 

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -76,7 +76,7 @@ opa:
   ## "enforcement" can assume either "dryrun" or "deny".
   imageRegistry:
     enabled: true
-    enforcement: deny
+    enforcement: warn
     URL:
       - set-me
       - harbor.example.com
@@ -88,7 +88,7 @@ opa:
   ## by at least one network policy.
   networkPolicies:
     enabled: true
-    enforcement: deny
+    enforcement: warn
 
   ## Enable rule that requires pods to have resource requests.
   resourceRequests:
@@ -98,7 +98,7 @@ opa:
   ## It will not allow any image with the latest tag
   disallowedTags:
     enabled: true
-    enforcement: dryrun
+    enforcement: deny
     tags:
      - latest
 

--- a/migration/v0.28.x-v0.29.x/upgrade-apps.md
+++ b/migration/v0.28.x-v0.29.x/upgrade-apps.md
@@ -47,6 +47,19 @@
     ./scripts/S3/entry.sh --s3cfg "$CK8S_CONFIG_PATH/.state/s3cfg.ini" create
     ```
 
+1. **Warning** The default Gatekeeper enforcements have been updated:
+
+    - Disallow latest tag `disallowedTags.enforcement` default is now `deny` - was `dryrun`
+    - Require trusted image registry `imageRegistry.enforcement` default is now `warn` - was `deny`
+    - Require network policies `networkPolicies.enforcement` default is now `warn` - was `deny`
+    - Require resource requests `resourceRequests.enforcement` default is unchanged as `deny`
+
+    As changing these enforcements can be disruptive, especially when going from `dryrun` to `deny`, here are some recommendations:
+
+    - If the new default is `deny` and the environment does not already have `deny` on that specific policy, then override with `warn` and inform the user that they should work toward being able to have `deny` in the future.
+    - If the new default is `warn` and the environment has `deny`, then leave it at `deny` (possibly requiring an override config).
+    - If the new default is `warn` and the environment has `dryrun`, then use `warn` (possibly requiring removal of override config) and inform the user that they will start seeing warnings from that policy.
+
 ## Upgrade steps
 
 1. Run bootstrap to create `fluentd-system` namespaces:


### PR DESCRIPTION
**What this PR does / why we need it**:
Update Gatekeeper default enforcements
**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1326 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->
[Docs PR](https://github.com/elastisys/compliantkubernetes/pull/510)

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [x] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
