### PR TITLE
apps sc: upgraded grafana to the latest patch release

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,13 @@
+### Release notes
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Updated
+
+- Upgraded Grafana chart version to `6.57.4` and app version to `9.5.5`
+
+### Removed

--- a/helmfile/upstream/grafana/Chart.yaml
+++ b/helmfile/upstream/grafana/Chart.yaml
@@ -5,7 +5,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/grafana/grafana
 apiVersion: v2
-appVersion: 9.5.3
+appVersion: 9.5.5
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png
@@ -26,4 +26,4 @@ sources:
 - https://github.com/grafana/grafana
 - https://github.com/grafana/helm-charts
 type: application
-version: 6.57.1
+version: 6.57.4

--- a/helmfile/upstream/grafana/README.md
+++ b/helmfile/upstream/grafana/README.md
@@ -162,6 +162,7 @@ This version requires Helm >= 3.1.0.
 | `sidecar.alerts.reloadURL`           | Full url of datasource configuration reload API endpoint, to invoke after a config-map change | `"http://localhost:3000/api/admin/provisioning/alerting/reload"` |
 | `sidecar.alerts.skipReload`          | Enabling this omits defining the REQ_URL and REQ_METHOD environment variables | `false` |
 | `sidecar.alerts.initDatasources`     | Set to true to deploy the datasource sidecar as an initContainer in addition to a container. This is needed if skipReload is true, to load any alerts defined at startup time. | `false` |
+| `sidecar.alerts.extraMounts`         | Additional alerts sidecar volume mounts. | `[]`                               |
 | `sidecar.dashboards.enabled`              | Enables the cluster wide search for dashboards and adds/updates/deletes them in grafana | `false`       |
 | `sidecar.dashboards.SCProvider`           | Enables creation of sidecar provider          | `true`                                                  |
 | `sidecar.dashboards.provider.name`        | Unique name of the grafana provider           | `sidecarProvider`                                       |
@@ -267,7 +268,7 @@ This version requires Helm >= 3.1.0.
 | `imageRenderer.revisionHistoryLimit`       | number of image-renderer replica sets to keep                                      | `10`                             |
 | `imageRenderer.networkPolicy.limitIngress` | Enable a NetworkPolicy to limit inbound traffic from only the created grafana pods | `true`                           |
 | `imageRenderer.networkPolicy.limitEgress`  | Enable a NetworkPolicy to limit outbound traffic to only the created grafana pods  | `false`                          |
-| `imageRenderer.resources`                  | Set resource limits for image-renderer pdos                                        | `{}`                             |
+| `imageRenderer.resources`                  | Set resource limits for image-renderer pods                                        | `{}`                             |
 | `imageRenderer.nodeSelector`               | Node labels for pod assignment                | `{}`                                                    |
 | `imageRenderer.tolerations`                | Toleration labels for pod assignment          | `[]`                                                    |
 | `imageRenderer.affinity`                   | Affinity settings for pod assignment          | `{}`                                                    |

--- a/helmfile/upstream/grafana/templates/_pod.tpl
+++ b/helmfile/upstream/grafana/templates/_pod.tpl
@@ -331,6 +331,9 @@ containers:
     volumeMounts:
       - name: sc-alerts-volume
         mountPath: "/etc/grafana/provisioning/alerting"
+      {{- with .Values.sidecar.alerts.extraMounts }}
+      {{- toYaml . | trim | nindent 6 }}
+      {{- end }}        
 {{- end}}
 {{- if .Values.sidecar.dashboards.enabled }}
   - name: {{ include "grafana.name" . }}-sc-dashboard

--- a/helmfile/upstream/grafana/values.yaml
+++ b/helmfile/upstream/grafana/values.yaml
@@ -850,6 +850,8 @@ sidecar:
     script: null
     skipReload: false
     # Deploy the alert sidecar as an initContainer in addition to a container.
+    # Additional alert sidecar volume mounts
+    extraMounts: []
     # Sets the size limit of the alert sidecar emptyDir volume
     sizeLimit: {}
   dashboards:

--- a/helmfile/values/grafana/grafana-ops.yaml.gotmpl
+++ b/helmfile/values/grafana/grafana-ops.yaml.gotmpl
@@ -81,6 +81,9 @@ grafana.ini:
   server:
     root_url: https://{{ .Values.grafana.ops.subdomain }}.{{ .Values.global.opsDomain }}
   {{ if .Values.grafana.ops.oidc.enabled -}}
+  # Enable user lookup based on email in addition to using unique ID provided by IdPs.
+  auth:
+    oauth_allow_insecure_email_lookup: true
   auth.generic_oauth:
     name: dex
     enabled: {{ .Values.grafana.ops.oidc.enabled }}

--- a/helmfile/values/grafana/grafana-user.yaml.gotmpl
+++ b/helmfile/values/grafana/grafana-user.yaml.gotmpl
@@ -81,6 +81,9 @@ datasources:
 grafana.ini:
   server:
     root_url: https://{{ .Values.grafana.user.subdomain }}.{{ .Values.global.baseDomain }}
+  # Enable user lookup based on email in addition to using unique ID provided by IdPs.
+  auth:
+    oauth_allow_insecure_email_lookup: true
   auth.generic_oauth:
     name: dex
     enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**: to upgrade Grafana to the latest patch release

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [ ] I upgraded no Chart.
  - [x] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
