### PR TITLE
apps: really fix kube-prometheus-stack migration script

### DIFF
--- a/migration/v0.30/apply/20-remove-kube-prometheus-components.sh
+++ b/migration/v0.30/apply/20-remove-kube-prometheus-components.sh
@@ -9,8 +9,8 @@ run() {
   case "${1:-}" in
   execute)
     for CLUSTER in sc wc; do
-      old_state_metrics=$(kubectl get deployments.apps -n monitoring -l app.kubernetes.io/instance=kube-prometheus-stack,app.kubernetes.io/name=kube-state-metrics,app.kubernetes.io/version!=2.8.0 --output=jsonpath={.items..metadata.name})
-      old_node_exporter=$(kubectl get daemonset -n monitoring -l app=prometheus-node-exporter --output=jsonpath={.items..metadata.name})
+      old_state_metrics=$(kubectl_do $CLUSTER get deployments.apps -n monitoring -l app.kubernetes.io/instance=kube-prometheus-stack,app.kubernetes.io/name=kube-state-metrics,app.kubernetes.io/version!=2.8.0 --output=jsonpath={.items..metadata.name})
+      old_node_exporter=$(kubectl_do $CLUSTER get daemonset -n monitoring -l app=prometheus-node-exporter --output=jsonpath={.items..metadata.name})
 
       if [[ -n "${old_state_metrics}" ]]; then
         log_info "- removing kube-state-metrics from $CLUSTER"


### PR DESCRIPTION
**What this PR does / why we need it**:

Can't run bare kubectl in this context, fails with
> The connection to the server localhost:8080 was refused - did you specify the right host or port?
> [ck8s] v0.30/apply: apply snippet execute failure

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes ... see above

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [x] requires running a migration script. *(fix for an existing migration script)*
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
