### PR TITLE
apps sc: Added support for swift in rclone-sync.

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Added
 
+- Added support for Swift in rclone-sync.
+  - It is now possible to specify type (S3/Swift) per bucket.
+
 ### Changed
 
 - Increased window for `FrequentPacketsDroppedFromWorkload` and `FrequentPacketsDroppedToWorkload` alerts

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -9,7 +9,7 @@ global:
     - ${CK8S_ENVIRONMENT_NAME}-wc
 
 objectStorage:
-  ## Swift can be enabled separately for Harbor and Thanos only.
+  ## Swift can be enabled separately for Harbor, Thanos and rclone-sync only.
   # swift:
   #   authVersion: 0 # auto detect
   #   authUrl: set-me
@@ -32,15 +32,19 @@ objectStorage:
     enabled: false
     # dryrun: false
 
-    ## Options are 's3'
+    ## Options are 's3 and swift'
     type: none
+    # secondaryUrl: set-me if regionEndpoint and or authUrl does not have all the relevant ips and or ports used for rclone-sync networkpolicy.
     # s3:
     #   region: set-me
     #   regionEndpoint: set-me
     #   # Generally false when using AWS and Exoscale and true for other providers.
     #   forcePathStyle: set-me
     #   # v2Auth: false
-
+    ## rclone-sync needs authUrl with a /v3 suffix for swift.
+    # swift:
+    #   authUrl: set-me
+    #   region: set-me
     ## Sync all buckets under 'objectStorage.buckets'
     ## These will be appended to 'buckets' using the same name from source as destination, and the default schedule.
     syncDefaultBuckets: false
@@ -53,7 +57,8 @@ objectStorage:
       # - source: source-bucket
       #   # destination: destination-bucket # if unset it will be the same as 'source'
       #   # schedule: 0 5 * * *             # if unset it will be the same as 'defaultSchedule'
-
+      #   # sourceType: Optional but if included it uses s3 or swift
+      #   # destinationType: Optional but if included it uses s3 or swift.
     # Encrypt (symmetric) before syncing
     encrypt:
       enabled: false
@@ -1107,10 +1112,8 @@ welcomingDashboard:
 networkPolicies:
   global:
     objectStorageSwift:
-      ips:
-        - set-me-if-enabled
-      ports:
-        - set-me-if-enabled
+      ips: [] # - set-me-if-enabled
+      ports: [] # - set-me-if-enabled
     scApiserver:
       # usually private ip of control-plane nodes
       ips:
@@ -1205,12 +1208,15 @@ networkPolicies:
 
   rcloneSync:
     enabled: true
-    destinationObjectStorage:
-      ips:
-        - "set-me-if-objectStorage.sync.enabled"
-      ports:
-        - 443
-
+    destinationObjectStorageS3:
+      ips: [] # - "set-me-if-objectStorage.sync.enabled-and-type-is-s3"
+      ports: [] # - 443
+    destinationObjectStorageSwift:
+      ips: [] # - "set-me-if-objectStorage.sync.enabled-and-type-is-swift"
+      ports: [] # - 443
+    secondaryUrl:
+      ips: [] # - "set-me-if-secondaryUrl-has-a-url"
+      ports: [] # - 443
   s3Exporter:
     enabled: true
 

--- a/config/secrets/sc-secrets.yaml
+++ b/config/secrets/sc-secrets.yaml
@@ -8,7 +8,7 @@ objectStorage: {}
   # swift:
   #   username: set-me
   #   password: set-me
-  #   # Configure application credential to use with Thanos
+  #   # Configure application credential to use with Thanos and or rclone-sync
   #   applicationCredentialID: "set-me"
   #   applicationCredentialSecret: "set-me"
   #
@@ -17,6 +17,9 @@ objectStorage: {}
   #   s3:
   #     accessKey: "set-me"
   #     secretKey: "set-me"
+  #   swift:
+  #     applicationCredentialID: "set-me"
+  #     applicationCredentialSecret: "set-me"
   #   encrypt:
   #     password: "set-me" # generate with `pwgen 32 1`
   #     salt: "set-me" # generate with `pwgen 32 1`

--- a/helmfile/charts/networkpolicy/service-cluster/templates/rclone-sync.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/rclone-sync.yaml
@@ -18,23 +18,23 @@ spec:
           protocol: TCP
     {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
     - to:
-        {{- range .Values.global.objectStorage.ips }}
+        {{- range .Values.global.objectStorage.ips | uniq }}
         - ipBlock:
             cidr: {{ . }}
         {{- end }}
       ports:
-        {{- range .Values.global.objectStorage.ports }}
+        {{- range .Values.global.objectStorage.ports | uniq }}
         - port: {{ . }}
         {{- end }}
     {{- end }}
     {{- if and .Values.rcloneSync.destinationObjectStorage.ips .Values.rcloneSync.destinationObjectStorage.ports }}
     - to:
-        {{- range .Values.rcloneSync.destinationObjectStorage.ips }}
+        {{- range .Values.rcloneSync.destinationObjectStorage.ips | uniq }}
         - ipBlock:
             cidr: {{ . }}
         {{- end }}
       ports:
-        {{- range .Values.rcloneSync.destinationObjectStorage.ports }}
+        {{- range .Values.rcloneSync.destinationObjectStorage.ports | uniq }}
         - port: {{ . }}
         {{- end }}
     {{- end }}

--- a/helmfile/charts/rclone-sync/files/rclone.conf
+++ b/helmfile/charts/rclone-sync/files/rclone.conf
@@ -1,23 +1,21 @@
-[{{ .Values.config.source.name }}]
-type = {{ .Values.config.source.type }}
-{{- if eq .Values.config.source.type "s3" }}
-access_key_id = {{ .Values.config.source.s3.accessKey }}
-secret_access_key = {{ .Values.config.source.s3.secretKey }}
-region = {{ .Values.config.source.s3.region }}
-endpoint = {{ .Values.config.source.s3.regionEndpoint }}
-force_path_style = {{ .Values.config.source.s3.forcePathStyle }}
-v2_auth = {{ .Values.config.source.s3.v2Auth }}
+{{- range concat .Values.config.source .Values.config.destination }}
+[{{ .name }}]
+type = {{ .type }}
+{{- if eq .type "s3" }}
+access_key_id = {{ .s3.accessKey }}
+secret_access_key = {{ .s3.secretKey }}
+region = {{ .s3.region }}
+endpoint = {{ .s3.regionEndpoint }}
+force_path_style = {{ .s3.forcePathStyle }}
+v2_auth = {{ .s3.v2Auth | default false }}
 {{- end }}
 
-[{{ .Values.config.destination.name }}]
-type = {{ .Values.config.destination.type }}
-{{- if eq .Values.config.destination.type "s3" }}
-access_key_id = {{ .Values.config.destination.s3.accessKey }}
-secret_access_key = {{ .Values.config.destination.s3.secretKey }}
-region = {{ .Values.config.destination.s3.region }}
-endpoint = {{ .Values.config.destination.s3.regionEndpoint }}
-force_path_style = {{ .Values.config.destination.s3.forcePathStyle }}
-v2_auth = {{.Values.config.destination.s3.v2Auth }}
+{{- if eq .type "swift" }}
+application_credential_id = {{ .swift.applicationCredentialID }}
+application_credential_secret = {{ .swift.applicationCredentialSecret }}
+auth = {{ .swift.authUrl }}
+region = {{ .swift.region }}
+{{- end }}
 {{- end }}
 
 {{- if .Values.config.encrypt.enabled }}

--- a/helmfile/charts/rclone-sync/templates/cronjob.yaml
+++ b/helmfile/charts/rclone-sync/templates/cronjob.yaml
@@ -29,11 +29,11 @@ spec:
               image: {{ $.Values.image.repository }}:{{ $.Values.image.tag }}
               args:
                 - sync
-                - {{ $.Values.config.source.name }}:{{ .source }}
+                - src-{{ .sourceType }}:{{ .source }}
                 {{- if $.Values.config.encrypt.enabled }}
                 - "{{ $.Values.config.encrypt.name }}-{{ .destination }}:"
                 {{- else }}
-                - {{ $.Values.config.destination.name }}:{{ .destination }}
+                - dest-{{ .destinationType }}:{{ .destination }}
                 {{- end }}
                 - --log-level
                 - DEBUG

--- a/helmfile/charts/rclone-sync/values.yaml
+++ b/helmfile/charts/rclone-sync/values.yaml
@@ -6,7 +6,7 @@ config:
   dryrun: false
 
   source:
-    name: provider-region-a
+  - name: provider-region-a
     type: s3
     s3:
       region: region
@@ -15,9 +15,16 @@ config:
       secretKey: secret-key
       forcePathStyle: true
       v2Auth: false
+  - name: provider-region-a
+    type: swift
+    swift:
+      applicationCredentialID: access-key
+      applicationCredentialSecret: secret-key
+      authUrl: swift.region.provider.net
+      region: region
 
   destination:
-    name: provider-region-b
+  - name: provider-region-b
     type: s3
     s3:
       region: region
@@ -26,6 +33,13 @@ config:
       secretKey: secret-key
       forcePathStyle: true
       v2Auth: false
+  - name: provider-region-b
+    type: swift
+    swift:
+      applicationCredentialID: access-key
+      applicationCredentialSecret: secret-key
+      authUrl: swift.region.provider.net
+      region: region
 
   encrypt:
     enabled: false
@@ -44,6 +58,8 @@ buckets:
   - source: bucket
     destination: other-bucket
     schedule: 0 5 * * *
+    sourceType: # Optional but if included types are s3 or swift.
+    destinationType: # Optional but if included types are s3 or swift.
 
 resources:
   requests:

--- a/helmfile/values/networkpolicy/service-cluster.yaml.gotmpl
+++ b/helmfile/values/networkpolicy/service-cluster.yaml.gotmpl
@@ -9,14 +9,20 @@ global:
   wcIngress:
     ips: {{- toYaml .Values.networkPolicies.global.wcIngress.ips | nindent 6 }}
   objectStorage:
+  {{ $sourceSwift := "" }}
+  {{- range .Values.objectStorage.sync.buckets }}
+  {{- if or (eq (get "sourceType" "" .) "swift") (and (ne (get "sourceType" "" .) "s3") (eq $.Values.objectStorage.type "swift") ) }}
+  {{ $sourceSwift = "true" }}
+  {{- end }}
+  {{- end }}
     ips:
       {{- toYaml .Values.networkPolicies.global.objectStorage.ips | nindent 6 }}
-      {{- if or (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") }}
+      {{- if and (or (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") ($sourceSwift)) (.Values.networkPolicies.global.objectStorageSwift.ips) }}
       {{- toYaml .Values.networkPolicies.global.objectStorageSwift.ips | nindent 6 }}
       {{- end }}
     ports:
       {{- toYaml .Values.networkPolicies.global.objectStorage.ports | nindent 6 }}
-      {{- if or (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") }}
+      {{- if and (or (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") ($sourceSwift)) (.Values.networkPolicies.global.objectStorageSwift.ports) }}
       {{- toYaml .Values.networkPolicies.global.objectStorageSwift.ports | nindent 6 }}
       {{- end }}
   externalLoadBalancer: {{ .Values.networkPolicies.global.externalLoadBalancer }}
@@ -68,9 +74,29 @@ fluentd:
 
 rcloneSync:
   enabled: {{ and .Values.objectStorage.sync.enabled .Values.networkPolicies.rcloneSync.enabled }}
+  {{- if and .Values.objectStorage.sync.enabled .Values.networkPolicies.rcloneSync.enabled }}
   destinationObjectStorage:
-    ips: {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorage.ips | nindent 6 }}
-    ports: {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorage.ports | nindent 6 }}
+    ips:
+      {{- if and (hasKey .Values.objectStorage.sync.s3 "regionEndpoint" ) (.Values.objectStorage.sync.s3.regionEndpoint) (.Values.networkPolicies.rcloneSync.destinationObjectStorageS3.ips) }}
+      {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorageS3.ips | nindent 6 }}
+      {{- end }}
+      {{- if and (hasKey .Values.objectStorage.sync.swift "authUrl" ) (.Values.objectStorage.sync.swift.authUrl) (.Values.networkPolicies.rcloneSync.destinationObjectStorageSwift.ips) }}
+      {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorageSwift.ips | nindent 6 }}
+      {{- end }}
+      {{- if and (hasKey .Values.objectStorage.sync "secondaryUrl" ) (.Values.objectStorage.sync.secondaryUrl) (.Values.networkPolicies.rcloneSync.secondaryUrl.ips) }}
+      {{- toYaml .Values.networkPolicies.rcloneSync.secondaryUrl.ips | nindent 6 }}
+      {{- end }}
+    ports:
+      {{- if and (hasKey .Values.objectStorage.sync.s3 "regionEndpoint" ) (.Values.objectStorage.sync.s3.regionEndpoint) (.Values.networkPolicies.rcloneSync.destinationObjectStorageS3.ports) }}
+      {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorageS3.ports | nindent 6 }}
+      {{- end }}
+      {{- if and (hasKey .Values.objectStorage.sync.swift "authUrl" ) (.Values.objectStorage.sync.swift.authUrl) (.Values.networkPolicies.rcloneSync.destinationObjectStorageSwift.ports) }}
+      {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorageSwift.ports | nindent 6 }}
+      {{- end }}
+      {{- if and (hasKey .Values.objectStorage.sync "secondaryUrl" ) (.Values.objectStorage.sync.secondaryUrl) (.Values.networkPolicies.rcloneSync.secondaryUrl.ports) }}
+      {{- toYaml .Values.networkPolicies.rcloneSync.secondaryUrl.ports | nindent 6 }}
+      {{- end }}
+  {{- end }}
 
 s3Exporter:
   enabled: {{ and (eq .Values.objectStorage.type "s3") (and .Values.s3Exporter.enabled .Values.networkPolicies.s3Exporter.enabled) }}

--- a/helmfile/values/rclone-sync.yaml.gotmpl
+++ b/helmfile/values/rclone-sync.yaml.gotmpl
@@ -1,5 +1,10 @@
-{{- if or (ne .Values.objectStorage.type "s3") (ne .Values.objectStorage.sync.type "s3") }}
-{{- fail "rclone-sync is (for now) only supported using s3 on both ends" }}
+{{- range .Values.objectStorage.sync.buckets }}
+{{- if or (and (ne (get "sourceType" "s3" .) "s3") (ne (get "sourceType" "swift" .) "swift") ) (and (ne $.Values.objectStorage.type "s3") (ne $.Values.objectStorage.type "swift") ) }}
+{{- fail "rclone-sync only supports using s3 and swift on source ends" }}
+{{- end }}
+{{- if or (and (ne (get "destinationType" "s3" .) "s3") (ne (get "destinationType" "swift" .) "swift") ) (and (ne $.Values.objectStorage.sync.type "s3") (ne $.Values.objectStorage.sync.type "swift") ) }}
+{{- fail "rclone-sync only supports using s3 and swift on destination ends" }}
+{{- end }}
 {{- end }}
 
 {{- if not (or .Values.objectStorage.sync.syncDefaultBuckets .Values.objectStorage.sync.buckets) }}
@@ -11,10 +16,29 @@ config:
   dryrun: {{ .Values.objectStorage.sync.dryrun }}
 {{- end }}
 
+{{ $sourceS3 := "" }}
+{{ $sourceSwift := "" }}
+{{ $destinationS3 := "" }}
+{{ $destinationSwift := "" }}
+
+{{- range .Values.objectStorage.sync.buckets }}
+{{- if or (eq (get "sourceType" "" .) "s3") (and (ne (get "sourceType" "" .) "swift") (eq $.Values.objectStorage.type "s3") ) }}
+{{ $sourceS3 = "true" }}
+{{- else if or (eq (get "sourceType" "" .) "swift") (and (ne (get "sourceType" "" .) "s3") (eq $.Values.objectStorage.type "swift") ) }}
+{{ $sourceSwift = "true" }}
+{{- end }}
+
+{{- if or (eq (get "destinationType" "" .) "s3") (and (ne (get "destinationType" "" .) "swift") (eq $.Values.objectStorage.sync.type "s3") ) }}
+{{ $destinationS3 = "true" }}
+{{- else if or (eq (get "destinationType" "" .) "swift") (and (ne (get "destinationType" "" .) "s3") (eq $.Values.objectStorage.sync.type "swift") ) }}
+{{ $destinationSwift = "true" }}
+{{- end }}
+{{- end }}
+
   source:
-    name: default
-    type: {{ .Values.objectStorage.type }}
-  {{- if eq .Values.objectStorage.type "s3" }}
+  {{- if $sourceS3 }}
+  - name: src-s3
+    type: s3
     s3:
       accessKey: {{ .Values.objectStorage.s3.accessKey }}
       secretKey: {{ .Values.objectStorage.s3.secretKey }}
@@ -26,10 +50,20 @@ config:
     {{- end }}
   {{- end }}
 
+  {{- if $sourceSwift }}
+  - name: src-swift
+    type: swift
+    swift:
+      applicationCredentialID: {{ .Values.objectStorage.swift.applicationCredentialID }}
+      applicationCredentialSecret: {{ .Values.objectStorage.swift.applicationCredentialSecret }}
+      authUrl: {{ .Values.objectStorage.swift.authUrl }}
+      region: {{ .Values.objectStorage.swift.region }}
+  {{- end }}
+
   destination:
-    name: backup
-    type: {{ .Values.objectStorage.sync.type }}
-  {{- if eq .Values.objectStorage.sync.type "s3" }}
+  {{- if $destinationS3 }}
+  - name: dest-s3
+    type: s3
     s3:
       accessKey: {{ .Values.objectStorage.sync.s3.accessKey }}
       secretKey: {{ .Values.objectStorage.sync.s3.secretKey }}
@@ -39,6 +73,15 @@ config:
     {{- if hasKey .Values.objectStorage.sync.s3 "v2Auth" }}
       v2Auth: {{ .Values.objectStorage.sync.s3.v2Auth }}
     {{- end }}
+  {{- end }}
+  {{- if $destinationSwift }}
+  - name: dest-swift
+    type: swift
+    swift:
+      applicationCredentialID: {{ .Values.objectStorage.sync.swift.applicationCredentialID }}
+      applicationCredentialSecret: {{ .Values.objectStorage.sync.swift.applicationCredentialSecret }}
+      authUrl: {{ .Values.objectStorage.sync.swift.authUrl }}
+      region: {{ .Values.objectStorage.sync.swift.region }}
   {{- end }}
 
   encrypt:
@@ -73,6 +116,8 @@ buckets:
     {{- if hasKey . "schedule" }}
     schedule: {{ .schedule | quote }}
     {{- end }}
+    sourceType: {{ . | dig "sourceType" $.Values.objectStorage.type }}
+    destinationType: {{ . | dig "destinationType" $.Values.objectStorage.sync.type }}
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Added support for type swift in rclone-sync and made it so you can switch types for individual buckets as well. / Needed for when s3 has issues doing its job and to be able to choose type.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1305

**Special notes for reviewer**:
Used different key: value pairs to minimize the amount needed to be configured. 
A restriction that requires the global.ck8sCloudProvider to be specific providers should not be relevant because this is a public repository which anyone can pull from.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).


<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
