### PR TITLE
apps: Correct version checks in migration script library

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -16,6 +16,7 @@
 - Increased interval for rook-ceph service monitor which fixes the grafana dashboard
 - Add document splits to helmfiles to prepare support for helmfile v0.150+
 - Added option to use nodePort for ingress-nginx.
+- Correct version checks in migration script library
 
 ### Updated
 

--- a/scripts/migration/lib.sh
+++ b/scripts/migration/lib.sh
@@ -226,7 +226,7 @@ check_version() {
   if [ "${VERSION["${1}-config"]}" = "any" ]; then
     log_warn "skipping version validation of ${1}-config for version \"${VERSION["${1}-config"]}\""
     return
-  elif [[ ! "${version}" =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+  elif [[ ! "${VERSION["${1}-config"]}" =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
     log_warn "reducing version validation of ${1}-config for version \"${VERSION["${1}-config"]}\""
   else
     log_info "version validation of ${1}-config for version \"${VERSION["${1}-config"]}\""
@@ -268,8 +268,7 @@ check_version() {
 
   local repo_version
   repo_version="$(git_version)"
-
-  if [[ "${repo_version%%.*}" == "${CK8S_TARGET_VERSION}" ]]; then
+  if [[ "${repo_version%.*}" == "${CK8S_TARGET_VERSION}" ]]; then
     log_info "valid repository version \"${repo_version}\""
   elif [[ "${repo_version}" == "${VERSION["${1}-config"]}" ]]; then
     log_warn "valid repository version \"${repo_version}\""


### PR DESCRIPTION
**What this PR does / why we need it**:

Found this bug when I demo:d the new upgrade method.

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
