### PR TITLE
apps sc: missing uri and permissions for opensearch exporter

### DIFF
--- a/helmfile/values/opensearch/configurer.yaml.gotmpl
+++ b/helmfile/values/opensearch/configurer.yaml.gotmpl
@@ -158,13 +158,14 @@ config:
         - "cluster_monitor"
         - "cluster:admin/repository/get"
         - "cluster:admin/snapshot/get"
+        - "cluster:admin/snapshot/status"
         index_permissions:
         - index_patterns:
           - "*"
           allowed_actions:
-          - "indices:monitor/stats"
-          - "indices:monitor/settings/get"
+          - "indices_monitor"
           - "indices:admin/mappings/get"
+          - "indices:admin/aliases/get"
     {{- with .Values.opensearch.extraRoles }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/helmfile/values/prometheus-opensearch-exporter.yaml.gotmpl
+++ b/helmfile/values/prometheus-opensearch-exporter.yaml.gotmpl
@@ -1,7 +1,7 @@
 es:
   # Set to null! This is set through env instead.
   # See https://github.com/justwatchcom/elasticsearch_exporter/issues/307
-  uri:
+  uri: https://{{ .Values.opensearch.clusterName }}-master:9200
   all: true
   indices: true
   indices_settings: true


### PR DESCRIPTION
**What this PR does / why we need it**: fixes to opensearch exporter

**Special notes for reviewer**:
- I used this [list](https://github.com/prometheus-community/elasticsearch_exporter#elasticsearch-7x-security-privileges) to determine the permissions needed by the exporter

**Add a screenshot or an example to illustrate the proposed solution:**
![image](https://user-images.githubusercontent.com/77267293/236424468-d287f2fe-97fb-411c-8170-80558eba3070.png)

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
