### PR TITLE
apps: fix kube-prometheus-stack migration script

### DIFF
--- a/helmfile/11-prometheus-operator.yaml
+++ b/helmfile/11-prometheus-operator.yaml
@@ -32,7 +32,7 @@ releases:
   labels:
     app: kube-prometheus-stack
   chart: ./upstream/kube-prometheus-stack
-  version: 19.2.2
+  version: 45.2.0
   # https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations
   # The --dry-run flag of helm install and helm upgrade is not currently supported for CRDs.
   disableValidationOnInstall: true

--- a/migration/v0.30/apply/20-remove-kube-prometheus-components.sh
+++ b/migration/v0.30/apply/20-remove-kube-prometheus-components.sh
@@ -9,11 +9,27 @@ run() {
   case "${1:-}" in
   execute)
     for CLUSTER in sc wc; do
-      log_info "  - removing kube-state-metrics from $CLUSTER"
-      kubectl_do $CLUSTER delete deployments.apps -l app.kubernetes.io/instance=kube-prometheus-stack,app.kubernetes.io/name=kube-state-metrics --cascade=orphan -n monitoring
-      log_info "  - removing prometheus-node-exporter from $CLUSTER"
-      kubectl_do $CLUSTER delete daemonset -l app=prometheus-node-exporter -n monitoring
+      old_state_metrics=$(kubectl get deployments.apps -n monitoring -l app.kubernetes.io/instance=kube-prometheus-stack,app.kubernetes.io/name=kube-state-metrics,app.kubernetes.io/version!=2.8.0 --output=jsonpath={.items..metadata.name})
+      old_node_exporter=$(kubectl get daemonset -n monitoring -l app=prometheus-node-exporter --output=jsonpath={.items..metadata.name})
+
+      if [[ -n "${old_state_metrics}" ]]; then
+        log_info "- removing kube-state-metrics from $CLUSTER"
+        kubectl_do $CLUSTER delete deployments.apps -l app.kubernetes.io/instance=kube-prometheus-stack,app.kubernetes.io/name=kube-state-metrics,app.kubernetes.io/version!=2.8.0 --cascade=orphan -n monitoring
+      fi
+
+      if [[ -n "${old_node_exporter}" ]]; then
+        log_info "- removing prometheus-node-exporter from $CLUSTER"
+        kubectl_do $CLUSTER delete daemonset -l app=prometheus-node-exporter -n monitoring
+      fi
     done
+
+    # --- sc ---
+    helmfile_upgrade sc app=kube-prometheus-stack
+    helmfile_upgrade sc app=thanos
+
+    # --- wc ---
+    helmfile_upgrade wc app=kube-prometheus-stack
+    helmfile_upgrade wc app=user-alertmanager
     ;;
   rollback)
     log_warn "rollback not implemented"

--- a/migration/v0.30/apply/80-apply.sh
+++ b/migration/v0.30/apply/80-apply.sh
@@ -12,14 +12,17 @@ skipped=(
   "app!=common-np"
   "app!=gatekeeper"
   "app!=psp"
+  "app!=kube-prometheus-stack"
 )
 declare -a skipped_sc
 skipped_sc=(
   "app!=service-cluster-np"
+  "app!=thanos"
 )
 declare -a skipped_wc
 skipped_wc=(
   "app!=workload-cluster-np"
+  "app!=user-alertmanager"
 )
 
 run() {


### PR DESCRIPTION
**What this PR does / why we need it**: the script to remove monitoring components should run only when needed

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1496 

**Special notes for reviewer**:
- the `app=prometheus-node-exporter` label does not exists in the new version of node-exporter, so the daemonset will not be removed if we re-run the upgrade scripts

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
