### PR TITLE
apps: log bodies from audit events

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ### Added
 - Add PrometheusRule to alert for dropped packets to/from workloads.
+
 ### Fixed
 
 - Networkpolicies now contain checks to prevent allowing all traffic when ips/ports are empty.
 
 ### Updated
+- `responseObject` and `requestObject` are no longer dropped in Fluentd from Kubernetes audit events.
 
 ### Changed
 

--- a/helmfile/values/fluentd/forwarder-common.yaml.gotmpl
+++ b/helmfile/values/fluentd/forwarder-common.yaml.gotmpl
@@ -125,12 +125,18 @@ extraConfigMaps:
       </parse>
     </source>
 
-    # Remove keys that include raw data causing errors
-    # See: https://github.com/uken/fluent-plugin-elasticsearch/issues/452
+    # Jsonify responseObject and requestObject keys so that their
+    # contents won't be dynamically mapped in Opensearch and instead be indexed
+    # as json text.
     <filter kubeaudit.**>
       @id kube_api_audit_normalize
       @type record_transformer
-      remove_keys responseObject,requestObject
+      auto_typecast false
+      enable_ruby true
+      <record>
+        responseObject ${record["responseObject"].nil? ? "none": record["responseObject"].to_json}
+        requestObject ${record["requestObject"].nil? ? "none": record["requestObject"].to_json}
+      </record>
     </filter>
 
   12-kubernetes.conf: |-


### PR DESCRIPTION
**What this PR does / why we need it**:
To improve our kubernetes audit logs in opensearch to include relevant information

**Which issue this PR fixes**:
fixes #1455 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
I haven't looked at the chunk settings in fluentd but they might need to be tweaked now that there is the possibliity that response or request bodies can be quite large.

**Add a screenshot or an example to illustrate the proposed solution:**
![image](https://user-images.githubusercontent.com/12396964/225659286-f76cdb90-0478-432a-a4a9-8486741f1b20.png)


**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
