### PR TITLE
apps: falco filter for image cleanup by containerd

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add gatekeeper mutation for setting seccomp profile
 - Allow drop all capabilites mutation to be disabled per service
 - Added annotation for the grafana dashboard "Compute Resources / Pod" to show container restarts
+- Add falco filter to not warn when containerd removes images that contain static log files or shell files
 
 ### Fixed
 

--- a/helmfile/values/falco.yaml.gotmpl
+++ b/helmfile/values/falco.yaml.gotmpl
@@ -159,6 +159,14 @@ customRules:
             )
           )
         )
+    - macro: allowed_clear_log_files
+      condition: (
+          fd.name startswith "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/" and proc.cmdline = containerd
+        )
+    - macro: user_known_shell_config_modifiers
+      condition: (
+          fd.name startswith "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/" and proc.cmdline = containerd
+        )
 
 falcosidekick:
   enabled: {{ .Values.falco.alerts.enabled }}


### PR DESCRIPTION
**What this PR does / why we need it**: Noticed that falco triggers alerts when containerd deletes images if they contain certain files (log files and shell config). So this will exclude any of those alerts if the file is deleted by containerd and it was in the image storage.

Link to the original falco rules:
https://github.com/elastisys/compliantkubernetes-apps/blob/ef3c1a55f529e3f75a4f17c91b3f01ad46d3aa07/helmfile/upstream/falco/rules/falco_rules.yaml#L453
https://github.com/elastisys/compliantkubernetes-apps/blob/ef3c1a55f529e3f75a4f17c91b3f01ad46d3aa07/helmfile/upstream/falco/rules/falco_rules.yaml#L2595

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
