### PR TITLE
apps: OPA always enabled

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -6,6 +6,8 @@
 - kube-prometheus-stack:
   - the portName for alertmanager and prometheus have been renamed from `web` to `http-web`. If this port names are used by you application or to port-forward to prometheus/alertmanager, you will need to update them to `http-web` or use the port numbers instead (e.g 9090 for prometheus and 9093 for alertmanager)
   - added default metric relabeling for cAdvisor and apiserver metrics to reduce cardinality. See [CHANGELOG](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-36x-to-37x)
+- Gatekeeper:
+  - OPA / Gatekeeper will now be mandatory as it will be used to enforce PodSecurityPolicies with constraints instead of vanilla Kubernetes PodSecurityPolicies as they are unavailable from Kubernetes v1.25.
 
 ### Added
 

--- a/bootstrap/namespaces/helmfile/values/namespaces-sc.yaml.gotmpl
+++ b/bootstrap/namespaces/helmfile/values/namespaces-sc.yaml.gotmpl
@@ -61,12 +61,10 @@ namespaces:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/warn: privileged
 {{ end }}
-{{ if .Values.opa.enabled }}
 - name: gatekeeper-system
   labels:
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/enforce: restricted
     pod-security.kubernetes.io/warn: restricted
-{{ end }}
 commonLabels:
   owner: operator

--- a/bootstrap/namespaces/helmfile/values/namespaces-wc.yaml.gotmpl
+++ b/bootstrap/namespaces/helmfile/values/namespaces-wc.yaml.gotmpl
@@ -49,13 +49,11 @@ namespaces:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/warn: privileged
 {{ end }}
-{{ if .Values.opa.enabled }}
 - name: gatekeeper-system
   labels:
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/enforce: restricted
     pod-security.kubernetes.io/warn: restricted
-{{ end }}
 {{ if .Values.hnc.enabled }}
 - name: hnc-system
   labels:

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -583,8 +583,6 @@ clusterAdmin:
 
 ## Open policy agent configuration
 opa:
-  enabled: true
-
   mutations:
     enabled: true
 

--- a/helmfile/12-gatekeeper.yaml
+++ b/helmfile/12-gatekeeper.yaml
@@ -30,7 +30,6 @@ releases:
     component: gatekeeper
   chart: ./upstream/gatekeeper
   version: 3.11.0
-  installed: {{ .Values.opa.enabled }}
   disableValidationOnInstall: true
   wait: true
   values:

--- a/helmfile/13-gatekeeper-templates.yaml
+++ b/helmfile/13-gatekeeper-templates.yaml
@@ -30,7 +30,6 @@ releases:
     component: gatekeeper-templates
   chart: ./charts/gatekeeper/templates
   version: 1.6.0
-  installed: {{ .Values.opa.enabled }}
   wait: true
   values:
   - values/gatekeeper/templates.yaml.gotmpl

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -204,7 +204,6 @@ releases:
     component: gatekeeper-metrics
   chart: ./charts/gatekeeper/metrics
   version: 0.1.0
-  installed: {{ .Values.opa.enabled }}
 
 - name: gatekeeper-mutations
   namespace: gatekeeper-system
@@ -213,7 +212,7 @@ releases:
     component: gatekeeper-mutations
   chart: ./charts/gatekeeper/mutations
   version: 0.1.0
-  installed: {{ and .Values.opa.enabled .Values.opa.mutations.enabled }}
+  installed: {{ .Values.opa.mutations.enabled }}
   values:
   - values/gatekeeper/mutations.yaml.gotmpl
 
@@ -665,7 +664,6 @@ releases:
     component: gatekeeper-constraints
   chart: ./charts/gatekeeper/constraints
   version: 1.6.0
-  installed: {{ .Values.opa.enabled }}
   values:
   - values/gatekeeper/constraints.yaml.gotmpl
 

--- a/helmfile/values/networkpolicy/common.yaml.gotmpl
+++ b/helmfile/values/networkpolicy/common.yaml.gotmpl
@@ -100,7 +100,7 @@ fluentd:
   enabled: {{ and .Values.fluentd.enabled .Values.networkPolicies.fluentd.enabled }}
 
 gatekeeper:
-  enabled: {{ and .Values.opa.enabled .Values.networkPolicies.gatekeeper.enabled }}
+  enabled: true
 
 rookCeph:
   enabled: {{ .Values.networkPolicies.rookCeph.enabled }}

--- a/migration/v0.30/prepare/09-gatekeeper-enabled.sh
+++ b/migration/v0.30/prepare/09-gatekeeper-enabled.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+log_info "- ensure .opa.enabled is removed"
+yq_remove common .opa.enabled
+yq_remove sc .opa.enabled
+yq_remove wc .opa.enabled

--- a/pipeline/test/services/workload-cluster/testPodsReady.sh
+++ b/pipeline/test/services/workload-cluster/testPodsReady.sh
@@ -6,7 +6,6 @@ source "${INNER_SCRIPTS_PATH}/../funcs.sh"
 
 enable_falco_alerts=$(yq4 -e '.falco.alerts.enabled' "${CONFIG_FILE}" 2>/dev/null)
 enable_falco=$(yq4 -e '.falco.enabled' "${CONFIG_FILE}" 2>/dev/null)
-enable_opa=$(yq4 -e '.opa.enabled' "${CONFIG_FILE}" 2>/dev/null)
 enable_hnc=$(yq4 -e '.hnc.enabled' "${CONFIG_FILE}" 2>/dev/null)
 enable_hnc_ha=$(yq4 -e '.hnc.ha' "${CONFIG_FILE}" 2>/dev/null)
 enable_user_alertmanager=$(yq4 -e '.user.alertmanager.enabled' "${CONFIG_FILE}" 2>/dev/null)
@@ -24,15 +23,13 @@ deployments=(
     "cert-manager cert-manager"
     "cert-manager cert-manager-cainjector"
     "cert-manager cert-manager-webhook"
+    "gatekeeper-system gatekeeper-controller-manager"
+    "ingress-nginx ingress-nginx-default-backend"
     "kube-system coredns"
     "kube-system metrics-server"
-    "ingress-nginx ingress-nginx-default-backend"
     "monitoring kube-prometheus-stack-operator"
     "monitoring kube-prometheus-stack-kube-state-metrics"
 )
-if "${enable_opa}"; then
-    deployments+=("gatekeeper-system gatekeeper-controller-manager")
-fi
 if "${enable_hnc}"; then
     deployments+=("hnc-system hnc-controller-controller-manager")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Since we rely on Gatekeeper for PSP, we can't really disable it nowadays.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
