### PR TITLE
apps sc: Use emptyDir with log-manager compaction

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -70,6 +70,7 @@
 - Another network policy fix for Harbor to allow garbage collection
 - Fix migration and race condition for HNC and HierarchyConfigurations
 - Rook-Ceph mgr netpol to allow blackbox exporter probes
+- Run log-manager compaction with emptyDir volume
 
 ### Updated
 

--- a/helmfile/charts/log-manager/templates/cronjob-compaction.yaml
+++ b/helmfile/charts/log-manager/templates/cronjob-compaction.yaml
@@ -28,9 +28,6 @@ spec:
             - name: compaction
               imagePullPolicy: {{ $.Values.image.pullPolicy }}
               image: {{ $.Values.image.repository }}:{{ default $.Chart.AppVersion $.Values.image.tag }}
-              {{- if .compaction.ephemeralVolumes.enabled }}
-              workingDir: /scratch
-              {{- end }}
               command: [/scripts/compaction.sh]
               env:
                 - name: S3_CONFIG
@@ -41,10 +38,8 @@ spec:
                   value: {{ .prefix }}
                 - name: COMPACT_DAYS
                   value: {{ .compaction.days | quote }}
-                {{- if .compaction.ephemeralVolumes.enabled }}
                 - name: TMP_DIR
                   value: /scratch
-                {{- end }}
               {{- with $.Values.securityContext }}
               securityContext: {{- toYaml . | nindent 16 }}
               {{- end }}
@@ -58,10 +53,8 @@ spec:
                 - name: scripts
                   mountPath: /scripts
                   readOnly: true
-                {{- if .compaction.ephemeralVolumes.enabled }}
-                - name: ephemeral-scratch
+                - name: scratch
                   mountPath: /scratch
-                {{- end }}
           volumes:
             - name: s3cfg
               secret:
@@ -70,8 +63,8 @@ spec:
               configMap:
                 name: {{ include "log-manager.fullname" $ }}-scripts
                 defaultMode: 0777
-            {{- if .compaction.ephemeralVolumes.enabled }}
-            - name: ephemeral-scratch
+            - name: scratch
+              {{- if .compaction.ephemeralVolumes.enabled }}
               ephemeral:
                 volumeClaimTemplate:
                   metadata:
@@ -79,12 +72,16 @@ spec:
                       {{- include "log-manager.labels" $ | nindent 22 }}
                   spec:
                     accessModes: [ "ReadWriteOnce" ]
-                    storageClassName: "cinder-csi"
+                    {{- with $.Values.storageClassName }}
+                    storageClassName: {{ . }}
+                    {{- end }}
                     resources:
                       {{- with $.Values.compaction.volume }}
                       requests: {{- toYaml . | nindent 24 }}
                       {{- end }}
-            {{- end }}
+              {{- else }}
+              emptyDir: {}
+              {{- end }}
           {{- with $.Values.imagePullSecrets }}
           imagePullSecrets: {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/helmfile/charts/log-manager/values.yaml
+++ b/helmfile/charts/log-manager/values.yaml
@@ -47,6 +47,8 @@ securityContext:
     drop:
     - ALL
 
+storageClassName: ""
+
 compaction:
   resources: {}
 retention:

--- a/helmfile/values/fluentd/log-manager.yaml.gotmpl
+++ b/helmfile/values/fluentd/log-manager.yaml.gotmpl
@@ -55,6 +55,8 @@ instances:
   {{- end }}
   {{- end }}
 
+storageClassName: {{ .Values.storageClasses.default }}
+
 compaction:
   resources: {{- toYaml .Values.fluentd.logManager.compaction.resources | nindent 4 }}
   volume: {{- toYaml .Values.fluentd.logManager.compaction.volume | nindent 4 }}

--- a/helmfile/values/podsecuritypolicies/common/fluentd.yaml.gotmpl
+++ b/helmfile/values/podsecuritypolicies/common/fluentd.yaml.gotmpl
@@ -33,6 +33,7 @@ constraints:
         volumes:
           - configMap
           - secret
+          - emptyDir
           - ephemeral
     {{- end }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

So it has space for files. (Else it would write to a tmpfs mount which is normally in memory, which is accounted towards it resources usage.)

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [ ] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
