### PR TITLE
Aarnq/allow multiple creation rules

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -34,6 +34,7 @@
 - Ensure `opensearch-configurer` runs on changes
 - Correct `fluentd-aggregator` buffer settings
 - Source `extra-fluentd-config` user supplied settings
+- Change config option `falco.customRules` to a map
 
 ### Updated
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -49,6 +49,7 @@
 - Replace chown init container with fsGroup in OpenSearch
 - Restructure Gatekeeper charts and values
 - Changed the default promIndexAlerts alertsize for authlog from 0.2 to 2.
+- Allow SOPS config to contain multiple creation rules
 
 ### Removed
 

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -99,7 +99,7 @@ falco:
   enabled: true
   ## additional falco rules
   ## ref: https://falco.org/docs/rules/
-  customRules: []
+  customRules: {}
   resources:
     limits:
       cpu: 200m


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the opportunity to use multiple creation rules in sops

And I found why [this](https://github.com/elastisys/compliantkubernetes-apps/issues/1505) happens.

Fixes: #1505

**Add a screenshot or an example to illustrate the proposed solution:**

New error print with one rule missing pgp fps:
```console
$ ./bin/ck8s validate sc
[ck8s] Validating sc config
[ck8s] ERROR: SOPS config contains no or invalid PGP keys.
[ck8s] SOPS config: /<path>/.sops.yaml:
fingerprints:
  - <fingerprint>
  - ...
  - "null"
[ck8s] Fingerprints must be uppercase and separated by colon.
[ck8s] Delete or edit the SOPS config to fix the issue
```

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
