### PR TITLE
wip: dev user as service account

### DIFF
--- a/bin/ck8s
+++ b/bin/ck8s
@@ -122,7 +122,7 @@ case "${1}" in
         sops_exec_file "${secrets[s3cfg_file]}" 's3cmd --config="{}" '"${*}"
     ;;
     kubeconfig)
-        [[ "${2}" =~ ^(user|admin)$ ]] || usage
+        [[ "${2}" =~ ^(user|dev|admin)$ ]] || usage
         shift
         "${here}/kubeconfig.bash" "${@}"
         ;;

--- a/bin/kubeconfig.bash
+++ b/bin/kubeconfig.bash
@@ -7,8 +7,75 @@ here="$(dirname "$(readlink -f "$0")")"
 source "${here}/common.bash"
 
 usage() {
-    echo "Usage: kubeconfig <user|admin <wc|sc> [cluster_name]>" >&2
+    echo "Usage: kubeconfig <user| dev <serviceaccount> |admin <wc|sc> [cluster_name]>" >&2
     exit 1
+}
+
+get_user_server() {
+    (
+        with_kubeconfig "${kubeconfig}" \
+            kubectl config view -o jsonpath="{.clusters[0].cluster.server}"
+    )
+}
+
+set_cluster() {
+
+    user_kubeconfig=$1
+
+    user_server=$(get_user_server)
+    user_certificate_authority=/tmp/user-authority.pem
+    append_trap "rm ${user_certificate_authority}" EXIT
+    (
+        with_kubeconfig "${kubeconfig}" \
+            kubectl config view --raw \
+                -o jsonpath="{.clusters[0].cluster.certificate-authority-data}" \
+                | base64 --decode > ${user_certificate_authority}
+    )
+
+    kubectl --kubeconfig="${user_kubeconfig}" config set-cluster "${cluster_name}" \
+    --server="${user_server}" \
+    --certificate-authority="${user_certificate_authority}" --embed-certs=true
+}
+
+set_dex_credentials() {
+    user_kubeconfig=$1
+    name=$2
+    cluster_name=$3
+
+    base_domain=$(yq4 '.global.baseDomain' "${cluster_config}")
+
+    kubectl --kubeconfig="${user_kubeconfig}" config set-credentials "${name}@${cluster_name}" \
+    --exec-command=kubectl \
+    --exec-api-version=client.authentication.k8s.io/v1beta1 \
+    --exec-arg=oidc-login \
+    --exec-arg=get-token \
+    --exec-arg=--oidc-issuer-url="https://dex.${base_domain}" \
+    --exec-arg=--oidc-client-id=kubelogin \
+    --exec-arg=--oidc-client-secret="$(sops -d --extract '["dex"]["kubeloginClientSecret"]' "${secrets[secrets_file]}")" \
+    --exec-arg=--oidc-extra-scope=email \
+    --exec-arg=--oidc-extra-scope=groups
+}
+
+set_context() {
+
+    user_kubeconfig=$1
+    cluster_name=$2
+    context_name=$3
+    user_name=$4
+    context_namespace=$5
+
+    kubectl --kubeconfig="${user_kubeconfig}" config set-context \
+    "${context_name}" \
+    --user "${user_name}@${cluster_name}" --cluster="${cluster_name}" --namespace="${context_namespace}"
+}
+
+use_context() {
+
+    user_kubeconfig=$1
+    cluster_name=$2
+
+    kubectl --kubeconfig="${user_kubeconfig}" config use-context \
+    "${cluster_name}"
 }
 
 case "${1}" in
@@ -17,6 +84,24 @@ case "${1}" in
         cluster_config="${config[config_file_wc]}"
         kubeconfig="${config[kube_config_wc]}"
         user_kubeconfig=${CK8S_CONFIG_PATH}/user/secret/kubeconfig.yaml
+    ;;
+    dev)
+        log_info "Adding dev ${2} context to wc-config"
+
+        config_load wc
+        cluster_config="${config[config_file_wc]}"
+        kubeconfig="${config[kube_config_wc]}"
+
+        token=$(with_kubeconfig "${kubeconfig}" kubectl get secrets secret-"${2}" -ojsonpath="{.data.token}" | base64 -d)
+        cluster_name=$(yq4 '.global.clusterName' "${cluster_config}")
+
+        kubectl --kubeconfig="${kubeconfig}" config set-credentials "${2}@${cluster_name}" \
+        --token="${token}"
+
+        set_context "${kubeconfig}" "${cluster_name}" "${2}" "${2}" "default"
+
+        log_info "Dev context finished"
+        exit
     ;;
     admin)
         case "${2}" in
@@ -47,42 +132,12 @@ if [[ ! -f "${kubeconfig}" ]]; then
     usage
 fi
 
-get_user_server() {
-    (
-        with_kubeconfig "${kubeconfig}" \
-            kubectl config view -o jsonpath="{.clusters[0].cluster.server}"
-    )
-}
-
 log_info "Creating kubeconfig for the ${1}"
 
 cluster_name=$(yq4 '.global.clusterName' "${cluster_config}")
-base_domain=$(yq4 '.global.baseDomain' "${cluster_config}")
 
-# Get server and certificate from the admin kubeconfig
-user_server=$(get_user_server)
-user_certificate_authority=/tmp/user-authority.pem
-append_trap "rm ${user_certificate_authority}" EXIT
-(
-    with_kubeconfig "${kubeconfig}" \
-        kubectl config view --raw \
-            -o jsonpath="{.clusters[0].cluster.certificate-authority-data}" \
-            | base64 --decode > ${user_certificate_authority}
-)
-
-kubectl --kubeconfig="${user_kubeconfig}" config set-cluster "${cluster_name}" \
-    --server="${user_server}" \
-    --certificate-authority="${user_certificate_authority}" --embed-certs=true
-kubectl --kubeconfig="${user_kubeconfig}" config set-credentials "${1}@${cluster_name}" \
-    --exec-command=kubectl \
-    --exec-api-version=client.authentication.k8s.io/v1beta1 \
-    --exec-arg=oidc-login \
-    --exec-arg=get-token \
-    --exec-arg=--oidc-issuer-url="https://dex.${base_domain}" \
-    --exec-arg=--oidc-client-id=kubelogin \
-    --exec-arg=--oidc-client-secret="$(sops -d --extract '["dex"]["kubeloginClientSecret"]' "${secrets[secrets_file]}")" \
-    --exec-arg=--oidc-extra-scope=email \
-    --exec-arg=--oidc-extra-scope=groups
+set_cluster "${user_kubeconfig}"
+set_dex_credentials "${user_kubeconfig}" "${1}" "${cluster_name}"
 
 # Create context with relevant namespace
 # Pick the first namespace
@@ -92,10 +147,7 @@ else
     context_namespace="default"
 fi
 
-kubectl --kubeconfig="${user_kubeconfig}" config set-context \
-    "${cluster_name}" \
-    --user "${1}@${cluster_name}" --cluster="${cluster_name}" --namespace="${context_namespace}"
-kubectl --kubeconfig="${user_kubeconfig}" config use-context \
-    "${cluster_name}"
+set_context "${user_kubeconfig}" "${cluster_name}" "${cluster_name}" "${1}" "${context_namespace}"
+use_context "${user_kubeconfig}" "${cluster_name}"
 
 log_info "User kubeconfig can now be found at ${user_kubeconfig}."

--- a/helmfile/charts/user-rbac/templates/clusterrolebindings/user-admin-cluster-wide-delegation.yaml
+++ b/helmfile/charts/user-rbac/templates/clusterrolebindings/user-admin-cluster-wide-delegation.yaml
@@ -18,3 +18,8 @@ subjects:
   kind: Group
   name: {{ $group }}
 {{- end }}
+{{- range $serviceAccount := $.Values.serviceAccounts }}
+- kind: ServiceAccount
+  name: {{ $serviceAccount }}
+  namespace: default
+{{- end }}

--- a/helmfile/charts/user-rbac/templates/clusterrolebindings/user-view.yaml
+++ b/helmfile/charts/user-rbac/templates/clusterrolebindings/user-view.yaml
@@ -18,3 +18,8 @@ subjects:
   kind: Group
   name: {{ $group }}
 {{- end }}
+{{- range $serviceAccount := $.Values.serviceAccounts }}
+- kind: ServiceAccount
+  name: {{ $serviceAccount }}
+  namespace: default
+{{- end }}

--- a/helmfile/charts/user-rbac/templates/rolebindings/falco-viewer.yaml
+++ b/helmfile/charts/user-rbac/templates/rolebindings/falco-viewer.yaml
@@ -20,4 +20,9 @@ subjects:
   kind: Group
   name: {{ $group }}
 {{- end }}
+{{- range $serviceAccount := $.Values.serviceAccounts }}
+- kind: ServiceAccount
+  name: {{ $serviceAccount }}
+  namespace: default
+{{- end }}
 {{- end }}

--- a/helmfile/charts/user-rbac/templates/rolebindings/fluentd-configurer.yaml
+++ b/helmfile/charts/user-rbac/templates/rolebindings/fluentd-configurer.yaml
@@ -19,3 +19,8 @@ subjects:
   kind: Group
   name: {{ $group }}
 {{- end }}
+{{- range $serviceAccount := $.Values.serviceAccounts }}
+- kind: ServiceAccount
+  name: {{ $serviceAccount }}
+  namespace: default
+{{- end }}

--- a/helmfile/charts/user-rbac/templates/rolebindings/prometheus.yaml
+++ b/helmfile/charts/user-rbac/templates/rolebindings/prometheus.yaml
@@ -18,3 +18,8 @@ subjects:
   kind: Group
   name: {{ $group }}
 {{- end }}
+{{- range $serviceAccount := $.Values.serviceAccounts }}
+- kind: ServiceAccount
+  name: {{ $serviceAccount }}
+  namespace: default
+{{- end }}

--- a/helmfile/charts/user-rbac/templates/rolebindings/workload-admin.yaml
+++ b/helmfile/charts/user-rbac/templates/rolebindings/workload-admin.yaml
@@ -20,6 +20,11 @@ subjects:
   kind: Group
   name: {{ $group }}
 {{- end }}
+{{- range $serviceAccount := $.Values.serviceAccounts }}
+- kind: ServiceAccount
+  name: {{ $serviceAccount }}
+  namespace: default
+{{- end }}
 {{- $known := lookup "v1" "Service" "default" "kubernetes" }}
 {{- $value := lookup "rbac.authorization.k8s.io/v1" "RoleBinding" $namespace.name "extra-workload-admins" }}
 {{- if and $known (not $value) (or $.Release.IsInstall $.Release.IsUpgrade) }}

--- a/helmfile/charts/user-rbac/templates/serviceAccounts/sa.yaml
+++ b/helmfile/charts/user-rbac/templates/serviceAccounts/sa.yaml
@@ -1,0 +1,16 @@
+{{- range $serviceAccount := $.Values.serviceAccounts }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $serviceAccount }}
+  namespace: default
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-{{ $serviceAccount }}
+  namespace: default
+  annotations:
+    kubernetes.io/service-account.name: "{{ $serviceAccount }}"
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/helmfile/charts/user-rbac/values.yaml
+++ b/helmfile/charts/user-rbac/values.yaml
@@ -1,5 +1,6 @@
 namespaces: []
 users: []
 groups: []
+serviceAccounts: []
 createNamespaces: true
 enableFalcoViewer: false

--- a/helmfile/values/user-rbac.yaml.gotmpl
+++ b/helmfile/values/user-rbac.yaml.gotmpl
@@ -9,7 +9,18 @@ namespaces:
     {{- end }}
 {{- end }}
 
-users: {{ toYaml .Values.user.adminUsers | nindent 2 }}
+users:
+{{- range $user := .Values.user.adminUsers }}
+{{ if not (contains "serviceAccount:" $user) }}
+  - {{ $user }}
+{{- end }}
+{{- end }}
 groups: {{ toYaml .Values.user.adminGroups | nindent 2 }}
+serviceAccounts:
+{{- range $user := .Values.user.adminUsers }}
+{{ if contains "serviceAccount:" $user }}
+  - {{ $user | trimPrefix "serviceAccount:" }}
+{{- end }}
+{{- end }}
 createNamespaces: {{ .Values.user.createNamespaces }}
 enableFalcoViewer: {{ toYaml .Values.falco.enabled | nindent 2 }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Some times when during dev work for user admin it is nice to have a kubeconfig with the correct permissions.
So I added the possibility to add service accounts and add context to the wc kubeconfig for the service account.

also restructured the functions. 

**Which issue this PR fixes**: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
    - [ ] I upgraded no Chart.
    - [ ] I upgraded a Chart and determined that no migration steps are needed.
    - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
