### PR TITLE
apps: fix migration hnc label

### DIFF
--- a/migration/v0.30/apply/14-hnc-labels.sh
+++ b/migration/v0.30/apply/14-hnc-labels.sh
@@ -18,8 +18,8 @@ update_hierarchyconfigurations() {
       continue
     fi
 
-    kubectl_do wc annotate hierarchyconfigurations.hnc.x-k8s.io -n "${i}" hierarchy helm.sh/hook- helm.sh/resource-policy- meta.helm.sh/release-name=user-rbac meta.helm.sh/release-namespace=kube-system
-    kubectl_do wc label hierarchyconfigurations.hnc.x-k8s.io -n "${i}" hierarchy app.kubernetes.io/managed-by=Helm
+    kubectl_do wc annotate hierarchyconfigurations.hnc.x-k8s.io -n "${i}" hierarchy helm.sh/hook- helm.sh/resource-policy- meta.helm.sh/release-name=user-rbac meta.helm.sh/release-namespace=kube-system --overwrite
+    kubectl_do wc label hierarchyconfigurations.hnc.x-k8s.io -n "${i}" hierarchy app.kubernetes.io/managed-by=Helm --overwrite
 
     config="$(kubectl_do wc get hierarchyconfigurations.hnc.x-k8s.io -n "${i}" hierarchy -oyaml)"
 

--- a/migration/v0.31/apply/14-hnc-labels.sh
+++ b/migration/v0.31/apply/14-hnc-labels.sh
@@ -18,8 +18,8 @@ update_hierarchyconfigurations() {
       continue
     fi
 
-    kubectl_do wc annotate hierarchyconfigurations.hnc.x-k8s.io -n "${i}" hierarchy helm.sh/hook- helm.sh/resource-policy- meta.helm.sh/release-name=user-rbac meta.helm.sh/release-namespace=kube-system
-    kubectl_do wc label hierarchyconfigurations.hnc.x-k8s.io -n "${i}" hierarchy app.kubernetes.io/managed-by=Helm
+    kubectl_do wc annotate hierarchyconfigurations.hnc.x-k8s.io -n "${i}" hierarchy helm.sh/hook- helm.sh/resource-policy- meta.helm.sh/release-name=user-rbac meta.helm.sh/release-namespace=kube-system --overwrite
+    kubectl_do wc label hierarchyconfigurations.hnc.x-k8s.io -n "${i}" hierarchy app.kubernetes.io/managed-by=Helm --overwrite
 
     config="$(kubectl_do wc get hierarchyconfigurations.hnc.x-k8s.io -n "${i}" hierarchy -oyaml)"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix when adding annotation and labels for hnc.

**Which issue this PR fixes**: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
