### PR TITLE
apps sc: changed location for opensearch-curator image

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     hooks:
       - id: markdownlint
         name: check markdown
-        exclude: ^helmfile/upstream/|^CHANGELOG.md$|^WIP-CHANGELOG.md$|^helmfile/charts/grafana-ops/files/welcome.md$|^helmfile/charts/opensearch/configurer/files/dashboards-resources/welcome.md$
+        exclude: ^helmfile/upstream/|^CHANGELOG.md$|^WIP-CHANGELOG.md$|^helmfile/charts/grafana-ops/files/welcome.md$|^helmfile/charts/opensearch/configurer/files/dashboards-resources/welcome.md$|^images/elasticsearch-curator/README.md
         args:
           - -r
           - ~MD013,~MD024,~MD026,~MD028,~MD034

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -44,6 +44,7 @@
 - Rework thanos networkpolicies with generator chart
 - Rework monitoring networkpolicies with generator chart
 - New fluentd-elasticsearch custom image tag `v4.3.9-ck8s1` which includes a plugin for dot replacement, as this functionality has been removed from the `kubernetes_metadata_filter` plugin.
+- Changed location for opensearch-curator image.
 
 ## Updated
 

--- a/helmfile/charts/opensearch/curator/values.yaml
+++ b/helmfile/charts/opensearch/curator/values.yaml
@@ -1,7 +1,7 @@
 # NOTE: This is the last release of elasticsearch-curator that will work with OpenSearch.
 #       Switch to opensearch-curator whenever it becomes available.
 image:
-  repository: bitnami/elasticsearch-curator
+  repository: ghcr.io/elastisys/bitnami/elasticsearch-curator
   tag: 5.8.4-debian-10-r235
   pullPolicy: IfNotPresent
 

--- a/images/elasticsearch-curator/5/debian-10/Dockerfile
+++ b/images/elasticsearch-curator/5/debian-10/Dockerfile
@@ -1,0 +1,38 @@
+FROM docker.io/bitnami/minideb:buster
+LABEL maintainer "Bitnami <containers@bitnami.com>"
+
+ENV BITNAMI_PKG_CHMOD="-R g+rwX" \
+    HOME="/" \
+    OS_ARCH="amd64" \
+    OS_FLAVOUR="debian-10" \
+    OS_NAME="linux"
+
+COPY prebuildfs /
+# Install required system packages and dependencies
+RUN install_packages ca-certificates curl gzip libbz2-1.0 libc6 libffi6 liblzma5 libncursesw6 libreadline7 libsqlite3-0 libssl1.1 libtinfo6 locales procps tar wget zlib1g
+RUN wget -nc -P /tmp/bitnami/pkg/cache/ https://downloads.bitnami.com/files/stacksmith/python-3.6.15-5-linux-amd64-debian-10.tar.gz && \
+    echo "5d96e59953a65611f9ef522a397993988a931b0a0f99736213636e1935b6a21a  /tmp/bitnami/pkg/cache/python-3.6.15-5-linux-amd64-debian-10.tar.gz" | sha256sum -c - && \
+    tar -zxf /tmp/bitnami/pkg/cache/python-3.6.15-5-linux-amd64-debian-10.tar.gz -P --transform 's|^[^/]*/files|/opt/bitnami|' --wildcards '*/files' && \
+    rm -rf /tmp/bitnami/pkg/cache/python-3.6.15-5-linux-amd64-debian-10.tar.gz
+RUN wget -nc -P /tmp/bitnami/pkg/cache/ https://downloads.bitnami.com/files/stacksmith/elasticsearch-curator-5.8.4-0-linux-amd64-debian-10.tar.gz && \
+    echo "4deac538ceb2ad1811e173b3df36f89919c132d8a7a9148b2b6196521716d85e  /tmp/bitnami/pkg/cache/elasticsearch-curator-5.8.4-0-linux-amd64-debian-10.tar.gz" | sha256sum -c - && \
+    tar -zxf /tmp/bitnami/pkg/cache/elasticsearch-curator-5.8.4-0-linux-amd64-debian-10.tar.gz -P --transform 's|^[^/]*/files|/opt/bitnami|' --wildcards '*/files' && \
+    rm -rf /tmp/bitnami/pkg/cache/elasticsearch-curator-5.8.4-0-linux-amd64-debian-10.tar.gz
+RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8
+RUN update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX && \
+    DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales
+RUN echo 'en_GB.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen
+RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen
+
+COPY rootfs /
+RUN /opt/bitnami/scripts/locales/add-extra-locales.sh
+ENV BITNAMI_APP_NAME="elasticsearch-curator" \
+    BITNAMI_IMAGE_VERSION="5.8.4-debian-10-r235" \
+    LANG="en_US.UTF-8" \
+    LANGUAGE="en_US:en" \
+    NAMI_PREFIX="/.nami" \
+    PATH="/opt/bitnami/python/bin:/opt/bitnami/elasticsearch-curator/bin:$PATH"
+
+USER 1001
+ENTRYPOINT [ "curator" ]
+CMD [ "--help" ]

--- a/images/elasticsearch-curator/5/debian-10/docker-compose.yml
+++ b/images/elasticsearch-curator/5/debian-10/docker-compose.yml
@@ -1,0 +1,4 @@
+version: '2'
+services:
+  elasticsearch-curator:
+    image: docker.io/bitnami/elasticsearch-curator:5

--- a/images/elasticsearch-curator/5/debian-10/prebuildfs/opt/bitnami/.bitnami_components.json
+++ b/images/elasticsearch-curator/5/debian-10/prebuildfs/opt/bitnami/.bitnami_components.json
@@ -1,0 +1,16 @@
+{
+    "elasticsearch-curator": {
+        "arch": "amd64",
+        "digest": "4deac538ceb2ad1811e173b3df36f89919c132d8a7a9148b2b6196521716d85e",
+        "distro": "debian-10",
+        "type": "NAMI",
+        "version": "5.8.4-0"
+    },
+    "python": {
+        "arch": "amd64",
+        "digest": "5d96e59953a65611f9ef522a397993988a931b0a0f99736213636e1935b6a21a",
+        "distro": "debian-10",
+        "type": "NAMI",
+        "version": "3.6.15-5"
+    }
+}

--- a/images/elasticsearch-curator/5/debian-10/prebuildfs/opt/bitnami/licenses/licenses.txt
+++ b/images/elasticsearch-curator/5/debian-10/prebuildfs/opt/bitnami/licenses/licenses.txt
@@ -1,0 +1,3 @@
+Bitnami containers ship with software bundles. You can find the licenses under:
+/opt/bitnami/nami/COPYING
+/opt/bitnami/[name-of-bundle]/licenses/[bundle-version].txt

--- a/images/elasticsearch-curator/5/debian-10/prebuildfs/usr/sbin/install_packages
+++ b/images/elasticsearch-curator/5/debian-10/prebuildfs/usr/sbin/install_packages
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+set -u
+export DEBIAN_FRONTEND=noninteractive
+n=0
+max=2
+until [ $n -gt $max ]; do
+    set +e
+    (
+      apt-get update -qq &&
+      apt-get install -y --no-install-recommends "$@"
+    )
+    CODE=$?
+    set -e
+    if [ $CODE -eq 0 ]; then
+        break
+    fi
+    if [ $n -eq $max ]; then
+        exit $CODE
+    fi
+    echo "apt failed, retrying"
+    # shellcheck disable=SC2004
+    n=$(($n + 1))
+done
+rm -r /var/lib/apt/lists /var/cache/apt/archives

--- a/images/elasticsearch-curator/5/debian-10/rootfs/opt/bitnami/scripts/locales/add-extra-locales.sh
+++ b/images/elasticsearch-curator/5/debian-10/rootfs/opt/bitnami/scripts/locales/add-extra-locales.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+
+set -o errexit
+set -o nounset
+set -o pipefail
+# set -o xtrace # Uncomment this line for debugging purpose
+
+# Defaults
+WITH_ALL_LOCALES="${WITH_ALL_LOCALES:-no}"
+EXTRA_LOCALES="${EXTRA_LOCALES:-}"
+
+# Constants
+LOCALES_FILE="/etc/locale.gen"
+SUPPORTED_LOCALES_FILE="/usr/share/i18n/SUPPORTED"
+
+# Helper function for enabling locale only when it was not added before
+enable_locale() {
+    local -r locale="${1:?missing locale}"
+    if ! grep -q -E "^${locale}$" "$SUPPORTED_LOCALES_FILE"; then
+        echo "Locale ${locale} is not supported in this system"
+        return 1
+    fi
+    if ! grep -q -E "^${locale}" "$LOCALES_FILE"; then
+        echo "$locale" >> "$LOCALES_FILE"
+    else
+        echo "Locale ${locale} is already enabled"
+    fi
+}
+
+if [[ "$WITH_ALL_LOCALES" =~ ^(yes|true|1)$ ]]; then
+    echo "Enabling all locales"
+    cp "$SUPPORTED_LOCALES_FILE" "$LOCALES_FILE"
+else
+    # shellcheck disable=SC2001
+    LOCALES_TO_ADD="$(sed 's/[,;]\s*/\n/g' <<< "$EXTRA_LOCALES")"
+    while [[ -n "$LOCALES_TO_ADD" ]] && read -r locale; do
+        echo "Enabling locale ${locale}"
+        enable_locale "$locale"
+    done <<< "$LOCALES_TO_ADD"
+fi
+
+locale-gen

--- a/images/elasticsearch-curator/LICENSE.md
+++ b/images/elasticsearch-curator/LICENSE.md
@@ -1,0 +1,13 @@
+Copyright &copy; 2022 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/images/elasticsearch-curator/README.md
+++ b/images/elasticsearch-curator/README.md
@@ -1,0 +1,170 @@
+# Elasticsearch Curator packaged by Bitnami
+
+## What is Elasticsearch Curator?
+
+> Elasticsearch Curator is a tool that helps curate and manage indices and snapshots in Elasticsearch clusters.
+
+[Overview of Elasticsearch Curator](https://github.com/elastic/curator)
+
+Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
+
+## TL;DR
+
+```console
+$ docker run --name elasticsearch-curator bitnami/elasticsearch-curator:latest
+```
+
+### Docker Compose
+
+```console
+$ curl -sSL https://raw.githubusercontent.com/bitnami/bitnami-docker-elasticsearch-curator/master/docker-compose.yml > docker-compose.yml
+$ docker-compose up -d
+```
+
+## Why use Bitnami Images?
+
+* Bitnami closely tracks upstream source changes and promptly publishes new versions of this image using our automated systems.
+* With Bitnami images the latest bug fixes and features are available as soon as possible.
+* Bitnami containers, virtual machines and cloud images use the same components and configuration approach - making it easy to switch between formats based on your project needs.
+* All our images are based on [minideb](https://github.com/bitnami/minideb) a minimalist Debian based container image which gives you a small base container image and the familiarity of a leading Linux distribution.
+* All Bitnami images available in Docker Hub are signed with [Docker Content Trust (DCT)](https://docs.docker.com/engine/security/trust/content_trust/). You can use `DOCKER_CONTENT_TRUST=1` to verify the integrity of the images.
+* Bitnami container images are released daily with the latest distribution packages available.
+
+> This [CVE scan report](https://quay.io/repository/bitnami/elasticsearch-curator?tab=tags) contains a security report with all open CVEs. To get the list of actionable security issues, find the "latest" tag, click the vulnerability report link under the corresponding "Security scan" field and then select the "Only show fixable" filter on the next page.
+
+## Why use a non-root container?
+
+Non-root container images add an extra layer of security and are generally recommended for production environments. However, because they run as a non-root user, privileged tasks are typically off-limits. Learn more about non-root containers [in our docs](https://docs.bitnami.com/tutorials/work-with-non-root-containers/).
+
+## Supported tags and respective `Dockerfile` links
+
+Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
+
+
+* [`5`, `5-debian-10`, `5.8.4`, `5.8.4-debian-10-r235`, `latest` (5/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-elasticsearch-curator/blob/5.8.4-debian-10-r235/5/debian-10/Dockerfile)
+
+Subscribe to project updates by watching the [bitnami/elasticsearch-curator GitHub repo](https://github.com/bitnami/bitnami-docker-elasticsearch-curator).
+
+## Get this image
+
+The recommended way to get the Bitnami Elasticsearch Curator Docker Image is to pull the prebuilt image from the [Docker Hub Registry](https://hub.docker.com/r/bitnami/elasticsearch-curator).
+
+```console
+$ docker pull bitnami/elasticsearch-curator:latest
+```
+
+To use a specific version, you can pull a versioned tag. You can view the [list of available versions](https://hub.docker.com/r/bitnami/elasticsearch-curator/tags/) in the Docker Hub Registry.
+
+```console
+$ docker pull bitnami/elasticsearch-curator:[TAG]
+```
+
+If you wish, you can also build the image yourself.
+
+```console
+$ docker build -t bitnami/elasticsearch-curator:latest 'https://github.com/bitnami/bitnami-docker-elasticsearch-curator.git#master:5/debian-10'
+```
+
+## Connecting to other containers
+
+Using [Docker container networking](https://docs.docker.com/engine/userguide/networking/), a different server running inside a container can easily be accessed by your application containers and vice-versa.
+
+Containers attached to the same network can communicate with each other using the container name as the hostname.
+
+### Using the Command Line
+
+#### Step 1: Create a network
+
+```console
+$ docker network create elasticsearch-curator-network --driver bridge
+```
+
+#### Step 2: Launch the Elasticsearch Curator container within your network
+
+Use the `--network <NETWORK>` argument to the `docker run` command to attach the container to the `elasticsearch-curator-network` network.
+
+```console
+$ docker run --name elasticsearch-curator-node1 --network elasticsearch-curator-network bitnami/elasticsearch-curator:latest
+```
+
+#### Step 3: Run another containers
+
+We can launch another containers using the same flag (`--network NETWORK`) in the `docker run` command. If you also set a name to your container, you will be able to use it as hostname in your network.
+
+## Configuration
+
+Find all of the Elasticsearch Curator configuration options in the official [Curator Reference page](https://www.elastic.co/guide/en/elasticsearch/client/curator/current/index.html).
+
+## Logging
+
+The Bitnami Elasticsearch Curator Docker image sends the container logs to `stdout`. To view the logs:
+
+```console
+$ docker logs elasticsearch-curator
+```
+
+You can configure the containers [logging driver](https://docs.docker.com/engine/admin/logging/overview/) using the `--log-driver` option if you wish to consume the container logs differently. In the default configuration docker uses the `json-file` driver.
+
+## Maintenance
+
+### Upgrade this image
+
+Bitnami provides up-to-date versions of Elasticsearch Curator, including security patches, soon after they are made upstream. We recommend that you follow these steps to upgrade your container.
+
+#### Step 1: Get the updated image
+
+```console
+$ docker pull bitnami/elasticsearch-curator:latest
+```
+
+#### Step 2: Stop the running container
+
+Stop the currently running container using the command
+
+```console
+$ docker stop elasticsearch-curator
+```
+
+#### Step 3: Remove the currently running container
+
+```console
+$ docker rm -v elasticsearch-curator
+```
+
+#### Step 4: Run the new image
+
+Re-create your container from the new image.
+
+```console
+$ docker run --name elasticsearch-curator bitnami/elasticsearch-curator:latest
+```
+
+## Contributing
+
+We'd love for you to contribute to this container. You can request new features by creating an [issue](https://github.com/bitnami/bitnami-docker-elasticsearch-curator/issues), or submit a [pull request](https://github.com/bitnami/bitnami-docker-elasticsearch-curator/pulls) with your contribution.
+
+## Issues
+
+If you encountered a problem running this container, you can file an [issue](https://github.com/bitnami/bitnami-docker-elasticsearch-curator/issues/new). For us to provide better support, be sure to include the following information in your issue:
+
+- Host OS and version
+- Docker version (`docker version`)
+- Output of `docker info`
+- Version of this container
+- The command you used to run the container, and any relevant output you saw (masking any sensitive information)
+
+## License
+
+Copyright &copy; 2022 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/images/elasticsearch-curator/docker-compose.yml
+++ b/images/elasticsearch-curator/docker-compose.yml
@@ -1,0 +1,4 @@
+version: '2'
+services:
+  elasticsearch-curator:
+    image: docker.io/bitnami/elasticsearch-curator:5


### PR DESCRIPTION
**What this PR does / why we need it**:

Noticed that the image had been removed from bitnamis docker hub. This is because the bitnami elasticsearch-curator was deprecated about a year ago, so now they removed the images.

Found the Dockerfile and related files in their repository by browsing the commit history, built it and pushed to our ghcr.

Now we can use the image again.

This warrants a patch version as the old image can not be pulled anymore.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
