### PR TITLE
docs: Add release constraints

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -3,6 +3,7 @@
 - The Fluentd deplyoment has changed considerably and users must ensure that their custom filters continues to work as expected.
 - In 1.10 the containers in pods created by cert-manager have been renamed to better reflect what they do. This can be breaking for automation that relies on these names being static.
 - In 1.11 the cert-manager Gateway API integration uses the v1beta1 API version. ExperimentalGatewayAPISupport alpha feature users must ensure that v1beta of Gateway API is installed in cluster.
+- Releases now have constraints set on them to ensure the stability of upgrades and updates and to better match the expected changes within releases, you can find them in the release document.
 
 ### Added
 

--- a/release/README.md
+++ b/release/README.md
@@ -1,7 +1,54 @@
 # Release process
 
-The releases will follow semantic versioning and be handled with git tags.
-https://semver.org/
+The releases will follow [semantic versioning](https://semver.org/) and be handled with git tags.
+
+## Constraints
+
+The following constraints apply on releases:
+
+1. Major releases (v**X**.Y.Z and v0.**Y**.Z):
+
+    > *Updates that bring new features and improvements that require coordination with the user.*
+
+    - May perform major additions, modifications, or deletions to the configuration structure.
+
+        Example of major change would be to change the way configuration is processed.
+
+    - May perform major upgrades and updates to the deployed services.
+
+        Example of major change would be to upgrade or replace major services or stacks.
+
+1. Minor releases (vX.**Y**.Z):
+
+    > *Updates that bring new features and improvements that does not require coordination with the user.*
+
+    - May **only** perform minor additions, modifications, or deletions to the configuration structure.
+
+        The configuration *should* keep similar management and structure between different minor releases to ensure that they work with similar sets of features and tools on the same major version.
+
+        Example of minor change would be to change parts of the configuration for services and components.
+
+    - May **only** perform minor upgrades or updates to the deployed services.
+
+        The deployed services *should* be the same between different minor releases to ensure that they work with similar sets of features and tools on the same major version.
+
+        Example of minor change would be to upgrade or change minor services or components.
+
+1. Patch releases (vX.Y.**Z**):
+
+    > *Patches to fix known vulnerabilities threatening user data assessed as an immediate risk.*
+
+    - May **only** perform patch additions or modifications to the configuration structure.
+
+        The configuration **must** keep similar management and structure between different patch releases to ensure that they work with the same sets of features and tools, and can be applied over any patch version on the same minor version.
+
+        Example of allowed patches would be for missing or invalid configurations.
+
+    - May **only** perform patch or security updates to the deployed services.
+
+        The deployed services **must** be the same between different patch releases to ensure that they work with the same sets of features and tools, and can be applied over any patch version on the same minor version.
+
+        Example of allowed patches would be for upgrading patch versions of services due to security vulnerabilities.
 
 ## Major and minor releases
 


### PR DESCRIPTION
**What this PR does / why we need it**:

To better constrain what different types of releases may contain, especially for patch releases.

**Which issue this PR fixes**:

fixes #1374

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
