### PR TITLE
Vf/falco hnc psp

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add Gatekeeper PSPs for Velero.
 - Metrics and Grafana dashboard for Harbor.
 - Added so the user admins can read hierarchyconfigurations.
+- Add Gatekeeper PSPs for falco.
 
 ### Fixed
 
@@ -56,3 +57,4 @@
 
 - Kubernetes PSP for ingress-nginx and monitoring namespace.
 - Remove Kubernetes PSPs for Fluentd and OpenSearch
+- Remove Kubernetes PSPs for falco

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add Gatekeeper PSPs for Velero.
 - Metrics and Grafana dashboard for Harbor.
 - Added so the user admins can read hierarchyconfigurations.
+- Add Gatekeeper PSPs for HNC.
 - Add Gatekeeper PSPs for falco.
 
 ### Fixed

--- a/bootstrap/namespaces/helmfile/values/namespaces-wc.yaml.gotmpl
+++ b/bootstrap/namespaces/helmfile/values/namespaces-wc.yaml.gotmpl
@@ -44,6 +44,10 @@ namespaces:
     pod-security.kubernetes.io/warn: privileged
 {{ if .Values.falco.enabled }}
 - name: falco
+  labels:
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
 {{ end }}
 {{ if .Values.opa.enabled }}
 - name: gatekeeper-system

--- a/bootstrap/namespaces/helmfile/values/namespaces-wc.yaml.gotmpl
+++ b/bootstrap/namespaces/helmfile/values/namespaces-wc.yaml.gotmpl
@@ -58,6 +58,10 @@ namespaces:
 {{ end }}
 {{ if .Values.hnc.enabled }}
 - name: hnc-system
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
 {{ end }}
 {{ if .Values.user.alertmanager.enabled }}
 - name: alertmanager

--- a/helmfile/14-podsecuritypolicies.yaml
+++ b/helmfile/14-podsecuritypolicies.yaml
@@ -32,6 +32,7 @@ releases:
   chart: ./charts/gatekeeper/podsecuritypolicies
   version: 0.1.0
   values:
+  - values/podsecuritypolicies/common/falco.yaml.gotmpl
   - values/podsecuritypolicies/common/fluentd.yaml.gotmpl
   - values/podsecuritypolicies/common/ingress-nginx.yaml.gotmpl
   - values/podsecuritypolicies/common/kured.yaml.gotmpl

--- a/helmfile/values/falco-exporter.yaml.gotmpl
+++ b/helmfile/values/falco-exporter.yaml.gotmpl
@@ -5,7 +5,7 @@ tolerations: {{- toYaml .Values.falco.falcoExporter.tolerations | nindent 2  }}
 
 podSecurityPolicy:
   # Specifies whether a PSP, Role and RoleBinding should be created
-  create: true
+  create: {{ .Values.kubernetesPSP }}
 
 falco:
   grpcUnixSocketPath: "unix:///var/run/falco/falco.sock"
@@ -13,3 +13,6 @@ falco:
 serviceMonitor:
   # Enable the deployment of a Service Monitor for the Prometheus Operator.
   enabled: true
+
+securityContext:
+  runAsUser: 0

--- a/helmfile/values/falco.yaml.gotmpl
+++ b/helmfile/values/falco.yaml.gotmpl
@@ -12,6 +12,19 @@ falco:
   grpc_output:
     enabled: true
 
+containerSecurityContext:
+  runAsUser: 0
+  privileged: true
+  allowPrivilegeEscalation: true
+
+driver:
+  loader:
+    initContainer:
+      securityContext:
+        runAsUser: 0
+        privileged: true
+        allowPrivilegeEscalation: true
+
 resources: {{- toYaml .Values.falco.resources | nindent 2  }}
 nodeSelector: {{- toYaml .Values.falco.nodeSelector | nindent 2  }}
 affinity: {{- toYaml .Values.falco.affinity | nindent 2  }}
@@ -150,7 +163,7 @@ customRules:
 falcosidekick:
   enabled: {{ .Values.falco.alerts.enabled }}
   podSecurityPolicy:
-    create: true
+    create: {{ .Values.kubernetesPSP }}
   config:
     debug: false
     {{ if eq .Values.falco.alerts.type "slack" }}

--- a/helmfile/values/podsecuritypolicies/common/falco.yaml.gotmpl
+++ b/helmfile/values/podsecuritypolicies/common/falco.yaml.gotmpl
@@ -1,0 +1,41 @@
+{{- if .Values.falco.enabled }}
+constraints:
+  falco:
+    falco:
+      podSelectorLabels:
+        app.kubernetes.io/name: falco
+      allow:
+        privileged: true
+        allowPrivilegeEscalation: true
+        allowedHostPaths:
+        - pathPrefix: /boot
+        - pathPrefix: /lib/modules
+        - pathPrefix: /usr
+        - pathPrefix: /etc
+        - pathPrefix: /dev
+        - pathPrefix: /sys/module/falco
+        - pathPrefix: /var/run/docker.sock
+        - pathPrefix: /run/containerd/containerd.sock
+        - pathPrefix: /run/crio/crio.sock
+        - pathPrefix: /proc
+        - pathPrefix: /var/run/falco
+        volumes:
+        - configMap
+        - hostPath
+        - projected
+        - emptyDir
+        runAsUser:
+          rule: RunAsAny
+    falco-exporter:
+      podSelectorLabels:
+        app.kubernetes.io/name: falco-exporter
+      allow:
+        allowedHostPaths:
+        - pathPrefix: /var/run/falco
+        volumes:
+        - configMap
+        - hostPath
+        - projected
+        runAsUser:
+          rule: RunAsAny
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1448 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
