### PR TITLE
apps: add more falco exceptions

### DIFF
--- a/helmfile/values/falco.yaml.gotmpl
+++ b/helmfile/values/falco.yaml.gotmpl
@@ -49,6 +49,7 @@ customRules:
       condition: >
         ((evt.type = connect and evt.dir=<) or
           (evt.type in (sendto,sendmsg))) and ssh_port
+        and not (k8s.ns.name = argocd-system and k8s.pod.name startswith argocd-repo-server)
       output: >
         Outbound SSH connection (user=%user.name server_ip=%fd.sip server_port=%fd.sport client_ip=%fd.cip)
       priority: WARNING
@@ -101,11 +102,10 @@ customRules:
           container.image.repository in (
             ghcr.io/elastisys/compliantkubernetes-apps-log-manager,
             registry.opensource.zalan.do/acid/spilo-14
-          ) or (
-            container.image.repository = docker.io/library/redis and proc.cmdline = 'sh -c sleep 5 && redis-server /redis/redis.conf'
-          ) or (
-            container.image.repository = quay.io/calico/cni and proc.cmdline = 'install'
-          )
+          ) or
+          (container.image.repository = docker.io/library/redis and proc.cmdline = 'sh -c sleep 5 && redis-server /redis/redis.conf') or
+          (k8s.pod.name startswith 'rfs-' and ((container.image.repository=docker.io/library/redis and (proc.cmdline='sh -c redis-cli -h $(hostname) -p 26379 ping')))) or
+          (container.image.repository = quay.io/calico/cni and proc.cmdline = 'install')
         )
     - macro: user_known_create_files_below_dev_activities
       condition: (
@@ -125,17 +125,18 @@ customRules:
         )
     - macro: user_known_db_spawned_processes
       condition: (
-          container.image.repository = registry.opensource.zalan.do/acid/spilo-14 and proc.cmdline glob 'sh -c envdir "/run/etc/wal-e.d/env" /scripts/restore_command.sh *'
+          (container.image.repository = registry.opensource.zalan.do/acid/spilo-14 and proc.cmdline glob 'sh -c envdir "/run/etc/wal-e.d/env" /scripts/restore_command.sh *') or
+          (container.image.repository = registry.opensource.zalan.do/acid/spilo-15 and (proc.cmdline glob 'sh -c envdir "/run/etc/wal-e.d/env" timeout "0" /scripts/restore_command.sh *'))
         )
     - macro: user_known_k8s_client_container_parens
       condition: (
           container.image.repository in (
             docker.io/bitnami/kubectl,
-            docker.io/openpolicyagent/gatekeeper-crds,
-            ghcr.io/elastisys/argocd-managed-namespaces-manager
-          ) or (
-            k8s.ns.name = "tekton-pipelines" and k8s.pod.name startswith upgrade
-          )
+            docker.io/openpolicyagent/gatekeeper-crds
+          ) or
+          (k8s.ns.name = "tekton-pipelines" and k8s.pod.name startswith upgrade) or
+          (container.image.repository = ghcr.io/elastisys/argocd-managed-namespaces-manager and proc.cmdline startswith 'kubectl patch secret -n argocd-system argocd-manager-config') or
+          (k8s.ns.name = argocd-system and k8s.pod.name startswith argocd-managed-namespaces-manager- and proc.cmdline = 'kubectl get rolebindings --all-namespaces -o json')
         )
     - macro: user_known_write_monitored_dir_conditions
       condition: (
@@ -164,7 +165,10 @@ customRules:
           (container.image.repository = quay.io/ceph/ceph and proc.cmdline startswith container) or
           (container.image.repository = quay.io/ceph/ceph and proc.cmdline startswith 'rook cmd-reporter') or
           (container.image.repository = k8s.gcr.io/sig-storage/csi-provisioner and proc.cmdline startswith container) or
-          (container.image.repository = registry.k8s.io/sig-storage/csi-snapshotter and proc.cmdline startswith 'csi-snapshotter --csi-address=unix:///csi/csi-provisioner.sock')
+          (container.image.repository = registry.k8s.io/sig-storage/csi-snapshotter and proc.cmdline startswith 'csi-snapshotter --csi-address=unix:///csi/csi-provisioner.sock') or
+          (container.image.repository = ghcr.io/elastisys/logical-backup and proc.cmdline startswith container) or
+          (container.image.repository = ghcr.io/elastisys/logical-backup and proc.cmdline = 'dump.sh bash /dump.sh') or
+          (container.image.repository = ghcr.io/elastisys/logical-backup and proc.cmdline = 'bash /dump.sh')
         )
     - macro: user_known_contact_k8s_api_server_activities
       condition: (
@@ -176,7 +180,11 @@ customRules:
           (container.image.repository = k8s.gcr.io/sig-storage/csi-attacher and proc.cmdline startswith 'csi-attacher') or
           (container.image.repository = k8s.gcr.io/sig-storage/csi-provisioner and proc.cmdline startswith 'csi-provisioner') or
           (k8s.ns.name = "tekton-pipelines" and k8s.pod.name startswith upgrade) or
-          (proc.cmdline = 'kube-webhook-ce create --host=ingress-nginx-controller-admission,ingress-nginx-controller-admission.ingress-nginx.svc --namespace=ingress-nginx --secret-name=ingress-nginx-admission')
+          (proc.cmdline = 'kube-webhook-ce create --host=ingress-nginx-controller-admission,ingress-nginx-controller-admission.ingress-nginx.svc --namespace=ingress-nginx --secret-name=ingress-nginx-admission') or
+          (container.image.repository = ghcr.io/zalando/spilo-15 and proc.cmdline = 'patroni /usr/local/bin/patroni /home/postgres/postgres.yml') or
+          (container.image.repository = ghcr.io/zalando/spilo-15 and proc.cmdline = 'patronictl /usr/local/bin/patronictl show-config') or
+          (container.image.repository = quay.io/argoproj/argocd and proc.cmdline = argocd-applicat) or
+          (k8s.ns.name = argocd-system and k8s.pod.name startswith argocd-managed-namespaces-manager- and proc.cmdline = 'kubectl get rolebindings --all-namespaces -o json')
         )
     - macro: user_known_package_manager_in_container
       condition: (
@@ -184,10 +192,8 @@ customRules:
             docker.io/elastisys/curl-jq,
             ghcr.io/elastisys/fluentd,
             registry.k8s.io/dns/k8s-dns-node-cache
-          ) or (
-            container.image.repository = registry.k8s.io/kube-proxy and
-            proc.cmdline startswith update-alternat
-          )
+          ) or
+          (container.image.repository = registry.k8s.io/kube-proxy and proc.cmdline startswith update-alternat)
         )
     - macro: user_known_stand_streams_redirect_activities
       condition: (
@@ -211,11 +217,14 @@ customRules:
           (container.image.repository = docker.io/rook/ceph and proc.cmdline = 'toolbox.sh -e /usr/local/bin/toolbox.sh') or
           (container.image.repository = docker.io/ceph/ceph and proc.cmdline = 'tini -- /rook/rook ceph osd provision') or
           (container.image.repository = quay.io/cephcsi/cephcsi and proc.cmdline startswith cephcsi) or
-          (container.image.repository = registry.opensource.zalan.do/acid/spilo-14)
+          (container.image.repository = registry.opensource.zalan.do/acid/spilo-14) or
+          (container.image.repository = ghcr.io/zalando/spilo-15 and proc.cmdline = 'python3 /scripts/configure_spilo.py all') or
+          (container.image.repository = ghcr.io/zalando/spilo-15 and proc.cmdline = 'sh /launch.sh')
         )
     - macro: user_known_write_below_root_activities
       condition: (
-          container.image.repository = ghcr.io/elastisys/logical-backup and proc.name = aws
+          (container.image.repository = ghcr.io/elastisys/logical-backup and proc.name = aws) or
+          (container.image.repository = ghcr.io/zalando/spilo-15 and proc.cmdline = 'sh /launch.sh')
         )
     - macro: user_sensitive_mount_containers
       condition: (
@@ -243,22 +252,34 @@ customRules:
         )
     - macro: allowed_clear_log_files
       condition: (
-          fd.name startswith "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/" and proc.cmdline = containerd
+          (fd.name startswith "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/" and proc.cmdline = container) or
+          (fd.name glob "/var/lib/containerd/tmpmounts/containerd-mount*/var/log/dpkg.log" and proc.cmdline = containerd)
         )
     - macro: user_shell_container_exclusions
       condition: (
-          container.image.repository = registry.opensource.zalan.do/acid/spilo-14 and
-          proc.cmdline glob 'sh -c envdir "/run/etc/wal-e.d/env" /scripts/restore_command.sh *'
+          (container.image.repository = registry.opensource.zalan.do/acid/spilo-14 and proc.cmdline glob 'sh -c envdir "/run/etc/wal-e.d/env" /scripts/restore_command.sh *') or
+          (container.image.repository = docker.io/library/rabbitmq and proc.cmdline = 'sh -c "/usr/local/lib/erlang/erts-13.0.4/bin/epmd" -daemon')
         )
     - macro: user_known_shell_config_modifiers
       condition: (
-          fd.name startswith "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/" and proc.cmdline = containerd
+          (fd.name startswith "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/" and proc.cmdline = containerd) or
+          (fd.name glob "/var/lib/containerd/tmpmounts/containerd-mount*/root/.bashrc" and proc.cmdline = containerd) or
+          (fd.name glob "/var/lib/containerd/tmpmounts/containerd-mount*/root/.profile" and proc.cmdline = containerd) or
+          (fd.name glob "/var/lib/containerd/tmpmounts/containerd-mount*/etc/skel/.bash_logout" and proc.cmdline = containerd) or
+          (fd.name glob "/var/lib/containerd/tmpmounts/containerd-mount*/etc/skel/.bashrc" and proc.cmdline = containerd) or
+          (fd.name glob "/var/lib/containerd/tmpmounts/containerd-mount*/etc/skel/.profile" and proc.cmdline = containerd) or
+          (fd.name glob "/var/lib/containerd/tmpmounts/containerd-mount*/etc/skel/.bash_profile" and proc.cmdline = containerd)
+        )
+    - macro: user_expected_terminal_shell_in_container_conditions
+      condition: (
+        (container.image.repository = ghcr.io/zalando/spilo-15 and proc.cmdline = bash)
         )
     - macro: user_known_ingress_remote_file_copy_activities
       condition: (
           proc.cmdline = 'curl --retry 3 -w %{http_code} -o /dev/null -sk https://localhost/healthz'
         )
     - list: known_binaries_to_read_environment_variables_from_proc_files
+      append: true
       items: [systemd-run, rook, udevadm]
 
 falcosidekick:


### PR DESCRIPTION
**What this PR does / why we need it**: to add more exception for falco

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
