### PR TITLE
apps sc: harbor jobservice netpol allow garbage collection

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -12,3 +12,4 @@
 
 - Fixed issue with compaction job on ephemeral volumes
 - Fixed duplicate exception for falco alerts
+- Another network policy fix for Harbor to allow garbage collection

--- a/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-jobservice.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/harbor/allow-harbor-jobservice.yaml
@@ -131,4 +131,5 @@ spec:
               component: registry
       ports:
         - port: 8080
+        - port: 5000
 {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Noticed that this was a problem for an environment I was working with on apps `v0.29`. Saw that there was a fix in the `v0.30` QA process but apparently port 5000 is also needed, as I got a few of these error messages:
```console
2023-05-26T11:54:24Z [ERROR] [/jobservice/job/impl/gc/garbage_collection.go:286]: [4/28394] failed to delete manifest with v2 API, ***, Get "http://harbor-registry:5000/v2/": dial tcp 10.233.54.101:5000: i/o timeout
```
And saw it was blocked by netpols:
![image](https://github.com/elastisys/compliantkubernetes-apps/assets/22236722/16708086-4ddd-438a-a34c-f09aef71e8f1)

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [x] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
