### PR TITLE
apps: added the possibility to enable metrics for Cluster API

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -22,6 +22,7 @@
 - Add Gatekeeper PSPs for HNC.
 - Add Gatekeeper PSPs for falco.
 - Add cache-image workflow
+- Possibility to enable metrics for Cluster API in `kube-state-metrics`.
 
 ### Fixed
 

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -289,6 +289,9 @@ kubeStateMetrics:
     limits:
       cpu: 30m
       memory: 100Mi
+  # Enable this if your cluster is managed by Cluster API to get Cluster API metrics.
+  clusterAPIMetrics:
+    enabled: false
 
 prometheus:
   replicas: 1

--- a/helmfile/11-prometheus-operator.yaml
+++ b/helmfile/11-prometheus-operator.yaml
@@ -44,6 +44,16 @@ releases:
   - values/kube-prometheus-stack-wc.yaml.gotmpl
 {{ end }}
 
+- name: kube-state-metrics-extra-resource-metrics
+  namespace: monitoring
+  labels:
+    app: kube-prometheus-stack
+  chart: ./charts/kube-state-metrics-extra-resource-metrics
+  version: 0.1.0
+  installed: {{ .Values.kubeStateMetrics.clusterAPIMetrics.enabled }}
+  values:
+  - values/kube-state-metrics-extra-resource-metrics.yaml.gotmpl
+
 - name: thanos-ingress-secret
 {{- if eq .Environment.Name "service_cluster" }}
   namespace: thanos

--- a/helmfile/charts/kube-state-metrics-extra-resource-metrics/Chart.yaml
+++ b/helmfile/charts/kube-state-metrics-extra-resource-metrics/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: kube-state-metrics-extra-resource-metrics
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0

--- a/helmfile/charts/kube-state-metrics-extra-resource-metrics/README.md
+++ b/helmfile/charts/kube-state-metrics-extra-resource-metrics/README.md
@@ -1,0 +1,5 @@
+# README
+
+Currently only includes metrics for Cluster API. This chart adds a ConfigMap with additional config for the [kube-state-metrics](../../upstream/kube-prometheus-stack/chart/kube-state-metrics) chart, which is part of `kube-prometheus-stack`.
+
+The [clusterapi-metrics.yaml](files/clusterapi-metrics.yaml) file was found through [this page](https://github.com/kubernetes-sigs/cluster-api/blob/v1.4.1/hack/observability/kube-state-metrics/crd-config.yaml).

--- a/helmfile/charts/kube-state-metrics-extra-resource-metrics/files/clusterapi-metrics.yaml
+++ b/helmfile/charts/kube-state-metrics-extra-resource-metrics/files/clusterapi-metrics.yaml
@@ -1,0 +1,966 @@
+spec:
+  resources:
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: Cluster
+      version: v1beta1
+    labelsFromPath:
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_cluster
+    metrics:
+    - name: info
+      help: Information about a cluster.
+      each:
+        info:
+          labelsFromPath:
+            topology_version:
+            - spec
+            - topology
+            - version
+            topology_class:
+            - spec
+            - topology
+            - class
+            control_plane_endpoint_host:
+            - spec
+            - controlPlaneEndpoint
+            - host
+            control_plane_endpoint_port:
+            - spec
+            - controlPlaneEndpoint
+            - port
+            control_plane_reference_kind:
+            - spec
+            - controlPlaneRef
+            - kind
+            control_plane_reference_name:
+            - spec
+            - controlPlaneRef
+            - name
+            infrastructure_reference_kind:
+            - spec
+            - infrastructureRef
+            - kind
+            infrastructure_reference_name:
+            - spec
+            - infrastructureRef
+            - name
+        type: Info
+    - name: spec_paused
+      help: Whether the cluster is paused and any of its resources will not be processed by the controllers.
+      each:
+        gauge:
+          nilIsZero: true
+          path:
+          - spec
+          - paused
+        type: Gauge
+    - name: status_phase
+      help: The clusters current phase.
+      each:
+        stateSet:
+          labelName: phase
+          list:
+          - Pending
+          - Provisioning
+          - Provisioned
+          - Deleting
+          - Failed
+          - Unknown
+          path:
+          - status
+          - phase
+        type: StateSet
+    - name: created
+      help: Unix creation timestamp.
+      each:
+        gauge:
+          path:
+          - metadata
+          - creationTimestamp
+        type: Gauge
+    - name: annotation_paused
+      help: Whether the cluster is paused and any of its resources will not be processed by the controllers.
+      each:
+        info:
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+          labelsFromPath:
+            paused_value: []
+        type: Info
+    - name: status_condition
+      help: The condition of a cluster.
+      each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - 'True'
+          - 'False'
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+  - groupVersionKind:
+      group: controlplane.cluster.x-k8s.io
+      kind: KubeadmControlPlane
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - metadata
+      - ownerReferences
+      - '[kind=Cluster]'
+      - name
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_kubeadmcontrolplane
+    metrics:
+    - name: info
+      help: Information about a kubeadmcontrolplane.
+      each:
+        info:
+          labelsFromPath:
+            version:
+            - spec
+            - version
+        type: Info
+    - name: status_replicas
+      help: The number of replicas per kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - status
+          - replicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_ready
+      help: The number of ready replicas per kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - status
+          - readyReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_unavailable
+      help: The number of unavailable replicas per kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - status
+          - unavailableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_updated
+      help: The number of updated replicas per kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - status
+          - updatedReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: spec_replicas
+      help: The number of desired machines for a kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - spec
+          - replicas
+        type: Gauge
+    - name: spec_strategy_rollingupdate_max_surge
+      help: Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - spec
+          - rolloutStrategy
+          - rollingUpdate
+          - maxSurge
+        type: Gauge
+    - name: created
+      help: Unix creation timestamp.
+      each:
+        gauge:
+          path:
+          - metadata
+          - creationTimestamp
+        type: Gauge
+    - name: annotation_paused
+      help: Whether the kubeadmcontrolplane is paused and any of its resources will not be processed by the controllers.
+      each:
+        info:
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+          labelsFromPath:
+            paused_value: []
+        type: Info
+    - name: status_condition
+      help: The condition of a kubeadmcontrolplane.
+      each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - 'True'
+          - 'False'
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+    - name: owner
+      help: Owner references.
+      each:
+        info:
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: Machine
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - spec
+      - clusterName
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_machine
+    metrics:
+    - name: info
+      help: Information about a machine.
+      each:
+        info:
+          labelsFromPath:
+            container_runtime_version:
+            - status
+            - nodeInfo
+            - containerRuntimeVersion
+            failure_domain:
+            - spec
+            - failureDomain
+            kernel_version:
+            - status
+            - nodeInfo
+            - kernelVersion
+            kubelet_version:
+            - status
+            - nodeInfo
+            - kubeletVersion
+            kube_proxy_version:
+            - status
+            - nodeInfo
+            - kubeProxyVersion
+            os_image:
+            - status
+            - nodeInfo
+            - osImage
+            provider_id:
+            - spec
+            - providerID
+            version:
+            - spec
+            - version
+        type: Info
+    - name: addresses
+      help: Address information about a machine.
+      each:
+        info:
+          path:
+          - status
+          - addresses
+          labelsFromPath:
+            type:
+            - type
+            address:
+            - address
+        type: Info
+    - name: status_noderef
+      help: Information about the node reference of a machine.
+      each:
+        info:
+          labelsFromPath:
+            node_name:
+            - status
+            - nodeRef
+            - name
+            node_uid:
+            - status
+            - nodeRef
+            - uid
+        type: Info
+    - name: status_phase
+      help: The machines current phase.
+      each:
+        stateSet:
+          labelName: phase
+          list:
+          - Pending
+          - Provisioning
+          - Provisioned
+          - Running
+          - Deleting
+          - Deleted
+          - Failed
+          - Unknown
+          path:
+          - status
+          - phase
+        type: StateSet
+    - name: created
+      help: Unix creation timestamp.
+      each:
+        gauge:
+          path:
+          - metadata
+          - creationTimestamp
+        type: Gauge
+    - name: annotation_paused
+      help: Whether the machine is paused and any of its resources will not be processed by the controllers.
+      each:
+        info:
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+          labelsFromPath:
+            paused_value: []
+        type: Info
+    - name: status_condition
+      help: The condition of a machine.
+      each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - 'True'
+          - 'False'
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+    - name: owner
+      help: Owner references.
+      each:
+        info:
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: MachineDeployment
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - spec
+      - clusterName
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_machinedeployment
+    metrics:
+    - name: spec_paused
+      help: Whether the machinedeployment is paused and any of its resources will not be processed by the controllers.
+      each:
+        gauge:
+          nilIsZero: true
+          path:
+          - spec
+          - paused
+        type: Gauge
+    - name: spec_replicas
+      help: The number of desired machines for a machinedeployment.
+      each:
+        gauge:
+          path:
+          - spec
+          - replicas
+        type: Gauge
+    - name: spec_strategy_rollingupdate_max_surge
+      help: Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a machinedeployment.
+      each:
+        gauge:
+          path:
+          - spec
+          - strategy
+          - rollingUpdate
+          - maxSurge
+        type: Gauge
+    - name: spec_strategy_rollingupdate_max_unavailable
+      help: Maximum number of unavailable replicas during a rolling update of a machinedeployment.
+      each:
+        gauge:
+          path:
+          - spec
+          - strategy
+          - rollingUpdate
+          - maxUnavailable
+        type: Gauge
+    - name: status_phase
+      help: The machinedeployments current phase.
+      each:
+        stateSet:
+          labelName: phase
+          list:
+          - ScalingUp
+          - ScalingDown
+          - Running
+          - Failed
+          - Unknown
+          path:
+          - status
+          - phase
+        type: StateSet
+    - name: status_replicas
+      help: The number of replicas per machinedeployment.
+      each:
+        gauge:
+          path:
+          - status
+          - replicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_available
+      help: The number of available replicas per machinedeployment.
+      each:
+        gauge:
+          path:
+          - status
+          - availableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_ready
+      help: The number of ready replicas per machinedeployment.
+      each:
+        gauge:
+          path:
+          - status
+          - readyReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_unavailable
+      help: The number of unavailable replicas per machinedeployment.
+      each:
+        gauge:
+          path:
+          - status
+          - unavailableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_updated
+      help: The number of updated replicas per machinedeployment.
+      each:
+        gauge:
+          path:
+          - status
+          - updatedReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: created
+      help: Unix creation timestamp.
+      each:
+        gauge:
+          path:
+          - metadata
+          - creationTimestamp
+        type: Gauge
+    - name: annotation_paused
+      help: Whether the machinedeployment is paused and any of its resources will not be processed by the controllers.
+      each:
+        info:
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+          labelsFromPath:
+            paused_value: []
+        type: Info
+    - name: status_condition
+      help: The condition of a machinedeployment.
+      each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - 'True'
+          - 'False'
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+    - name: owner
+      help: Owner references.
+      each:
+        info:
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: MachineHealthCheck
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - spec
+      - clusterName
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_machinehealthcheck
+    metrics:
+    - name: status_current_healthy
+      help: Current number of healthy machines.
+      each:
+        gauge:
+          path:
+          - status
+          - currentHealthy
+        type: Gauge
+    - name: status_expected_machines
+      help: Total number of pods counted by this machinehealthcheck.
+      each:
+        gauge:
+          path:
+          - status
+          - expectedMachines
+        type: Gauge
+    - name: status_remediations_allowed
+      help: Number of machine remediations that are currently allowed.
+      each:
+        gauge:
+          path:
+          - status
+          - remediationsAllowed
+        type: Gauge
+    - name: created
+      help: Unix creation timestamp.
+      each:
+        gauge:
+          path:
+          - metadata
+          - creationTimestamp
+        type: Gauge
+    - name: annotation_paused
+      help: Whether the machinehealthcheck is paused and any of its resources will not be processed by the controllers.
+      each:
+        info:
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+          labelsFromPath:
+            paused_value: []
+        type: Info
+    - name: status_condition
+      help: The condition of a machinehealthcheck.
+      each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - 'True'
+          - 'False'
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+    - name: owner
+      help: Owner references.
+      each:
+        info:
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: MachineSet
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - spec
+      - clusterName
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_machineset
+    metrics:
+    - name: spec_replicas
+      help: The number of desired machines for a machineset.
+      each:
+        gauge:
+          path:
+          - spec
+          - replicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_available_replicas
+      help: The number of available replicas per machineset.
+      each:
+        gauge:
+          path:
+          - status
+          - availableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_fully_labeled_replicas
+      help: The number of fully labeled replicas per machineset.
+      each:
+        gauge:
+          path:
+          - status
+          - fullyLabeledReplicas
+        type: Gauge
+    - name: status_ready_replicas
+      help: The number of ready replicas per machineset.
+      each:
+        gauge:
+          path:
+          - status
+          - readyReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas
+      help: The number of replicas per machineset.
+      each:
+        gauge:
+          path:
+          - status
+          - replicas
+          nilIsZero: true
+        type: Gauge
+    - name: created
+      help: Unix creation timestamp.
+      each:
+        gauge:
+          path:
+          - metadata
+          - creationTimestamp
+        type: Gauge
+    - name: annotation_paused
+      help: Whether the machineset is paused and any of its resources will not be processed by the controllers.
+      each:
+        info:
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+          labelsFromPath:
+            paused_value: []
+        type: Info
+    - name: status_condition
+      help: The condition of a machineset.
+      each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - 'True'
+          - 'False'
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+    - name: owner
+      help: Owner references.
+      each:
+        info:
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: MachinePool
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - spec
+      - clusterName
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_machinepool
+    metrics:
+    - name: spec_replicas
+      help: The number of desired machines for a machinepool.
+      each:
+        gauge:
+          path:
+          - spec
+          - replicas
+        type: Gauge
+    - name: status_replicas
+      help: The number of replicas per machinepool.
+      each:
+        gauge:
+          path:
+          - status
+          - replicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_ready
+      help: The number of ready replicas per machinepool.
+      each:
+        gauge:
+          path:
+          - status
+          - readyReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_available
+      help: The number of available replicas per machinepool.
+      each:
+        gauge:
+          path:
+          - status
+          - availableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_unavailable
+      help: The number of unavailable replicas per machinepool.
+      each:
+        gauge:
+          path:
+          - status
+          - unavailableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: info
+      each:
+        type: Info
+        info:
+          labelsFromPath:
+            infrastructure_reference_name:
+            - spec
+            - template
+            - spec
+            - infrastructureRef
+            - name
+            infrastructure_reference_kind:
+            - spec
+            - template
+            - spec
+            - infrastructureRef
+            - kind
+            bootstrap_configuration_reference_name:
+            - spec
+            - template
+            - spec
+            - bootstrap
+            - configRef
+            - name
+            bootstrap_configuration_reference_kind:
+            - spec
+            - template
+            - spec
+            - bootstrap
+            - configRef
+            - kind
+            failure_domain:
+            - spec
+            - template
+            - spec
+            - failureDomain
+            version:
+            - spec
+            - template
+            - spec
+            - version
+    - name: status_phase
+      help: The machinepools current phase.
+      each:
+        stateSet:
+          labelName: phase
+          list:
+          - ScalingUp
+          - ScalingDown
+          - Running
+          - Failed
+          - Unknown
+          path:
+          - status
+          - phase
+        type: StateSet
+    - name: created
+      help: Unix creation timestamp.
+      each:
+        gauge:
+          path:
+          - metadata
+          - creationTimestamp
+        type: Gauge
+    - name: annotation_paused
+      help: Whether the machinepool is paused and any of its resources will not be processed by the controllers.
+      each:
+        info:
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+          labelsFromPath:
+            paused_value: []
+        type: Info
+    - name: status_condition
+      help: The condition of a machinepool.
+      each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - 'True'
+          - 'False'
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+    - name: owner
+      help: Owner references.
+      each:
+        info:
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info

--- a/helmfile/charts/kube-state-metrics-extra-resource-metrics/templates/clusterapi-configmap.yaml
+++ b/helmfile/charts/kube-state-metrics-extra-resource-metrics/templates/clusterapi-configmap.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.clusterAPIMetrics.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-state-metrics-clusterapi
+data:
+  clusterapi-metrics.yaml: |-
+    {{ .Files.Get "files/clusterapi-metrics.yaml" | nindent 4 }}
+{{- end }}

--- a/helmfile/charts/kube-state-metrics-extra-resource-metrics/values.yaml
+++ b/helmfile/charts/kube-state-metrics-extra-resource-metrics/values.yaml
@@ -1,0 +1,2 @@
+clusterAPIMetrics:
+  enabled: false

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -10,6 +10,74 @@ kube-state-metrics:
   podSecurityPolicy:
     enabled: {{ .Values.kubernetesPSP }}
   resources: {{- toYaml .Values.kubeStateMetrics.resources | nindent 4 }}
+  {{- if .Values.kubeStateMetrics.clusterAPIMetrics.enabled }}
+  rbac:
+    extraRules:
+      - apiGroups:
+          - cluster.x-k8s.io
+        resources:
+          - clusters
+          - machinedeployments
+          - machinesets
+          - machines
+          - machinehealthchecks
+          - machinepools
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - controlplane.cluster.x-k8s.io
+        resources:
+          - kubeadmcontrolplanes
+        verbs:
+          - get
+          - list
+          - watch
+  collectors:
+    - certificatesigningrequests
+    - configmaps
+    - cronjobs
+    - daemonsets
+    - deployments
+    - endpoints
+    - horizontalpodautoscalers
+    - ingresses
+    - jobs
+    - limitranges
+    - mutatingwebhookconfigurations
+    - namespaces
+    - networkpolicies
+    - nodes
+    - persistentvolumeclaims
+    - persistentvolumes
+    - poddisruptionbudgets
+    - pods
+    - replicasets
+    - replicationcontrollers
+    - resourcequotas
+    - secrets
+    - services
+    - statefulsets
+    - storageclasses
+    - validatingwebhookconfigurations
+    - volumeattachments
+    - clusters
+    - machinedeployments
+    - machinesets
+    - machines
+    - machinehealthchecks
+    - kubeadmcontrolplanes
+  volumeMounts:
+    - mountPath: /etc/config
+      name: kube-state-metrics-clusterapi-volume
+  volumes:
+    - configMap:
+        name: kube-state-metrics-clusterapi
+      name: kube-state-metrics-clusterapi-volume
+  extraArgs:
+    - "--custom-resource-state-config-file=/etc/config/clusterapi-metrics.yaml"
+  {{- end }}
 
 kubeApiServer:
   serviceMonitor:

--- a/helmfile/values/kube-prometheus-stack-wc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-wc.yaml.gotmpl
@@ -28,6 +28,74 @@ kube-state-metrics:
   podSecurityPolicy:
     enabled: true
   resources: {{- toYaml .Values.kubeStateMetrics.resources | nindent 4 }}
+  {{- if .Values.kubeStateMetrics.clusterAPIMetrics.enabled }}
+  rbac:
+    extraRules:
+      - apiGroups:
+          - cluster.x-k8s.io
+        resources:
+          - clusters
+          - machinedeployments
+          - machinesets
+          - machines
+          - machinehealthchecks
+          - machinepools
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - controlplane.cluster.x-k8s.io
+        resources:
+          - kubeadmcontrolplanes
+        verbs:
+          - get
+          - list
+          - watch
+  collectors:
+    - certificatesigningrequests
+    - configmaps
+    - cronjobs
+    - daemonsets
+    - deployments
+    - endpoints
+    - horizontalpodautoscalers
+    - ingresses
+    - jobs
+    - limitranges
+    - mutatingwebhookconfigurations
+    - namespaces
+    - networkpolicies
+    - nodes
+    - persistentvolumeclaims
+    - persistentvolumes
+    - poddisruptionbudgets
+    - pods
+    - replicasets
+    - replicationcontrollers
+    - resourcequotas
+    - secrets
+    - services
+    - statefulsets
+    - storageclasses
+    - validatingwebhookconfigurations
+    - volumeattachments
+    - clusters
+    - machinedeployments
+    - machinesets
+    - machines
+    - machinehealthchecks
+    - kubeadmcontrolplanes
+  volumeMounts:
+    - mountPath: /etc/config
+      name: kube-state-metrics-clusterapi-volume
+  volumes:
+    - configMap:
+        name: kube-state-metrics-clusterapi
+      name: kube-state-metrics-clusterapi-volume
+  extraArgs:
+    - "--custom-resource-state-config-file=/etc/config/clusterapi-metrics.yaml"
+  {{- end }}
 
 prometheus-node-exporter:
   resources: {{- toYaml .Values.prometheusNodeExporter.resources | nindent 4 }}

--- a/helmfile/values/kube-state-metrics-extra-resource-metrics.yaml.gotmpl
+++ b/helmfile/values/kube-state-metrics-extra-resource-metrics.yaml.gotmpl
@@ -1,0 +1,2 @@
+clusterAPIMetrics:
+  enabled: {{ .Values.kubeStateMetrics.clusterAPIMetrics.enabled }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Wasn't able to find any prepared dashboards or alerts, will create issues to make our own.

fixes the metrics part of [this issue](https://github.com/elastisys/ck8s-cluster-api/issues/11).

**Special notes for reviewer**:

Decided to add it to both SC & WC for flexibility, even though we will likely only use this in SC internally.

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [X] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
