### PR TITLE
apps sc: Added possibility to change Alertmanager template for slack

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -28,6 +28,7 @@
 - Allow drop all capabilites mutation to be disabled per service
 - Added annotation for the grafana dashboard "Compute Resources / Pod" to show container restarts
 - Added so Grafana egress can be configured from sc-config.
+- Added possibility to change Alertmanager template for slack alerts.
 
 ### Fixed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -1054,6 +1054,17 @@ alerts:
     name: set-me-if-enabled
   slack:
     channel: set-me-if-enabled
+    # Alertmanager templating: https://prometheus.io/docs/alerting/notifications/ 
+    customTemplate: {}
+    ## Example:
+    # customTemplate: |-
+    #   *Common summary:* {{ .CommonAnnotations.summary }}
+    #   *Common description:* {{ .CommonAnnotations.description }}
+
+    #   *Individual alerts below*
+    #   {{ range .Alerts }}
+    #   *Status:* {{ .Status }}
+    #   {{ end }}
   opsGenie:
     apiUrl: https://api.eu.opsgenie.com
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -1054,7 +1054,7 @@ alerts:
     name: set-me-if-enabled
   slack:
     channel: set-me-if-enabled
-    # Alertmanager templating: https://prometheus.io/docs/alerting/notifications/ 
+    # Alertmanager templating: https://prometheus.io/docs/alerting/notifications/
     customTemplate: {}
     ## Example:
     # customTemplate: |-

--- a/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -145,6 +145,9 @@ alertmanager:
         text: |-
           <!channel>
           *Cluster:* {{ .Values.prometheus.grafana.subdomain }}.{{ .Values.global.opsDomain }}
+          {{- if .Values.alerts.slack.customTemplate }}
+          {{ .Values.alerts.slack.customTemplate | nindent 10 }}
+          {{- else }}
           {{`
           *Common summary:* {{ .CommonAnnotations.summary }}
           *Common description:* {{ .CommonAnnotations.description }}
@@ -159,6 +162,7 @@ alertmanager:
           *{{ .Name }}:* {{ .Value }}
           {{ end }}
           {{ end }}`}}
+          {{- end }}
       {{ end }}
     - name: opsgenie
       {{ if eq .Values.alerts.alertTo "opsgenie" }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Added templating to be able to change the Alertmanager template for slack alerts. An on-prem customer asked about this.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
