### PR TITLE
apps wc: add default securitycontext mutations for user namespaces

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -30,6 +30,7 @@
 - Add falco filter to not warn when containerd removes images that contain static log files or shell files
 - Added fluentd-system on the excluded list for hnc
 - Added so log-manager compaction can use ephemeral volumes.
+- Add default securitycontext mutations for restricted user namespaces
 
 ### Fixed
 

--- a/helmfile/14-podsecuritypolicies.yaml
+++ b/helmfile/14-podsecuritypolicies.yaml
@@ -105,3 +105,14 @@ releases:
     values:
       - values/podsecuritypolicies/service/opensearch.yaml.gotmpl
 {{- end }}
+
+{{- if eq .Environment.Name "workload_cluster" }}
+  - name: podsecuritypolicy
+    namespace: default
+    labels:
+      psp: default
+    chart: ./charts/gatekeeper/podsecuritypolicies
+    version: 0.1.0
+    values:
+      - values/podsecuritypolicies/workload/default.yaml.gotmpl
+{{- end }}

--- a/helmfile/values/podsecuritypolicies/workload/default.yaml.gotmpl
+++ b/helmfile/values/podsecuritypolicies/workload/default.yaml.gotmpl
@@ -1,0 +1,14 @@
+constraints:
+  default: {}
+
+mutations:
+  # Select user restricted namespaces
+  namespaceSelectorLabels:
+    - key: owner
+      operator: NotIn
+      values:
+        - operator
+    - key: pod-security.kubernetes.io/enforce
+      operator: In
+      values:
+        - restricted


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the default mutation for user namespaces that are locked down with the restricted pod security policy. The helm release is installed in the default namespace. This means that the gatekeeper constraints are applied to that namespace, which should be fine as no user should have access to the default namespace.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
