### PR TITLE
bin: add logging flag

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -38,6 +38,7 @@
 - Add option to override usernamespace `restricted` PSA level
   - Namespaces overridden will not be managed by HNC.
 - Add usernamespace gatekeeper constraints, for overridden usernamespaces.
+- Added `--logging-enabled` flag for test scripts and disabled logging by default
 
 ### Fixed
 

--- a/bin/ck8s
+++ b/bin/ck8s
@@ -14,7 +14,7 @@ usage() {
     echo "  bootstrap <wc|sc>                                 bootstrap the cluster" 1>&2
     echo "  apps <wc|sc> [--sync] [--skip-template-validate]  deploy the applications" 1>&2
     echo "  apply <wc|sc> [--sync] [--skip-template-validate] bootstrap and apps" 1>&2
-    echo "  test <wc|sc>                                      test the applications" 1>&2
+    echo "  test <wc|sc> [--logging-enabled]                  test the applications" 1>&2
     echo "  dry-run <wc|sc> [--kubectl]                       runs helmfile diff" 1>&2
     echo "  upgrade <version-matching-migration> prepare      runs all prepare steps upgrading the configuration" 1>&2
     echo "  upgrade <version-matching-migration> apply        runs all apply steps upgrading the environment" 1>&2
@@ -43,6 +43,7 @@ SYNC=""
 SKIP=""
 KUBECTL=""
 GEN_NEW_SECRETS=""
+LOGGING=""
 
 for arg in "$@"; do
   case "$arg" in
@@ -50,6 +51,7 @@ for arg in "$@"; do
     "--sync") SYNC="sync" ;;
     "--kubectl") KUBECTL="kubectl" ;;
     "--generate-new-secrets") GEN_NEW_SECRETS="--generate-new-secrets" ;;
+    "--logging-enabled") LOGGING="--logging-enabled" ;;
   esac
 done
 

--- a/bin/test.bash
+++ b/bin/test.bash
@@ -24,13 +24,15 @@ source "${pipeline_path}/test/services/workload-cluster/testHNC.sh"
 test_apps_sc() {
     log_info "Testing service cluster"
 
-    "${pipeline_path}/test/services/test-sc.sh" "${config[config_file_sc]}"
+    "${pipeline_path}/test/services/test-sc.sh" "${config[config_file_sc]}" "${@}"
+
 }
 
 test_apps_wc() {
     log_info "Testing workload cluster"
 
-    "${pipeline_path}/test/services/test-wc.sh" "${config[config_file_wc]}"
+    "${pipeline_path}/test/services/test-wc.sh" "${config[config_file_wc]}" "${@}"
+
 }
 
 function sc_help() {
@@ -40,6 +42,7 @@ function sc_help() {
     printf "\t%-23s %s\n" "cert-manager" "Cert Manager checks"
     printf "\t%-23s %s\n" "ingress" "Ingress checks"
     printf "%s\n" "[NOTE] If no target is specified, the default sc apps tests will be executed."
+    printf "%s\n" "[NOTE] Logging can be enabled for the sc apps tests by using the --logging-enabled flag."
     exit 0
 }
 
@@ -50,12 +53,13 @@ function wc_help() {
     printf "\t%-23s %s\n" "ingress" "Ingress checks"
     printf "\t%-23s %s\n" "hnc" "HNC checks"
     printf "%s\n" "[NOTE] If no target is specified, the default wc apps tests will be executed."
+    printf "%s\n" "[NOTE] Logging can be enabled for wc apps tests by using the --logging-enabled flag."
     exit 0
 }
 
 function sc() {
-    if [[ ${#} == 0 ]]; then
-        test_apps_sc
+    if [[ ${#} == 0 ]] || [[ ${#} == 1 && ${1} == "--logging-enabled" ]]; then
+        test_apps_sc "${@}"
     else
         case ${1} in
         opensearch)
@@ -81,8 +85,8 @@ function sc() {
 }
 
 function wc() {
-    if [[ ${#} == 0 ]]; then
-        test_apps_wc
+    if [[ ${#} == 0 ]] || [[ ${#} == 1 && ${1} == "--logging-enabled" ]]; then
+        test_apps_wc "${@}"
     else
         case ${1} in
         cert-manager)

--- a/pipeline/test/services/service-cluster/testPodsReady.sh
+++ b/pipeline/test/services/service-cluster/testPodsReady.sh
@@ -238,7 +238,7 @@ for cronjob in "${cronjobs[@]}"; do
     namespace="${arr[0]}"
     name="${arr[1]}"
     echo -n -e "\n${name}\t"
-    if testResourceExistence cronjob "${namespace}" "${name}"; then
+    if testResourceExistence cronjob "${namespace}" "${name}" && [ -n "$LOGGING" ]; then
         logCronJob "${namespace}" "${name}"
     fi
 done

--- a/pipeline/test/services/test-sc.sh
+++ b/pipeline/test/services/test-sc.sh
@@ -7,7 +7,7 @@ if [[ ! -f $1 ]];then
     exit 1
 fi
 export CONFIG_FILE=$1
-
+LOGGING="${2:-}"
 SUCCESSES=0
 FAILURES=0
 DEBUG_OUTPUT=("")
@@ -29,7 +29,7 @@ source "${SCRIPTS_PATH}"/service-cluster/testPrometheusTargets.sh
 echo -e "\nSuccesses: $SUCCESSES"
 echo "Failures: $FAILURES"
 
-if [ $FAILURES -gt 0 ]
+if [ $FAILURES -gt 0 ] && [ -n "$LOGGING" ]
 then
     echo "Something failed"
     echo
@@ -42,6 +42,21 @@ then
     echo "==============================="
     echo
     echo "Exists in events/ServiceCluster/<kind>/<namespace>"
+    echo
+    echo "Json output of failed test resources"
+    echo "===================================="
+    echo
+    echo "${DEBUG_OUTPUT[@]}" | jq .
+    echo
+    echo "Unhealthy/missing prometheus targets"
+    echo "===================================="
+    echo
+    echo "${DEBUG_PROMETHEUS_TARGETS[@]}"
+    echo
+    exit 1
+elif [ $FAILURES -gt 0 ]
+then
+    echo "Something failed"
     echo
     echo "Json output of failed test resources"
     echo "===================================="

--- a/pipeline/test/services/test-wc.sh
+++ b/pipeline/test/services/test-wc.sh
@@ -7,7 +7,7 @@ if [[ ! -f $1 ]];then
 fi
 
 export CONFIG_FILE=$1
-
+LOGGING="${2:-}"
 SUCCESSES=0
 FAILURES=0
 DEBUG_OUTPUT=("")
@@ -28,7 +28,7 @@ source "${SCRIPTS_PATH}"/workload-cluster/testUserRbac.sh
 echo -e "\nSuccesses: $SUCCESSES"
 echo "Failures: $FAILURES"
 
-if [ $FAILURES -gt 0 ]
+if [ $FAILURES -gt 0 ] && [ -n "$LOGGING" ]
 then
     echo "Something failed"
     echo
@@ -41,6 +41,21 @@ then
     echo "==============================="
     echo
     echo "Exists in events/WorkloadCluster/<kind>/<namespace>"
+    echo
+    echo "Json output of failed test resources"
+    echo "===================================="
+    echo
+    echo "${DEBUG_OUTPUT[@]}" | jq .
+    echo
+    echo "Unhealthy/missing prometheus targets"
+    echo "===================================="
+    echo
+    echo "${DEBUG_PROMETHEUS_TARGETS[@]}"
+    echo
+    exit 1
+elif [ $FAILURES -gt 0 ]
+then
+    echo "Something failed"
     echo
     echo "Json output of failed test resources"
     echo "===================================="


### PR DESCRIPTION
**What this PR does / why we need it**:
Test scripts take a long time when writing logs/events to files, this is now disabled by default and can be enabled with the `--logging-enabled` flag.
**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1563 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
