### PR TITLE
apps sc: opensearch configurer snapshot register logic rework

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -79,6 +79,7 @@
 - Install Gatekeeper PSPs per stack to improve targeting and modularity
 - Limit resource types checked by Gatekeeper
 - Allow for target discovery of all probes in workload cluster
+- Opensearch-configurer will only re-register the snapshot repository if the bucket name has changed
 
 ### Removed
 

--- a/helmfile/values/opensearch/securityadmin.yaml.gotmpl
+++ b/helmfile/values/opensearch/securityadmin.yaml.gotmpl
@@ -112,6 +112,7 @@ securityConfig:
       reserved: false
       cluster_permissions:
       - "cluster:admin/repository/put"
+      - "cluster:admin/repository/get"
       - "cluster_manage_index_templates"
       - "cluster:admin/opendistro/ism/policy/*"
       - indices:admin/index_template/put

--- a/migration/v0.30/README.md
+++ b/migration/v0.30/README.md
@@ -151,6 +151,20 @@ After doing the `disruptive` step for either the automatic or manual method, you
         http: 30080
         https: 30443
     ```
+1. **Optional** Enable opensearch-securityadmin if disabled.
+
+    ```diff
+    # sc-config.yaml
+    opensearch:
+    - securityadmin:
+    -   enabled: false
+    ```
+
+    This is necessary to update the permissions for opensearch-configurer.
+    If opensearch-securityadmin is left disabled, opensearch-configurer will continue to always register the snapshot repository when run.
+    Note, that any manual edits done to the security config will be wiped once opensearch-securityadmin has run.
+    The need to manually have to edit the security config should be less significant now as it is possible to create static users by configuring `opensearch.extraUsers` in `secrets.yaml`.
+
 1. Check if user-alertmanager is disabled and disable it in the overwrite `common-config`:
 
    ```bash


### PR DESCRIPTION
**What this PR does / why we need it**:
Opensearch will check if the snapshot repo already exists and if it is pointing to the same bucket.
If bucket name changes it will re-register the repository.

**Which issue this PR fixes**:

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
