### PR TITLE
apps wc: Move rolebinding to user-rbac chart

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -56,6 +56,7 @@
   - Disallow latest tag default is now `deny`, was `dryrun`
   - Require trusted image registry default is now `warn`, was `deny`
   - Require network policies default is now `warn`, was `deny`
+- Moved creation of `extra-workload-admins` to the `user-rbac` chart
 
 ### Removed
 

--- a/helmfile/charts/user-rbac/templates/rolebindings/workload-admin.yaml
+++ b/helmfile/charts/user-rbac/templates/rolebindings/workload-admin.yaml
@@ -20,4 +20,19 @@ subjects:
   kind: Group
   name: {{ $group }}
 {{- end }}
+{{- $value := lookup "rbac.authorization.k8s.io/v1" "RoleBinding" $namespace "extra-workload-admins" }}
+{{- if and (or $.Release.IsInstall $.Release.IsUpgrade) (not $value) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
+  name: extra-workload-admins
+  namespace: {{ $namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+{{- end }}
 {{- end }}

--- a/migration/v0.29/README.md
+++ b/migration/v0.29/README.md
@@ -131,7 +131,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ```bash
     ./scripts/S3/entry.sh --s3cfg "$CK8S_CONFIG_PATH/.state/s3cfg.ini" create
     # or
-    ./migration/v0.29/apply/01-create-buckets.sh
+    ./migration/v0.29/apply/01-create-buckets.sh execute
     ```
 
 1. **Warning** The default Gatekeeper enforcements have been updated:
@@ -156,25 +156,37 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ```bash
     ./bin/ck8s bootstrap {sc|wc}
     # or
-    ./migration/v0.29/apply/10-bootstrap.sh
+    ./migration/v0.29/apply/10-bootstrap.sh execute
+    ```
+
+1. Upgrade Starboard CRDs:
+
+    ```bash
+    ./migration/v0.29/apply/11-crds.sh execute
     ```
 
 1. Upgrade kured:
 
     ```bash
-    ./migration/v0.29/apply/20-kured.sh
+    ./migration/v0.29/apply/20-kured.sh execute
     ```
 
 1. Upgrade metrics-server:
 
     ```bash
-    ./migration/v0.29/apply/20-metrics-server.sh
+    ./migration/v0.29/apply/20-metrics-server.sh execute
     ```
 
 1. Upgrade fluentd:
 
     ```bash
-    ./migration/v0.29/apply/21-fluentd.sh
+    ./migration/v0.29/apply/21-fluentd.sh execute
+    ```
+
+1. Sync user-rbac to add extra-workload-admins rolebinding:
+
+    ```bash
+    ./migration/v0.29/apply/50-user-rbac.sh execute
     ```
 
 1. Upgrade applications:
@@ -182,7 +194,13 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ```bash
     ./bin/ck8s apply {sc|wc}
     # or
-    ./migration/v0.29/apply/99-apply.sh
+    ./migration/v0.29/apply/80-apply.sh execute
+    ```
+
+1. Uninstall prometheus-elasticsearch-exporter:
+
+    ```bash
+    ./migration/v0.29/apply/90-uninstalls.sh execute
     ```
 
 ## Postrequisite:

--- a/migration/v0.29/apply/50-user-rbac.sh
+++ b/migration/v0.29/apply/50-user-rbac.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+run() {
+  case "${1:-}" in
+  execute)
+    helmfile_do wc sync -lapp=user-rbac
+    ;;
+  rollback)
+    log_warn "rollback not implemented"
+    ;;
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/scripts/deploy-wc.sh
+++ b/scripts/deploy-wc.sh
@@ -40,17 +40,6 @@ else
   kubectl create -f "${SCRIPTS_PATH}/../manifests/user-rbac/clusterrolebindings/extra-user-view.yaml"
 fi
 
-user_namespaces=$(yq4 '.user.namespaces[]' "${config['config_file_wc']}")
-
-for namespace in ${user_namespaces}; do
-    if [ "$(kubectl get rolebinding -n "${namespace}" extra-workload-admins)" ] ; then
-        echo "extra-workload-admins RoleBinding already exists in ${namespace} namespace. Ignoring."
-    else
-        echo "Creating extra-workload-admins RoleBinding in ${namespace} namespace"
-        kubectl create rolebinding extra-workload-admins -n "${namespace}" --clusterrole=admin
-    fi
-done
-
 echo "Installing helm charts" >&2
 cd "${SCRIPTS_PATH}/../helmfile"
 declare -a helmfile_opt_flags

--- a/scripts/migration/lib.sh
+++ b/scripts/migration/lib.sh
@@ -179,8 +179,6 @@ check_config() {
     log_fatal "error: \"THIS\" is unset"
   elif [ -z "${ROOT:-}" ]; then
     log_fatal "error: \"ROOT\" is unset"
-  elif [ -z "${CK8S_TARGET_VERSION:-}" ]; then
-    log_fatal "error: \"CK8S_TARGET_VERSION\" is unset"
   elif [ -z "${CK8S_CONFIG_PATH:-}" ]; then
     log_fatal "error: \"CK8S_CONFIG_PATH\" is unset"
   elif [ ! -d "${CK8S_CONFIG_PATH}" ]; then
@@ -221,6 +219,8 @@ check_config() {
 check_version() {
   if [[ ! "${1:-}" =~ ^(sc|wc)$ ]] || [[ ! "${2:-}" =~ ^(prepare|apply)$ ]]; then
     log_fatal "usage: check_version <sc|wc> <prepare|apply>"
+  elif [ -z "${CK8S_TARGET_VERSION:-}" ]; then
+    log_fatal "error: \"CK8S_TARGET_VERSION\" is unset"
   fi
 
   if [ "${VERSION["${1}-config"]}" = "any" ]; then
@@ -280,7 +280,12 @@ check_version() {
 
 # Root scripts need to manage this themselves
 if [ -z "${CK8S_ROOT_SCRIPT:-}" ]; then
-  export CK8S_STACK="${CK8S_STACK}/${THIS}"
+  if [ -z "${CK8S_STACK:-}" ]; then
+    export CK8S_STACK="${THIS}"
+  else
+    export CK8S_STACK="${CK8S_STACK:-}/${THIS}"
+  fi
+
   check_config
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We can't have it where it is right now as it tries to create it before the namespaces exists, and I like to keep everything in helm charts so I came up with a different solution.

**Special notes for reviewer**:

It will only try to install it on install/upgrade if it doesn't already exists and it has the annotation to kept so in subsequent runs it's just ignored.

We could employ this trick more to remove the need for the deploy script completely.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
