### PR TITLE
apps: configurable disk alerts

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -36,6 +36,8 @@
 - Added Prometheus Blackbox Exporter dashboard to Grafana
 - Added option to configure `max_shards_per_node` in opensearch via config option `opensearch.maxShardsPerNode`
 - Dependency check to main bin scripts
+- Add possibility to add and tune disk usage alerts
+  - Add pattern matching for node and disk
 
 ### Changed
 

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -352,6 +352,97 @@ prometheus:
         - name: elastisys
           pattern: ".*-elastisys-.*"
           limit: 80
+  diskAlerts:
+    storage:
+      predictLinear:
+        - hours: 24
+          freeSpacePercentage: 30
+          severity: warning
+          for: 1h
+          pattern:
+            include:
+              node: ".*"
+              disk: ".*"
+            exclude:
+              node: ""
+              disk: ""
+        - hours: 4
+          freeSpacePercentage: 15
+          severity: critical
+          for: 1h
+          pattern:
+            include:
+              node: ".*"
+              disk: ".*"
+            exclude:
+              node: ""
+              disk: ""
+      space:
+        - freeSpacePercentage: 5
+          severity: warning
+          for: 30m
+          pattern:
+            include:
+              node: ".*"
+              disk: ".*"
+            exclude:
+              node: ""
+              disk: ""
+        - freeSpacePercentage: 3
+          severity: critical
+          for: 30m
+          pattern:
+            include:
+              node: ".*"
+              disk: ".*"
+            exclude:
+              node: ""
+              disk: ""
+    inode:
+      predictLinear:
+        - hours: 24
+          freeSpacePercentage: 40
+          severity: warning
+          for: 1h
+          pattern:
+            include:
+              node: ".*"
+              disk: ".*"
+            exclude:
+              node: ""
+              disk: ""
+        - hours: 4
+          freeSpacePercentage: 20
+          severity: critical
+          for: 1h
+          pattern:
+            include:
+              node: ".*"
+              disk: ".*"
+            exclude:
+              node: ""
+              disk: ""
+      space:
+        - freeSpacePercentage: 5
+          severity: warning
+          for: 1h
+          pattern:
+            include:
+              node: ".*"
+              disk: ".*"
+            exclude:
+              node: ""
+              disk: ""
+        - freeSpacePercentage: 3
+          severity: critical
+          for: 1h
+          pattern:
+            include:
+              node: ".*"
+              disk: ".*"
+            exclude:
+              node: ""
+              disk: ""
 
 thanos:
   # Enables Thanos components.

--- a/helmfile/charts/prometheus-alerts/templates/alerts/node-exporter.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/alerts/node-exporter.yaml
@@ -17,149 +17,85 @@ spec:
   groups:
   - name: node-exporter
     rules:
+{{- range .Values.diskAlerts.storage.space }}
+    - alert: NodeFilesystemAlmostOutOfSpace
+      annotations:
+        description: Filesystem on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available space left.
+        runbook_url: {{ $.Values.defaultRules.runbookUrl }}alert-name-nodefilesystemalmostoutofspace
+        summary: Filesystem has less than {{ .freeSpacePercentage }}% space left.
+      expr: |-
+        (
+          node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!="",device=~"{{ .pattern.include.disk }}",device!~"{{ .pattern.exclude.disk }}",instance=~"{{ .pattern.include.node }}",instance!~"{{ .pattern.exclude.node }}"} / node_filesystem_size_bytes{job="node-exporter",fstype!="",mountpoint!="",device=~"{{ .pattern.include.disk }}",device!~"{{ .pattern.exclude.disk }}",instance=~"{{ .pattern.include.node }}",instance!~"{{ .pattern.exclude.node }}"} * 100 < {{ .freeSpacePercentage }}
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!="",device=~"{{ .pattern.include.disk }}",device!~"{{ .pattern.exclude.disk }}",instance=~"{{ .pattern.include.node }}",instance!~"{{ .pattern.exclude.node }}"} == 0
+        )
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+  {{- if $.Values.defaultRules.additionalRuleLabels }}
+  {{ toYaml $.Values.defaultRules.additionalRuleLabels | indent 8 }}
+  {{- end }}
+{{- end }}
+{{- range .Values.diskAlerts.storage.predictLinear }}
     - alert: NodeFilesystemSpaceFillingUp
       annotations:
         description: Filesystem on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available space left and is filling up.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-nodefilesystemspacefillingup
-        summary: Filesystem is predicted to run out of space within the next 24 hours.
+        runbook_url: {{ $.Values.defaultRules.runbookUrl }}alert-name-nodefilesystemspacefillingup
+        summary: Filesystem is predicted to run out of space within the next {{ .hours }} hours.
       expr: |-
         (
-          node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!="",mountpoint!=""} * 100 < 30
+          node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!="",device=~"{{ .pattern.include.disk }}",device!~"{{ .pattern.exclude.disk }}",instance=~"{{ .pattern.include.node }}",instance!~"{{ .pattern.exclude.node }}"} / node_filesystem_size_bytes{job="node-exporter",fstype!="",mountpoint!="",device=~"{{ .pattern.include.disk }}",device!~"{{ .pattern.exclude.disk }}",instance=~"{{ .pattern.include.node }}",instance!~"{{ .pattern.exclude.node }}"} * 100 < {{ .freeSpacePercentage }}
         and
-          predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!=""}[6h], 24*60*60) < 0
+          predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!="",device=~"{{ .pattern.include.disk }}",device!~"{{ .pattern.exclude.disk }}",instance=~"{{ .pattern.include.node }}",instance!~"{{ .pattern.exclude.node }}"}[6h], {{ .hours }}*60*60) < 0
         and
-          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!=""} == 0
+          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!="",device=~"{{ .pattern.include.disk }}",device!~"{{ .pattern.exclude.disk }}",instance=~"{{ .pattern.include.node }}",instance!~"{{ .pattern.exclude.node }}"} == 0
         )
-      for: 1h
+      for: {{ .for }}
       labels:
-        severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+        severity: {{ .severity }}
+  {{- if $.Values.defaultRules.additionalRuleLabels }}
+  {{ toYaml $.Values.defaultRules.additionalRuleLabels | indent 8 }}
+  {{- end }}
 {{- end }}
+{{- range .Values.diskAlerts.inode.space }}
+    - alert: NodeFilesystemAlmostOutOfSpace
+      annotations:
+        description: Filesystem on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available inodes left.
+        runbook_url: {{ $.Values.defaultRules.runbookUrl }}alert-name-nodefilesystemalmostoutoffiles
+        summary: Filesystem has less than {{ .freeSpacePercentage }}% inodes left.
+      expr: |-
+        (
+          node_filesystem_files_free{job="node-exporter",fstype!="",mountpoint!="",device=~"{{ .pattern.include.disk }}",device!~"{{ .pattern.exclude.disk }}",instance=~"{{ .pattern.include.node }}",instance!~"{{ .pattern.exclude.node }}"} / node_filesystem_files{job="node-exporter",fstype!="",mountpoint!="",device=~"{{ .pattern.include.disk }}",device!~"{{ .pattern.exclude.disk }}",instance=~"{{ .pattern.include.node }}",instance!~"{{ .pattern.exclude.node }}"} * 100 < {{ .freeSpacePercentage }}
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!="",device=~"{{ .pattern.include.disk }}",device!~"{{ .pattern.exclude.disk }}",instance=~"{{ .pattern.include.node }}",instance!~"{{ .pattern.exclude.node }}"} == 0
+        )
+      for: {{ .for }}
+      labels:
+        severity: {{ .severity }}
+  {{- if $.Values.defaultRules.additionalRuleLabels }}
+  {{ toYaml $.Values.defaultRules.additionalRuleLabels | indent 8 }}
+  {{- end }}
+{{- end }}
+{{- range .Values.diskAlerts.inode.predictLinear }}
     - alert: NodeFilesystemSpaceFillingUp
       annotations:
-        description: Filesystem on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available space left and is filling up fast.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-nodefilesystemspacefillingup
-        summary: Filesystem is predicted to run out of space within the next 4 hours.
-      expr: |-
-        (
-          node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!="",mountpoint!=""} * 100 < 15
-        and
-          predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!=""}[6h], 4*60*60) < 0
-        and
-          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!=""} == 0
-        )
-      for: 1h
-      labels:
-        severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
-    - alert: NodeFilesystemAlmostOutOfSpace
-      annotations:
-        description: Filesystem on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available space left.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-nodefilesystemalmostoutofspace
-        summary: Filesystem has less than 5% space left.
-      expr: |-
-        (
-          node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!="",mountpoint!=""} * 100 < 5
-        and
-          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!=""} == 0
-        )
-      for: 30m
-      labels:
-        severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
-    - alert: NodeFilesystemAlmostOutOfSpace
-      annotations:
-        description: Filesystem on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available space left.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-nodefilesystemalmostoutofspace
-        summary: Filesystem has less than 3% space left.
-      expr: |-
-        (
-          node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!="",mountpoint!=""} * 100 < 3
-        and
-          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!=""} == 0
-        )
-      for: 30m
-      labels:
-        severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
-    - alert: NodeFilesystemFilesFillingUp
-      annotations:
-        description: Filesystem on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available inodes left and is filling up.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-nodefilesystemfilesfillingup
-        summary: Filesystem is predicted to run out of inodes within the next 24 hours.
-      expr: |-
-        (
-          node_filesystem_files_free{job="node-exporter",fstype!="",mountpoint!=""} / node_filesystem_files{job="node-exporter",fstype!="",mountpoint!=""} * 100 < 40
-        and
-          predict_linear(node_filesystem_files_free{job="node-exporter",fstype!="",mountpoint!=""}[6h], 24*60*60) < 0
-        and
-          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!=""} == 0
-        )
-      for: 1h
-      labels:
-        severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
-    - alert: NodeFilesystemFilesFillingUp
-      annotations:
         description: Filesystem on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available inodes left and is filling up fast.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-nodefilesystemfilesfillingup
-        summary: Filesystem is predicted to run out of inodes within the next 4 hours.
+        runbook_url: {{ $.Values.defaultRules.runbookUrl }}alert-name-nodefilesystemfilesfillingup
+        summary: Filesystem is predicted to run out of inodes within the next {{ .hours }} hours.
       expr: |-
         (
-          node_filesystem_files_free{job="node-exporter",fstype!=""} / node_filesystem_files{job="node-exporter",fstype!=""} * 100 < 20
+          node_filesystem_files_free{job="node-exporter",fstype!="",mountpoint!="",device=~"{{ .pattern.include.disk }}",device!~"{{ .pattern.exclude.disk }}",instance=~"{{ .pattern.include.node }}",instance!~"{{ .pattern.exclude.node }}"} / node_filesystem_files{job="node-exporter",fstype!="",device=~"{{ .pattern.include.disk }}",device!~"{{ .pattern.exclude.disk }}",instance=~"{{ .pattern.include.node }}",instance!~"{{ .pattern.exclude.node }}"} * 100 < {{ .freeSpacePercentage }}
         and
-          predict_linear(node_filesystem_files_free{job="node-exporter",fstype!=""}[6h], 4*60*60) < 0
+          predict_linear(node_filesystem_files_free{job="node-exporter",fstype!="",mountpoint!="",device=~"{{ .pattern.include.disk }}",device!~"{{ .pattern.exclude.disk }}",instance=~"{{ .pattern.include.node }}",instance!~"{{ .pattern.exclude.node }}"}[6h], {{ .hours }}*60*60) < 0
         and
-          node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!="",device=~"{{ .pattern.include.disk }}",device!~"{{ .pattern.exclude.disk }}",instance=~"{{ .pattern.include.node }}",instance!~"{{ .pattern.exclude.node }}"} == 0
         )
-      for: 1h
+      for: {{ .for }}
       labels:
-        severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
-    - alert: NodeFilesystemAlmostOutOfFiles
-      annotations:
-        description: Filesystem on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available inodes left.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-nodefilesystemalmostoutoffiles
-        summary: Filesystem has less than 5% inodes left.
-      expr: |-
-        (
-          node_filesystem_files_free{job="node-exporter",fstype!="",mountpoint!=""} / node_filesystem_files{job="node-exporter",fstype!="",mountpoint!=""} * 100 < 5
-        and
-          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!=""} == 0
-        )
-      for: 1h
-      labels:
-        severity: warning
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
-{{- end }}
-    - alert: NodeFilesystemAlmostOutOfFiles
-      annotations:
-        description: Filesystem on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available inodes left.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-nodefilesystemalmostoutoffiles
-        summary: Filesystem has less than 3% inodes left.
-      expr: |-
-        (
-          node_filesystem_files_free{job="node-exporter",fstype!="",mountpoint!=""} / node_filesystem_files{job="node-exporter",fstype!="",mountpoint!=""} * 100 < 3
-        and
-          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!=""} == 0
-        )
-      for: 1h
-      labels:
-        severity: critical
-{{- if .Values.defaultRules.additionalRuleLabels }}
-{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+        severity: {{ .severity }}
+  {{- if $.Values.defaultRules.additionalRuleLabels }}
+  {{ toYaml $.Values.defaultRules.additionalRuleLabels | indent 8 }}
+  {{- end }}
 {{- end }}
     - alert: NodeNetworkReceiveErrs
       annotations:

--- a/helmfile/charts/prometheus-alerts/values.yaml
+++ b/helmfile/charts/prometheus-alerts/values.yaml
@@ -18,6 +18,56 @@ s3BucketAlerts:
     percent: 80
     count: 1638400
   exclude: []
+
+diskAlerts:
+  storage:
+    #  - hours: 24 # How many hours to predict over
+    #    freeSpacePercentage: 30 # At what percentage to alert at
+    #    severity: warning
+    #    for: 1h
+    #    pattern:
+    #      include:
+    #        node: ".*" # Node to pattern match on
+    #        disk: ".*" # Disk to pattern match on
+    #      exclude:
+    #        node: "" # Node to filter out from pattern matching
+    #        disk: "" # Disk to filter out from pattern matching
+    predictLinear: []
+    #  - freeSpacePercentage: 5 # At what percentage to alert at
+    #    severity: warning
+    #    for: 30m
+    #    pattern:
+    #      include:
+    #        node: ".*" # Node to pattern match on
+    #        disk: ".*" # Disk to pattern match on
+    #      exclude:
+    #        node: "" # Node to filter out from pattern matching
+    #        disk: "" # Disk to filter out from pattern matching
+    space: []
+  inode:
+    #  - freeSpacePercentage: 5 # At what percentage to alert at
+    #    severity: warning
+    #    for: 30m
+    #    pattern:
+    #      include:
+    #        node: ".*" # Node to pattern match on
+    #        disk: ".*" # Disk to pattern match on
+    #      exclude:
+    #        node: "" # Node to filter out from pattern matching
+    #        disk: "" # Disk to filter out from pattern matching
+    predictLinear: []
+    #  - freeSpacePercentage: 5 # At what percentage to alert at
+    #    severity: warning
+    #    for: 30m
+    #    pattern:
+    #      include:
+    #        node: ".*" # Node to pattern match on
+    #        disk: ".*" # Disk to pattern match on
+    #      exclude:
+    #        node: "" # Node to filter out from pattern matching
+    #        disk: "" # Disk to filter out from pattern matching
+    space: []
+
 defaultRules:
   create: true
   ## Any labels to add to the alert rules

--- a/helmfile/values/prometheus-alerts-sc.yaml.gotmpl
+++ b/helmfile/values/prometheus-alerts-sc.yaml.gotmpl
@@ -61,3 +61,5 @@ buckets:
   opensearch: {{ .Values.objectStorage.buckets.opensearch }}
   scFluentd: {{ .Values.objectStorage.buckets.scFluentd }}
   thanos: {{ .Values.objectStorage.buckets.thanos }}
+
+diskAlerts: {{ toYaml .Values.prometheus.diskAlerts | nindent 2 }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add option to config disk usage alerts, including pattern filtering. Which can be used for local disk alerts.

Im considering if i should split it out from node-exporter alert file and place them in a new file.

**Which issue this PR fixes**: fixes #1303

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
