### PR TITLE
apps: Expose all `fluentd-aggregator` buffer settings

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -59,6 +59,7 @@
 - Restructure Gatekeeper charts and values
 - Changed the default promIndexAlerts alertsize for authlog from 0.2 to 2.
 - Allow SOPS config to contain multiple creation rules
+- Expose all `fluentd-aggregator` buffer settings
 
 ### Removed
 

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -175,7 +175,23 @@ fluentd:
       #   </match>
 
   aggregator:
-    buffer: {}
+    # All buffer settings are available, keys are transformed to snake_case as required by fluentd config
+    buffer:
+      chunkLimitSize: 50MB
+      totalLimitSize: 9GB
+
+      flushMode: interval
+      flushInterval: 15m
+      flushThreadCount: 4
+      flushThreadBurstInterval: 0.2
+
+      retryType: exponential_backoff
+      retryForever: true
+      retryMaxInterval: 30
+
+      timekey: 10m
+      timekeyWait: 1m
+      timekeyUseUtc: true
 
     persistence:
       storage: 10Gi
@@ -185,7 +201,7 @@ fluentd:
         cpu: 300m
         memory: 500Mi
       limits:
-        cpu: 500m
+        cpu: 750m
         memory: 1000Mi
 
     tolerations: []

--- a/helmfile/values/fluentd/aggregator-common.yaml.gotmpl
+++ b/helmfile/values/fluentd/aggregator-common.yaml.gotmpl
@@ -132,13 +132,9 @@ aggregator:
     buffer.prop: |
       @type file
 
-      overflow_action {{ .Values.fluentd.aggregator.buffer | get "overflowAction" "block" }}
-      chunk_limit_size {{ .Values.fluentd.aggregator.buffer | get "chunkLimitSize" "50MB" }}
-      total_limit_size {{ .Values.fluentd.aggregator.buffer | get "totalLimitSize" "9GB" }}
-
-      timekey {{ .Values.fluentd.aggregator.buffer | get "timekey" "10m" }}
-      timekey_wait {{ .Values.fluentd.aggregator.buffer | get "timekeyWait" "1m" }}
-      timekey_use_utc true
+      {{- range $key, $value := .Values.fluentd.aggregator.buffer }}
+      {{ $key | snakecase }} {{ $value }}
+      {{- end }}
 
     store.prop: |
       @type s3


### PR DESCRIPTION
**What this PR does / why we need it**:

So we can tune buffer settings to cope with higher log volumes.

**Special notes for reviewer**:

Should I do this for forwarder as well?

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
