### PR TITLE
apps sc: use the latest patch release for grafana

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -75,6 +75,7 @@
 - prometheus-elasticsearch-exporter to v5.1.1
 - velero to v1.10.2, chart v3.1.6
 - Update falco exceptions to reduce false positives
+- grafana to v9.3.13 to fix some security issues
 
 ### Changed
 

--- a/helmfile/values/grafana-user.yaml.gotmpl
+++ b/helmfile/values/grafana-user.yaml.gotmpl
@@ -1,7 +1,7 @@
 adminPassword: {{ .Values.user.grafanaPassword }}
 
 image:
-  tag: 9.3.8
+  tag: 9.3.13
 
 testFramework:
   enabled: false

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -184,7 +184,7 @@ kubeScheduler:
 
 grafana:
   image:
-    tag: 9.3.8
+    tag: 9.3.13
 
   testFramework:
     enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**: to use the latest patch release that has some security fixes

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

