### PR TITLE
apps: Add empty ip/port checks in network policies

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,13 @@
+### Release notes
+
+### Added
+
+### Fixed
+
+- Networkpolicies now contain checks to prevent allowing all traffic when ips/ports are empty.
+
+### Updated
+
+### Changed
+
+### Removed

--- a/helmfile/charts/networkpolicy/common/templates/cert-manager/cainjector.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/cert-manager/cainjector.yaml
@@ -14,6 +14,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.port .Values.global.apiserver.ips }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -22,4 +23,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/cert-manager/certmanager.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/cert-manager/certmanager.yaml
@@ -25,6 +25,7 @@ spec:
     - ports:
       - port: 53
         protocol: UDP
+    {{- if and .Values.certManager.letsencrypt.ips .Values.certManager.letsencrypt.port }}
     - to:
         {{- range $IP := .Values.certManager.letsencrypt.ips }}
         - ipBlock:
@@ -33,6 +34,8 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.certManager.letsencrypt.port }}
+    {{- end }}
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -41,13 +44,15 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
+    {{- if or .Values.global.ingress.ips (and .Values.global.nodes.ips .Values.global.ingressUsingHostNetwork) }}
     - to:
-      {{- if .Values.global.externalLoadBalancer }}
+      {{- if and .Values.global.ingress.ips .Values.global.externalLoadBalancer }}
         {{- range $IP := .Values.global.ingress.ips }}
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
-      {{- else if .Values.global.ingressUsingHostNetwork }}
+      {{- else if and .Values.global.nodes.ips .Values.global.ingressUsingHostNetwork }}
         {{- range $IP := .Values.global.nodes.ips }}
         - ipBlock:
             cidr: {{ $IP }}
@@ -70,4 +75,5 @@ spec:
           port: 443
         - protocol: TCP
           port: 80
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/cert-manager/resolver.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/cert-manager/resolver.yaml
@@ -11,7 +11,7 @@ spec:
       acme.cert-manager.io/http01-solver: "true"
   ingress:
     - from:
-      {{- if $.Values.global.ingressUsingHostNetwork }}
+      {{- if and $.Values.global.nodes.ips $.Values.global.ingressUsingHostNetwork }}
         {{- range $ip := $.Values.global.nodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}

--- a/helmfile/charts/networkpolicy/common/templates/cert-manager/startupapicheck.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/cert-manager/startupapicheck.yaml
@@ -11,6 +11,7 @@ spec:
   policyTypes:
     - Egress
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -19,4 +20,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/cert-manager/webhook.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/cert-manager/webhook.yaml
@@ -12,6 +12,7 @@ spec:
     - Ingress
     - Egress
   ingress:
+    {{- if .Values.global.apiserver.ips }}
     - from:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -20,10 +21,12 @@ spec:
       ports:
         - protocol: TCP
           port: 10250 ## admission, use api server loop
+    {{- end }}
   egress:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.port .Values.global.apiserver.ips }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -32,4 +35,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/ciskubebench-exporter/allow-ciskubebench-exporter-metrics.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/ciskubebench-exporter/allow-ciskubebench-exporter-metrics.yaml
@@ -19,6 +19,7 @@ spec:
       ports:
         - port: 9100
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -27,6 +28,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/common/templates/coredns/allow-coredns.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/coredns/allow-coredns.yaml
@@ -30,6 +30,7 @@ spec:
       ports:
         - port: 9153
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
       {{- range $IP := .Values.global.apiserver.ips }}
       - ipBlock:
@@ -37,22 +38,31 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
+    {{- if or .Values.global.nodes.ips .Values.coredns.serviceIp.ips .Values.coredns.externalDns.ips }}
     - to:
+      {{- if .Values.global.nodes.ips }}
       {{- range $IP := .Values.global.nodes.ips }}
       - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
+      {{- end }}
+      {{- if .Values.coredns.serviceIp.ips }}
       {{- range $IP := .Values.coredns.serviceIp.ips }}
       - ipBlock:
           cidr: {{ $IP }}
         {{- end }}
+      {{- end }}
+      {{- if .Values.coredns.externalDns.ips }}
       {{- range $IP := .Values.coredns.externalDns.ips }}
       - ipBlock:
           cidr: {{ $IP }}
+      {{- end }}
       {{- end }}
       ports:
         - port: 53
           protocol: UDP
         - port: 53
           protocol: TCP
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/dns-autoscaler/allow-dns-autoscaler.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/dns-autoscaler/allow-dns-autoscaler.yaml
@@ -11,19 +11,26 @@ spec:
     - Egress
     - Ingress
   ingress:
+    {{- if or .Values.global.nodes.ips .Values.global.apiserver.ips }}
     - from:
+      {{- if .Values.global.nodes.ips }}
       {{- range $ip := .Values.global.nodes.ips }}
       - ipBlock:
           cidr: {{ $ip }}
       {{- end }}
+      {{- end }}
+      {{- if .Values.global.apiserver.ips }}
       {{- range $IP := .Values.global.apiserver.ips }}
       - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
+      {{- end }}
       ports:
         - port: 8080
           protocol: TCP
+    {{- end }}
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
       {{- range $IP := .Values.global.apiserver.ips }}
       - ipBlock:
@@ -31,4 +38,5 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/falco/allow-falco.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/falco/allow-falco.yaml
@@ -18,6 +18,7 @@ spec:
             app.kubernetes.io/name: falcosidekick
       ports:
         - port: 2801
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
       - ipBlock:
@@ -25,6 +26,8 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
+    {{- if and .Values.falco.plugins.ips .Values.falco.plugins.ports }}
     - to:
         {{- range $ip := .Values.falco.plugins.ips }}
         - ipBlock:
@@ -35,6 +38,7 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
         - port: 53
           protocol: UDP

--- a/helmfile/charts/networkpolicy/common/templates/kube-system/csi-cinder.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/kube-system/csi-cinder.yaml
@@ -18,6 +18,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -25,6 +26,8 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
+    {{- if and .Values.kubeSystem.openstack.ips .Values.kubeSystem.openstack.ports }}
     - to:
         {{- range .Values.kubeSystem.openstack.ips }}
         - ipBlock:
@@ -34,4 +37,5 @@ spec:
         {{- range .Values.kubeSystem.openstack.ports }}
         - port: {{ . }}
         {{- end }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/kube-system/csi-upcloud.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/kube-system/csi-upcloud.yaml
@@ -18,6 +18,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -25,6 +26,8 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
+    {{- if and .Values.kubeSystem.upcloud.ips .Values.kubeSystem.upcloud.ports }}
     - to:
         {{- range .Values.kubeSystem.upcloud.ips }}
         - ipBlock:
@@ -34,4 +37,5 @@ spec:
         {{- range .Values.kubeSystem.upcloud.ports }}
         - port: {{ . }}
         {{- end }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/kube-system/metrics-server.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/kube-system/metrics-server.yaml
@@ -14,6 +14,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: metrics-server
   ingress:
+    {{- if .Values.global.apiserver.ips }}
     - from:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -21,10 +22,12 @@ spec:
         {{- end }}
       ports:
         - port: 8443
+    {{- end }}
   egress:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -32,6 +35,8 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
+    {{- if .Values.global.nodes.ips }}
     - to:
         {{- range .Values.global.nodes.ips }}
         - ipBlock:
@@ -39,4 +44,5 @@ spec:
         {{- end }}
       ports:
         - port: 10250
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/kube-system/snapshot-controller.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/kube-system/snapshot-controller.yaml
@@ -18,6 +18,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -25,4 +26,5 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/kured/allow.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/kured/allow.yaml
@@ -21,6 +21,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -28,7 +29,8 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
-    {{- if .Values.kured.notificationSlack.enabled }}
+    {{- end }}
+    {{- if and .Values.kured.notificationSlack.enabled .Values.kured.notificationSlack.ips .Values.kured.notificationSlack.ports }}
     - to:
         {{- range .Values.kured.notificationSlack.ips }}
         - ipBlock:

--- a/helmfile/charts/networkpolicy/common/templates/prometheus/allow-blackbox-exporter.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/prometheus/allow-blackbox-exporter.yaml
@@ -23,11 +23,13 @@ spec:
     - to:
         - namespaceSelector: {}
     # probes to pods with hostnetwork
+    {{- if .Values.global.nodes.ips }}
     - to:
         {{- range $ip := .Values.global.nodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/common/templates/prometheus/allow-kube-state-metrics.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/prometheus/allow-kube-state-metrics.yaml
@@ -19,6 +19,7 @@ spec:
       ports:
         - port: 8080
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -27,4 +28,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/prometheus/allow-prometheus-admission-create.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/prometheus/allow-prometheus-admission-create.yaml
@@ -12,6 +12,7 @@ spec:
     - Ingress
     - Egress
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -20,4 +21,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/prometheus/allow-prometheus-admission-patch.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/prometheus/allow-prometheus-admission-patch.yaml
@@ -12,6 +12,7 @@ spec:
     - Ingress
     - Egress
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -20,4 +21,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/prometheus/allow-prometheus-operator.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/prometheus/allow-prometheus-operator.yaml
@@ -18,6 +18,7 @@ spec:
               app: prometheus
       ports:
         - port: 10250
+    {{- if .Values.global.apiserver.ips }}
     - from:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -25,7 +26,9 @@ spec:
         {{- end }}
       ports:
         - port: 10250
+    {{- end }}
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -34,4 +37,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/prometheus/allow-prometheus.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/prometheus/allow-prometheus.yaml
@@ -28,6 +28,7 @@ spec:
     # metrics from pods in the cluster
     - to:
         - namespaceSelector: {}
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -36,12 +37,15 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
     # metrics from kubelet, calico and other host-network exporters
+    {{- if .Values.global.nodes.ips }}
     - to:
         {{- range $ip := .Values.global.nodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/ceph-tools.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/ceph-tools.yaml
@@ -11,6 +11,7 @@ spec:
     matchLabels:
       app: rook-ceph-tools
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -19,6 +20,7 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
     - to:
         - podSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/csi-detect-version.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/csi-detect-version.yaml
@@ -11,6 +11,7 @@ spec:
     matchLabels:
       app: rook-ceph-csi-detect-version
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -19,4 +20,5 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/csi-rbdplugin-provisioner.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/csi-rbdplugin-provisioner.yaml
@@ -11,6 +11,7 @@ spec:
     matchLabels:
       app: csi-rbdplugin-provisioner
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -19,6 +20,7 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
     - to:
         - podSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/detect-version.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/detect-version.yaml
@@ -11,6 +11,7 @@ spec:
     matchLabels:
       app: rook-ceph-detect-version
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -19,4 +20,5 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/mgr.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/mgr.yaml
@@ -25,9 +25,11 @@ spec:
         - podSelector:
             matchLabels:
               app: rook-ceph-osd
+        {{- if .Values.global.nodes.ips }}
         {{- range $ip := .Values.global.nodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
+        {{- end }}
         {{- end }}
         - podSelector:
             matchLabels:
@@ -47,6 +49,7 @@ spec:
         - port: 6800
           protocol: TCP
           endPort: 7300
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -55,6 +58,7 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
     - to:
         - podSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/mon.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/mon.yaml
@@ -22,9 +22,11 @@ spec:
         - podSelector:
             matchLabels:
               app: rook-ceph-osd
+        {{- if .Values.global.nodes.ips }}
         {{- range $ip := .Values.global.nodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
+        {{- end }}
         {{- end }}
         - podSelector:
             matchLabels:
@@ -62,6 +64,7 @@ spec:
           endPort: 7300
         - port: 9283
           protocol: TCP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -70,6 +73,7 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
     - to:
         - podSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/operator.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/operator.yaml
@@ -32,6 +32,7 @@ spec:
           endPort: 7300
         - port: 9283
           protocol: TCP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -40,6 +41,7 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
     - to:
         - podSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/osd-prepare.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/osd-prepare.yaml
@@ -11,6 +11,7 @@ spec:
     matchLabels:
       app: rook-ceph-osd-prepare
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -19,6 +20,7 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
     - to:
         - podSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/osd.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/osd.yaml
@@ -25,9 +25,11 @@ spec:
         - podSelector:
             matchLabels:
               app: csi-rbdplugin-provisioner
+        {{- if .Values.global.nodes.ips }}
         {{- range $ip := .Values.global.nodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
+        {{- end }}
         {{- end }}
       ports:
         - port: 6800
@@ -44,6 +46,7 @@ spec:
           endPort: 7300
         - port: 9283
           protocol: TCP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -52,6 +55,7 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
     - to:
         - podSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/common/templates/starboard/allow-cisbenchmark-scanner.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/starboard/allow-cisbenchmark-scanner.yaml
@@ -12,6 +12,7 @@ spec:
   policyTypes:
     - Egress
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -20,6 +21,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/common/templates/starboard/allow-starboard-operator.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/starboard/allow-starboard-operator.yaml
@@ -12,6 +12,7 @@ spec:
   policyTypes:
     - Egress
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -20,4 +21,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/starboard/allow-vulnerability-report-scanner.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/starboard/allow-vulnerability-report-scanner.yaml
@@ -11,6 +11,7 @@ spec:
   policyTypes:
     - Egress
   egress:
+    {{- if and .Values.global.trivy.ips .Values.global.trivy.port }}
     - to:
         {{- range $IP := .Values.global.trivy.ips }}
         - ipBlock:
@@ -19,6 +20,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.trivy.port }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/common/templates/velero/allow-restic.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/velero/allow-restic.yaml
@@ -18,6 +18,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -25,6 +26,8 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -34,4 +37,5 @@ spec:
         {{- range .Values.global.objectStorage.ports }}
         - port: {{ . }}
         {{- end }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/velero/allow-velero-upgrade-crds.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/velero/allow-velero-upgrade-crds.yaml
@@ -17,6 +17,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -24,4 +25,5 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/velero/allow-velero.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/velero/allow-velero.yaml
@@ -22,6 +22,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -29,6 +30,8 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -38,4 +41,5 @@ spec:
         {{- range .Values.global.objectStorage.ports }}
         - port: {{ . }}
         {{- end }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/vulnerability-exporter/allow-vulnerability-exporter-metrics.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/vulnerability-exporter/allow-vulnerability-exporter-metrics.yaml
@@ -19,6 +19,7 @@ spec:
       ports:
         - port: 9100
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -27,6 +28,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/service-cluster/templates/alertmanager/allow-alertmanager.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/alertmanager/allow-alertmanager.yaml
@@ -40,6 +40,7 @@ spec:
         - podSelector:
             matchLabels:
               app: alertmanager
+    {{- if and .Values.monitoring.alertmanager.alertReceivers.ips .Values.monitoring.alertmanager.alertReceivers.ports }}
     - to:
         {{- range $ip := .Values.monitoring.alertmanager.alertReceivers.ips }}
         - ipBlock:
@@ -49,6 +50,7 @@ spec:
         {{- range $port := .Values.monitoring.alertmanager.alertReceivers.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/service-cluster/templates/dex/allow-dex.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/dex/allow-dex.yaml
@@ -13,7 +13,7 @@ spec:
       app.kubernetes.io/name: dex
   ingress:
     - from:
-      {{- if .Values.global.ingressUsingHostNetwork }}
+      {{- if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
@@ -58,6 +58,7 @@ spec:
       ports:
         - port: 5558
   egress:
+    {{- if and .Values.dex.connectors.ips .Values.dex.connectors.ports }}
     - to:
       {{- range $ip := .Values.dex.connectors.ips }}
       - ipBlock:
@@ -67,6 +68,8 @@ spec:
         {{- range $port := .Values.dex.connectors.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
+    {{- if and .Values.global.scApiserver.ips .Values.global.scApiserver.port }}
     - to:
         {{- range $IP := .Values.global.scApiserver.ips }}
       - ipBlock:
@@ -74,6 +77,7 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.scApiserver.port }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/service-cluster/templates/grafana/allow-grafana.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/grafana/allow-grafana.yaml
@@ -13,7 +13,7 @@ spec:
     - Egress
   ingress:
     - from:
-      {{- if .Values.global.ingressUsingHostNetwork }}
+      {{- if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
@@ -64,6 +64,7 @@ spec:
       ports:
         - port: 5556
           protocol: TCP
+    {{- if and .Values.global.scApiserver.ips .Values.global.scApiserver.port }}
     - to:
         {{- range $ip := .Values.global.scApiserver.ips }}
         - ipBlock:
@@ -72,7 +73,9 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.scApiserver.port }}
+    {{- end }}
     # loading dashboards from grafana website
+    {{- if and .Values.monitoring.grafana.externalDashboardProvider.ips .Values.monitoring.grafana.externalDashboardProvider.ports }}
     - to:
         {{- range $ip := .Values.monitoring.grafana.externalDashboardProvider.ips }}
         - ipBlock:
@@ -82,6 +85,7 @@ spec:
         {{- range $port := .Values.monitoring.grafana.externalDashboardProvider.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: TCP
         port: 53

--- a/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-acme-pods.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-acme-pods.yaml
@@ -12,12 +12,12 @@ spec:
       acme.cert-manager.io/http01-solver: "true"
   ingress:
     - from:
-      {{- if .Values.global.externalLoadBalancer }}
+      {{- if and .Values.global.externalLoadBalancer .Values.global.scIngress.ips }}
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
-      {{- else if .Values.global.ingressUsingHostNetwork }}
+      {{- else if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-backup.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-backup.yaml
@@ -21,6 +21,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -30,5 +31,6 @@ spec:
         {{- range .Values.global.objectStorage.ports }}
         - port: {{ . }}
         {{- end }}
+    {{- end }}
 {{- end }}
 {{ end }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-chartmuseum.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-chartmuseum.yaml
@@ -49,6 +49,7 @@ spec:
       {{- end }}
     {{- end }}
   {{- end }}
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $IP := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -59,4 +60,5 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
 {{ end }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-core.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-core.yaml
@@ -17,20 +17,22 @@ spec:
           protocol: TCP
   egress:
     - to:
-      {{- if .Values.global.externalLoadBalancer }}
+      {{- if and .Values.global.externalLoadBalancer .Values.global.scIngress.ips }}
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
-      {{- else if .Values.global.ingressUsingHostNetwork }}
+      {{- else if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
       {{- else }}
+        {{- if .Values.global.scIngress.ips }}
         {{- range $IP := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $IP }}
+        {{- end }}
         {{- end }}
         - namespaceSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-registry.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-registry.yaml
@@ -20,6 +20,7 @@ spec:
         - port: 5000
         - port: 8080
   egress:
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $IP := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -30,6 +31,7 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
     {{- if eq .Values.harbor.redis.type "internal" }}
     - to:
         - podSelector:

--- a/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-trivy.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-trivy.yaml
@@ -58,6 +58,7 @@ spec:
               component: core
       ports:
         - port: 8080
+    {{- if and .Values.harbor.trivy.ips .Values.harbor.trivy.port }}
     - to:
         {{- range $IP := .Values.harbor.trivy.ips }}
         - ipBlock:
@@ -66,4 +67,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.harbor.trivy.port }}
+    {{- end }}
 {{ end }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/ingress-nginx/controller.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/ingress-nginx/controller.yaml
@@ -12,18 +12,21 @@ spec:
     - Ingress
     - Egress
   ingress:
+    {{- if or .Values.ingressNginx.ingressOverride.ips .Values.global.scNodes.ips .Values.global.scIngress.ips }}
     - from:
-      {{- if .Values.ingressNginx.ingressOverride.enabled }}
+      {{- if and .Values.ingressNginx.ingressOverride.enabled .Values.ingressNginx.ingressOverride.ips }}
         {{- range $IP := .Values.ingressNginx.ingressOverride.ips }}
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
       {{- else if not (or .Values.global.externalLoadBalancer .Values.global.ingressUsingHostNetwork) }}
+        {{- if .Values.global.scNodes.ips }}
         {{- range $IP := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
-      {{- else }}
+        {{- end }}
+      {{- else if .Values.global.scIngress.ips }}
         {{- range $IP := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $IP }}
@@ -34,6 +37,7 @@ spec:
           port: 443
         - protocol: TCP
           port: 80
+    {{- end }}
     - from:
         - namespaceSelector:
             matchLabels:
@@ -44,9 +48,11 @@ spec:
       ports:
         - port: 10254
     - from:
+        {{- if .Values.global.scApiserver.ips }}
         {{- range $IP := .Values.global.scApiserver.ips }}
         - ipBlock:
             cidr: {{ $IP }}
+        {{- end }}
         {{- end }}
         - namespaceSelector:
             matchLabels:
@@ -62,13 +68,14 @@ spec:
     - ports:
       - port: 53
         protocol: UDP
+    {{- if or .Values.ingressNginx.ingressOverride.ips .Values.global.scIngress.ips }}
     - to:
-      {{- if .Values.ingressNginx.ingressOverride.enabled }}
+      {{- if and .Values.ingressNginx.ingressOverride.enabled .Values.ingressNginx.ingressOverride.ips }}
         {{- range $IP := .Values.ingressNginx.ingressOverride.ips }}
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
-      {{- else }}
+      {{- else if .Values.global.scIngress.ips }}
         {{- range $IP := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $IP }}
@@ -79,6 +86,8 @@ spec:
           port: 443
         - protocol: TCP
           port: 80
+    {{- end }}
+    {{- if and .Values.global.scApiserver.ips .Values.global.scApiserver.port }}
     - to:
         {{- range $IP := .Values.global.scApiserver.ips }}
         - ipBlock:
@@ -87,6 +96,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.scApiserver.port }}
+    {{- end }}
     - to:
         - namespaceSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/service-cluster/templates/ingress-nginx/default-backend.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/ingress-nginx/default-backend.yaml
@@ -12,7 +12,7 @@ spec:
     - Ingress
   ingress:
     - from:
-      {{- if .Values.global.ingressUsingHostNetwork }}
+      {{- if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/ingress-nginx/webhook.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/ingress-nginx/webhook.yaml
@@ -14,6 +14,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.scApiserver.ips .Values.global.scApiserver.port }}
     - to:
         {{- range $IP := .Values.global.scApiserver.ips }}
         - ipBlock:
@@ -22,4 +23,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.scApiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/client.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/client.yaml
@@ -27,7 +27,7 @@ spec:
         - port: 9300
     # Allow api port from ingress-ngix
     - from:
-      {{- if .Values.global.ingressUsingHostNetwork }}
+      {{- if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
@@ -56,6 +56,7 @@ spec:
               app.kubernetes.io/component: opensearch-client
       ports:
         - port: 9300
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $ip := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -66,6 +67,8 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
+    {{- if and .Values.opensearch.plugins.ips .Values.opensearch.plugins.ports }}
     - to:
         {{- range $ip := .Values.opensearch.plugins.ips }}
         - ipBlock:
@@ -76,6 +79,7 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
         - port: 53
           protocol: UDP

--- a/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/dashboard.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/dashboard.yaml
@@ -13,7 +13,7 @@ spec:
       app: opensearch-dashboards
   ingress:
     - from:
-      {{- if .Values.global.ingressUsingHostNetwork }}
+      {{- if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
@@ -43,20 +43,22 @@ spec:
         - port: 53
           protocol: UDP
     - to:
-      {{- if .Values.global.externalLoadBalancer }}
+      {{- if and .Values.global.externalLoadBalancer .Values.global.scIngress.ips }}
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
-      {{- else if .Values.global.ingressUsingHostNetwork }}
+      {{- else if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
       {{- else }}
+        {{- if .Values.global.scIngress.ips }}
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
+        {{- end }}
         {{- end }}
         - namespaceSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/data.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/data.yaml
@@ -38,6 +38,7 @@ spec:
               app.kubernetes.io/component: opensearch-client
       ports:
         - port: 9300
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $ip := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -48,6 +49,8 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
+    {{- if and .Values.opensearch.plugins.ips .Values.opensearch.plugins.ports }}
     - to:
         {{- range $ip := .Values.opensearch.plugins.ips }}
         - ipBlock:
@@ -58,6 +61,7 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
         - port: 53
           protocol: UDP

--- a/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/master.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/master.yaml
@@ -36,7 +36,7 @@ spec:
               app.kubernetes.io/instance: opensearch-securityadmin
       {{- if not .Values.opensearch.client.enabled }}
       # Allow api port from ingress-ngix
-      {{- if .Values.global.ingressUsingHostNetwork }}
+      {{- if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
@@ -88,6 +88,7 @@ spec:
               kubernetes.io/metadata.name: dex
       ports:
         - port: 5556
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $ip := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -98,6 +99,8 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
+    {{- if and .Values.opensearch.plugins.ips .Values.opensearch.plugins.ports }}
     - to:
         {{- range $ip := .Values.opensearch.plugins.ips }}
         - ipBlock:
@@ -108,21 +111,24 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
     - to:
-      {{- if .Values.global.externalLoadBalancer }}
+      {{- if and .Values.global.externalLoadBalancer .Values.global.scIngress.ips }}
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
-      {{- else if .Values.global.ingressUsingHostNetwork }}
+      {{- else if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
       {{- else }}
+        {{- if .Values.global.scIngress.ips }}
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
+        {{- end }}
         {{- end }}
         - namespaceSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/service-cluster/templates/prometheus/allow-blackbox-exporter.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/prometheus/allow-blackbox-exporter.yaml
@@ -11,27 +11,31 @@ spec:
   policyTypes:
     - Egress
   egress:
+    {{- if .Values.global.wcIngress.ips }}
     - to:
         {{- range $ip := .Values.global.wcIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
+    {{- end }}
     # probes to sc ingress
     - to:
-      {{- if .Values.global.externalLoadBalancer }}
+      {{- if and .Values.global.externalLoadBalancer .Values.global.scIngress.ips }}
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
-      {{- else if .Values.global.ingressUsingHostNetwork }}
+      {{- else if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
       {{- else }}
+        {{- if .Values.global.scIngress.ips }}
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
+        {{- end }}
         {{- end }}
         - namespaceSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/service-cluster/templates/rclone-sync.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/rclone-sync.yaml
@@ -16,6 +16,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -25,6 +26,8 @@ spec:
         {{- range .Values.global.objectStorage.ports }}
         - port: {{ . }}
         {{- end }}
+    {{- end }}
+    {{- if and .Values.rcloneSync.destinationObjectStorage.ips .Values.rcloneSync.destinationObjectStorage.ports }}
     - to:
         {{- range .Values.rcloneSync.destinationObjectStorage.ips }}
         - ipBlock:
@@ -34,4 +37,5 @@ spec:
         {{- range .Values.rcloneSync.destinationObjectStorage.ports }}
         - port: {{ . }}
         {{- end }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/s3-exporter.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/s3-exporter.yaml
@@ -19,6 +19,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -28,4 +29,5 @@ spec:
         {{- range .Values.global.objectStorage.ports }}
         - port: {{ . }}
         {{- end }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-buketweb.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-buketweb.yaml
@@ -23,6 +23,7 @@ spec:
         - port: 8080
           protocol: TCP
   egress:
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $ip := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -32,6 +33,7 @@ spec:
         {{- range $port := .Values.global.objectStorage.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-compactor.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-compactor.yaml
@@ -23,6 +23,7 @@ spec:
         - port: 10902
           protocol: TCP
   egress:
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $ip := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -32,6 +33,7 @@ spec:
         {{- range $port := .Values.global.objectStorage.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-receive-distributor.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-receive-distributor.yaml
@@ -13,7 +13,7 @@ spec:
     - Egress
   ingress:
     - from:
-      {{- if .Values.global.ingressUsingHostNetwork }}
+      {{- if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-receive.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-receive.yaml
@@ -33,6 +33,7 @@ spec:
         - port: 10902
           protocol: TCP
   egress:
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $ip := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -42,6 +43,7 @@ spec:
         {{- range $port := .Values.global.objectStorage.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-ruler.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-ruler.yaml
@@ -47,6 +47,7 @@ spec:
       ports:
         - port: 9093
           protocol: TCP
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $ip := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -56,6 +57,7 @@ spec:
         {{- range $port := .Values.global.objectStorage.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: TCP
         port: 53

--- a/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-storegateway.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-storegateway.yaml
@@ -30,6 +30,7 @@ spec:
         - port: 10902
           protocol: TCP
   egress:
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $ip := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -39,6 +40,7 @@ spec:
         {{- range $port := .Values.global.objectStorage.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/alertmanager/allow-alertmanager.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/alertmanager/allow-alertmanager.yaml
@@ -46,6 +46,7 @@ spec:
         - podSelector:
             matchLabels:
               app: alertmanager
+    {{- if .Values.global.wcApiserver.ips }}
     - from:
         {{- range $ip := .Values.global.wcApiserver.ips }}
         - ipBlock:
@@ -54,11 +55,13 @@ spec:
       ports:
         - port: 9093
           protocol: TCP
+    {{- end }}
   egress:
     - to:
         - podSelector:
             matchLabels:
               app: alertmanager
+    {{- if and .Values.alertmanager.alertReceivers.ips .Values.alertmanager.alertReceivers.ports }}
     - to:
         {{- range $ip := .Values.alertmanager.alertReceivers.ips }}
         - ipBlock:
@@ -68,6 +71,7 @@ spec:
         {{- range $port := .Values.alertmanager.alertReceivers.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/gatekeeper/allow-controller-manager.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/gatekeeper/allow-controller-manager.yaml
@@ -28,14 +28,17 @@ spec:
           podSelector:
             matchLabels:
               app.kubernetes.io/name: prometheus-blackbox-exporter
+        {{- if .Values.global.wcApiserver.ips }}
         {{- range $IP := .Values.global.wcApiserver.ips }}
         - ipBlock:
             cidr: {{ $IP }}
+        {{- end }}
         {{- end }}
       ports:
         - protocol: TCP
           port: 8443
   egress:
+    {{- if and .Values.global.wcApiserver.ips .Values.global.wcApiserver.port }}
     - to:
         {{- range $IP := .Values.global.wcApiserver.ips }}
         - ipBlock:
@@ -44,4 +47,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.wcApiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/gatekeeper/allow-gatekeeper-audit-controller.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/gatekeeper/allow-gatekeeper-audit-controller.yaml
@@ -22,6 +22,7 @@ spec:
       ports:
         - port: 8888
   egress:
+    {{- if and .Values.global.wcApiserver.ips .Values.global.wcApiserver.port }}
     - to:
         {{- range $IP := .Values.global.wcApiserver.ips }}
         - ipBlock:
@@ -30,4 +31,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.wcApiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/gatekeeper/allow-gatekeeper-update-crds-hook.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/gatekeeper/allow-gatekeeper-update-crds-hook.yaml
@@ -12,6 +12,7 @@ spec:
     - Ingress
     - Egress
   egress:
+    {{- if and .Values.global.wcApiserver.ips .Values.global.wcApiserver.port }}
     - to:
         {{- range $IP := .Values.global.wcApiserver.ips }}
         - ipBlock:
@@ -20,4 +21,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.wcApiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/gatekeeper/allow-gatekeeper-update-namespace-label.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/gatekeeper/allow-gatekeeper-update-namespace-label.yaml
@@ -12,6 +12,7 @@ spec:
     - Ingress
     - Egress
   egress:
+    {{- if and .Values.global.wcApiserver.ips .Values.global.wcApiserver.port }}
     - to:
         {{- range $IP := .Values.global.wcApiserver.ips }}
         - ipBlock:
@@ -20,4 +21,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.wcApiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/ingress-nginx/controller.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/ingress-nginx/controller.yaml
@@ -12,18 +12,21 @@ spec:
     - Ingress
     - Egress
   ingress:
+    {{- if or .Values.ingressNginx.ingressOverride.ips .Values.global.wcNodes.ips .Values.global.wcIngress.ips }}
     - from:
-      {{- if .Values.ingressNginx.ingressOverride.enabled }}
+      {{- if and .Values.ingressNginx.ingressOverride.enabled .Values.ingressNginx.ingressOverride.ips }}
         {{- range $IP := .Values.ingressNginx.ingressOverride.ips }}
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
       {{- else if not (or .Values.global.externalLoadBalancer .Values.global.ingressUsingHostNetwork) }}
+        {{- if .Values.global.wcNodes.ips }}
         {{- range $IP := .Values.global.wcNodes.ips }}
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
-      {{- else }}
+        {{- end }}
+      {{- else if .Values.global.wcIngress.ips }}
         {{- range $IP := .Values.global.wcIngress.ips }}
         - ipBlock:
             cidr: {{ $IP }}
@@ -34,6 +37,7 @@ spec:
           port: 443
         - protocol: TCP
           port: 80
+    {{- end }}
     - from:
         - namespaceSelector:
             matchLabels:
@@ -44,9 +48,11 @@ spec:
       ports:
         - port: 10254
     - from:
+        {{- if .Values.global.wcApiserver.ips }}
         {{- range $IP := .Values.global.wcApiserver.ips }}
         - ipBlock:
             cidr: {{ $IP }}
+        {{- end }}
         {{- end }}
         - namespaceSelector:
             matchLabels:
@@ -62,13 +68,14 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if or .Values.ingressNginx.ingressOverride.ips .Values.global.wcIngress.ips }}
     - to:
-      {{- if .Values.ingressNginx.ingressOverride.enabled }}
+      {{- if and .Values.ingressNginx.ingressOverride.enabled .Values.ingressNginx.ingressOverride.ips }}
         {{- range $IP := .Values.ingressNginx.ingressOverride.ips }}
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
-      {{- else }}
+      {{- else if .Values.global.wcIngress.ips }}
         {{- range $IP := .Values.global.wcIngress.ips }}
         - ipBlock:
             cidr: {{ $IP }}
@@ -79,6 +86,8 @@ spec:
           port: 443
         - protocol: TCP
           port: 80
+    {{- end }}
+    {{- if and .Values.global.wcApiserver.ips .Values.global.wcApiserver.port }}
     - to:
         {{- range $IP := .Values.global.wcApiserver.ips }}
         - ipBlock:
@@ -87,6 +96,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.wcApiserver.port }}
+    {{- end }}
     - to:
         - namespaceSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/ingress-nginx/default-backend.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/ingress-nginx/default-backend.yaml
@@ -12,7 +12,7 @@ spec:
     - Ingress
   ingress:
     - from:
-      {{- if .Values.global.ingressUsingHostNetwork }}
+      {{- if and .Values.global.ingressUsingHostNetwork .Values.global.wcNodes.ips }}
       {{- range $ip := .Values.global.wcNodes.ips }}
       - ipBlock:
           cidr: {{ $ip }}

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/ingress-nginx/webhook.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/ingress-nginx/webhook.yaml
@@ -14,6 +14,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.wcApiserver.ips .Values.global.wcApiserver.port }}
     - to:
         {{- range $IP := .Values.global.wcApiserver.ips }}
         - ipBlock:
@@ -22,4 +23,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.wcApiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/prometheus/allow-prometheus.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/prometheus/allow-prometheus.yaml
@@ -13,6 +13,7 @@ spec:
     - Ingress
   egress:
     # thanos
+    {{- if .Values.global.scIngress.ips }}
     - to:
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
@@ -21,10 +22,12 @@ spec:
       ports:
       - protocol: TCP
         port: 443
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53
   ingress:
+    {{- if .Values.global.wcApiserver.ips }}
     - from:
         {{- range $ip := .Values.global.wcApiserver.ips }}
         - ipBlock:
@@ -33,4 +36,5 @@ spec:
       ports:
         - port: 9090
           protocol: TCP
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add empty ip/port checks in network policies to prevent allowing all traffic.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1363  

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
