### PR TITLE
apps sc: Ensure opensearch-configurer runs on changes

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -30,6 +30,7 @@
 - Add missing PSPs for user Fluentd
 - Make `user-rbac` chart `extra-workload-admins` rolebinding idempotent
 - Indentation issue in the `fluentd-forwarder-workload-cluster-system` values file.
+- Ensure `opensearch-configurer` runs on changes
 
 ### Updated
 

--- a/helmfile/charts/opensearch/configurer/templates/config.yml
+++ b/helmfile/charts/opensearch/configurer/templates/config.yml
@@ -5,9 +5,10 @@ metadata:
   labels:
     {{- include "opensearch-configurer.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": {{ .Values.helm.hook }}
-    "helm.sh/hook-weight": "-10"
-    "helm.sh/hook-delete-policy": {{ .Values.helm.deletePolicy }}
+    helm.sh/hook: {{ .Values.helm.hook }}
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: {{ .Values.helm.deletePolicy }}
+    checksum/config: {{ print .Values.config | sha256sum }}
 type: Opaque
 stringData:
   configurer.sh: |-

--- a/helmfile/charts/opensearch/configurer/templates/job.yaml
+++ b/helmfile/charts/opensearch/configurer/templates/job.yaml
@@ -5,11 +5,11 @@ metadata:
   labels:
     {{- include "opensearch-configurer.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": {{ .Values.helm.hook }}
-    # Use higher value so that the secret is created before this job
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": {{ .Values.helm.deletePolicy }}
+    helm.sh/hook: {{ .Values.helm.hook }}
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: {{ .Values.helm.deletePolicy }}
     checksum/securityconfig: {{ print .Values.securityConfig | sha256sum }}
+    checksum/config: {{ print .Values.config | sha256sum }}
 spec:
   activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds }}
   backoffLimit: {{ .Values.backoffLimit }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Since else it requires a sync.

**Which issue this PR fixes**:
fixes #1507 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
