### PR TITLE
apps wc: Make user-rbac extra-workload-admins idempotent

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -27,6 +27,7 @@
 - Run migration apply snippet without filters
 - Add enabled checks for Fluentd network policies
 - Add missing PSPs for user Fluentd
+- Make `user-rbac` chart `extra-workload-admins` rolebinding idempotent
 
 ### Updated
 

--- a/helmfile/charts/user-rbac/templates/rolebindings/workload-admin.yaml
+++ b/helmfile/charts/user-rbac/templates/rolebindings/workload-admin.yaml
@@ -20,8 +20,9 @@ subjects:
   kind: Group
   name: {{ $group }}
 {{- end }}
+{{- $known := lookup "v1" "Service" "default" "kubernetes" }}
 {{- $value := lookup "rbac.authorization.k8s.io/v1" "RoleBinding" $namespace "extra-workload-admins" }}
-{{- if and (or $.Release.IsInstall $.Release.IsUpgrade) (not $value) }}
+{{- if and $known (not $value) (or $.Release.IsInstall $.Release.IsUpgrade) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
**What this PR does / why we need it**:
Else diff will report it as new all the time.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
