### PR TITLE
apps: Run apply snippet without filters

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add document splits to helmfiles to prepare support for helmfile v0.150+
 - Added option to use nodePort for ingress-nginx.
 - Correct version checks in migration script library
+- Run migration apply snippet without filters
 
 ### Updated
 

--- a/migration/template/README.md
+++ b/migration/template/README.md
@@ -68,7 +68,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     > *Done before maintenance window.*
 
     ```bash
-    ./bin/ck8s upgrade prepare ${new_version}
+    ./bin/ck8s upgrade ${new_version} prepare
     ```
 
 1. Apply upgrade - *disruptive*
@@ -76,7 +76,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     > *Done during maintenance window.*
 
     ```bash
-    ./bin/ck8s upgrade apply ${new_version}
+    ./bin/ck8s upgrade ${new_version} apply
     ```
 
 ## Manual method
@@ -119,7 +119,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ```bash
     ./bin/ck8s apply {sc|wc}
     # or
-    ./migration/${new_version}/apply/99-apply.sh
+    ./migration/${new_version}/apply/80-apply.sh
     ```
 
 ## Postrequisite:

--- a/migration/template/apply/80-apply.sh
+++ b/migration/template/apply/80-apply.sh
@@ -24,16 +24,17 @@ run() {
     local selector
 
     filters=("${skipped[@]}" "${skipped_sc[@]}")
-    selector="${filters[*]}"
+    selector="${filters[*]:-"app!=null"}"
     helmfile_upgrade sc "${selector// /,}"
-
     filters=("${skipped[@]}" "${skipped_wc[@]}")
-    selector="${filters[*]}"
+    selector="${filters[*]:-"app!=null"}"
     helmfile_upgrade wc "${selector// /,}"
     ;;
+
   rollback)
     log_warn "rollback not implemented"
     ;;
+
   *)
     log_fatal "usage: \"${0}\" <execute|rollback>"
     ;;

--- a/migration/v0.30/apply/80-apply.sh
+++ b/migration/v0.30/apply/80-apply.sh
@@ -24,16 +24,17 @@ run() {
     local selector
 
     filters=("${skipped[@]}" "${skipped_sc[@]}")
-    selector="${filters[*]}"
+    selector="${filters[*]:-"app!=null"}"
     helmfile_upgrade sc "${selector// /,}"
-
     filters=("${skipped[@]}" "${skipped_wc[@]}")
-    selector="${filters[*]}"
+    selector="${filters[*]:-"app!=null"}"
     helmfile_upgrade wc "${selector// /,}"
     ;;
+
   rollback)
     log_warn "rollback not implemented"
     ;;
+
   *)
     log_fatal "usage: \"${0}\" <execute|rollback>"
     ;;

--- a/scripts/migration/helmfile.sh
+++ b/scripts/migration/helmfile.sh
@@ -125,7 +125,7 @@ helmfile_replace() {
 # will rollback on failure if CK8S_ROLLBACK is not false
 helmfile_upgrade() {
   if [[ "${#}" -lt 2 ]] || [[ ! "${1}" =~ ^(sc|wc)$ ]]; then
-    log_fatal "usage: helmfile_replace <sc|wc> <selectors>..."
+    log_fatal "usage: helmfile_upgrade <sc|wc> <selectors>..."
   fi
 
   log_info "upgrading ${1} ${*:2}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Bug that prevented the apply snippet to run when it doesn't have filters set.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
