### PR TITLE
apps: Use set cluster DNS for egress rule

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -72,6 +72,7 @@
 - Fix migration and race condition for HNC and HierarchyConfigurations
 - Rook-Ceph mgr netpol to allow blackbox exporter probes
 - Run log-manager compaction with emptyDir volume
+- Use set cluster DNS for egress rule
 
 ### Updated
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -73,6 +73,7 @@
 - Rook-Ceph mgr netpol to allow blackbox exporter probes
 - Run log-manager compaction with emptyDir volume
 - Use set cluster DNS for egress rule
+- Add missing ingress rules for harbor core
 
 ### Updated
 

--- a/helmfile/values/networkpolicies/common/common.yaml.gotmpl
+++ b/helmfile/values/networkpolicies/common/common.yaml.gotmpl
@@ -25,7 +25,7 @@
 rules:
   egress-rule-dns:
     peers:
-      - cidr: 10.233.0.3/32
+      - cidr: {{ .Values.global.clusterDns }}/32
     ports:
       - tcp: 53
       - udp: 53

--- a/helmfile/values/networkpolicies/service/harbor.yaml.gotmpl
+++ b/helmfile/values/networkpolicies/service/harbor.yaml.gotmpl
@@ -125,6 +125,18 @@ policies:
         - rule: ingress-rule-ingress
           ports:
             - tcp: 8080
+        - name: ingress-http
+          peers:
+            - podSelectorLabels:
+                component: exporter
+            - podSelectorLabels:
+                component: jobservice
+            - podSelectorLabels:
+                component: trivy
+            - podSelectorLabels:
+                job-name: init-harbor-job
+          ports:
+            - tcp: 8080
       egress:
         - rule: egress-rule-dns
         - rule: egress-rule-ingress


### PR DESCRIPTION
**What this PR does / why we need it**:

So the egress rule isn't hard coded.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
