### PR TITLE
apps: add gatekeeper psps for rook-ceph

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add Gatekeeper PSPs for Fluentd and OpenSearch
 - Add Gatekeeper PSPs for Kured.
 - Add Gatekeeper PSPs for Harbor
+- Add Gatekeeper PSPs for rook-ceph
 - Add Gatekeeper mutation for setting job TTL if not already set. By default, a TTL of 7 days will be set.
 - Enabled Pod Security Admission for `dex` and `cert-manager`
 - Add Gatekeeper PSPs for Velero.

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -150,6 +150,7 @@ set_storage_class() {
             storage_class=rook-ceph-block
 
             yq4 -i '.networkPolicies.rookCeph.enabled = true' "${file}"
+            yq4 -i '.rookCeph.enabled = true' "${file}"
             ;;
         aws)
             storage_class=ebs-gp2

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -810,3 +810,7 @@ networkPolicies:
 
   dnsAutoscaler:
     enabled: true
+
+# Gatekeeper PSP for rook-ceph enabled/disabled
+rookCeph:
+  enabled: false

--- a/helmfile/14-podsecuritypolicies.yaml
+++ b/helmfile/14-podsecuritypolicies.yaml
@@ -85,6 +85,16 @@ releases:
     values:
       - values/podsecuritypolicies/common/velero.yaml.gotmpl
 
+  - name: podsecuritypolicy
+    namespace: rook-ceph
+    labels:
+      psp: rook-ceph
+    chart: ./charts/gatekeeper/podsecuritypolicies
+    version: 0.1.0
+    installed: {{ .Values.rookCeph.enabled }}
+    values:
+      - values/podsecuritypolicies/common/rook-ceph.yaml.gotmpl
+
 {{- if eq .Environment.Name "service_cluster" }}
   - name: podsecuritypolicy
     namespace: harbor

--- a/helmfile/charts/gatekeeper/podsecuritypolicies/templates/default/capabilities.yaml
+++ b/helmfile/charts/gatekeeper/podsecuritypolicies/templates/default/capabilities.yaml
@@ -2,7 +2,7 @@
 {{- $exceptions := list }}
 {{- range $namespace, $services := .Values.constraints }}
 {{- range $services }}
-{{- if hasKey .allow "allowedCapabilities" }}
+{{- if or ( hasKey .allow "allowedCapabilities" ) ( get .allow "privileged" ) ( . | dig "mutation" "dropAllCapabilities" true | not ) }}
 {{- $exceptions = append $exceptions .podSelectorLabels }}
 {{- end }}
 {{- end }}

--- a/helmfile/charts/gatekeeper/podsecuritypolicies/templates/default/mutations/privilege-escalation.yaml
+++ b/helmfile/charts/gatekeeper/podsecuritypolicies/templates/default/mutations/privilege-escalation.yaml
@@ -1,6 +1,15 @@
 {{- $namespaceSelectorLabels := .Values.mutations.namespaceSelectorLabels }}
 {{- $namespaces := keys .Values.constraints | sortAlpha }}
 {{- $exceptions := .Values.mutations.exceptions }}
+
+{{- range $namespace, $services := .Values.constraints }}
+{{- range $name, $value := $services }}
+{{- if $value | dig "allow" "allowPrivilegeEscalation" false }}
+{{- $exceptions = append $exceptions $value.podSelectorLabels }}
+{{- end }}
+{{- end }}
+{{- end }}
+---
 ---
 apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign

--- a/helmfile/charts/gatekeeper/podsecuritypolicies/templates/default/privilege-escalation.yaml
+++ b/helmfile/charts/gatekeeper/podsecuritypolicies/templates/default/privilege-escalation.yaml
@@ -2,7 +2,7 @@
 {{- $exceptions := list }}
 {{- range $namespace, $services := .Values.constraints }}
 {{- range $services }}
-{{- if get .allow "allowPrivilegeEscalation" }}
+{{- if or (get .allow "allowPrivilegeEscalation") (get .allow "privileged") }}
 {{- $exceptions = append $exceptions .podSelectorLabels }}
 {{- end }}
 {{- end }}

--- a/helmfile/values/podsecuritypolicies/common/rook-ceph.yaml.gotmpl
+++ b/helmfile/values/podsecuritypolicies/common/rook-ceph.yaml.gotmpl
@@ -1,0 +1,237 @@
+{{- if .Values.rookCeph.enabled }}
+constraints:
+  rook-ceph:
+
+    operator:
+      podSelectorLabels:
+        app: rook-ceph-operator
+      allow:
+        privileged: true
+        allowPrivilegeEscalation: true
+        volumes:
+          - emptyDir
+          - projected
+
+    csi-rbdplugin-provisioner:
+      podSelectorLabels:
+        app: csi-rbdplugin-provisioner
+      allow:
+        privileged: true
+        allowPrivilegeEscalation: true
+        volumes:
+          - emptyDir
+          - projected
+          - hostPath
+        allowedHostPaths:
+          - pathPrefix: "/dev"
+          - pathPrefix: "/sys"
+          - pathPrefix: "/lib/modules"
+        runAsUser:
+          rule: RunAsAny
+        runAsGroup:
+          rule: RunAsAny
+        supplementalGroups:
+          rule: RunAsAny
+        fsGroup:
+          rule: RunAsAny
+      mutation:
+        dropAllCapabilities: false
+
+    csi-rbdplugin:
+      podSelectorLabels:
+        app: csi-rbdplugin
+      allow:
+        privileged: true
+        allowPrivilegeEscalation: true
+        hostNetworkPorts: true
+        hostNamespace: true
+        volumes:
+          - emptyDir
+          - projected
+          - hostPath
+        allowedHostPaths:
+          - pathPrefix: "/run/udev"
+          - pathPrefix: "/dev"
+          - pathPrefix: "/var/lib/rook"
+          - pathPrefix: "/var/lib/kubelet/plugins_registry"
+          - pathPrefix: "/var/lib/kubelet/plugins"
+          - pathPrefix: "/var/lib/kubelet/pods"
+          - pathPrefix: "/sys"
+          - pathPrefix: "/run/mount"
+          - pathPrefix: "/lib/modules"
+        runAsUser:
+          rule: RunAsAny
+        runAsGroup:
+          rule: RunAsAny
+        supplementalGroups:
+          rule: RunAsAny
+        fsGroup:
+          rule: RunAsAny
+      mutation:
+        dropAllCapabilities: false
+
+    crashcollector:
+      podSelectorLabels:
+        app: rook-ceph-crashcollector
+      allow:
+        allowPrivilegeEscalation: true
+        volumes:
+          - secret
+          - projected
+          - hostPath
+        allowedHostPaths:
+          - pathPrefix: "/var/lib/rook"
+        supplementalGroups:
+          rule: RunAsAny
+      mutation:
+        runAsGroup: 167
+        runAsUser: 167
+        fsGroup: 167
+
+    osd:
+      podSelectorLabels:
+        app: rook-ceph-osd
+      allow:
+        privileged: true
+        allowPrivilegeEscalation: true
+        volumes:
+          - secret
+          - projected
+          - hostPath
+        allowedHostPaths:
+          - pathPrefix: "/run/udev"
+          - pathPrefix: "/dev"
+          - pathPrefix: "/var/lib/rook"
+        runAsUser:
+          rule: RunAsAny
+        runAsGroup:
+          rule: RunAsAny
+        supplementalGroups:
+          rule: RunAsAny
+        fsGroup:
+          rule: RunAsAny
+      mutation:
+        dropAllCapabilities: false
+
+    mgr:
+      podSelectorLabels:
+        app: rook-ceph-mgr
+      allow:
+        allowPrivilegeEscalation: true
+        volumes:
+          - emptyDir
+          - secret
+          - projected
+          - hostPath
+        allowedHostPaths:
+          - pathPrefix: "/var/lib/rook"
+        runAsUser:
+          rule: RunAsAny
+        runAsGroup:
+          rule: RunAsAny
+        supplementalGroups:
+          rule: RunAsAny
+        fsGroup:
+          rule: RunAsAny
+      mutation:
+        dropAllCapabilities: false
+
+    mon:
+      podSelectorLabels:
+        app: rook-ceph-mon
+      allow:
+        allowPrivilegeEscalation: true
+        volumes:
+          - secret
+          - projected
+          - hostPath
+        allowedHostPaths:
+          - pathPrefix: "/var/lib/rook"
+        runAsUser:
+          rule: RunAsAny
+        runAsGroup:
+          rule: RunAsAny
+        fsGroup:
+          rule: RunAsAny
+        supplementalGroups:
+          rule: RunAsAny
+      mutation:
+        dropAllCapabilities: false
+
+    tools:
+      podSelectorLabels:
+        app: rook-ceph-tools
+      allow:
+        volumes:
+          - configMap
+          - emptyDir
+          - projected
+        runAsUser:
+          rule: MustRunAsNonRoot
+        allowPrivilegeEscalation: true
+      mutation:
+        fsGroup: 2016
+
+    detect-version:
+      podSelectorLabels:
+        app: rook-ceph-detect-version
+      allow:
+        privileged: true
+        allowPrivilegeEscalation: true
+        volumes:
+          - emptyDir
+          - projected
+        runAsUser:
+          rule: RunAsAny
+        runAsGroup:
+          rule: RunAsAny
+        supplementalGroups:
+          rule: RunAsAny
+        fsGroup:
+          rule: RunAsAny
+      mutation:
+        dropAllCapabilities: false
+
+    csi-detect-version:
+      podSelectorLabels:
+        app: rook-ceph-csi-detect-version
+      allow:
+        privileged: true
+        allowPrivilegeEscalation: true
+        volumes:
+          - emptyDir
+          - projected
+        runAsUser:
+          rule: RunAsAny
+        runAsGroup:
+          rule: RunAsAny
+        supplementalGroups:
+          rule: RunAsAny
+        fsGroup:
+          rule: RunAsAny
+      mutation:
+        dropAllCapabilities: false
+
+    osd-prepare:
+      podSelectorLabels:
+        app: rook-ceph-osd-prepare
+      allow:
+        privileged: true
+        allowPrivilegeEscalation: true
+        volumes:
+          - emptyDir
+          - projected
+          - hostPath
+        allowedHostPaths:
+          - pathPrefix: "/"
+        runAsUser:
+          rule: RunAsAny
+        runAsGroup:
+          rule: RunAsAny
+        supplementalGroups:
+          rule: RunAsAny
+        fsGroup:
+          rule: RunAsAny
+      mutation:
+        dropAllCapabilities: false
+{{- end }}

--- a/migration/v0.30/README.md
+++ b/migration/v0.30/README.md
@@ -72,6 +72,8 @@ After doing the `disruptive` step for either the automatic or manual method, you
    ./migration/v0.30/apply/14-kubernetes-psp.sh clean
    ```
 
+1. If you want to enable Gatekeeper PSP for rook-ceph, set `rookCeph.enabled` to `true` in your `common-config.yaml`.
+
 ## Automatic method
 
 1. Pull the latest changes and switch to the correct branch:


### PR DESCRIPTION
**What this PR does / why we need it**:
add gatekeeper psps for rook-ceph
**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1451 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
