### PR TITLE
bin: swift support in update-ips

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -39,6 +39,7 @@
 - Add possibility to add and tune disk usage alerts
   - Add pattern matching for node and disk
 - Added support for configuring multiple kube-apiservers for blackbox exporter in sc
+- `./bin/ck8s update-ips` now adds the IPs and port for swift endpoint
 
 ### Changed
 
@@ -58,12 +59,6 @@
   - Moved all grafana value templates to a separate folder
   - Moved grafana config from `prometheus.grafana` and `user.grafana` to `grafana.ops` and `grafana.user`
 
-## Updated
-
-- Upgraded Thanos helm chart to version `12.6.2` which bumps the application version to `0.31.0`
-    - Now supports authentication via Openstack application credentials when using Swift as the object storage backend
-- Allow egress to port 53 TCP for all network policies
-
 ### Fixed
 
 - Fixed issue with compaction job on ephemeral volumes
@@ -77,6 +72,9 @@
 
 ### Updated
 
+- Upgraded Thanos helm chart to version `12.6.2` which bumps the application version to `0.31.0`
+    - Now supports authentication via Openstack application credentials when using Swift as the object storage backend
+- Allow egress to port 53 TCP for all network policies
 - Update Trivy Operator Dashboard to improve the user experience
 - Bump sops to version `3.7.3`.
 - Update Falco rules


### PR DESCRIPTION
**What this PR does / why we need it**:

bin/ck8s update-ips should now add the IPs and port for the swift endpoint.

**Which issue this PR fixes**: 
fixes #1629 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

I'll need to test this a bit more but so far on our support infra provider elastx it works just fine with using application credentials.

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
