### PR TITLE
apps-sc: PSA and gatekeeper PSP for harbor

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add Gatekeeper PSPs for ingress-nginx and monitoring namespaces.
 - Add Gatekeeper PSPs for Fluentd and OpenSearch
 - Add Gatekeeper PSPs for Kured.
+- Add Gatekeeper PSPs for Harbor
 
 ### Fixed
 

--- a/bootstrap/namespaces/helmfile/values/namespaces-sc.yaml.gotmpl
+++ b/bootstrap/namespaces/helmfile/values/namespaces-sc.yaml.gotmpl
@@ -34,6 +34,10 @@ namespaces:
 - name: velero
 {{ if .Values.harbor.enabled }}
 - name: harbor
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
 {{ end }}
 {{ if .Values.thanos.enabled }}
 - name: thanos

--- a/helmfile/14-podsecuritypolicies.yaml
+++ b/helmfile/14-podsecuritypolicies.yaml
@@ -37,5 +37,6 @@ releases:
   - values/podsecuritypolicies/common/kured.yaml.gotmpl
   - values/podsecuritypolicies/common/monitoring.yaml.gotmpl
   {{- if eq .Environment.Name "service_cluster" }}
+  - values/podsecuritypolicies/service/harbor.yaml.gotmpl
   - values/podsecuritypolicies/service/opensearch.yaml.gotmpl
   {{- end }}

--- a/helmfile/values/podsecuritypolicies/service/harbor.yaml.gotmpl
+++ b/helmfile/values/podsecuritypolicies/service/harbor.yaml.gotmpl
@@ -1,0 +1,52 @@
+{{- if .Values.harbor.enabled }}
+constraints:
+  harbor:
+    harbor-database:
+      podSelectorLabels:
+        app: harbor
+        component: database
+      allow: {}
+      mutation:
+        runAsUser: 999
+        fsGroup: 999
+    harbor-core:
+      podSelectorLabels:
+        app: harbor
+        component: core
+      allow: {}
+      mutation:
+        runAsUser: 10000
+        fsGroup: 10000
+    harbor-chartmuseum:
+      podSelectorLabels:
+        app: harbor
+        component: chartmuseum
+      allow: {}
+      mutation:
+        runAsUser: 10000
+        fsGroup: 10000
+    harbor-jobservice:
+      podSelectorLabels:
+        app: harbor
+        component: jobservice
+      allow: {}
+      mutation:
+        runAsUser: 10000
+        fsGroup: 10000
+    harbor-registry:
+      podSelectorLabels:
+        app: harbor
+        component: registry
+      allow: {}
+      mutation:
+        runAsUser: 10000
+        fsGroup: 10000
+    harbor-trivy:
+      podSelectorLabels:
+        app: harbor
+        component: trivy
+      allow: {}
+      mutation:
+        runAsUser: 10000
+        fsGroup: 10000
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**: Fix PSA and gatekeeper PSP for Harbor. Tested backup and restore as well.

Based on https://github.com/elastisys/compliantkubernetes-apps/pull/1477 but I will rebase once that is merged.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1450 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
