### PR TITLE
Script to get BOM

### DIFF
--- a/scripts/bom/get-bom.py
+++ b/scripts/bom/get-bom.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+Helper script to generate Software Bill of Materials (BOM).
+
+Usage:
+    git clone -b $RELEASE git@github.com:elastisys/compliantkubernetes-apps
+    cd compliantkubernetes-apps
+    ./scripts/bom/get-bom.py
+
+Input:
+    Helm Charts in ./helmfile/upstream
+
+Output:
+    CSV-like file
+
+Limitations:
+    - Does not look at Ansible `get-requirements.yaml`
+    - Does not extract licenses
+    - Does not extract copyright owner
+    - Does not extract CNCF status
+"""
+
+import csv
+import logging
+import os
+import re
+
+import requests
+import yaml
+
+def parse_chart_yaml(file):
+    with open(file) as f:
+        try:
+            chart = yaml.safe_load(f)
+
+            name = chart["name"]
+            version = chart["version"]
+            appVersion = chart["appVersion"]
+            sources = chart.get("sources")
+            home = chart.get("home")
+
+            if chart == 'opensearch' and not sources:
+                sources = ['https://github.com/opensearch-project/OpenSearch']
+
+            return name, appVersion, version
+        except Exception as e:
+            logging.error(f'Cannot parse {file}: {e}')
+
+components = [ ]
+for root, dirs, filenames in os.walk('./helmfile/upstream'):
+    for filename in filenames:
+        file = os.path.join(root, filename)
+        if filename == 'Chart.yaml':
+            components.append(parse_chart_yaml(file))
+
+print('name', 'appVersion', 'version', sep=',')
+for component in sorted(components):
+    print(*component, sep=',')


### PR DESCRIPTION
**What this PR does / why we need it**:

We sometimes gets questions around the Compliant Kubernetes Bill of Materials (BOM). The purpose of the BOM is to ensure that:
- We don't violate any licenses.
- We are aware of the risks involved with "one men shows" and components getting abandoned.
- We are aware of the risks with various copyright owners, e.g., bankruptcy, change in license, etc.

The BOM essentially allows us to verify that we comply with [ADR-0015](https://elastisys.io/compliantkubernetes/adr/0015-we-believe-in-community-driven-open-source/).

Automating the whole process across Helm Charts, Ansible scripts and Python dependencies, etc. is a tedious work. Partial solutions exist out [there](https://github.com/kubernetes-sigs/bom), but don't quite suit our needs.

This script partially automates producing a BOM.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [X] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
