### PR TITLE
migration: added a script to remove the jobs without ttl

### DIFF
--- a/migration/v0.32/README.md
+++ b/migration/v0.32/README.md
@@ -109,6 +109,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
 > *Done during maintenance window.*
 
+1. Delete the jobs with no TTL set
+
+    ```bash
+    ./migration/v0.31/apply/12-remove-no-ttl-jobs.sh execute
+    ```
+
 1. Rerun bootstrap:
 
     ```bash

--- a/migration/v0.32/apply/12-remove-no-ttl-jobs.sh
+++ b/migration/v0.32/apply/12-remove-no-ttl-jobs.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+find_delete_no_ttl_jobs() {
+  date_7d_ago=$(date --date="7 days ago" -u +"%Y-%m-%dT%H:%M:%SZ")
+  export date_7d_ago
+  for n in $(kubectl_do "${1}" get ns -o name); do
+      n=${n##namespace/}
+      for job in $(kubectl_do "${1}" -n "${n}" get jobs -oyaml | yq4 '.items[] | select(.spec.ttlSecondsAfterFinished == null and .status.startTime < strenv(date_7d_ago) and .status.active == null) | .metadata.name'); do
+          if [[ "${job}" != "null" ]]; then
+              log_info "--- delete job ${job} in namespace ${n}"
+              kubectl_do "${1}" delete job "${job}" -n "${n}"
+          fi
+      done
+  done
+}
+
+run() {
+  case "${1:-}" in
+  execute)
+    for cluster in sc wc; do
+        log_info "--- check if jobs with not ttl exist in ${cluster}"
+        find_delete_no_ttl_jobs ${cluster}
+    done
+    ;;
+  rollback)
+    log_warn "rollback not implemented"
+    ;;
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"


### PR DESCRIPTION
**What this PR does / why we need it**: to add a migration script to remove the jobs without ttl

Fixes [#4198](https://github.com/elastisys/ck8s-ops/issues/4198)

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).