### PR TITLE
apps sc: Use FQDN for Grafana to Dex communication

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -40,6 +40,7 @@
 - Source `extra-fluentd-config` user supplied settings
 - Change config option `falco.customRules` to a map
 - Synced the default prometheus interval with the grafana dashboards and datasources
+- Use FQDN for Grafana to Dex communication
 
 ### Updated
 

--- a/helmfile/values/grafana-user.yaml.gotmpl
+++ b/helmfile/values/grafana-user.yaml.gotmpl
@@ -114,9 +114,9 @@ grafana.ini:
     client_id: grafana
     client_secret: {{ .Values.grafana.clientSecret }}
     scopes: {{ .Values.user.grafana.oidc.scopes }}
-    auth_url: https://{{ .Values.dex.subdomain }}.{{ .Values.global.baseDomain }}/auth
-    token_url: http://dex.dex.svc.cluster.local:5556/token
-    api_url: http://dex.dex.svc.cluster.local:5556/api
+    auth_url: https://{{ .Values.dex.subdomain }}.{{ .Values.global.baseDomain }}./auth
+    token_url: http://dex.dex.svc.cluster.local.:5556/token
+    api_url: http://dex.dex.svc.cluster.local.:5556/api
     allowed_domains: {{ join " " .Values.user.grafana.oidc.allowedDomains }}
     allow_sign_up: true
     tls_skip_verify_insecure: {{ not .Values.global.verifyTls }}

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -245,9 +245,9 @@ grafana:
       client_id: grafana-ops
       client_secret: {{ .Values.grafana.opsClientSecret }}
       scopes: {{ .Values.prometheus.grafana.oidc.scopes }}
-      auth_url: https://{{ .Values.dex.subdomain }}.{{ .Values.global.baseDomain }}/auth
-      token_url: http://dex.dex.svc.cluster.local:5556/token
-      api_url: http://dex.dex.svc.cluster.local:5556/api
+      auth_url: https://{{ .Values.dex.subdomain }}.{{ .Values.global.baseDomain }}./auth
+      token_url: http://dex.dex.svc.cluster.local.:5556/token
+      api_url: http://dex.dex.svc.cluster.local.:5556/api
       allowed_domains: {{ join " " .Values.prometheus.grafana.oidc.allowedDomains }}
       allow_sign_up: true
       tls_skip_verify_insecure: {{ not .Values.global.verifyTls }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This should fix the issue that may come up on Cleura when Grafana can't resolve the IP to Dex.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
