### PR TITLE
apps: use stageTimestamp as timekey for audit logs

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -26,5 +26,6 @@
 - grafana to v9.3.8
 
 ### Changed
+- Changed timekey to `stageTimestamp` for Kubernetes audit logs. Use `auditID` to correlate stages of the same request.
 
 ### Removed

--- a/helmfile/values/fluentd/forwarder-common.yaml.gotmpl
+++ b/helmfile/values/fluentd/forwarder-common.yaml.gotmpl
@@ -121,7 +121,7 @@ extraConfigMaps:
         @type multi_format
         <pattern>
           format json
-          time_key requestReceivedTimestamp
+          time_key stageTimestamp
           time_format %Y-%m-%dT%H:%M:%S.%NZ
         </pattern>
       </parse>


### PR DESCRIPTION
**What this PR does / why we need it**:
I think it might make more sense to base time from the timestamp for a request based on when it enters a stage.
Previously requests for all stages got the same timestamp.

Let me know what you think

**Which issue this PR fixes**:

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**
Before
![image](https://user-images.githubusercontent.com/12396964/226647602-dc36aae7-bf9b-4d47-89c6-44baea54063b.png)

After (ignore the requestReceived stage)
![image](https://user-images.githubusercontent.com/12396964/226648125-c4745f9f-c129-4f40-a3ca-e95a991de8e0.png)

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
