### PR TITLE
apps sc & wc: private subnet as node-ips

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Updated
 
 - Upgraded falco-exporter chart version to `v0.9.6` and app version to `v0.8.3`
+- Added "IPs in Subnet mask" logic in checkIfDiffAndUpdateDNSIPs, checkIfDiffAndUpdateKubectlIPs and checkIfDiffAndUpdateIPs of update-ips.bash
 
 ### Removed
 

--- a/bin/ck8s
+++ b/bin/ck8s
@@ -36,7 +36,7 @@ usage() {
     echo "  validate <wc|sc>                                  validates config files" 1>&2
     echo "  providers                                         lists supported cloud providers" 1>&2
     echo "  flavors                                           lists supported configuration flavors" 1>&2
-    echo "  update-ips <wc|sc|both> <update|dry-run>          Automatically fetches and updates the IPs for network policies" 1>&2
+    echo "  update-ips <wc|sc|both> <apply|dry-run>           Automatically fetches and applies the IPs for network policies" 1>&2
     exit 1
 }
 
@@ -152,7 +152,7 @@ case "${1}" in
     flavors) echo "${ck8s_flavors[@]}" ;;
     update-ips)
         [[ "${2}" =~ ^(wc|sc|both)$ ]] || usage
-        [[ "${3}" =~ ^(update|dry-run)$ ]] || usage
+        [[ "${3}" =~ ^(apply|dry-run)$ ]] || usage
         "${here}/update-ips.bash" "${2}" "${3}"
         ;;
     *) usage ;;

--- a/bin/update-ips.bash
+++ b/bin/update-ips.bash
@@ -206,7 +206,7 @@ processIPRanges(){
     yq4 -i "$inputSource"' = []' "$inputConfig"
 
     # IF config value is not empty, go ahead with the following:
-    # 1. Check if any got kubectlIPs fit inside of the IPs existing in the config-files.
+    # 1. Check if any got IPS fit inside of the IPs existing in the config-files.
     # 2. IF True = Put the working subnet-address and kube-address in assigned arrays for comparison and remove copies.
     # 3. Merge the working subnet-addresses and kube-addresses into a finalized list.
     if [ "${#multiIPRanges[@]}" -gt 0 ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/elastisys/compliantkubernetes-apps/issues/1453 https://github.com/elastisys/compliantkubernetes-apps/issues/1677

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: 
fixes #1453 
fixes #1677

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
Ready for review.

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
