### PR TITLE
apps: Increase default promIndexAlerts alertsize for authlog

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -41,6 +41,7 @@
 - vulnerability and kube-bench reporter runs as non root.
 - Replace chown init container with fsGroup in OpenSearch
 - Restructure Gatekeeper charts and values
+- Changed the default promIndexAlerts alertsize for authlog from 0.2 to 2.
 
 ### Removed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -928,7 +928,7 @@ opensearch:
     - prefix: other-default
       alertSizeMB: 400
     - prefix: authlog-default
-      alertSizeMB: 0.2
+      alertSizeMB: 2
 
   # Snapshot and snapshot lifecycle configuration
   # Requires S3 or GCS to be enabled

--- a/migration/v0.30/prepare/05-increase-promIndexAlerts-authlog.sh
+++ b/migration/v0.30/prepare/05-increase-promIndexAlerts-authlog.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+yq4 -i 'with(
+  .opensearch.promIndexAlerts[];
+  with(
+    select(
+      .prefix == "authlog-default" and .alertSizeMB < 2
+    );
+    .alertSizeMB = 2
+  )
+)' "${CK8S_CONFIG_PATH}/sc-config.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase default promIndexAlerts alertsize for authlog from 0.2 to 2
**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
