### PR TITLE
apps: add gatekeeper psps for velero

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add Gatekeeper PSPs for Harbor
 - Add Gatekeeper mutation for setting job TTL if not already set. By default, a TTL of 7 days will be set.
 - Enabled Pod Security Admission for `dex` and `cert-manager`
+- Add Gatekeeper PSPs for Velero.
 
 ### Fixed
 

--- a/bootstrap/namespaces/helmfile/values/namespaces-sc.yaml.gotmpl
+++ b/bootstrap/namespaces/helmfile/values/namespaces-sc.yaml.gotmpl
@@ -40,6 +40,10 @@ namespaces:
 - name: falco
 {{ end }}
 - name: velero
+  labels:
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
 {{ if .Values.harbor.enabled }}
 - name: harbor
   labels:

--- a/bootstrap/namespaces/helmfile/values/namespaces-wc.yaml.gotmpl
+++ b/bootstrap/namespaces/helmfile/values/namespaces-wc.yaml.gotmpl
@@ -38,6 +38,10 @@ namespaces:
     pod-security.kubernetes.io/warn: baseline
     {{ end }}
 - name: velero
+  labels:
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
 {{ if .Values.falco.enabled }}
 - name: falco
 {{ end }}

--- a/helmfile/14-podsecuritypolicies.yaml
+++ b/helmfile/14-podsecuritypolicies.yaml
@@ -36,6 +36,7 @@ releases:
   - values/podsecuritypolicies/common/ingress-nginx.yaml.gotmpl
   - values/podsecuritypolicies/common/kured.yaml.gotmpl
   - values/podsecuritypolicies/common/monitoring.yaml.gotmpl
+  - values/podsecuritypolicies/common/velero.yaml.gotmpl
   {{- if eq .Environment.Name "service_cluster" }}
   - values/podsecuritypolicies/service/harbor.yaml.gotmpl
   - values/podsecuritypolicies/service/opensearch.yaml.gotmpl

--- a/helmfile/values/podsecuritypolicies/common/velero.yaml.gotmpl
+++ b/helmfile/values/podsecuritypolicies/common/velero.yaml.gotmpl
@@ -1,0 +1,20 @@
+{{- if .Values.velero.enabled }}
+constraints:
+  velero:
+    restic:
+      podSelectorLabels:
+        name: restic
+      allow:
+        volumes:
+          - hostPath
+          - emptyDir
+          - projected
+          - secret
+        allowedHostPaths:
+          - pathPrefix: /var/lib/kubelet/pods
+            readOnly: false
+        runAsUser:
+          rule: RunAsAny
+        privileged: true
+        allowPrivilegeEscalation: true
+{{- end }}

--- a/helmfile/values/velero-sc.yaml.gotmpl
+++ b/helmfile/values/velero-sc.yaml.gotmpl
@@ -88,6 +88,12 @@ restic:
   resources:   {{- toYaml .Values.velero.restic.resources | nindent 4  }}
   tolerations: {{- toYaml .Values.velero.restic.tolerations | nindent 4  }}
 
+  privileged: true
+
+  containerSecurityContext:
+    runAsUser: 0
+    allowPrivilegeEscalation: true
+
 schedules:
   daily-backup:
     schedule: {{ .Values.velero.schedule }}

--- a/helmfile/values/velero-wc.yaml.gotmpl
+++ b/helmfile/values/velero-wc.yaml.gotmpl
@@ -88,6 +88,12 @@ restic:
   resources:   {{- toYaml .Values.velero.restic.resources | nindent 4  }}
   tolerations: {{- toYaml .Values.velero.restic.tolerations | nindent 4  }}
 
+  privileged: true
+
+  containerSecurityContext:
+    runAsUser: 0
+    allowPrivilegeEscalation: true
+
 schedules:
   daily-backup:
     schedule: {{ .Values.velero.schedule }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Velero seems to be fine running using the default restricted securityContext.
Restic needs privilege, I used postgres for my test to confirm functionality by taking a backup and restoring that backup, and I couldn't get that to work unless running as privileged. 

**Which issue this PR fixes**:
fixes #1449 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
