### PR TITLE
Dependency check in bin scripts

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -35,6 +35,7 @@
 - Possibility to add custom config for node-local-dns
 - Added Prometheus Blackbox Exporter dashboard to Grafana
 - Added option to configure `max_shards_per_node` in opensearch via config option `opensearch.maxShardsPerNode`
+- Dependency check to main bin scripts
 
 ### Changed
 

--- a/bin/ck8s
+++ b/bin/ck8s
@@ -55,32 +55,39 @@ done
 
 case "${1}" in
     init)
+        check_tools
         "${here}/init.bash" "${GEN_NEW_SECRETS}"
         ;;
     bootstrap)
         [[ "${2}" =~ ^(wc|sc)$ ]] || usage
+        check_tools
         "${here}/bootstrap.bash" "${2}"
         ;;
     apps)
         [[ "${2}" =~ ^(wc|sc)$ ]] || usage
+        check_tools
         "${here}/apps.bash" "${2}" "${SKIP}" "${SYNC}"
         ;;
     apply)
         [[ "${2}" =~ ^(wc|sc)$ ]] || usage
+        check_tools
         "${here}/bootstrap.bash" "${2}"
         "${here}/apps.bash" "${2}" "${SKIP}" "${SYNC}"
         ;;
     test)
         [[ "${2}" =~ ^(wc|sc)$ ]] || usage
+        check_tools
         with_kubeconfig "${config["kube_config_${2}"]}" "${here}/test.bash" "${@:2}"
         ;;
     dry-run)
         [[ "${2}" =~ ^(wc|sc)$ ]] || usage
+        check_tools
         "${here}/dry-run.bash" "${2}" "${KUBECTL}"
         ;;
     upgrade)
         [[ "${2}" =~ ^(v[0-9]+\.[0-9]+)$ ]] || usage
         [[ "${3}" =~ ^(prepare|apply)$ ]] || usage
+        check_tools
         "${here}/upgrade.bash" "${2}" "${3}"
         ;;
     team)
@@ -132,6 +139,7 @@ case "${1}" in
         ;;
     validate)
         [[ "${2}" =~ ^(wc|sc)$ ]] || usage
+        check_tools
         config_load "$2"
         echo "Config validation successful"
         ;;


### PR DESCRIPTION
**What this PR does / why we need it**:

So we can easily see when we've got different versions of bin script dependencies.

**Which issue this PR fixes**

fixes: #1478

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

When on a tty it will prompt if you want to abort, with default as no.

**Add a screenshot or an example to illustrate the proposed solution:**

```console
$ ./bin/ck8s dry-run wc
[ck8s] Required dependency yq4 not using recommended version: (expected 4.26.1 - actual 4.33.3)
[ck8s] Required dependency kubectl not using recommended version: (expected 1.24.4 - actual 1.27.1)
[ck8s] Required dependency helm not using recommended version: (expected 3.8.0 - actual 3.12.0)
[ck8s] Required dependency helmfile not using recommended version: (expected 0.146.0 - actual 0.154.0)
[ck8s] Required dependency helm diff plugin not using recommended version: (expected 3.5.0 - actual 3.7.0)
[ck8s] Required dependency helm secrets plugin not using recommended version: (expected 3.12.0 - actual 4.4.2)
[ck8s] Do you want to abort? (y/N): n
[ck8s] Running helmfile diff on the workload cluster
[ck8s] Validating wc config
...
```

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
