### PR TITLE
apps: add mutation for setting job ttl

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -14,6 +14,8 @@
 - Add Gatekeeper PSPs for Fluentd and OpenSearch
 - Add Gatekeeper PSPs for Kured.
 - Add Gatekeeper PSPs for Harbor
+- Add Gatekeeper mutation for setting job TTL if not already set.
+  By default, a TTL of 7 days will be set.
 
 ### Fixed
 

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -566,6 +566,13 @@ clusterAdmin:
 opa:
   enabled: true
 
+  mutations:
+    enabled: true
+
+    jobTTL:
+      enabled: true
+      ttlSeconds: 604800
+
   controllerManager:
     resources:
       requests:

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -241,6 +241,17 @@ releases:
   values:
     - values/calico-default-deny.yaml.gotmpl
 
+# gatekeeper-mutations
+- name: gatekeeper-mutations
+  namespace: gatekeeper-system
+  labels:
+    app: gatekeeper-mutations
+  chart: ./charts/gatekeeper/mutations
+  version: 0.1.0
+  installed: {{ and .Values.opa.enabled .Values.opa.mutations.enabled }}
+  values:
+  - values/gatekeeper/mutations.yaml.gotmpl
+
 # Service cluster releases
 {{ if eq .Environment.Name "service_cluster" }}
 # Dex

--- a/helmfile/charts/gatekeeper/mutations/.helmignore
+++ b/helmfile/charts/gatekeeper/mutations/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helmfile/charts/gatekeeper/mutations/Chart.yaml
+++ b/helmfile/charts/gatekeeper/mutations/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A helm chart containing various gatekeeper mutations
+name: gatekeeper-mutations
+version: 0.1.0

--- a/helmfile/charts/gatekeeper/mutations/templates/job-ttl.yaml
+++ b/helmfile/charts/gatekeeper/mutations/templates/job-ttl.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.jobTTL.enabled }}
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: job-ttl
+spec:
+  applyTo:
+    - groups: ["batch"]
+      kinds: ["Job"]
+      versions: ["v1"]
+  match:
+    scope: Namespaced
+    kinds:
+      - apiGroups: ["batch"]
+        kinds: ["Job"]
+  location: "spec.ttlSecondsAfterFinished"
+  parameters:
+    assign:
+      value: {{ .Values.jobTTL.ttlSeconds }}
+    pathTests:
+      - subPath: "spec.ttlSecondsAfterFinished"
+        condition: MustNotExist
+{{- end }}

--- a/helmfile/charts/gatekeeper/mutations/values.yaml
+++ b/helmfile/charts/gatekeeper/mutations/values.yaml
@@ -1,0 +1,3 @@
+jobTTL:
+  enabled: true
+  ttlSeconds: 604800

--- a/helmfile/values/gatekeeper/mutations.yaml.gotmpl
+++ b/helmfile/values/gatekeeper/mutations.yaml.gotmpl
@@ -1,0 +1,3 @@
+jobTTL:
+  enabled: {{ .Values.opa.mutations.jobTTL.enabled }}
+  ttlSeconds: {{ .Values.opa.mutations.jobTTL.ttlSeconds }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new chart containing a single gatekeeper mutation for setting job ttl if not already set.
By default, a ttl of7 days is set.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
Let me know what you think

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
