### PR TITLE
apps: enabled psa for dex and cert-manager

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -14,8 +14,8 @@
 - Add Gatekeeper PSPs for Fluentd and OpenSearch
 - Add Gatekeeper PSPs for Kured.
 - Add Gatekeeper PSPs for Harbor
-- Add Gatekeeper mutation for setting job TTL if not already set.
-  By default, a TTL of 7 days will be set.
+- Add Gatekeeper mutation for setting job TTL if not already set. By default, a TTL of 7 days will be set.
+- Enabled Pod Security Admission for `dex` and `cert-manager`
 
 ### Fixed
 
@@ -34,8 +34,8 @@
 - grafana to v9.3.8
 
 ### Changed
-- Changed timekey to `stageTimestamp` for Kubernetes audit logs. Use `auditID` to correlate stages of the same request.
 
+- Changed timekey to `stageTimestamp` for Kubernetes audit logs. Use `auditID` to correlate stages of the same request.
 - vulnerability and kube-bench reporter runs as non root.
 - Replace chown init container with fsGroup in OpenSearch
 - Restructure Gatekeeper charts and values

--- a/bootstrap/namespaces/helmfile/values/namespaces-sc.yaml.gotmpl
+++ b/bootstrap/namespaces/helmfile/values/namespaces-sc.yaml.gotmpl
@@ -1,6 +1,14 @@
 namespaces:
 - name: cert-manager
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
 - name: dex
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
 - name: opensearch-system
 {{- if .Values.fluentd.enabled }}
 - name: fluentd-system

--- a/bootstrap/namespaces/helmfile/values/namespaces-wc.yaml.gotmpl
+++ b/bootstrap/namespaces/helmfile/values/namespaces-wc.yaml.gotmpl
@@ -1,5 +1,9 @@
 namespaces:
 - name: cert-manager
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
 {{- if .Values.fluentd.enabled }}
 - name: fluentd
   labels:

--- a/helmfile/values/cert-manager.yaml.gotmpl
+++ b/helmfile/values/cert-manager.yaml.gotmpl
@@ -20,4 +20,4 @@ installCRDs: true
 
 global:
   podSecurityPolicy:
-    enabled: true
+    enabled: {{ .Values.kubernetesPSP }}

--- a/helmfile/values/dex.yaml.gotmpl
+++ b/helmfile/values/dex.yaml.gotmpl
@@ -96,6 +96,14 @@ config:
       userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
 {{ end }}
 
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 serviceMonitor:
   enabled: {{ .Values.dex.serviceMonitor.enabled }}
 


### PR DESCRIPTION
**What this PR does / why we need it**: to enabled PSA for dex and cert-manager

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1447 

**Special notes for reviewer**:
- dex:
   - changes: I added the necessary securitycontext setting to match the restricted policy
   - tested: delete and re-install the chart, logs, login using dex
- cert-manager
   - changes: nothing all the setting were add in the upstream chart
   - tested: delete and re-install the chart, logs, force renew a certificate and check that it worked
   - tbd: there are some situations when the webhook component might need hostNetwork and/or hostPorts, but as we do not use it at the moment I didn't switch to gatekeeper contrains

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
