### PR TITLE
apps sc: upgrade dex chart to v0.14.1, app v2.36.0

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -41,6 +41,7 @@
 - kube-prometheus-stack chart to v45.2.0. Full [CHANGELOG](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-44x-to-45x)
 - prometheus-operator to v0.63.0
 - grafana to v9.3.8
+- Upgraded Dex to v2.36.0, chart v0.14.1
 
 ### Changed
 

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -260,7 +260,7 @@ releases:
   labels:
     app: dex
   chart: ./upstream/dex
-  version: 0.8.2
+  version: 0.14.1
   wait: true
   values:
   - values/dex.yaml.gotmpl

--- a/helmfile/upstream/dex/Chart.yaml
+++ b/helmfile/upstream/dex/Chart.yaml
@@ -1,12 +1,12 @@
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Update Dex to 2.35.1"
+    - kind: added
+      description: "Supporting template evaluation in ingress hosts"
   artifacthub.io/images: |
     - name: dex
-      image: ghcr.io/dexidp/dex:v2.35.1
+      image: ghcr.io/dexidp/dex:v2.36.0
 apiVersion: v2
-appVersion: 2.35.1
+appVersion: 2.36.0
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable
   connectors.
 home: https://dexidp.io/
@@ -26,4 +26,4 @@ sources:
 - https://github.com/dexidp/dex
 - https://github.com/dexidp/helm-charts/tree/master/charts/dex
 type: application
-version: 0.12.0
+version: 0.14.1

--- a/helmfile/upstream/dex/README.md
+++ b/helmfile/upstream/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.12.0](https://img.shields.io/badge/version-0.12.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.35.1](https://img.shields.io/badge/app%20version-2.35.1-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.14.1](https://img.shields.io/badge/version-0.14.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.36.0](https://img.shields.io/badge/app%20version-2.36.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 
@@ -111,6 +111,7 @@ ingress:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | replicaCount | int | `1` | Number of replicas (pods) to launch. |
+| commonLabels | object | `{}` | Labels to apply to all resources and selectors. |
 | image.repository | string | `"ghcr.io/dexidp/dex"` | Name of the image repository to pull the container image from. |
 | image.pullPolicy | string | `"IfNotPresent"` | [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for updating already existing images on a node. |
 | image.tag | string | `""` | Image tag override for the default value (chart appVersion). |

--- a/helmfile/upstream/dex/templates/_helpers.tpl
+++ b/helmfile/upstream/dex/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "dex.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/helmfile/upstream/dex/templates/ingress.yaml
+++ b/helmfile/upstream/dex/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $ | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/helmfile/upstream/dex/values.yaml
+++ b/helmfile/upstream/dex/values.yaml
@@ -5,6 +5,10 @@
 # -- Number of replicas (pods) to launch.
 replicaCount: 1
 
+# -- Labels to apply to all resources and selectors.
+commonLabels: {}
+# team_name: dev
+
 image:
   # -- Name of the image repository to pull the container image from.
   repository: ghcr.io/dexidp/dex


### PR DESCRIPTION
**What this PR does / why we need it**: Upgraded dex to chart v0.14.1, app v2.36.0

**Which issue this PR fixes**: fixes #1406 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [X] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
