### PR TITLE
apps wc: user-alertmanager secret handling

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -14,6 +14,7 @@
 - Changed image location for some images from `elastisys/` to `ghcr.io/elastisys/`
 - Added secret as a volumetype for osdprepare jobs
 - The `score.sh` script now presents results in either structured yaml or machine readable csv
+- User alertmanager will re-use the secret if exists, instead of using the `"helm.sh/hook": pre-install` annotation
 
 ### Fixed
 

--- a/helmfile/charts/user-alertmanager/templates/_helpers.tpl
+++ b/helmfile/charts/user-alertmanager/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+{{/*
+Do not update alertmanager secret if exists
+*/}}
+{{- define "gen.secret" -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace "alertmanager-alertmanager" -}}
+{{- if $secret -}}
+{{/*
+  Reusing existing secret data
+*/}}
+alertmanager.yaml: {{ index $secret.data "alertmanager.yaml" }}
+{{- else -}}
+{{/*
+  Generate new data
+*/}}
+alertmanager.yaml: {{ .Files.Get "files/alertmanager-config.yaml" | b64enc }}
+{{- end -}}
+{{- end -}}

--- a/helmfile/charts/user-alertmanager/templates/secret.yaml
+++ b/helmfile/charts/user-alertmanager/templates/secret.yaml
@@ -2,8 +2,5 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: alertmanager-alertmanager
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "0"
 data:
-  alertmanager.yaml: {{ .Files.Get "files/alertmanager-config.yaml" | b64enc }}
+{{- ( include "gen.secret" . ) | indent 2 -}}

--- a/migration/v0.32/apply/30-alertmanager-config.sh
+++ b/migration/v0.32/apply/30-alertmanager-config.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+
+wait_velero_backup() {
+  TIMEOUT=15
+  while [ $TIMEOUT -gt 0 ]; do
+    backup_status=$(kubectl_do wc get backup -n velero alertmanager-config-backup -o yaml | yq4 '.status.phase')
+    if [ "${backup_status}" == Completed ]; then
+      log_info "- backup completed"
+      break
+    fi
+    TIMEOUT=$((TIMEOUT - 1))
+    sleep 5
+  done
+  if [ $TIMEOUT -eq 0 ]; then
+    log_warn "- the velero backup didn't complete"
+  fi
+}
+
+run() {
+  case "${1:-}" in
+  execute)
+    # Note: 00-template.sh will be skipped by the upgrade command
+    log_info "- backing-up wc alertmanager namespace using velero"
+    kubectl_do wc apply -f "${HERE}"/alertmanager_velero_backup.yaml
+
+    log_info "- waiting for the backup to be complete"
+    wait_velero_backup
+
+    log_info "- adding the new annotations to wc alertmanager secret"
+    kubectl_do wc annotate secret -n alertmanager alertmanager-alertmanager helm.sh/hook- helm.sh/hook-weight- app.kubernetes.io/managed-by=Helm meta.helm.sh/release-name=user-alertmanager meta.helm.sh/release-namespace=alertmanager --overwrite
+    kubectl_do wc label secret -n alertmanager alertmanager-alertmanager app.kubernetes.io/managed-by=Helm --overwrite
+
+    helmfile_upgrade wc app=user-alertmanager
+    ;;
+
+  rollback)
+    log_warn "rollback not implemented"
+    ;;
+
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.32/apply/80-apply.sh
+++ b/migration/v0.32/apply/80-apply.sh
@@ -15,6 +15,7 @@ skipped_sc=(
 )
 declare -a skipped_wc
 skipped_wc=(
+  "app!=user-alertmanager"
 )
 
 run() {

--- a/migration/v0.32/apply/alertmanager_velero_backup.yaml
+++ b/migration/v0.32/apply/alertmanager_velero_backup.yaml
@@ -1,0 +1,13 @@
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  creationTimestamp: null
+  name: alertmanager-config-backup
+  namespace: velero
+spec:
+  hooks: {}
+  includedNamespaces:
+  - alertmanager
+  metadata: {}
+  ttl: 720h0m0s
+status: {}


### PR DESCRIPTION
**What this PR does / why we need it**: as the pre-install helm hook to handle the secret for user-alertmanager is not very clear I want to see if using a `_helper.tpl` to not update it if exists is a better solution

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [ ] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
