### PR TITLE
apps wc: exclude fluentd-system ns from hnc

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -28,6 +28,7 @@
 - Allow drop all capabilites mutation to be disabled per service
 - Added annotation for the grafana dashboard "Compute Resources / Pod" to show container restarts
 - Add falco filter to not warn when containerd removes images that contain static log files or shell files
+- Added fluentd-system on the excluded list for hnc
 
 ### Fixed
 

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -79,6 +79,7 @@ hnc:
     - cert-manager
     - falco
     - fluentd
+    - fluentd-system
     - hnc-system
     - ingress-nginx
     - kube-node-lease


### PR DESCRIPTION
**What this PR does / why we need it**: to exclude fluentd-system ns from hnc and velero

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
