### PR TITLE
apps sc: add option to configure max shards in opensearch

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -34,6 +34,7 @@
 - Added RBAC for admin users to view events and logs
 - Possibility to add custom config for node-local-dns
 - Added Prometheus Blackbox Exporter dashboard to Grafana
+- Added option to configure `max_shards_per_node` in opensearch via config option `opensearch.maxShardsPerNode`
 
 ### Changed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -672,6 +672,9 @@ opensearch:
   # Change this value before applying opensearch to adjust indices.query.bool.max_clause_count
   maxClauseCount: 1024
 
+  # Configure how many shards a node with the data role can hold
+  maxShardsPerNode: 1000
+
   # Create initial indices upon first startup
   createIndices: true
 

--- a/helmfile/values/opensearch/common.yaml.gotmpl
+++ b/helmfile/values/opensearch/common.yaml.gotmpl
@@ -6,6 +6,7 @@ config:
   opensearch.yml: |
     cluster:
       name: {{ .Values.opensearch.clusterName }}
+      max_shards_per_node: {{ .Values.opensearch.maxShardsPerNode }}
 
     network:
       host: 0.0.0.0


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**: 
fixes #1645

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [x] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
