### PR TITLE
apps: rook-ceph netpol allow prometheus

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -43,6 +43,7 @@
 - Use FQDN for Grafana to Dex communication
 - Ensure Gatekeeper constraints cannot be circumvented by unavailability
 - Install Gatekeeper metrics in the service cluster
+- Rook-ceph netpol to allow prometheus scrape
 
 ### Updated
 

--- a/helmfile/charts/networkpolicy/common/templates/rook-ceph/mgr.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/rook-ceph/mgr.yaml
@@ -12,6 +12,9 @@ spec:
     matchLabels:
       app: rook-ceph-mgr
   ingress:
+    - from: {{ toYaml .Values.global.prometheusSelector | nindent 8 }}
+      ports:
+        - port: 9283
     - from:
         - podSelector:
             matchLabels:


### PR DESCRIPTION
**What this PR does / why we need it**: to allow prometheus scrape the rook-ceph metrics

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).