### PR TITLE
apps wc: allow user admin to view events/logs

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -31,6 +31,7 @@
 - Added config option to support [Cluster API](https://cluster-api.sigs.k8s.io/) managed Kubernetes clusters
 - Added grafana dashboard for cluster-api management
 - Alerts for CoreDNS and Node-local-dns
+- Added RBAC for admin users to view events and logs
 
 ### Changed
 

--- a/helmfile/charts/user-rbac/templates/clusterroles/user-view.yaml
+++ b/helmfile/charts/user-rbac/templates/clusterroles/user-view.yaml
@@ -10,7 +10,7 @@ rules:
   resources: ["pods","nodes"]
   verbs: ["get", "watch", "list"]
 - apiGroups: [""]
-  resources: ["pods"]
+  resources: ["pods", "pods/log", events]
   verbs: ["get", "watch", "list"]
 - apiGroups: ["cert-manager.io"]
   resources: ["clusterissuers"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow user admin to view event and logs cluster-wide
**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1616 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
