### PR TITLE
apps sc: Added so Grafana egress can be configured from sc-config.

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,3 +1,34 @@
+### Release notes
+
+- alertmanager:
+  - using`regex` field from the `Matcher` type is deprecated and it will be removed in a future version. See [CHANGELOG](https://github.com/prometheus-operator/prometheus-operator/blob/main/CHANGELOG.md#0570--2022-06-02)
+  - added support for new matching syntax in the routes configuration of the AlertmanagerConfig CRD. See [CHANGELOG](https://github.com/prometheus-operator/prometheus-operator/blob/main/CHANGELOG.md#0530--2021-12-16)
+- kube-prometheus-stack:
+  - the portName for alertmanager and prometheus have been renamed from `web` to `http-web`. If this port names are used by you application or to port-forward to prometheus/alertmanager, you will need to update them to `http-web` or use the port numbers instead (e.g 9090 for prometheus and 9093 for alertmanager)
+  - added default metric relabeling for cAdvisor and apiserver metrics to reduce cardinality. See [CHANGELOG](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-36x-to-37x)
+
+### Added
+
+- Add PrometheusRule to alert for dropped packets to/from workloads.
+- Add Gatekeeper PSPs for ingress-nginx and monitoring namespaces.
+- Add Gatekeeper PSPs for Fluentd and OpenSearch
+- Add Gatekeeper PSPs for Kured.
+- Add Gatekeeper PSPs for Harbor
+- Add Gatekeeper mutation for setting job TTL if not already set. By default, a TTL of 7 days will be set.
+- Enabled Pod Security Admission for `dex` and `cert-manager`
+- Add Gatekeeper PSPs for Velero.
+- Metrics and Grafana dashboard for Harbor.
+- Added so the user admins can read hierarchyconfigurations.
+- Add Gatekeeper PSPs for HNC.
+- Add Gatekeeper PSPs for falco.
+- Add cache-image workflow
+- Possibility to enable metrics for Cluster API in `kube-state-metrics`.
+- Add node-local-dns Grafana dashboard
+- Add gatekeeper mutation for setting seccomp profile
+- Allow drop all capabilites mutation to be disabled per service
+- Added annotation for the grafana dashboard "Compute Resources / Pod" to show container restarts
+- Added so Grafana egress can be configured from sc-config.
+
 ### Fixed
 
 - Fixed issue with compaction job on ephemeral volumes

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -1148,6 +1148,13 @@ networkPolicies:
   monitoring:
     enabled: true
     grafana:
+     # allows sc-config to add ip and ports to access user Grafana
+      externalDataSources:
+        enabled: false
+        ips:
+          - "set-me-if-externalDataSources.enabled"
+        ports:
+          - "set-me-if-externalDataSources.enabled"
       # loading dashboards from grafana website
       externalDashboardProvider:
         ips:

--- a/helmfile/charts/networkpolicy/service-cluster/templates/grafana/allow-grafana.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/grafana/allow-grafana.yaml
@@ -86,6 +86,18 @@ spec:
         - port: {{ $port }}
         {{- end }}
     {{- end }}
+    # allows sc-config to add ip and ports to access user Grafana
+    {{- if .Values.monitoring.grafana.externalDataSources.enabled }}
+    - to:
+        {{- range $ip := .Values.monitoring.grafana.externalDataSources.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        {{- range $port := .Values.monitoring.grafana.externalDataSources.ports }}
+        - port: {{ $port }}
+        {{- end }}
+    {{- end }}
     - ports:
       - protocol: TCP
         port: 53

--- a/helmfile/charts/networkpolicy/service-cluster/values.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/values.yaml
@@ -86,6 +86,13 @@ harbor:
 monitoring:
   enabled: true
   grafana:
+  # allows sc-config to add ip and ports to access user Grafana
+    externalDataSources:
+      enabled: false
+      ips:
+        - "0.0.0.0/0"
+      ports:
+        - 9090
     # loading dashboards from grafana website
     externalDashboardProvider:
       ips:

--- a/helmfile/values/networkpolicy/service-cluster.yaml.gotmpl
+++ b/helmfile/values/networkpolicy/service-cluster.yaml.gotmpl
@@ -57,6 +57,10 @@ harbor:
 monitoring:
   enabled: {{ .Values.networkPolicies.monitoring.enabled }}
   grafana:
+    externalDataSources:
+      enabled: {{ .Values.networkPolicies.monitoring.grafana.externalDataSources.enabled }}
+      ips: {{- toYaml .Values.networkPolicies.monitoring.grafana.externalDataSources.ips | nindent 8 }}
+      ports: {{- toYaml .Values.networkPolicies.monitoring.grafana.externalDataSources.ports | nindent 8 }}
     externalDashboardProvider:
       ips: {{- toYaml .Values.networkPolicies.monitoring.grafana.externalDashboardProvider.ips | nindent 8 }}
       ports: {{- toYaml .Values.networkPolicies.monitoring.grafana.externalDashboardProvider.ports | nindent 8 }}

--- a/pipeline/config/exoscale/sc-config.yaml
+++ b/pipeline/config/exoscale/sc-config.yaml
@@ -57,6 +57,8 @@ networkPolicies:
         - "0.0.0.0/0"
   monitoring:
     grafana:
+      externalDataSources:
+        enabled: false
       externalDashboardProvider:
         ips:
           - 0.0.0.0/0


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows sc-config to configure Grafana egress. / So it is easier to allow ip addresses and ports to access user Grafana.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1439

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
