### PR TITLE
Add alerts for dropped packets from/to workloads

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,63 @@
+### Release notes
+
+- The Fluentd deplyoment has changed considerably and users must ensure that their custom filters continues to work as expected.
+- In 1.10 the containers in pods created by cert-manager have been renamed to better reflect what they do. This can be breaking for automation that relies on these names being static.
+- In 1.11 the cert-manager Gateway API integration uses the v1beta1 API version. ExperimentalGatewayAPISupport alpha feature users must ensure that v1beta of Gateway API is installed in cluster.
+- Releases now have constraints set on them to ensure the stability of upgrades and updates and to better match the expected changes within releases, you can find them in the release document.
+- The upgrade process has changed considerably checkout the migration guide, it also contains information about how to follow the new process when writing migration steps
+
+### Added
+
+- Enable rook-ceph network polices by default for exoscale
+- Troubleshooting scripts for HNC
+- Tests for Groups RBAC
+- the possibility to add static users for opensearch
+- Support for extracting and storing audit logs with Fluentd
+- Compaction for logs stored directly in object store by Fluentd
+- New 'Log review overview' Opensearch dashboard
+- Added falco rules to ignore redis operator related alerts.
+- Add PrometheusRule to alert packets to/from workloads are dropped.
+### Fixed
+
+- The update-ips script can now fetch Calico Wireguard IPs
+- The update-ips script can now fetch object storage sync destination IPs
+- The test scripts can now always access the kubeconfig
+- The OpenSearch network policies now properly work with dedicated nodes and shapshots enabled
+- The `clean-sc` script now patches any pending challenges which would prevent the removal of certain namespaces
+
+### Updated
+
+- The NetworkPolicy Dashboard have been updated to be more clear
+- Upgraded the Starboard-operator helm chart to `0.10.11` which upgrades the app version to `0.15.11`
+- Upgrade Gatekeeper helm chart to `v3.11.0`, which also upgrades Gatekeeper to `v3.11.0`
+- Updated Gatekeeper Dashboard to new one from upstream
+- Renamed the ElasticSearch Dashboard to Opensearch in Grafana
+- Changed release name for `prometheus-elasticsearch-exporter` to `prometheus-opensearch-exporter`
+- Upgraded the cert-manager helm chart to `v1.11.0` which upgrades the app version to `v1.11.0`
+- Update deploy-wc.sh to create `extra-workload-admins` rolebinding on all user namespaces.
+- Update harbor backup job api version
+- The upgrade process has changed considerably, checkout the migration guide it also contains information about how to follow the new process when writing migration steps
+
+### Changed
+
+- Thanos Rulers now sends alerts to all Alertmanagers in an HA setup, sends requests directly to Queries, and are now accessible by Queries
+- Thanos components now use DNS SD to automatically find healthy replicas
+- Alerts can now be inspected in ops Grafana
+- Updated metrics-server chart to 0.6.2 which upgrades metrics-server to 3.8.3
+- Allow the creation of arbitrary network-policy in wc
+- Network polices
+  - Added missing network policy for rook-ceph-csi-detect-version for rook-ceph v1.10
+- Upgraded the kured helm chart to `4.4.1` which upgrades the app version to `1.12.1`
+- Fluentd in both SC and WC now use the `fluentd-elasticsearch` chart for forwarding, and the `fluentd` chart for aggregating
+  - This have changed the deployment for Fluentd considerably and users must ensure that their custom filter continues to work as expected
+- Retention for logs stored directly in object store have been reworked
+- Updated alertmanager network policy to allow ingress traffic from user pods.
+- Gatekeeper default enforcements have been changed for certain policies
+  - Disallow latest tag default is now `deny`, was `dryrun`
+  - Require trusted image registry default is now `warn`, was `deny`
+  - Require network policies default is now `warn`, was `deny`
+- Moved creation of `extra-workload-admins` to the `user-rbac` chart
+
+### Removed
+
+- GCS support for Fluentd

--- a/helmfile/charts/prometheus-alerts/templates/alerts/packets-dropped.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/alerts/packets-dropped.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.defaultRules.create .Values.defaultRules.rules.networkpolicies }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-alerts.fullname" .) "packets-dropped" | trunc 63 | trimSuffix "-" }}
+  labels:
+    app: {{ template "prometheus-alerts.name" . }}
+{{ include "prometheus-alerts.labels" . | indent 4 }}
+{{- if .Values.defaultRules.alertLabels }}
+{{ toYaml .Values.defaultRules.alertLabels | indent 4 }}
+{{- end }}
+{{- if .Values.defaultRules.annotations }}
+  annotations:
+{{ toYaml .Values.defaultRules.annotations | indent 4 }}
+{{- end }}
+spec:
+  groups:
+  - name: packets-dropped
+    rules:
+    - alert: PacketsDroppedToWorkload
+      annotations:
+        description: Number of packets dropped to a workload because no policies matched them
+        summary: Number of packets dropped to a workload
+      expr: |
+        rate(no_policy_drop_counter{type="tw", cluster=~".*", pod_namespace=~".*", exported_pod=~".*"}[1m]) > 0
+      for: 5m
+      labels:
+        severity: info
+    - alert: PacketsDroppedFromWorkload
+      annotations:
+        description: Number of packets dropped from a workload because no policies matched them
+        summary: Number of packets dropped from a workload
+      expr: |
+        rate(no_policy_drop_counter{type="fw", cluster=~".*", pod_namespace=~".*", exported_pod=~".*"}[1m]) > 0
+      for: 5m
+      labels:
+        severity: info
+
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- end }}

--- a/helmfile/charts/prometheus-alerts/values.yaml
+++ b/helmfile/charts/prometheus-alerts/values.yaml
@@ -62,6 +62,7 @@ defaultRules:
     kubeProxy: true
     kubeControllerManager: true
     configReloaders: true
+    networkpolicies: false
 
   appNamespacesTarget: ".*"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1307 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
