### PR TITLE
Qa 0.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - The test scripts can now always access the kubeconfig
 - The OpenSearch network policies now properly work with dedicated nodes and shapshots enabled
 - The `clean-sc` script now patches any pending challenges which would prevent the removal of certain namespaces
+- Networkpolicies now contain checks to prevent allowing all traffic when ips/ports are empty.
 
 ### Updated
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,11 @@
+### Release notes
+
+### Added
+
+### Fixed
+
+### Updated
+
+### Changed
+
+### Removed

--- a/get-requirements.yaml
+++ b/get-requirements.yaml
@@ -5,8 +5,8 @@
       install_user: "{{ lookup('env','USER') }}"
       kubectl_version: 1.24.4
       helm_version: 3.8.0
-      helmfile_version: 0.144.0
-      helmdiff_version: 3.1.2
+      helmfile_version: 0.146.0
+      helmdiff_version: 3.5.0
       helmsecrets_version: 3.12.0
       jq_version: 1.6
       s3cmd_version: 2.*
@@ -40,10 +40,13 @@
         - "--no-anchored"
         - "helm"
     - name: Get Helmfile
-      get_url:
-        url: https://github.com/roboll/helmfile/releases/download/v{{ helmfile_version }}/helmfile_linux_amd64
-        dest: "{{ install_path }}/helmfile"
+      unarchive:
+        src: https://github.com/helmfile/helmfile/releases/download/v{{ helmfile_version }}/helmfile_{{ helmfile_version }}_linux_amd64.tar.gz
+        dest: "{{ install_path }}"
         mode: 0775
+        remote_src: yes
+        extra_opts:
+        - "helmfile"
     - name: Check if helm-diff plugin exists
       stat:
         path: "/home/{{ install_user }}/.local/share/helm/plugins/helm-diff"

--- a/helmfile/charts/grafana-ops/dashboards/gatekeeper-dashboard.json
+++ b/helmfile/charts/grafana-ops/dashboards/gatekeeper-dashboard.json
@@ -53,10 +53,7 @@
       "type": "text"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PE090269EBE049DA8"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -66,10 +63,7 @@
       "id": 24,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "refId": "A"
         }
       ],
@@ -77,10 +71,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PE090269EBE049DA8"
-      },
+      "datasource": "$datasource",
       "description": "Description: Current number of constraint templates\n\"All NS\"\n\nUnderstanding this metric: Gatekeeper subscribes to a watch on all ConstraintTemplate resources. Whenever one is created or deleted on the cluster, this count gets updated.",
       "fieldConfig": {
         "defaults": {
@@ -129,10 +120,7 @@
       "pluginVersion": "9.2.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "sum by (status) (gatekeeper_constraint_templates{pod=~\"gatekeeper-controller-manager-.+\"})",
           "interval": "",
@@ -144,10 +132,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PE090269EBE049DA8"
-      },
+      "datasource": "$datasource",
       "description": "Description: The number of audit violations per constraint detected in the last audit cycle\n\nUnderstanding this metric: During each run, the audit sums up all of the violations that it finds and reports these counts per-enforcement-mode.",
       "fieldConfig": {
         "defaults": {
@@ -257,10 +242,7 @@
       "pluginVersion": "9.2.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "sum by (enforcement_action) (gatekeeper_violations)",
           "format": "time_series",
@@ -275,10 +257,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PE090269EBE049DA8"
-      },
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -326,10 +305,7 @@
       "pluginVersion": "9.2.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "editorMode": "code",
           "exemplar": true,
           "expr": "sum by (kind) (gatekeeper_violations{violating_namespace=~\"$namespace\"})",
@@ -341,10 +317,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "editorMode": "code",
           "exemplar": true,
           "expr": "sum by (violating_name) (gatekeeper_violations{violating_namespace=\"monitoring\"})",
@@ -362,10 +335,7 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PE090269EBE049DA8"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -376,10 +346,7 @@
       "panels": [],
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "refId": "A"
         }
       ],
@@ -387,10 +354,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PE090269EBE049DA8"
-      },
+      "datasource": "$datasource",
       "description": "The number of audit violations per constraint detected in the last audit cycle",
       "fieldConfig": {
         "defaults": {
@@ -500,10 +464,7 @@
       "pluginVersion": "9.2.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "sum by (enforcement_action) (gatekeeper_violations)",
           "format": "time_series",
@@ -518,10 +479,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PE090269EBE049DA8"
-      },
+      "datasource": "$datasource",
       "description": "Latency of audit operation",
       "fieldConfig": {
         "defaults": {
@@ -572,10 +530,7 @@
       "pluginVersion": "9.2.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "rate(gatekeeper_audit_duration_seconds_count[10m])",
           "interval": "",
@@ -588,10 +543,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PE090269EBE049DA8"
-      },
+      "datasource": "$datasource",
       "description": "Description: Timestamp of last audit run time",
       "fieldConfig": {
         "defaults": {
@@ -642,10 +594,7 @@
       "pluginVersion": "9.2.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "time() - gatekeeper_audit_last_run_time",
           "interval": "",
@@ -658,10 +607,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PE090269EBE049DA8"
-      },
+      "datasource": "$datasource",
       "description": "Total number of watched GroupVersionKinds",
       "fieldConfig": {
         "defaults": {
@@ -712,10 +658,7 @@
       "pluginVersion": "9.2.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "sum(gatekeeper_watch_manager_watched_gvk{pod=~\"gatekeeper-controller.+\"}) / sum(gatekeeper_watch_manager_watched_gvk{pod=~\"gatekeeper-controller.+\"})",
           "interval": "",
@@ -728,10 +671,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PE090269EBE049DA8"
-      },
+      "datasource": "$datasource",
       "description": "Total number of GroupVersionKinds with a registered watch intent",
       "fieldConfig": {
         "defaults": {
@@ -782,10 +722,7 @@
       "pluginVersion": "9.2.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "sum(gatekeeper_watch_manager_intended_watch_gvk{pod=~\"gatekeeper-controller.+\"}) / sum(gatekeeper_watch_manager_intended_watch_gvk{pod=~\"gatekeeper-controller.+\"})",
           "interval": "",
@@ -799,10 +736,7 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PE090269EBE049DA8"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -813,10 +747,7 @@
       "panels": [],
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "refId": "A"
         }
       ],
@@ -824,10 +755,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PE090269EBE049DA8"
-      },
+      "datasource": "$datasource",
       "description": "Description: The number of requests that are routed to mutation webhook",
       "fieldConfig": {
         "defaults": {
@@ -906,10 +834,7 @@
       "pluginVersion": "8.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "exemplar": false,
           "expr": "sum by (mutation_status, pod) (rate(gatekeeper_mutation_request_count[20m]))",
           "interval": "",
@@ -921,10 +846,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PE090269EBE049DA8"
-      },
+      "datasource": "$datasource",
       "description": "Description: The number of requests that are routed to validation webhook",
       "fieldConfig": {
         "defaults": {
@@ -1003,10 +925,7 @@
       "pluginVersion": "8.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "sum by (admission_status, pod) (rate(gatekeeper_validation_request_count[20m]))",
           "interval": "",
@@ -1019,10 +938,7 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PE090269EBE049DA8"
-      },
+      "datasource": "$datasource",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1033,10 +949,7 @@
       "panels": [],
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "refId": "A"
         }
       ],
@@ -1044,10 +957,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PE090269EBE049DA8"
-      },
+      "datasource": "$datasource",
       "description": "Description: Current number of constraint templates\n\nUnderstanding this metric: Gatekeeper subscribes to a watch on all ConstraintTemplate resources. Whenever one is created or deleted on the cluster, this count gets updated.",
       "fieldConfig": {
         "defaults": {
@@ -1096,10 +1006,7 @@
       "pluginVersion": "9.2.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "sum by (status) (gatekeeper_constraint_templates{pod=~\"gatekeeper-controller-manager-.+\"})",
           "interval": "",
@@ -1111,10 +1018,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PE090269EBE049DA8"
-      },
+      "datasource": "$datasource",
       "description": "Current number of constraints\nUnderstanding this metric: Gatekeeper subscribes to a watch on all constraint resources. Whenever one is created or deleted on the cluster, this count gets updated.",
       "fieldConfig": {
         "defaults": {
@@ -1224,10 +1128,7 @@
       "pluginVersion": "9.2.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "sum by (enforcement_action) (gatekeeper_constraints)",
           "format": "time_series",
@@ -1242,10 +1143,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PE090269EBE049DA8"
-      },
+      "datasource": "$datasource",
       "description": "Description: Constraint Template ingestion duration distribution\n\nUnderstanding this metric: When Gatekeeper is notified of a new constraint template, records the time from when it has loaded the resource from etcd to after OPA successfully returns from compiling the code. If there is a compilation error, the metric is not updated.",
       "fieldConfig": {
         "defaults": {
@@ -1324,10 +1222,7 @@
       "pluginVersion": "8.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PE090269EBE049DA8"
-          },
+          "datasource": "$datasource",
           "exemplar": true,
           "expr": "rate(gatekeeper_constraint_template_ingestion_count[10m])",
           "interval": "",
@@ -1349,8 +1244,8 @@
       {
         "current": {
           "selected": false,
-          "text": "Thanos All",
-          "value": "Thanos All"
+          "text": "default",
+          "value": "default"
         },
         "hide": 0,
         "includeAll": false,
@@ -1365,15 +1260,7 @@
         "type": "datasource"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "simon-sc",
-          "value": "simon-sc"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PE090269EBE049DA8"
-        },
+        "datasource": "$datasource",
         "definition": "label_values(kube_pod_info, cluster)",
         "hide": 2,
         "includeAll": false,
@@ -1425,7 +1312,7 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {

--- a/helmfile/charts/grafana-ops/files/welcome.md
+++ b/helmfile/charts/grafana-ops/files/welcome.md
@@ -4,12 +4,10 @@
 
 Here you can find the most relevant features and changes for the last couple of releases of Compliant Kubernetes
 
+- The Fluentd deplyoment has changed considerably and users must ensure that their custom filters continues to work as expected. **[v0.29]**
+- Static users can now be added in OpenSearch. **[v0.29]**
 - Nginx ingress controller service now allows multiple annotations. **[v0.28]**
 - All grafana dashboards now use the default organization timezone. **[v0.28]**
-- NetworkPolicies are now automatically propagated from a parent namespace to its child namespaces. **[v0.27]**
-- Made Dex tokens expiry times configurable. **[v0.27]**
-- Alertmanager for the user is enabled by default. **[v0.27]**
-- Admin users can now view Gatekeeper constraints. **[v0.27]**
 
 ## Public docs
 

--- a/helmfile/charts/grafana-ops/values.yaml
+++ b/helmfile/charts/grafana-ops/values.yaml
@@ -23,7 +23,7 @@ dashboards:
     enabled: true
     user_visible: false
     sync: []
-  elasticsearch:
+  opensearch:
     enabled: true
     user_visible: false
   falco:

--- a/helmfile/charts/log-manager/templates/cronjob-compaction.yaml
+++ b/helmfile/charts/log-manager/templates/cronjob-compaction.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .bucket }}-{{ .prefix }}-compaction
+  name: {{ .name }}-{{ .prefix }}-compaction
   labels:
     {{- include "log-manager.labels" $ | nindent 4 }}
 spec:

--- a/helmfile/charts/log-manager/templates/cronjob-retention.yaml
+++ b/helmfile/charts/log-manager/templates/cronjob-retention.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .bucket }}-{{ .prefix }}-retention
+  name: {{ .name }}-{{ .prefix }}-retention
   labels:
     {{- include "log-manager.labels" $ | nindent 4 }}
 spec:

--- a/helmfile/charts/networkpolicy/common/templates/cert-manager/cainjector.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/cert-manager/cainjector.yaml
@@ -14,6 +14,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.port .Values.global.apiserver.ips }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -22,4 +23,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/cert-manager/certmanager.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/cert-manager/certmanager.yaml
@@ -25,6 +25,7 @@ spec:
     - ports:
       - port: 53
         protocol: UDP
+    {{- if and .Values.certManager.letsencrypt.ips .Values.certManager.letsencrypt.port }}
     - to:
         {{- range $IP := .Values.certManager.letsencrypt.ips }}
         - ipBlock:
@@ -33,6 +34,8 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.certManager.letsencrypt.port }}
+    {{- end }}
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -41,13 +44,15 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
+    {{- if or .Values.global.ingress.ips (and .Values.global.nodes.ips .Values.global.ingressUsingHostNetwork) }}
     - to:
-      {{- if .Values.global.externalLoadBalancer }}
+      {{- if and .Values.global.ingress.ips .Values.global.externalLoadBalancer }}
         {{- range $IP := .Values.global.ingress.ips }}
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
-      {{- else if .Values.global.ingressUsingHostNetwork }}
+      {{- else if and .Values.global.nodes.ips .Values.global.ingressUsingHostNetwork }}
         {{- range $IP := .Values.global.nodes.ips }}
         - ipBlock:
             cidr: {{ $IP }}
@@ -70,4 +75,5 @@ spec:
           port: 443
         - protocol: TCP
           port: 80
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/cert-manager/resolver.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/cert-manager/resolver.yaml
@@ -11,7 +11,7 @@ spec:
       acme.cert-manager.io/http01-solver: "true"
   ingress:
     - from:
-      {{- if $.Values.global.ingressUsingHostNetwork }}
+      {{- if and $.Values.global.nodes.ips $.Values.global.ingressUsingHostNetwork }}
         {{- range $ip := $.Values.global.nodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}

--- a/helmfile/charts/networkpolicy/common/templates/cert-manager/startupapicheck.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/cert-manager/startupapicheck.yaml
@@ -11,6 +11,7 @@ spec:
   policyTypes:
     - Egress
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -19,4 +20,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/cert-manager/webhook.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/cert-manager/webhook.yaml
@@ -12,6 +12,7 @@ spec:
     - Ingress
     - Egress
   ingress:
+    {{- if .Values.global.apiserver.ips }}
     - from:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -20,10 +21,12 @@ spec:
       ports:
         - protocol: TCP
           port: 10250 ## admission, use api server loop
+    {{- end }}
   egress:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.port .Values.global.apiserver.ips }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -32,4 +35,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/ciskubebench-exporter/allow-ciskubebench-exporter-metrics.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/ciskubebench-exporter/allow-ciskubebench-exporter-metrics.yaml
@@ -19,6 +19,7 @@ spec:
       ports:
         - port: 9100
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -27,6 +28,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/common/templates/coredns/allow-coredns.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/coredns/allow-coredns.yaml
@@ -30,6 +30,7 @@ spec:
       ports:
         - port: 9153
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
       {{- range $IP := .Values.global.apiserver.ips }}
       - ipBlock:
@@ -37,22 +38,31 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
+    {{- if or .Values.global.nodes.ips .Values.coredns.serviceIp.ips .Values.coredns.externalDns.ips }}
     - to:
+      {{- if .Values.global.nodes.ips }}
       {{- range $IP := .Values.global.nodes.ips }}
       - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
+      {{- end }}
+      {{- if .Values.coredns.serviceIp.ips }}
       {{- range $IP := .Values.coredns.serviceIp.ips }}
       - ipBlock:
           cidr: {{ $IP }}
         {{- end }}
+      {{- end }}
+      {{- if .Values.coredns.externalDns.ips }}
       {{- range $IP := .Values.coredns.externalDns.ips }}
       - ipBlock:
           cidr: {{ $IP }}
+      {{- end }}
       {{- end }}
       ports:
         - port: 53
           protocol: UDP
         - port: 53
           protocol: TCP
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/dns-autoscaler/allow-dns-autoscaler.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/dns-autoscaler/allow-dns-autoscaler.yaml
@@ -11,19 +11,26 @@ spec:
     - Egress
     - Ingress
   ingress:
+    {{- if or .Values.global.nodes.ips .Values.global.apiserver.ips }}
     - from:
+      {{- if .Values.global.nodes.ips }}
       {{- range $ip := .Values.global.nodes.ips }}
       - ipBlock:
           cidr: {{ $ip }}
       {{- end }}
+      {{- end }}
+      {{- if .Values.global.apiserver.ips }}
       {{- range $IP := .Values.global.apiserver.ips }}
       - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
+      {{- end }}
       ports:
         - port: 8080
           protocol: TCP
+    {{- end }}
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
       {{- range $IP := .Values.global.apiserver.ips }}
       - ipBlock:
@@ -31,4 +38,5 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/falco/allow-falco.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/falco/allow-falco.yaml
@@ -18,6 +18,7 @@ spec:
             app.kubernetes.io/name: falcosidekick
       ports:
         - port: 2801
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
       - ipBlock:
@@ -25,6 +26,8 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
+    {{- if and .Values.falco.plugins.ips .Values.falco.plugins.ports }}
     - to:
         {{- range $ip := .Values.falco.plugins.ips }}
         - ipBlock:
@@ -35,6 +38,7 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
         - port: 53
           protocol: UDP

--- a/helmfile/charts/networkpolicy/common/templates/kube-system/csi-cinder.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/kube-system/csi-cinder.yaml
@@ -18,6 +18,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -25,6 +26,8 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
+    {{- if and .Values.kubeSystem.openstack.ips .Values.kubeSystem.openstack.ports }}
     - to:
         {{- range .Values.kubeSystem.openstack.ips }}
         - ipBlock:
@@ -34,4 +37,5 @@ spec:
         {{- range .Values.kubeSystem.openstack.ports }}
         - port: {{ . }}
         {{- end }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/kube-system/csi-upcloud.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/kube-system/csi-upcloud.yaml
@@ -18,6 +18,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -25,6 +26,8 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
+    {{- if and .Values.kubeSystem.upcloud.ips .Values.kubeSystem.upcloud.ports }}
     - to:
         {{- range .Values.kubeSystem.upcloud.ips }}
         - ipBlock:
@@ -34,4 +37,5 @@ spec:
         {{- range .Values.kubeSystem.upcloud.ports }}
         - port: {{ . }}
         {{- end }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/kube-system/metrics-server.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/kube-system/metrics-server.yaml
@@ -14,6 +14,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: metrics-server
   ingress:
+    {{- if .Values.global.apiserver.ips }}
     - from:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -21,10 +22,12 @@ spec:
         {{- end }}
       ports:
         - port: 8443
+    {{- end }}
   egress:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -32,6 +35,8 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
+    {{- if .Values.global.nodes.ips }}
     - to:
         {{- range .Values.global.nodes.ips }}
         - ipBlock:
@@ -39,4 +44,5 @@ spec:
         {{- end }}
       ports:
         - port: 10250
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/kube-system/snapshot-controller.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/kube-system/snapshot-controller.yaml
@@ -18,6 +18,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -25,4 +26,5 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/kured/allow.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/kured/allow.yaml
@@ -21,6 +21,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -28,7 +29,8 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
-    {{- if .Values.kured.notificationSlack.enabled }}
+    {{- end }}
+    {{- if and .Values.kured.notificationSlack.enabled .Values.kured.notificationSlack.ips .Values.kured.notificationSlack.ports }}
     - to:
         {{- range .Values.kured.notificationSlack.ips }}
         - ipBlock:

--- a/helmfile/charts/networkpolicy/common/templates/prometheus/allow-blackbox-exporter.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/prometheus/allow-blackbox-exporter.yaml
@@ -23,11 +23,13 @@ spec:
     - to:
         - namespaceSelector: {}
     # probes to pods with hostnetwork
+    {{- if .Values.global.nodes.ips }}
     - to:
         {{- range $ip := .Values.global.nodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/common/templates/prometheus/allow-kube-state-metrics.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/prometheus/allow-kube-state-metrics.yaml
@@ -19,6 +19,7 @@ spec:
       ports:
         - port: 8080
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -27,4 +28,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/prometheus/allow-prometheus-admission-create.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/prometheus/allow-prometheus-admission-create.yaml
@@ -12,6 +12,7 @@ spec:
     - Ingress
     - Egress
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -20,4 +21,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/prometheus/allow-prometheus-admission-patch.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/prometheus/allow-prometheus-admission-patch.yaml
@@ -12,6 +12,7 @@ spec:
     - Ingress
     - Egress
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -20,4 +21,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/prometheus/allow-prometheus-operator.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/prometheus/allow-prometheus-operator.yaml
@@ -18,6 +18,7 @@ spec:
               app: prometheus
       ports:
         - port: 10250
+    {{- if .Values.global.apiserver.ips }}
     - from:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -25,7 +26,9 @@ spec:
         {{- end }}
       ports:
         - port: 10250
+    {{- end }}
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -34,4 +37,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/prometheus/allow-prometheus.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/prometheus/allow-prometheus.yaml
@@ -28,6 +28,7 @@ spec:
     # metrics from pods in the cluster
     - to:
         - namespaceSelector: {}
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -36,12 +37,15 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
     # metrics from kubelet, calico and other host-network exporters
+    {{- if .Values.global.nodes.ips }}
     - to:
         {{- range $ip := .Values.global.nodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/ceph-tools.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/ceph-tools.yaml
@@ -11,6 +11,7 @@ spec:
     matchLabels:
       app: rook-ceph-tools
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -19,6 +20,7 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
     - to:
         - podSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/csi-detect-version.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/csi-detect-version.yaml
@@ -11,6 +11,7 @@ spec:
     matchLabels:
       app: rook-ceph-csi-detect-version
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -19,4 +20,5 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/csi-rbdplugin-provisioner.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/csi-rbdplugin-provisioner.yaml
@@ -11,6 +11,7 @@ spec:
     matchLabels:
       app: csi-rbdplugin-provisioner
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -19,6 +20,7 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
     - to:
         - podSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/detect-version.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/detect-version.yaml
@@ -11,6 +11,7 @@ spec:
     matchLabels:
       app: rook-ceph-detect-version
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -19,4 +20,5 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/mgr.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/mgr.yaml
@@ -25,9 +25,11 @@ spec:
         - podSelector:
             matchLabels:
               app: rook-ceph-osd
+        {{- if .Values.global.nodes.ips }}
         {{- range $ip := .Values.global.nodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
+        {{- end }}
         {{- end }}
         - podSelector:
             matchLabels:
@@ -47,6 +49,7 @@ spec:
         - port: 6800
           protocol: TCP
           endPort: 7300
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -55,6 +58,7 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
     - to:
         - podSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/mon.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/mon.yaml
@@ -22,9 +22,11 @@ spec:
         - podSelector:
             matchLabels:
               app: rook-ceph-osd
+        {{- if .Values.global.nodes.ips }}
         {{- range $ip := .Values.global.nodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
+        {{- end }}
         {{- end }}
         - podSelector:
             matchLabels:
@@ -62,6 +64,7 @@ spec:
           endPort: 7300
         - port: 9283
           protocol: TCP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -70,6 +73,7 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
     - to:
         - podSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/operator.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/operator.yaml
@@ -32,6 +32,7 @@ spec:
           endPort: 7300
         - port: 9283
           protocol: TCP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -40,6 +41,7 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
     - to:
         - podSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/osd-prepare.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/osd-prepare.yaml
@@ -11,6 +11,7 @@ spec:
     matchLabels:
       app: rook-ceph-osd-prepare
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -19,6 +20,7 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
     - to:
         - podSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/osd.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/osd.yaml
@@ -25,9 +25,11 @@ spec:
         - podSelector:
             matchLabels:
               app: csi-rbdplugin-provisioner
+        {{- if .Values.global.nodes.ips }}
         {{- range $ip := .Values.global.nodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
+        {{- end }}
         {{- end }}
       ports:
         - port: 6800
@@ -44,6 +46,7 @@ spec:
           endPort: 7300
         - port: 9283
           protocol: TCP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $ip := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -52,6 +55,7 @@ spec:
       ports:
         - port: {{ .Values.global.apiserver.port }}
           protocol: TCP
+    {{- end }}
     - to:
         - podSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/common/templates/starboard/allow-cisbenchmark-scanner.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/starboard/allow-cisbenchmark-scanner.yaml
@@ -12,6 +12,7 @@ spec:
   policyTypes:
     - Egress
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -20,6 +21,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/common/templates/starboard/allow-starboard-operator.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/starboard/allow-starboard-operator.yaml
@@ -12,6 +12,7 @@ spec:
   policyTypes:
     - Egress
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -20,4 +21,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/starboard/allow-vulnerability-report-scanner.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/starboard/allow-vulnerability-report-scanner.yaml
@@ -11,6 +11,7 @@ spec:
   policyTypes:
     - Egress
   egress:
+    {{- if and .Values.global.trivy.ips .Values.global.trivy.port }}
     - to:
         {{- range $IP := .Values.global.trivy.ips }}
         - ipBlock:
@@ -19,6 +20,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.trivy.port }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/common/templates/velero/allow-restic.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/velero/allow-restic.yaml
@@ -18,6 +18,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -25,6 +26,8 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -34,4 +37,5 @@ spec:
         {{- range .Values.global.objectStorage.ports }}
         - port: {{ . }}
         {{- end }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/velero/allow-velero-upgrade-crds.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/velero/allow-velero-upgrade-crds.yaml
@@ -17,6 +17,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -24,4 +25,5 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/velero/allow-velero.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/velero/allow-velero.yaml
@@ -22,6 +22,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range .Values.global.apiserver.ips }}
         - ipBlock:
@@ -29,6 +30,8 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.apiserver.port }}
+    {{- end }}
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -38,4 +41,5 @@ spec:
         {{- range .Values.global.objectStorage.ports }}
         - port: {{ . }}
         {{- end }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/common/templates/vulnerability-exporter/allow-vulnerability-exporter-metrics.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/vulnerability-exporter/allow-vulnerability-exporter-metrics.yaml
@@ -19,6 +19,7 @@ spec:
       ports:
         - port: 9100
   egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
     - to:
         {{- range $IP := .Values.global.apiserver.ips }}
         - ipBlock:
@@ -27,6 +28,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.apiserver.port }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/service-cluster/templates/alertmanager/allow-alertmanager.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/alertmanager/allow-alertmanager.yaml
@@ -40,6 +40,7 @@ spec:
         - podSelector:
             matchLabels:
               app: alertmanager
+    {{- if and .Values.monitoring.alertmanager.alertReceivers.ips .Values.monitoring.alertmanager.alertReceivers.ports }}
     - to:
         {{- range $ip := .Values.monitoring.alertmanager.alertReceivers.ips }}
         - ipBlock:
@@ -49,6 +50,7 @@ spec:
         {{- range $port := .Values.monitoring.alertmanager.alertReceivers.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/service-cluster/templates/dex/allow-dex.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/dex/allow-dex.yaml
@@ -13,7 +13,7 @@ spec:
       app.kubernetes.io/name: dex
   ingress:
     - from:
-      {{- if .Values.global.ingressUsingHostNetwork }}
+      {{- if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
@@ -58,6 +58,7 @@ spec:
       ports:
         - port: 5558
   egress:
+    {{- if and .Values.dex.connectors.ips .Values.dex.connectors.ports }}
     - to:
       {{- range $ip := .Values.dex.connectors.ips }}
       - ipBlock:
@@ -67,6 +68,8 @@ spec:
         {{- range $port := .Values.dex.connectors.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
+    {{- if and .Values.global.scApiserver.ips .Values.global.scApiserver.port }}
     - to:
         {{- range $IP := .Values.global.scApiserver.ips }}
       - ipBlock:
@@ -74,6 +77,7 @@ spec:
         {{- end }}
       ports:
         - port: {{ .Values.global.scApiserver.port }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/service-cluster/templates/grafana/allow-grafana.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/grafana/allow-grafana.yaml
@@ -13,7 +13,7 @@ spec:
     - Egress
   ingress:
     - from:
-      {{- if .Values.global.ingressUsingHostNetwork }}
+      {{- if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
@@ -64,6 +64,7 @@ spec:
       ports:
         - port: 5556
           protocol: TCP
+    {{- if and .Values.global.scApiserver.ips .Values.global.scApiserver.port }}
     - to:
         {{- range $ip := .Values.global.scApiserver.ips }}
         - ipBlock:
@@ -72,7 +73,9 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.scApiserver.port }}
+    {{- end }}
     # loading dashboards from grafana website
+    {{- if and .Values.monitoring.grafana.externalDashboardProvider.ips .Values.monitoring.grafana.externalDashboardProvider.ports }}
     - to:
         {{- range $ip := .Values.monitoring.grafana.externalDashboardProvider.ips }}
         - ipBlock:
@@ -82,6 +85,7 @@ spec:
         {{- range $port := .Values.monitoring.grafana.externalDashboardProvider.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: TCP
         port: 53

--- a/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-acme-pods.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-acme-pods.yaml
@@ -12,12 +12,12 @@ spec:
       acme.cert-manager.io/http01-solver: "true"
   ingress:
     - from:
-      {{- if .Values.global.externalLoadBalancer }}
+      {{- if and .Values.global.externalLoadBalancer .Values.global.scIngress.ips }}
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
-      {{- else if .Values.global.ingressUsingHostNetwork }}
+      {{- else if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-backup.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-backup.yaml
@@ -21,6 +21,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -30,5 +31,6 @@ spec:
         {{- range .Values.global.objectStorage.ports }}
         - port: {{ . }}
         {{- end }}
+    {{- end }}
 {{- end }}
 {{ end }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-chartmuseum.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-chartmuseum.yaml
@@ -49,6 +49,7 @@ spec:
       {{- end }}
     {{- end }}
   {{- end }}
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $IP := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -59,4 +60,5 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
 {{ end }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-core.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-core.yaml
@@ -17,20 +17,22 @@ spec:
           protocol: TCP
   egress:
     - to:
-      {{- if .Values.global.externalLoadBalancer }}
+      {{- if and .Values.global.externalLoadBalancer .Values.global.scIngress.ips }}
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
-      {{- else if .Values.global.ingressUsingHostNetwork }}
+      {{- else if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
       {{- else }}
+        {{- if .Values.global.scIngress.ips }}
         {{- range $IP := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $IP }}
+        {{- end }}
         {{- end }}
         - namespaceSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-registry.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-registry.yaml
@@ -20,6 +20,7 @@ spec:
         - port: 5000
         - port: 8080
   egress:
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $IP := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -30,6 +31,7 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
     {{- if eq .Values.harbor.redis.type "internal" }}
     - to:
         - podSelector:

--- a/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-trivy.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-trivy.yaml
@@ -58,6 +58,7 @@ spec:
               component: core
       ports:
         - port: 8080
+    {{- if and .Values.harbor.trivy.ips .Values.harbor.trivy.port }}
     - to:
         {{- range $IP := .Values.harbor.trivy.ips }}
         - ipBlock:
@@ -66,4 +67,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.harbor.trivy.port }}
+    {{- end }}
 {{ end }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/ingress-nginx/controller.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/ingress-nginx/controller.yaml
@@ -12,18 +12,21 @@ spec:
     - Ingress
     - Egress
   ingress:
+    {{- if or .Values.ingressNginx.ingressOverride.ips .Values.global.scNodes.ips .Values.global.scIngress.ips }}
     - from:
-      {{- if .Values.ingressNginx.ingressOverride.enabled }}
+      {{- if and .Values.ingressNginx.ingressOverride.enabled .Values.ingressNginx.ingressOverride.ips }}
         {{- range $IP := .Values.ingressNginx.ingressOverride.ips }}
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
       {{- else if not (or .Values.global.externalLoadBalancer .Values.global.ingressUsingHostNetwork) }}
+        {{- if .Values.global.scNodes.ips }}
         {{- range $IP := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
-      {{- else }}
+        {{- end }}
+      {{- else if .Values.global.scIngress.ips }}
         {{- range $IP := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $IP }}
@@ -34,6 +37,7 @@ spec:
           port: 443
         - protocol: TCP
           port: 80
+    {{- end }}
     - from:
         - namespaceSelector:
             matchLabels:
@@ -44,9 +48,11 @@ spec:
       ports:
         - port: 10254
     - from:
+        {{- if .Values.global.scApiserver.ips }}
         {{- range $IP := .Values.global.scApiserver.ips }}
         - ipBlock:
             cidr: {{ $IP }}
+        {{- end }}
         {{- end }}
         - namespaceSelector:
             matchLabels:
@@ -62,13 +68,14 @@ spec:
     - ports:
       - port: 53
         protocol: UDP
+    {{- if or .Values.ingressNginx.ingressOverride.ips .Values.global.scIngress.ips }}
     - to:
-      {{- if .Values.ingressNginx.ingressOverride.enabled }}
+      {{- if and .Values.ingressNginx.ingressOverride.enabled .Values.ingressNginx.ingressOverride.ips }}
         {{- range $IP := .Values.ingressNginx.ingressOverride.ips }}
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
-      {{- else }}
+      {{- else if .Values.global.scIngress.ips }}
         {{- range $IP := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $IP }}
@@ -79,6 +86,8 @@ spec:
           port: 443
         - protocol: TCP
           port: 80
+    {{- end }}
+    {{- if and .Values.global.scApiserver.ips .Values.global.scApiserver.port }}
     - to:
         {{- range $IP := .Values.global.scApiserver.ips }}
         - ipBlock:
@@ -87,6 +96,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.scApiserver.port }}
+    {{- end }}
     - to:
         - namespaceSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/service-cluster/templates/ingress-nginx/default-backend.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/ingress-nginx/default-backend.yaml
@@ -12,7 +12,7 @@ spec:
     - Ingress
   ingress:
     - from:
-      {{- if .Values.global.ingressUsingHostNetwork }}
+      {{- if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/ingress-nginx/webhook.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/ingress-nginx/webhook.yaml
@@ -14,6 +14,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.scApiserver.ips .Values.global.scApiserver.port }}
     - to:
         {{- range $IP := .Values.global.scApiserver.ips }}
         - ipBlock:
@@ -22,4 +23,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.scApiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/client.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/client.yaml
@@ -27,7 +27,7 @@ spec:
         - port: 9300
     # Allow api port from ingress-ngix
     - from:
-      {{- if .Values.global.ingressUsingHostNetwork }}
+      {{- if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
@@ -56,6 +56,7 @@ spec:
               app.kubernetes.io/component: opensearch-client
       ports:
         - port: 9300
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $ip := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -66,6 +67,8 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
+    {{- if and .Values.opensearch.plugins.ips .Values.opensearch.plugins.ports }}
     - to:
         {{- range $ip := .Values.opensearch.plugins.ips }}
         - ipBlock:
@@ -76,6 +79,7 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
         - port: 53
           protocol: UDP

--- a/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/dashboard.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/dashboard.yaml
@@ -13,7 +13,7 @@ spec:
       app: opensearch-dashboards
   ingress:
     - from:
-      {{- if .Values.global.ingressUsingHostNetwork }}
+      {{- if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
@@ -43,20 +43,22 @@ spec:
         - port: 53
           protocol: UDP
     - to:
-      {{- if .Values.global.externalLoadBalancer }}
+      {{- if and .Values.global.externalLoadBalancer .Values.global.scIngress.ips }}
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
-      {{- else if .Values.global.ingressUsingHostNetwork }}
+      {{- else if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
       {{- else }}
+        {{- if .Values.global.scIngress.ips }}
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
+        {{- end }}
         {{- end }}
         - namespaceSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/data.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/data.yaml
@@ -38,6 +38,7 @@ spec:
               app.kubernetes.io/component: opensearch-client
       ports:
         - port: 9300
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $ip := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -48,6 +49,8 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
+    {{- if and .Values.opensearch.plugins.ips .Values.opensearch.plugins.ports }}
     - to:
         {{- range $ip := .Values.opensearch.plugins.ips }}
         - ipBlock:
@@ -58,6 +61,7 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
         - port: 53
           protocol: UDP

--- a/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/master.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/master.yaml
@@ -36,7 +36,7 @@ spec:
               app.kubernetes.io/instance: opensearch-securityadmin
       {{- if not .Values.opensearch.client.enabled }}
       # Allow api port from ingress-ngix
-      {{- if .Values.global.ingressUsingHostNetwork }}
+      {{- if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
@@ -88,6 +88,7 @@ spec:
               kubernetes.io/metadata.name: dex
       ports:
         - port: 5556
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $ip := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -98,6 +99,8 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
+    {{- if and .Values.opensearch.plugins.ips .Values.opensearch.plugins.ports }}
     - to:
         {{- range $ip := .Values.opensearch.plugins.ips }}
         - ipBlock:
@@ -108,21 +111,24 @@ spec:
         - protocol: TCP
           port: {{ $port }}
         {{- end }}
+    {{- end }}
     - to:
-      {{- if .Values.global.externalLoadBalancer }}
+      {{- if and .Values.global.externalLoadBalancer .Values.global.scIngress.ips }}
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
-      {{- else if .Values.global.ingressUsingHostNetwork }}
+      {{- else if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
       {{- else }}
+        {{- if .Values.global.scIngress.ips }}
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
+        {{- end }}
         {{- end }}
         - namespaceSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/service-cluster/templates/prometheus/allow-blackbox-exporter.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/prometheus/allow-blackbox-exporter.yaml
@@ -11,27 +11,31 @@ spec:
   policyTypes:
     - Egress
   egress:
+    {{- if .Values.global.wcIngress.ips }}
     - to:
         {{- range $ip := .Values.global.wcIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
+    {{- end }}
     # probes to sc ingress
     - to:
-      {{- if .Values.global.externalLoadBalancer }}
+      {{- if and .Values.global.externalLoadBalancer .Values.global.scIngress.ips }}
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
-      {{- else if .Values.global.ingressUsingHostNetwork }}
+      {{- else if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}
         {{- end }}
       {{- else }}
+        {{- if .Values.global.scIngress.ips }}
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
             cidr: {{ $ip }}
+        {{- end }}
         {{- end }}
         - namespaceSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/service-cluster/templates/rclone-sync.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/rclone-sync.yaml
@@ -16,6 +16,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -25,6 +26,8 @@ spec:
         {{- range .Values.global.objectStorage.ports }}
         - port: {{ . }}
         {{- end }}
+    {{- end }}
+    {{- if and .Values.rcloneSync.destinationObjectStorage.ips .Values.rcloneSync.destinationObjectStorage.ports }}
     - to:
         {{- range .Values.rcloneSync.destinationObjectStorage.ips }}
         - ipBlock:
@@ -34,4 +37,5 @@ spec:
         {{- range .Values.rcloneSync.destinationObjectStorage.ports }}
         - port: {{ . }}
         {{- end }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/s3-exporter.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/s3-exporter.yaml
@@ -19,6 +19,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -28,4 +29,5 @@ spec:
         {{- range .Values.global.objectStorage.ports }}
         - port: {{ . }}
         {{- end }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-buketweb.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-buketweb.yaml
@@ -23,6 +23,7 @@ spec:
         - port: 8080
           protocol: TCP
   egress:
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $ip := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -32,6 +33,7 @@ spec:
         {{- range $port := .Values.global.objectStorage.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-compactor.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-compactor.yaml
@@ -23,6 +23,7 @@ spec:
         - port: 10902
           protocol: TCP
   egress:
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $ip := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -32,6 +33,7 @@ spec:
         {{- range $port := .Values.global.objectStorage.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-receive-distributor.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-receive-distributor.yaml
@@ -13,7 +13,7 @@ spec:
     - Egress
   ingress:
     - from:
-      {{- if .Values.global.ingressUsingHostNetwork }}
+      {{- if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
         {{- range $ip := .Values.global.scNodes.ips }}
         - ipBlock:
             cidr: {{ $ip }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-receive.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-receive.yaml
@@ -33,6 +33,7 @@ spec:
         - port: 10902
           protocol: TCP
   egress:
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $ip := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -42,6 +43,7 @@ spec:
         {{- range $port := .Values.global.objectStorage.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-ruler.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-ruler.yaml
@@ -47,6 +47,7 @@ spec:
       ports:
         - port: 9093
           protocol: TCP
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $ip := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -56,6 +57,7 @@ spec:
         {{- range $port := .Values.global.objectStorage.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: TCP
         port: 53

--- a/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-storegateway.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/thanos/allow-thanos-storegateway.yaml
@@ -30,6 +30,7 @@ spec:
         - port: 10902
           protocol: TCP
   egress:
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
         {{- range $ip := .Values.global.objectStorage.ips }}
         - ipBlock:
@@ -39,6 +40,7 @@ spec:
         {{- range $port := .Values.global.objectStorage.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/alertmanager/allow-alertmanager.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/alertmanager/allow-alertmanager.yaml
@@ -46,6 +46,7 @@ spec:
         - podSelector:
             matchLabels:
               app: alertmanager
+    {{- if .Values.global.wcApiserver.ips }}
     - from:
         {{- range $ip := .Values.global.wcApiserver.ips }}
         - ipBlock:
@@ -54,11 +55,13 @@ spec:
       ports:
         - port: 9093
           protocol: TCP
+    {{- end }}
   egress:
     - to:
         - podSelector:
             matchLabels:
               app: alertmanager
+    {{- if and .Values.alertmanager.alertReceivers.ips .Values.alertmanager.alertReceivers.ports }}
     - to:
         {{- range $ip := .Values.alertmanager.alertReceivers.ips }}
         - ipBlock:
@@ -68,6 +71,7 @@ spec:
         {{- range $port := .Values.alertmanager.alertReceivers.ports }}
         - port: {{ $port }}
         {{- end }}
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/gatekeeper/allow-controller-manager.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/gatekeeper/allow-controller-manager.yaml
@@ -28,14 +28,17 @@ spec:
           podSelector:
             matchLabels:
               app.kubernetes.io/name: prometheus-blackbox-exporter
+        {{- if .Values.global.wcApiserver.ips }}
         {{- range $IP := .Values.global.wcApiserver.ips }}
         - ipBlock:
             cidr: {{ $IP }}
+        {{- end }}
         {{- end }}
       ports:
         - protocol: TCP
           port: 8443
   egress:
+    {{- if and .Values.global.wcApiserver.ips .Values.global.wcApiserver.port }}
     - to:
         {{- range $IP := .Values.global.wcApiserver.ips }}
         - ipBlock:
@@ -44,4 +47,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.wcApiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/gatekeeper/allow-gatekeeper-audit-controller.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/gatekeeper/allow-gatekeeper-audit-controller.yaml
@@ -22,6 +22,7 @@ spec:
       ports:
         - port: 8888
   egress:
+    {{- if and .Values.global.wcApiserver.ips .Values.global.wcApiserver.port }}
     - to:
         {{- range $IP := .Values.global.wcApiserver.ips }}
         - ipBlock:
@@ -30,4 +31,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.wcApiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/gatekeeper/allow-gatekeeper-update-crds-hook.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/gatekeeper/allow-gatekeeper-update-crds-hook.yaml
@@ -12,6 +12,7 @@ spec:
     - Ingress
     - Egress
   egress:
+    {{- if and .Values.global.wcApiserver.ips .Values.global.wcApiserver.port }}
     - to:
         {{- range $IP := .Values.global.wcApiserver.ips }}
         - ipBlock:
@@ -20,4 +21,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.wcApiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/gatekeeper/allow-gatekeeper-update-namespace-label.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/gatekeeper/allow-gatekeeper-update-namespace-label.yaml
@@ -12,6 +12,7 @@ spec:
     - Ingress
     - Egress
   egress:
+    {{- if and .Values.global.wcApiserver.ips .Values.global.wcApiserver.port }}
     - to:
         {{- range $IP := .Values.global.wcApiserver.ips }}
         - ipBlock:
@@ -20,4 +21,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.wcApiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/ingress-nginx/controller.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/ingress-nginx/controller.yaml
@@ -12,18 +12,21 @@ spec:
     - Ingress
     - Egress
   ingress:
+    {{- if or .Values.ingressNginx.ingressOverride.ips .Values.global.wcNodes.ips .Values.global.wcIngress.ips }}
     - from:
-      {{- if .Values.ingressNginx.ingressOverride.enabled }}
+      {{- if and .Values.ingressNginx.ingressOverride.enabled .Values.ingressNginx.ingressOverride.ips }}
         {{- range $IP := .Values.ingressNginx.ingressOverride.ips }}
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
       {{- else if not (or .Values.global.externalLoadBalancer .Values.global.ingressUsingHostNetwork) }}
+        {{- if .Values.global.wcNodes.ips }}
         {{- range $IP := .Values.global.wcNodes.ips }}
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
-      {{- else }}
+        {{- end }}
+      {{- else if .Values.global.wcIngress.ips }}
         {{- range $IP := .Values.global.wcIngress.ips }}
         - ipBlock:
             cidr: {{ $IP }}
@@ -34,6 +37,7 @@ spec:
           port: 443
         - protocol: TCP
           port: 80
+    {{- end }}
     - from:
         - namespaceSelector:
             matchLabels:
@@ -44,9 +48,11 @@ spec:
       ports:
         - port: 10254
     - from:
+        {{- if .Values.global.wcApiserver.ips }}
         {{- range $IP := .Values.global.wcApiserver.ips }}
         - ipBlock:
             cidr: {{ $IP }}
+        {{- end }}
         {{- end }}
         - namespaceSelector:
             matchLabels:
@@ -62,13 +68,14 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if or .Values.ingressNginx.ingressOverride.ips .Values.global.wcIngress.ips }}
     - to:
-      {{- if .Values.ingressNginx.ingressOverride.enabled }}
+      {{- if and .Values.ingressNginx.ingressOverride.enabled .Values.ingressNginx.ingressOverride.ips }}
         {{- range $IP := .Values.ingressNginx.ingressOverride.ips }}
         - ipBlock:
             cidr: {{ $IP }}
         {{- end }}
-      {{- else }}
+      {{- else if .Values.global.wcIngress.ips }}
         {{- range $IP := .Values.global.wcIngress.ips }}
         - ipBlock:
             cidr: {{ $IP }}
@@ -79,6 +86,8 @@ spec:
           port: 443
         - protocol: TCP
           port: 80
+    {{- end }}
+    {{- if and .Values.global.wcApiserver.ips .Values.global.wcApiserver.port }}
     - to:
         {{- range $IP := .Values.global.wcApiserver.ips }}
         - ipBlock:
@@ -87,6 +96,7 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.wcApiserver.port }}
+    {{- end }}
     - to:
         - namespaceSelector:
             matchLabels:

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/ingress-nginx/default-backend.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/ingress-nginx/default-backend.yaml
@@ -12,7 +12,7 @@ spec:
     - Ingress
   ingress:
     - from:
-      {{- if .Values.global.ingressUsingHostNetwork }}
+      {{- if and .Values.global.ingressUsingHostNetwork .Values.global.wcNodes.ips }}
       {{- range $ip := .Values.global.wcNodes.ips }}
       - ipBlock:
           cidr: {{ $ip }}

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/ingress-nginx/webhook.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/ingress-nginx/webhook.yaml
@@ -14,6 +14,7 @@ spec:
     - ports:
         - port: 53
           protocol: UDP
+    {{- if and .Values.global.wcApiserver.ips .Values.global.wcApiserver.port }}
     - to:
         {{- range $IP := .Values.global.wcApiserver.ips }}
         - ipBlock:
@@ -22,4 +23,5 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.global.wcApiserver.port }}
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/networkpolicy/workload-cluster/templates/prometheus/allow-prometheus.yaml
+++ b/helmfile/charts/networkpolicy/workload-cluster/templates/prometheus/allow-prometheus.yaml
@@ -13,6 +13,7 @@ spec:
     - Ingress
   egress:
     # thanos
+    {{- if .Values.global.scIngress.ips }}
     - to:
         {{- range $ip := .Values.global.scIngress.ips }}
         - ipBlock:
@@ -21,10 +22,12 @@ spec:
       ports:
       - protocol: TCP
         port: 443
+    {{- end }}
     - ports:
       - protocol: UDP
         port: 53
   ingress:
+    {{- if .Values.global.wcApiserver.ips }}
     - from:
         {{- range $ip := .Values.global.wcApiserver.ips }}
         - ipBlock:
@@ -33,4 +36,5 @@ spec:
       ports:
         - port: 9090
           protocol: TCP
+    {{- end }}
 {{- end }}

--- a/helmfile/charts/opensearch/configurer/files/dashboards-resources/welcome.md
+++ b/helmfile/charts/opensearch/configurer/files/dashboards-resources/welcome.md
@@ -4,12 +4,10 @@
 
 Here you can find the most relevant features and changes for the last couple of releases of Compliant Kubernetes
 
+- The Fluentd deplyoment has changed considerably and users must ensure that their custom filters continues to work as expected. **[v0.29]**
+- Static users can now be added in OpenSearch. **[v0.29]**
 - Nginx ingress controller service now allows multiple annotations. **[v0.28]**
 - All grafana dashboards now use the default organization timezone. **[v0.28]**
-- NetworkPolicies are now automatically propagated from a parent namespace to its child namespaces. **[v0.27]**
-- Made Dex tokens expiry times configurable. **[v0.27]**
-- Alertmanager for the user is enabled by default. **[v0.27]**
-- Admin users can now view Gatekeeper constraints. **[v0.27]**
 
 ## Public docs
 

--- a/helmfile/values/fluentd/log-manager.yaml.gotmpl
+++ b/helmfile/values/fluentd/log-manager.yaml.gotmpl
@@ -8,6 +8,7 @@ instances:
   {{- if .Values.fluentd.audit.enabled }}
   {{- range .Values.global.clustersMonitoring }}
   - bucket: {{ $.Values.objectStorage.buckets.audit }}
+    name: audit
     prefix: {{ . }}
     compaction:
       enabled: {{ $.Values.fluentd.audit.compaction.enabled }}
@@ -22,6 +23,7 @@ instances:
   {{- if .Values.fluentd.enabled }}
   {{- if .Values.fluentd.audit.enabled }}
   - bucket: {{ .Values.objectStorage.buckets.audit }}
+    name: audit
     prefix: {{ .Values.global.clusterName }}
     compaction:
       enabled: {{ .Values.fluentd.audit.compaction.enabled }}
@@ -34,6 +36,7 @@ instances:
   {{- end }}
   {{- if .Values.fluentd.scLogs.enabled }}
   - bucket: {{ .Values.objectStorage.buckets.scFluentd }}
+    name: sc-logs
     prefix: logs
     compaction:
       enabled: {{ .Values.fluentd.scLogs.compaction.enabled }}

--- a/helmfile/values/gatekeeper.yaml.gotmpl
+++ b/helmfile/values/gatekeeper.yaml.gotmpl
@@ -5,3 +5,7 @@ controllerManager:
   resources: {{- toYaml .Values.opa.controllerManager.resources | nindent 4  }}
 audit:
   resources: {{- toYaml .Values.opa.audit.resources | nindent 4  }}
+
+postInstall:
+  probeWebhook:
+    enabled: false

--- a/helmfile/values/grafana-ops.yaml.gotmpl
+++ b/helmfile/values/grafana-ops.yaml.gotmpl
@@ -23,7 +23,7 @@ dashboards:
       - {{ .source }}
       {{- end }}
     {{- end }}
-  elasticsearch:
+  opensearch:
     enabled: true
     user_visible: true
   falco:

--- a/migration/v0.29/README.md
+++ b/migration/v0.29/README.md
@@ -35,6 +35,15 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
 ## Prerequisites
 
+- [ ] Upgrade your version of helmfile and helm diff by following these steps:
+    - Uninstall `helm-diff` so that the new version can be installed:
+        ```console
+        $ helm plugin uninstall diff
+        ```
+    - From the root of your `compliantkubernetes-apps` directory, run ansible to get the updated requirements:
+        ```console
+        $ ansible-playbook -e 'ansible_python_interpreter=/usr/bin/python3' --ask-become-pass --connection local --inventory 127.0.0.1, get-requirements.yaml
+        ```
 - [ ] Notify the users (if any) before the upgrade starts;
 - [ ] Check if there are any pending changes to the environment;
 - [ ] Check the state of the environment, pods, nodes and backup jobs:
@@ -44,7 +53,6 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ./bin/ck8s test sc|wc cert-manager
     ./bin/ck8s test sc|wc ingress
     ./bin/ck8s test sc opensearch
-    ./bin/ck8s test wc hnc
     ./bin/ck8s ops kubectl sc|wc get pods -A -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-false:status.containerStatuses[*].ready,REASON:status.containerStatuses[*].state.terminated.reason | grep false | grep -v Completed
     ./bin/ck8s ops kubectl sc|wc get nodes
     ./bin/ck8s ops kubectl sc|wc get jobs -A
@@ -84,7 +92,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     > *Done before maintenance window.*
 
     ```bash
-    ./bin/ck8s upgrade prepare v0.29
+    ./bin/ck8s upgrade v0.29 prepare
     ```
 
 1. Apply upgrade - *disruptive*
@@ -92,7 +100,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     > *Done during maintenance window.*
 
     ```bash
-    ./bin/ck8s upgrade apply v0.29
+    ./bin/ck8s upgrade v0.29 apply
     ```
 
 ## Manual method


### PR DESCRIPTION
**What this PR does / why we need it**:

- Cherry-picked "empty network policies" commit: https://github.com/elastisys/compliantkubernetes-apps/commit/19d8684cbaa3969ada6eac481391cb3c037e3e81
- Fixed a few issues with the new gatekeeper dashboard
- Disabled new gatekeeper post-install probe because it caused the "label namespace" job to fail
- Upgraded helmfile and helm diff versions in `get-requirements.yaml` to make them work with the new upgrade scripts
- Updated migration guide to add steps with helmfile/helm diff upgrade and fix a few issues
- Updated welcome dashboard
- Cherry-picked opensearch dashboard fix: https://github.com/elastisys/compliantkubernetes-apps/pull/1460/commits/0e1a3a94bcf68fbdf2b7ea5b415cd9ecf38496a3
- Shortened the names of log-manager cronjobs

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
