### PR TITLE
Add extra-workload-admins role binding

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -35,6 +35,7 @@
 - Renamed the ElasticSearch Dashboard to Opensearch in Grafana
 - Changed release name for `prometheus-elasticsearch-exporter` to `prometheus-opensearch-exporter`
 - Upgraded the cert-manager helm chart to `v1.11.0` which upgrades the app version to `v1.11.0`
+- Update deploy-wc.sh to create `extra-workload-admins` rolebinding on all user namespaces.
 
 ### Changed
 

--- a/scripts/deploy-wc.sh
+++ b/scripts/deploy-wc.sh
@@ -43,11 +43,11 @@ fi
 user_namespaces=$(yq4 '.user.namespaces[]' "${config['config_file_wc']}")
 
 for namespace in ${user_namespaces}; do
-    if [ "$(kubectl get rolebinding -n "$namespace" extra-workload-admins)" ] ; then
-        echo "extra-workload-admins RoleBinding already exists in $namespace namespace. Ignoring."
+    if [ "$(kubectl get rolebinding -n "${namespace}" extra-workload-admins)" ] ; then
+        echo "extra-workload-admins RoleBinding already exists in ${namespace} namespace. Ignoring."
     else
-        echo "Creating extra-workload-admins RoleBinding in $namespace namespace"
-        kubectl create rolebinding extra-workload-admins -n "$namespace" --clusterrole=admin
+        echo "Creating extra-workload-admins RoleBinding in ${namespace} namespace"
+        kubectl create rolebinding extra-workload-admins -n "${namespace}" --clusterrole=admin
     fi
 done
 

--- a/scripts/deploy-wc.sh
+++ b/scripts/deploy-wc.sh
@@ -40,6 +40,17 @@ else
   kubectl create -f "${SCRIPTS_PATH}/../manifests/user-rbac/clusterrolebindings/extra-user-view.yaml"
 fi
 
+user_namespaces=$(yq4 '.user.namespaces[]' "${config['config_file_wc']}")
+
+for namespace in ${user_namespaces}; do
+    if [ "$(kubectl get rolebinding -n "$namespace" extra-workload-admins)" ] ; then
+        echo "extra-workload-admins RoleBinding already exists in $namespace namespace. Ignoring."
+    else
+        echo "Creating extra-workload-admins RoleBinding in $namespace namespace"
+        kubectl create rolebinding extra-workload-admins -n "$namespace" --clusterrole=admin
+    fi
+done
+
 echo "Installing helm charts" >&2
 cd "${SCRIPTS_PATH}/../helmfile"
 declare -a helmfile_opt_flags


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1393 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
