### PR TITLE
apps: add migrations step for gatekeeper psps violations

### DIFF
--- a/migration/v0.30/README.md
+++ b/migration/v0.30/README.md
@@ -178,25 +178,25 @@ After doing the `disruptive` step for either the automatic or manual method, you
     ```bash
     ./bin/ck8s bootstrap {sc|wc}
     # or
-    ./migration/v0.30/apply/10-bootstrap.sh
+    ./migration/v0.30/apply/10-bootstrap.sh execute
     ```
 
 1. Apply the new kube-prometheus-stack CRDs:
 
     ```bash
-    ./migration/v0.30/apply/11-prometheus-operator-crds.sh
+    ./migration/v0.30/apply/11-prometheus-operator-crds.sh execute
     ```
 
 1. Update network policies:
 
     ```bash
-    ./migration/v0.30/apply/12-netpol.sh
+    ./migration/v0.30/apply/12-netpol.sh execute
     ```
 
 1. Apply the new Gatekeeper pod security policies:
 
     ```bash
-    ./migration/v0.30/apply/13-gatekeeper-psp.sh
+    ./migration/v0.30/apply/13-gatekeeper-psp.sh execute
     ```
 
 1. Apply bypass for Kubernetes pod security policy admission:
@@ -208,7 +208,7 @@ After doing the `disruptive` step for either the automatic or manual method, you
 1. Remove node-exporter and kube-state-metrics:
 
     ```bash
-    ./migration/v0.30/apply/20-remove-kube-prometheus-components.sh
+    ./migration/v0.30/apply/20-remove-kube-prometheus-components.sh execute
     ```
 
 1. Upgrade applications:
@@ -216,13 +216,19 @@ After doing the `disruptive` step for either the automatic or manual method, you
     ```bash
     ./bin/ck8s apply {sc|wc}
     # or
-    ./migration/v0.30/apply/80-apply.sh
+    ./migration/v0.30/apply/80-apply.sh execute
     ```
 
 1. Uninstall the old starboard stack including starboard-operator and its exporters:
 
     ```bash
     ./migration/v0.29/apply/90-uninstalls.sh execute
+    ```
+
+1. Restart pods violating the new Gatekeeper PSPs
+
+    ```bash
+    ./migration/v0.30/apply/99-psp-violations.sh execute
     ```
 
 ## Postrequisite:

--- a/migration/v0.30/apply/99-psp-violations.sh
+++ b/migration/v0.30/apply/99-psp-violations.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+results_mult_uniq=""
+
+exempt_namepsaces=("rook-ceph")
+
+function set_violating_resources() {
+  results_mult_uniq=""
+  results=()
+  cluster="$1"
+
+  # Get violations for PSPs
+  violations=$(kubectl_do "$cluster" get constraints -o yaml | yq4 '[.items[] | select(.kind == "K8sPSP*") | .status.violations[]]')
+
+  # Build array of maps with relevant information
+  resources=$(echo "$violations" | yq4 '.[] |[{"name": .name, "namespace": .namespace}]' | yq4 'unique_by(.name,.namespace)')
+
+  # Create bash array to be able to loop over each entry
+  readarray resource_arr < <(echo "$resources" | yq4 e -o=j -I=0 '.[]')
+
+  for resource in "${resource_arr[@]}"; do
+    namespace=$(echo "$resource" | yq4 e '.namespace')
+    pod_name=$(echo "$resource" | yq4 e '.name')
+
+    owner_reference=$(kubectl_do "$cluster" -n "$namespace" get pod "$pod_name" -oyaml | yq4 '.metadata.ownerReferences.[0]')
+
+    # Skip standalone pods
+    if [ "$owner_reference" = "null" ]; then continue; fi
+
+    owner_kind=$(echo "$owner_reference" | yq4 .kind)
+    owner_name=$(echo "$owner_reference" | yq4 .name)
+
+    # Get owner of ReplicaSets
+    if [ "$owner_kind" == "ReplicaSet" ]; then
+      owner_reference=$(kubectl_do "$cluster" -n "$namespace" get rs "$owner_name" -oyaml | yq4 '.metadata.ownerReferences.[0]')
+
+      # Skip standalone ReplicaSets
+      if [ "$owner_reference" = "null" ]; then continue; fi
+
+      owner_kind=$(echo "$owner_reference" | yq4 .kind)
+      owner_name=$(echo "$owner_reference" | yq4 .name)
+    fi
+
+    results+=('{name: '"$owner_name"', namespace: '"$namespace"', kind: '"$owner_kind"'}')
+  done
+
+  # Convert array to multiline string and keep only unique lines
+  results_mult_uniq=$(printf "%s\n" "${results[@]}" | sort -u)
+}
+
+function is_customer_namespace() {
+  namespace="$1"
+  cluster="$2"
+  operator_ns_regex="^($(kubectl_do "$cluster" get ns -l owner=operator '-ojsonpath={.items[*].metadata.name}' | sed 's/ /|/g'))$"
+
+  if [[ "$namespace" =~ $operator_ns_regex  ]]; then return 1; fi
+}
+
+function restart_violating_resources() {
+  IFS=$'\n'
+  cluster="$1"
+  # shellcheck disable=SC2128
+  for entry in $results_mult_uniq; do
+    kind=$(echo "$entry" | yq4 .kind)
+    name=$(echo "$entry" | yq4 .name)
+    namespace=$(echo "$entry" | yq4 .namespace)
+
+    # shellcheck disable=SC2076
+    if [[ "${exempt_namepsaces[*]}" =~ "${namespace}" ]] || is_customer_namespace "$namespace" "$cluster"; then
+      log_warn "$kind/$name in $namespace for cluster $cluster requires manual restart"
+    else
+      log_info "Will trigger a rollout restart of $kind/$name in $namespace for cluster $cluster"
+      kubectl_do "$cluster" rollout restart "$kind" "$name" -n "$namespace"
+    fi
+
+  done
+}
+
+run() {
+  case "${1:-}" in
+  execute)
+    for cluster in sc wc; do
+      set_violating_resources "$cluster"
+      restart_violating_resources "$cluster"
+    done
+    ;;
+
+  rollback)
+    log_warn "rollback not applicable"
+    ;;
+
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"


### PR DESCRIPTION
Add a step to the migration docs for restarting the pods that are or will be violating the new gatekeeper PSPs.

**What this PR does / why we need it**:

**Which issue this PR fixes**:
fixes #1495

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

```console
$ ./migration/v0.30/apply/90-psp-violations.sh execute
[ck8s] 90-psp-violations.sh: using config path: "/home/olle/Documents/olle-exoscale"
[ck8s] 90-psp-violations.sh: using sc kubeconfig unencrypted
[ck8s] 90-psp-violations.sh: using wc kubeconfig unencrypted
Will trigger a rollout restart of StatefulSet/alertmanager-kube-prometheus-stack-alertmanager in monitoring
Will trigger a rollout restart of DaemonSet/fluentd-forwarder in fluentd-system
Will trigger a rollout restart of DaemonSet/ingress-nginx-controller in ingress-nginx
Will trigger a rollout restart of Deployment/kube-prometheus-stack-operator in monitoring
Will trigger a rollout restart of DaemonSet/kube-prometheus-stack-prometheus-node-exporter in monitoring
Will trigger a rollout restart of DaemonSet/fluentd-fluentd-elasticsearch in fluentd
Will trigger a rollout restart of DaemonSet/fluentd-forwarder in fluentd-system
Will trigger a rollout restart of DaemonSet/ingress-nginx-controller in ingress-nginx
Will trigger a rollout restart of DaemonSet/kube-prometheus-stack-prometheus-node-exporter in monitoring
```

With rollout:
```console
[ck8s] 99-psp-violations.sh: Will trigger a rollout restart of DaemonSet/fluentd-forwarder in fluentd-system for cluster sc
daemonset.apps/fluentd-forwarder restarted
[ck8s] 99-psp-violations.sh: Will trigger a rollout restart of DaemonSet/ingress-nginx-controller in ingress-nginx for cluster sc
daemonset.apps/ingress-nginx-controller restarted
[ck8s] 99-psp-violations.sh: Will trigger a rollout restart of DaemonSet/kube-prometheus-stack-prometheus-node-exporter in monitoring for cluster sc
daemonset.apps/kube-prometheus-stack-prometheus-node-exporter restarted
[ck8s] 99-psp-violations.sh: StatefulSet/opensearch-client in opensearch-system for cluster sc requires manual restart
```

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
