### PR TITLE
apps: upgrade prometheus-elasticsearch-exporter to 5.1.1

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -62,6 +62,7 @@
 - Update pre-commit hooks
 - node-local-dns to use image `registry.k8s.io/dns/k8s-dns-node-cache:1.22.20`
 - metrics-server to v0.6.3, chart v3.10.0
+- prometheus-elasticsearch-exporter to v5.1.1
 
 ### Changed
 

--- a/helmfile/upstream/prometheus-elasticsearch-exporter/Chart.yaml
+++ b/helmfile/upstream/prometheus-elasticsearch-exporter/Chart.yaml
@@ -1,20 +1,18 @@
 apiVersion: v1
+appVersion: 1.5.0
 description: Elasticsearch stats exporter for Prometheus
-name: prometheus-elasticsearch-exporter
-version: 4.11.0
-kubeVersion: ">=1.10.0-0"
-appVersion: 1.3.0
 home: https://github.com/prometheus-community/elasticsearch_exporter
-sources:
-  - https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-elasticsearch-exporter
 keywords:
-  - metrics
-  - elasticsearch
-  - monitoring
+- metrics
+- elasticsearch
+- monitoring
+kubeVersion: '>=1.10.0-0'
 maintainers:
-  - name: svenmueller
-    email: sven.mueller@commercetools.com
-  - name: caarlos0
-    email: carlos@carlosbecker.com
-  - name: desaintmartin
-    email: cedric@desaintmartin.fr
+- email: sven.mueller@commercetools.com
+  name: svenmueller
+- email: cedric@desaintmartin.fr
+  name: desaintmartin
+name: prometheus-elasticsearch-exporter
+sources:
+- https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-elasticsearch-exporter
+version: 5.1.1

--- a/helmfile/upstream/prometheus-elasticsearch-exporter/README.md
+++ b/helmfile/upstream/prometheus-elasticsearch-exporter/README.md
@@ -11,16 +11,16 @@ cluster using the [Helm](https://helm.sh) package manager.
 
 - Kubernetes 1.10+
 
-## Get Repo Info
+## Get Helm Repository Info
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 ```
 
-_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-## Install Chart
+## Install Helm Chart
 
 ```console
 # Helm 3
@@ -36,7 +36,7 @@ _See [configuration](#configuration) below._
 
 _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-## Uninstall Chart
+## Uninstall Helm Chart
 
 ```console
 # Helm 3
@@ -50,7 +50,7 @@ This removes all the Kubernetes components associated with the chart and deletes
 
 _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Upgrading Chart
+## Upgrading Helm Chart
 
 ```console
 # Helm 3 or 2
@@ -58,6 +58,18 @@ $ helm upgrade [RELEASE_NAME] [CHART] --install
 ```
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+### To 5.0.0
+
+`securityContext` has been renamed to `podSecurityContext` and `securityContext.enabled` has no effect anymore. To mirror the behaviour of `securityContext.enabled=false` of 4.x unset `podSecurityContext`.
+
+```console
+helm install --set podSecurityContext=null my-exporter stable/elasticsearch-exporter
+```
+
+In 5.0.0 `securityContext` refers to the container's securityContext instead which was not configurable in earlier versions. The naming is aligned with the base charts created by Helm.
+
+Default values for `podSecurityContext` and `securityContext` have been updated to be compatible with the Pod Security Standard level "restricted". Most notably `seccompProfile.type` is set to `RuntimeDefault`.
 
 ### To 4.0.0
 
@@ -80,7 +92,7 @@ You now need to escape the rules (see `values.yaml`) for examples.
 
 ### To 2.0.0
 
-Some Kubernetes apis used from 1.x have been deprecated. You need to update your cluster to Kubernetes 1.10+ to support new definitions used in 2.x.
+Some Kubernetes APIs used from 1.x have been deprecated. You need to update your cluster to Kubernetes 1.10+ to support new definitions used in 2.x.
 
 ## Configuration
 

--- a/helmfile/upstream/prometheus-elasticsearch-exporter/ci/security-context.yaml
+++ b/helmfile/upstream/prometheus-elasticsearch-exporter/ci/security-context.yaml
@@ -1,5 +1,4 @@
 ---
-# Set default security context for kubernetes
+# Unset pod level securityContext
 
-securityContext:
-  disable: true
+podSecurityContext: null

--- a/helmfile/upstream/prometheus-elasticsearch-exporter/templates/_helpers.tpl
+++ b/helmfile/upstream/prometheus-elasticsearch-exporter/templates/_helpers.tpl
@@ -41,3 +41,45 @@ Return the appropriate apiVersion for rbac.
 {{- print "rbac.authorization.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Renders a value that contains a template.
+Usage:
+{{ include "elasticsearch-exporter.tplvalue.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "elasticsearch-exporter.tplvalue.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}
+
+
+{{/*
+Return the proper Docker Image Registry Secret Names evaluating values as templates
+{{ include "elasticsearch-exporter.image.pullSecret.name" ( dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "context" $) }}
+*/}}
+{{- define "elasticsearch-exporter.image.pullSecret.name" -}}
+  {{- $pullSecrets := list }}
+  {{- $context := .context }}
+
+  {{- if $context.Values.global }}
+    {{- range $context.Values.global.imagePullSecrets -}}
+      {{/* Is plain array of strings, compatible with all bitnami charts */}}
+      {{- $pullSecrets = append $pullSecrets (include "elasticsearch-exporter.tplvalue.render" (dict "value" . "context" $context)) -}}
+    {{- end -}}
+  {{- end -}}
+  {{- range .images -}}
+    {{- if .pullSecret -}}
+      {{- $pullSecrets = append $pullSecrets (include "elasticsearch-exporter.tplvalue.render" (dict "value" .pullSecret "context" $context)) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if (not (empty $pullSecrets)) }}
+imagePullSecrets:
+    {{- range $pullSecrets | uniq }}
+  - name: {{ . }}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/helmfile/upstream/prometheus-elasticsearch-exporter/templates/deployment.yaml
+++ b/helmfile/upstream/prometheus-elasticsearch-exporter/templates/deployment.yaml
@@ -7,9 +7,12 @@ metadata:
     app: {{ template "elasticsearch-exporter.name" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  {{- if .Values.deployment.annotations }}
+  {{- with .Values.deployment.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.deployment.annotations }}
   annotations:
-{{- toYaml .Values.deployment.annotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
@@ -27,12 +30,12 @@ spec:
       labels:
         app: {{ template "elasticsearch-exporter.name" . }}
         release: "{{ .Release.Name }}"
-        {{- if .Values.podLabels }}
-{{ toYaml .Values.podLabels | indent 8 }}
-        {{- end }}
-      {{- if .Values.podAnnotations }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podAnnotations }}
       annotations:
-{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       {{- if .Values.serviceAccount.create  }}
@@ -43,20 +46,16 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
 {{- end }}
-{{- if .Values.image.pullSecret }}
-      imagePullSecrets:
-        - name: {{ .Values.image.pullSecret }}
-{{- end }}
+      {{- include "elasticsearch-exporter.image.pullSecret.name" (dict "images" (list .Values.image) "context" $) | nindent 6 }}
       restartPolicy: {{ .Values.restartPolicy }}
-      {{- if .Values.securityContext.enabled }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: {{ .Values.securityContext.runAsUser }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
-{{- with .Values.dnsConfig }}
+      {{- with .Values.dnsConfig }}
       dnsConfig:
-{{ toYaml . | indent 8 }}
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: exporter
           env:
@@ -64,7 +63,7 @@ spec:
             - name: {{ $key }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "Must specify secret!" $value.secret }}
+                  name: {{ required "Must specify secret!" (tpl $value.secret $) }}
                   key: {{ required "Must specify key!" $value.key }}
             {{- end }}
             {{- range $key, $value := .Values.env }}
@@ -100,6 +99,9 @@ spec:
                     {{- if .Values.es.indices_mappings }}
                     "--es.indices_mappings",
                     {{- end }}
+                    {{- if .Values.es.aliases }}
+                    "--es.aliases",
+                    {{- end }}
                     {{- if .Values.es.shards }}
                     "--es.shards",
                     {{- end }}
@@ -108,6 +110,12 @@ spec:
                     {{- end }}
                     {{- if .Values.es.cluster_settings }}
                     "--es.cluster_settings",
+                    {{- end }}
+                    {{- if .Values.es.slm }}
+                    "--es.slm",
+                    {{- end }}
+                    {{- if .Values.es.data_stream }}
+                    "--es.data_stream",
                     {{- end }}
                     "--es.timeout={{ .Values.es.timeout }}",
                     {{- if .Values.es.sslSkipVerify }}
@@ -125,47 +133,35 @@ spec:
                     {{- end }}
                     "--web.listen-address=:{{ .Values.service.httpPort }}",
                     "--web.telemetry-path={{ .Values.web.path }}"]
+          {{- with .Values.securityContext }}
           securityContext:
-            capabilities:
-              drop:
-                - SETPCAP
-                - MKNOD
-                - AUDIT_WRITE
-                - CHOWN
-                - NET_RAW
-                - DAC_OVERRIDE
-                - FOWNER
-                - FSETID
-                - KILL
-                - SETGID
-                - SETUID
-                - NET_BIND_SERVICE
-                - SYS_CHROOT
-                - SETFCAP
-            readOnlyRootFilesystem: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.httpPort }}
-              name: http
+              name: {{ .Values.service.metricsPort.name }}
           livenessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: {{ .Values.service.metricsPort.name }}
             initialDelaySeconds: 5
             timeoutSeconds: 5
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: {{ .Values.service.metricsPort.name }}
             initialDelaySeconds: 1
             timeoutSeconds: 5
             periodSeconds: 5
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/bash", "-c", "sleep 20"]
+                command: ["/bin/ash", "-c", "sleep 20"]
           volumeMounts:
             {{- if and .Values.es.ssl.enabled (eq .Values.es.ssl.useExistingSecrets false) }}
             - mountPath: /ssl
@@ -178,21 +174,21 @@ spec:
               subPath: {{ .subPath }}
               {{- end }}
             {{- end }}
-            {{- if .Values.extraVolumeMounts }}
-            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
-{{- if .Values.nodeSelector }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-{{- end }}
-{{- if .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
-{{- end }}
-{{- if .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         {{- if and .Values.es.ssl.enabled (eq .Values.es.ssl.useExistingSecrets false) }}
         - name: ssl
@@ -204,6 +200,6 @@ spec:
           secret:
             secretName: {{ .secretName }}
         {{- end }}
-        {{- if .Values.extraVolumes }}
-        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helmfile/upstream/prometheus-elasticsearch-exporter/templates/podsecuritypolicies.yaml
+++ b/helmfile/upstream/prometheus-elasticsearch-exporter/templates/podsecuritypolicies.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podSecurityPolicies.enabled -}}
+{{- if and .Values.podSecurityPolicies.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/helmfile/upstream/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+++ b/helmfile/upstream/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
@@ -33,7 +33,7 @@ spec:
     metricRelabelings:
     {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 4 }}
     {{- end }}
-  jobLabel: "{{ .Release.Name }}"
+  jobLabel: {{ default .Release.Name .Values.serviceMonitor.jobLabel }}
   selector:
     matchLabels:
       app: {{ template "elasticsearch-exporter.name" . }}

--- a/helmfile/upstream/prometheus-elasticsearch-exporter/values.yaml
+++ b/helmfile/upstream/prometheus-elasticsearch-exporter/values.yaml
@@ -1,3 +1,9 @@
+## Global settings for all charts in a tree of dependent charts
+## This allows to set the same values for the imagePullSecrets, obviating the need
+## to set the same values for each chart (and image) separately
+global:
+  imagePullSecrets: []
+
 ## number of exporter instances
 ##
 replicaCount: 1
@@ -8,17 +14,22 @@ restartPolicy: Always
 
 image:
   repository: quay.io/prometheuscommunity/elasticsearch-exporter
-  tag: v1.3.0
+  tag: v1.5.0
   pullPolicy: IfNotPresent
   pullSecret: ""
 
-## Set enabled to false if you don't want securityContext
-## in your Deployment.
-## The below values are the default for kubernetes.
-## Openshift won't deploy with runAsUser: 1000 without additional permissions.
-securityContext:
-  enabled: true  # Should be set to false when running on OpenShift
+podSecurityContext:
+  runAsNonRoot: true
   runAsUser: 1000
+  seccompProfile:
+    type: "RuntimeDefault"
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
 
 # Custom DNS configuration to be added to prometheus-elasticsearch-exporter pods
 dnsConfig: {}
@@ -66,6 +77,7 @@ service:
 
 deployment:
   annotations: {}
+  labels: {}
 
 ## Extra environment variables that will be passed into the exporter pod
 ## example:
@@ -73,7 +85,6 @@ deployment:
 ##   KEY_1: value1
 ##   KEY_2: value2
 env: {}
-
 
 ## Extra arguments to pass to the container's executable
 ## example:
@@ -144,6 +155,10 @@ es:
   ##
   indices_mappings: true
 
+  ## If true, query stats for aliases.
+  ##
+  aliases: false
+
   ## If true, query stats for shards in the cluster.
   ##
   shards: true
@@ -156,6 +171,14 @@ es:
   ##
   cluster_settings: false
 
+  ## If true, query stats for SLM snapshots.
+  ##
+  slm: false
+
+  ## If true, query stats for data streams.
+  ##
+  data_stream: false
+
   ## Timeout for trying to get stats from Elasticsearch. (ex: 20s)
   ##
   timeout: 30s
@@ -164,7 +187,6 @@ es:
   ## (only available if image.tag >= 1.0.4rc1)
   ##
   sslSkipVerify: false
-
 
   ssl:
     ## If true, a secure connection to ES cluster is used
@@ -176,7 +198,6 @@ es:
     useExistingSecrets: false
 
     ca:
-
       ## PEM that contains trusted CAs used for setting up secure Elasticsearch connection
       ##
       # pem:
@@ -214,6 +235,7 @@ serviceMonitor:
   #  namespace: monitoring
   labels: {}
   interval: 10s
+  jobLabel: ""
   scrapeTimeout: 10s
   scheme: http
   relabelings: []

--- a/helmfile/values/prometheus-opensearch-exporter.yaml.gotmpl
+++ b/helmfile/values/prometheus-opensearch-exporter.yaml.gotmpl
@@ -33,4 +33,7 @@ resources: {{- toYaml .Values.opensearch.exporter.resources | nindent 2 }}
 
 tolerations: {{- toYaml .Values.opensearch.exporter.tolerations | nindent 2 }}
 
+podSecurityPolicies:
+  enabled: {{ .Values.kubernetesPSP }}
+
 fullnameOverride: "prometheus-opensearch-exporter"

--- a/helmfile/values/prometheus-opensearch-exporter.yaml.gotmpl
+++ b/helmfile/values/prometheus-opensearch-exporter.yaml.gotmpl
@@ -20,7 +20,8 @@ es:
 envFromSecret: opensearch-metrics-exporter-user
 
 env:
-  ES_URI: https://$(username):$(password)@{{ .Values.opensearch.clusterName }}-master:9200
+  ES_USERNAME: $(username)
+  ES_PASSWORD: $(password)
 
 serviceMonitor:
   enabled: true
@@ -34,6 +35,6 @@ resources: {{- toYaml .Values.opensearch.exporter.resources | nindent 2 }}
 tolerations: {{- toYaml .Values.opensearch.exporter.tolerations | nindent 2 }}
 
 podSecurityPolicies:
-  enabled: {{ .Values.kubernetesPSP }}
+  enabled: false
 
 fullnameOverride: "prometheus-opensearch-exporter"


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade prometheus-elasticsearch-exporter to 5.1.1
**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [x] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
