### PR TITLE
apps: add deployment option for ingress and nodeport

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Increased interval for rook-ceph service monitor which fixes the grafana dashboard
 - Add document splits to helmfiles to prepare support for helmfile v0.150+
+- Added option to use nodePort for ingress-nginx.
 
 ### Updated
 - `responseObject` and `requestObject` are no longer dropped in Fluentd from Kubernetes audit events.

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -394,6 +394,11 @@ ingressNginx:
       ## ref: https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#restrict-access-for-loadbalancer-service
       loadBalancerSourceRanges: []
 
+      ## type: NodePort
+      nodePorts:
+        http: "30080"
+        https: "30443"
+
     ## Additional configuration options for Nginx
     ## ref: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
     additionalConfig: {}

--- a/helmfile/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile/values/ingress-nginx.yaml.gotmpl
@@ -107,6 +107,9 @@ controller:
     {{ else }}
     enabled: false
     {{ end }}
+    {{ if eq .Values.ingressNginx.controller.service.type "NodePort" }}
+    nodePorts: {{- toYaml .Values.ingressNginx.controller.service.nodePorts | nindent 6 }}
+    {{ end }}
 
   metrics:
     enabled: true

--- a/migration/v0.30/README.md
+++ b/migration/v0.30/README.md
@@ -1,0 +1,180 @@
+# Upgrade to v0.30.x
+
+> **Warning**: Upgrade only supported from v0.29.x.
+
+<!--
+Notice to developers on writing migration steps:
+
+- Migration steps:
+  - are written per minor version and placed in a subdirectory of the migration directory with the name `vX.Y/`,
+  - are written to be idempotent and usable no matter which patch version you are upgrading from and to,
+  - are documented in this docuemnt to be able to run them manually,
+  - are divided into prepare and apply steps:
+    - Prepare steps:
+      - are placed in the `prepare/` directoy,
+      - may **only** modify the configuration of the environment,
+      - may **not** modify the state of the environment,
+      - steps are run in order of their names use two digit prefixes.
+    - Apply steps:
+      - are placed in the `apply/` directory,
+      - may **only** modify the state of the environment,
+      - may **not** modify the configuration of the environment,
+      - are run in order of their names use two digit prefixes,
+      - are run with the argument `execute` on upgrade and should return 1 on failure and 2 on succesful internal rollback,
+      - are rerun with the argument `rollback` on execute failure and should return 1 on failure.
+
+For prepare the init step is given.
+For apply the bootstrap and the apply steps are given, it is expected that releases upgraded in custom steps are excluded from the apply step.
+
+Upgrades of components that are dependant on each other should be done within the same snippet to easily manage the upgrade to a working state and to be able to rollback to a working state.
+
+Steps should use the `scripts/migration/lib.sh` which will provide helper functions, see the file for available helper functions.
+This script expects the `ROOT` environment variable to be set pointing to the root of the repository.
+As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
+-->
+
+## Prerequisites
+
+- [ ] Notify the users (if any) before the upgrade starts;
+- [ ] Check if there are any pending changes to the environment;
+- [ ] Check the state of the environment, pods, nodes and backup jobs:
+
+    ```bash
+    ./bin/ck8s test sc|wc
+    ./bin/ck8s test sc|wc cert-manager
+    ./bin/ck8s test sc|wc ingress
+    ./bin/ck8s test sc opensearch
+    ./bin/ck8s test wc hnc
+    ./bin/ck8s ops kubectl sc|wc get pods -A -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-false:status.containerStatuses[*].ready,REASON:status.containerStatuses[*].state.terminated.reason | grep false | grep -v Completed
+    ./bin/ck8s ops kubectl sc|wc get nodes
+    ./bin/ck8s ops kubectl sc|wc get jobs -A
+    ./bin/ck8s ops helm sc|wc list -A --all
+    velero get backup
+    ```
+
+- [ ] Silence the notifications for the alerts. e.g you can use [alertmanager silences](https://prometheus.io/docs/alerting/latest/alertmanager/#silences);
+
+## Automatic method
+
+1. Pull the latest changes and switch to the correct branch:
+
+    ```bash
+    git pull
+    git switch -d v0.30.x
+    ```
+
+    > **Optional**
+    > Configure ingress nginx:
+    >It is now possible from the config nginx to use NodePort.
+    > This is configured under `ingressNginx.controller`
+    > ```yaml
+    > # Use NodePort instead
+    > useHostPort: false
+    > service:
+    >   enabled: true
+    >   type: NodePort
+    >   nodePorts:
+    >     http: 30080
+    >     https: 30443
+    > ```
+
+1. Prepare upgrade - *non-disruptive*
+
+    > *Done before maintenance window.*
+
+    ```bash
+    ./bin/ck8s upgrade prepare v0.30
+    ```
+
+
+1. Apply upgrade - *disruptive*
+
+    > *Done during maintenance window.*
+
+    ```bash
+    ./bin/ck8s upgrade apply v0.30
+    ```
+
+## Manual method
+
+### Prepare upgrade - *non-disruptive*
+
+> *Done before maintenance window.*
+
+1. Pull the latest changes and switch to the correct branch:
+
+    ```bash
+    git pull
+    git switch -d v0.30.x
+    ```
+
+1. Update apps configuration:
+
+    This will take a backup into `backups/` before modifying any files.
+
+    ```bash
+    ./bin/ck8s init
+    # or
+    ./migration/v0.30/prepare/10-init.sh
+    ```
+
+1. **Optional** Configure ingress nginx:
+
+    It is now possible from the config nginx to use NodePort.
+
+    This is configured under `ingressNginx.controller`
+
+    ```yaml
+    # Use NodePort instead
+    useHostPort: false
+    service:
+      enabled: true
+      type: NodePort
+      nodePorts:
+        http: 30080
+        https: 30443
+    ```
+
+### Apply upgrade - *disruptive*
+
+> *Done during maintenance window.*
+
+1. Rerun bootstrap:
+
+    ```bash
+    ./bin/ck8s bootstrap {sc|wc}
+    # or
+    ./migration/v0.30/apply/10-bootstrap.sh
+    ```
+
+1. Upgrade applications:
+
+    ```bash
+    ./bin/ck8s apply {sc|wc}
+    # or
+    ./migration/v0.30/apply/99-apply.sh
+    ```
+
+## Postrequisite:
+
+- [ ] Check the state of the environment, pods and nodes:
+
+    ```bash
+    ./bin/ck8s test sc|wc
+    ./bin/ck8s test sc|wc cert-manager
+    ./bin/ck8s test sc|wc ingress
+    ./bin/ck8s test sc opensearch
+    ./bin/ck8s test wc hnc
+    ./bin/ck8s ops kubectl sc|wc get pods -A -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-false:status.containerStatuses[*].ready,REASON:status.containerStatuses[*].state.terminated.reason | grep false | grep -v Completed
+    ./bin/ck8s ops kubectl sc|wc get nodes
+    ./bin/ck8s ops helm sc|wc list -A --all
+    ```
+
+- [ ] Enable the notifications for the alerts;
+- [ ] Notify the users (if any) when the upgrade is complete;
+
+> **_Note:_** Additionally it is good to check:
+
+- if any alerts generated by the upgrade didn't close;
+- if you can login to Grafana, Opensearch or Harbor;
+- you can see fresh metrics and logs.

--- a/migration/v0.30/apply/00-template.sh
+++ b/migration/v0.30/apply/00-template.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+# functions currently available in the library:
+#   - logging:
+#     - log_info(_no_newline) <message>
+#     - log_warn(_no_newline) <message>
+#     - log_error(_no_newline) <message>
+#     - log_fatal <message> # this will call "exit 1"
+#
+#   - kubectl
+#     # Use kubectl with kubeconfig set
+#     - kubectl_do <sc|wc> <kubectl args...>
+#     # Perform kubectl delete, will not cause errors if the resource is missing
+#     - kubectl_delete <sc|wc> <resource> <namespace> <name>
+#
+#   - helm
+#     # Use helm with kubeconfig set
+#     - helm_do <sc|wc> <helm args...>
+#     # Checks if a release is installed
+#     - helm_installed <sc|wc> <namespace> <release>
+#     # Uninstalls a release if it is installed
+#     - helm_uninstall <sc|wc> <namespace> <release>
+#
+#   - helmfile
+#     # Use helmfile with kubeconfig set
+#     - helmfile_do <sc|wc> <helmfile args...>
+#     # For selector args all will be prefixed with "-l"
+#     # List releases matching the selector
+#     - helmfile_list <sc|wc> <selectors...>
+#     # Apply releases matching the selector
+#     - helmfile_apply <sc|wc> <selectors...>
+#     # Check for changes on releases matching the selector
+#     - helmfile_change <sc|wc> <selectors...>
+#     # Destroy releases matching the selector
+#     - helmfile_destroy <sc|wc> <selectors...>
+#     # Replaces the releases matching the selector, performing destroy and apply on each release individually
+#     - helmfile_replace <sc|wc> <selectors...>
+#     # Upgrades the releases matching the selector, performing automatic rollback on failure set "CK8S_ROLLBACK=false" to disable
+#     - helmfile_upgrade <sc|wc> <selectors...>
+
+run() {
+  case "${1:-}" in
+  execute)
+    # Note: 00-template.sh will be skipped by the upgrade command
+    log_info "no operation: this is a template"
+    ;;
+  rollback)
+    log_warn "rollback not implemented"
+    ;;
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.30/apply/10-bootstrap.sh
+++ b/migration/v0.30/apply/10-bootstrap.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+run() {
+  case "${1:-}" in
+  execute)
+    "${ROOT}/bin/ck8s" bootstrap sc
+    "${ROOT}/bin/ck8s" bootstrap wc
+    ;;
+  rollback)
+    log_warn "rollback not implemented"
+    ;;
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.30/apply/80-apply.sh
+++ b/migration/v0.30/apply/80-apply.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+# Add selector filters if covered by other snippets.
+# Example: "app!=something"
+declare -a skipped
+skipped=(
+)
+declare -a skipped_sc
+skipped_sc=(
+)
+declare -a skipped_wc
+skipped_wc=(
+)
+
+run() {
+  case "${1:-}" in
+  execute)
+    local -a filters
+    local selector
+
+    filters=("${skipped[@]}" "${skipped_sc[@]}")
+    selector="${filters[*]}"
+    helmfile_upgrade sc "${selector// /,}"
+
+    filters=("${skipped[@]}" "${skipped_wc[@]}")
+    selector="${filters[*]}"
+    helmfile_upgrade wc "${selector// /,}"
+    ;;
+  rollback)
+    log_warn "rollback not implemented"
+    ;;
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.30/prepare/00-template.sh
+++ b/migration/v0.30/prepare/00-template.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+# functions currently available in the library:
+#   - logging:
+#     - log_info(_no_newline) <message>
+#     - log_warn(_no_newline) <message>
+#     - log_error(_no_newline) <message>
+#     - log_fatal <message> # this will call "exit 1"
+#
+#  - yq:
+#     - yq_null <common|sc|wc> <target>
+#     - yq_copy <common|sc|wc> <source> <destination>
+#     - yq_move <common|sc|wc> <source> <destination>
+#     - yq_remove <common|sc|wc> <target>
+
+# Note: 00-template.sh will be skipped by the upgrade command
+log_info "no operation: this is a template"

--- a/migration/v0.30/prepare/10-init.sh
+++ b/migration/v0.30/prepare/10-init.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+"${ROOT}/bin/ck8s" init


### PR DESCRIPTION
**What this PR does / why we need it**:

Added option to run nginx controller as deployment and option to use service type nodeport.

Default is still deamonset.

**Which issue this PR fixes**: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
