### PR TITLE
apps: Add enabled checks for Fluentd network policies

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added option to use nodePort for ingress-nginx.
 - Correct version checks in migration script library
 - Run migration apply snippet without filters
+- Add enabled checks for Fluentd network policies
 
 ### Updated
 

--- a/helmfile/values/networkpolicy/common.yaml.gotmpl
+++ b/helmfile/values/networkpolicy/common.yaml.gotmpl
@@ -96,6 +96,9 @@ falco:
     ips: {{- toYaml .Values.networkPolicies.falco.plugins.ips | nindent 6 }}
     ports: {{- toYaml .Values.networkPolicies.falco.plugins.ports | nindent 6 }}
 
+fluentd:
+  enabled: {{ and .Values.fluentd.enabled .Values.networkPolicies.fluentd.enabled }}
+
 rookCeph:
   enabled: {{ .Values.networkPolicies.rookCeph.enabled }}
 

--- a/helmfile/values/networkpolicy/workload-cluster.yaml.gotmpl
+++ b/helmfile/values/networkpolicy/workload-cluster.yaml.gotmpl
@@ -36,7 +36,7 @@ monitoring:
   enabled: {{ .Values.networkPolicies.monitoring.enabled }}
 
 fluentd:
-  enabled: {{ .Values.networkPolicies.fluentd.enabled }}
+  enabled: {{ and .Values.fluentd.enabled .Values.networkPolicies.fluentd.enabled }}
 
 ingressNginx:
   enabled: {{ .Values.networkPolicies.ingressNginx.enabled }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes so you actually can disable Fluentd properly.

**Which issue this PR fixes**:

fixes #1481

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
