### PR TITLE
apps sc: added alerts for harbor and updated the dashboard

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -5,6 +5,7 @@
 - Extra component versions can be added in the Welcome dashboard via config
 - Probes from WC to SC to monitor how well clusters reach each other
 - Added so `bin/ck8s test` components can be used all at once in a cluster.
+- Alerts for Harbor
 
 ### Changed
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -14,6 +14,7 @@
 - Replaced image `elastisys/curl-jq:latest` with `ghcr.io/elastisys/curl-jq:1.0.0`.
 - Only mutate pods on create to prevent them from getting stuck
 - Increased the default `proxy-buffer-size` setting in ingress-nginx to `8k`.
+- The Grafana dashboard for Harbor to show the total number of artifacts and storage used per project
 
 ### Fixed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -427,6 +427,10 @@ harbor:
     enabled: true
     forceConfigure: false
     schedule: "0 0 0 * * SUN"
+  alerts:
+    # Alert if values are above the below threshold
+    maxTotalStorageUsedGB: 500
+    maxTotalArtifacts: 1000
 
 grafanaLabelEnforcer:
   resources:

--- a/helmfile/charts/grafana-dashboards/dashboards/harbor-dashboard.json
+++ b/helmfile/charts/grafana-dashboards/dashboards/harbor-dashboard.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 25,
+  "id": 55,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -32,7 +32,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "P53D806240F0B3878"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
@@ -46,7 +46,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P53D806240F0B3878"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -68,7 +68,8 @@
           "thresholds": {
             "mode": "absolute",
             "steps": []
-          }
+          },
+          "unit": "none"
         },
         "overrides": []
       },
@@ -80,6 +81,9 @@
       },
       "id": 4,
       "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -88,11 +92,9 @@
           "fields": "",
           "values": false
         },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "text": {}
+        "textMode": "auto"
       },
-      "pluginVersion": "9.2.4",
+      "pluginVersion": "9.5.5",
       "targets": [
         {
           "datasource": {
@@ -107,58 +109,374 @@
           "refId": "A"
         }
       ],
-      "title": "harbor health",
-      "type": "gauge"
+      "title": "Harbor health",
+      "type": "stat"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 6,
-        "w": 6,
+        "w": 4,
         "x": 4,
         "y": 1
       },
-      "hiddenSeries": false,
-      "id": 6,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
+      "id": 8,
       "options": {
-        "alertThreshold": true
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
       },
-      "percentage": false,
-      "pluginVersion": "9.2.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "9.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(harbor_system_info) by (auth_mode, harbor_version, pod)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "System info",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "auth_mode": ""
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "labelsToFields": false,
+            "mode": "seriesToRows",
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 25,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "harbor_project_total",
+          "interval": "",
+          "legendFormat": "Public: {{public}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Project total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 98,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(harbor_project_artifact_total)",
+          "interval": "",
+          "legendFormat": "Project: {{project_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Project artifacts total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 99,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(harbor_project_quota_usage_byte)",
+          "interval": "",
+          "legendFormat": "Project: {{project_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Project quota usage",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 7
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.13",
       "targets": [
         {
           "datasource": {
@@ -174,170 +492,91 @@
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "component up status",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "title": "Component up status",
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
           "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
-        "h": 6,
+        "h": 10,
         "w": 8,
-        "x": 10,
-        "y": 1
+        "x": 8,
+        "y": 7
       },
-      "hiddenSeries": false,
-      "id": 8,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
+      "id": 23,
       "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "9.2.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "harbor_system_info",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "system info",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
         },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
         }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
       },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 18,
-        "y": 1
-      },
-      "hiddenSeries": false,
-      "id": 17,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "9.2.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "9.3.13",
       "targets": [
         {
           "datasource": {
@@ -345,173 +584,94 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "harbor_artifact_pulled",
+          "expr": "harbor_project_repo_total",
           "interval": "",
           "legendFormat": "Project: {{project_name}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "artifact pulled",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "title": "Project repo total",
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 0,
-        "y": 7
-      },
-      "hiddenSeries": false,
-      "id": 25,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "9.2.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
           },
-          "editorMode": "code",
-          "expr": "harbor_project_total",
-          "interval": "",
-          "legendFormat": "Public: {{public}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Project total",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
         },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
+        "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 6,
+        "h": 10,
+        "w": 8,
+        "x": 16,
         "y": 7
       },
-      "hiddenSeries": false,
       "id": 19,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "9.2.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "9.3.13",
       "targets": [
         {
           "datasource": {
@@ -527,80 +687,105 @@
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "project members",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "title": "Project members",
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
       "description": "",
-      "fill": 1,
-      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total:"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 12,
-        "y": 7
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 17
       },
-      "hiddenSeries": false,
       "id": 21,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "9.2.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "9.3.13",
       "targets": [
         {
           "datasource": {
@@ -614,81 +799,120 @@
           "legendFormat": "Project: {{project_name}}",
           "range": true,
           "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Quota Usage",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
         },
         {
-          "format": "short",
-          "logBase": 1,
-          "show": true
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(harbor_project_quota_usage_byte)",
+          "hide": false,
+          "legendFormat": "Total:",
+          "range": true,
+          "refId": "B"
         }
       ],
-      "yaxis": {
-        "align": false
-      }
+      "title": "Quota Usage per project",
+      "transformations": [],
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "fill": 1,
-      "fillGradient": 0,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total:"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 18,
-        "y": 7
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 17
       },
-      "hiddenSeries": false,
-      "id": 23,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
+      "id": 97,
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "9.2.4",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "9.3.13",
       "targets": [
         {
           "datasource": {
@@ -696,54 +920,136 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "harbor_project_repo_total",
+          "expr": "harbor_project_artifact_total",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "Project: {{project_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(harbor_project_artifact_total)",
+          "hide": false,
+          "legendFormat": "Total:",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Number of Artifacts per project",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 17
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.13",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "harbor_artifact_pulled",
           "interval": "",
           "legendFormat": "Project: {{project_name}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Project repo total",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "title": "Artifact pulled",
+      "type": "timeseries"
     },
     {
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "P53D806240F0B3878"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 27
       },
       "id": 52,
       "panels": [
@@ -762,7 +1068,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 15
+            "y": 30
           },
           "hiddenSeries": false,
           "id": 58,
@@ -782,7 +1088,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -849,7 +1155,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 15
+            "y": 30
           },
           "hiddenSeries": false,
           "id": 94,
@@ -869,7 +1175,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -936,7 +1242,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 15
+            "y": 30
           },
           "hiddenSeries": false,
           "id": 66,
@@ -956,7 +1262,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1023,7 +1329,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 15
+            "y": 30
           },
           "hiddenSeries": false,
           "id": 56,
@@ -1043,7 +1349,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1110,7 +1416,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 23
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 70,
@@ -1130,7 +1436,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1197,7 +1503,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 23
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 62,
@@ -1217,7 +1523,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1285,7 +1591,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 23
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 60,
@@ -1305,7 +1611,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1372,7 +1678,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 23
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 68,
@@ -1392,7 +1698,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1459,7 +1765,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 31
+            "y": 46
           },
           "hiddenSeries": false,
           "id": 96,
@@ -1479,7 +1785,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1546,7 +1852,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 31
+            "y": 46
           },
           "hiddenSeries": false,
           "id": 54,
@@ -1566,7 +1872,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1634,7 +1940,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 31
+            "y": 46
           },
           "hiddenSeries": false,
           "id": 95,
@@ -1654,7 +1960,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1711,25 +2017,25 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P53D806240F0B3878"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
       ],
-      "title": "Genertal metrics",
+      "title": "General metrics",
       "type": "row"
     },
     {
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "P53D806240F0B3878"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 28
       },
       "id": 10,
       "panels": [
@@ -1748,7 +2054,7 @@
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 16
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 12,
@@ -1768,7 +2074,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1835,7 +2141,7 @@
             "h": 7,
             "w": 8,
             "x": 8,
-            "y": 16
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 26,
@@ -1855,7 +2161,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1923,7 +2229,7 @@
             "h": 7,
             "w": 8,
             "x": 16,
-            "y": 16
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 28,
@@ -1943,7 +2249,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2010,7 +2316,7 @@
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 23
+            "y": 45
           },
           "hiddenSeries": false,
           "id": 14,
@@ -2030,7 +2336,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2099,7 +2405,7 @@
             "h": 7,
             "w": 8,
             "x": 8,
-            "y": 23
+            "y": 45
           },
           "hiddenSeries": false,
           "id": 30,
@@ -2119,7 +2425,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2176,7 +2482,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P53D806240F0B3878"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -2188,13 +2494,13 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "P53D806240F0B3878"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 29
       },
       "id": 74,
       "panels": [
@@ -2213,7 +2519,7 @@
             "h": 4,
             "w": 16,
             "x": 0,
-            "y": 17
+            "y": 39
           },
           "hiddenSeries": false,
           "id": 76,
@@ -2233,7 +2539,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2298,7 +2604,7 @@
             "h": 7,
             "w": 8,
             "x": 16,
-            "y": 17
+            "y": 39
           },
           "hiddenSeries": false,
           "id": 90,
@@ -2318,7 +2624,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2386,7 +2692,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 21
+            "y": 43
           },
           "hiddenSeries": false,
           "id": 92,
@@ -2406,7 +2712,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2474,7 +2780,7 @@
             "h": 4,
             "w": 8,
             "x": 8,
-            "y": 21
+            "y": 43
           },
           "hiddenSeries": false,
           "id": 86,
@@ -2494,7 +2800,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2562,7 +2868,7 @@
             "h": 5,
             "w": 8,
             "x": 16,
-            "y": 24
+            "y": 46
           },
           "hiddenSeries": false,
           "id": 78,
@@ -2582,7 +2888,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2649,7 +2955,7 @@
             "h": 4,
             "w": 8,
             "x": 8,
-            "y": 25
+            "y": 47
           },
           "hiddenSeries": false,
           "id": 88,
@@ -2669,7 +2975,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2734,7 +3040,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 29
+            "y": 51
           },
           "hiddenSeries": false,
           "id": 80,
@@ -2754,7 +3060,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2821,7 +3127,7 @@
             "h": 6,
             "w": 8,
             "x": 8,
-            "y": 29
+            "y": 51
           },
           "hiddenSeries": false,
           "id": 82,
@@ -2841,7 +3147,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2908,7 +3214,7 @@
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 29
+            "y": 51
           },
           "hiddenSeries": false,
           "id": 84,
@@ -2928,7 +3234,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2985,7 +3291,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P53D806240F0B3878"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -2997,13 +3303,13 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "P53D806240F0B3878"
+        "uid": "${datasource}"
       },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 30
       },
       "id": 32,
       "panels": [
@@ -3022,7 +3328,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 18
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 35,
@@ -3042,7 +3348,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3109,7 +3415,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 18
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 36,
@@ -3129,7 +3435,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3196,7 +3502,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 18
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 50,
@@ -3216,7 +3522,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3283,7 +3589,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 26
+            "y": 48
           },
           "hiddenSeries": false,
           "id": 38,
@@ -3303,7 +3609,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3370,7 +3676,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 26
+            "y": 48
           },
           "hiddenSeries": false,
           "id": 40,
@@ -3390,7 +3696,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3457,7 +3763,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 26
+            "y": 48
           },
           "hiddenSeries": false,
           "id": 42,
@@ -3477,7 +3783,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3544,7 +3850,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 34
+            "y": 56
           },
           "hiddenSeries": false,
           "id": 44,
@@ -3564,7 +3870,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3631,7 +3937,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 34
+            "y": 56
           },
           "hiddenSeries": false,
           "id": 46,
@@ -3651,7 +3957,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3719,7 +4025,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 34
+            "y": 56
           },
           "hiddenSeries": false,
           "id": 48,
@@ -3739,7 +4045,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "9.2.4",
+          "pluginVersion": "9.5.5",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3796,7 +4102,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P53D806240F0B3878"
+            "uid": "${datasource}"
           },
           "refId": "A"
         }
@@ -3805,8 +4111,8 @@
       "type": "row"
     }
   ],
-  "refresh": false,
-  "schemaVersion": 37,
+  "refresh": "30s",
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -3832,7 +4138,7 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {

--- a/helmfile/charts/grafana-dashboards/dashboards/harbor-dashboard.json
+++ b/helmfile/charts/grafana-dashboards/dashboards/harbor-dashboard.json
@@ -24,7 +24,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 55,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -172,7 +171,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "max(harbor_system_info) by (auth_mode, harbor_version, pod)",
+          "expr": "max(harbor_system_info) by (auth_mode, harbor_version)",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -232,7 +231,32 @@
           },
           "unit": "none"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "false"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Private"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "true"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Public"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 6,
@@ -265,12 +289,13 @@
           "editorMode": "code",
           "expr": "harbor_project_total",
           "interval": "",
-          "legendFormat": "Public: {{public}}",
+          "legendFormat": "{{public}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Project total",
+      "title": "Total number of Projects (Public vs Private)",
+      "transformations": [],
       "type": "stat"
     },
     {
@@ -278,6 +303,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "Total number of artifacts type in a project",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -333,7 +359,7 @@
           "refId": "A"
         }
       ],
-      "title": "Project artifacts total",
+      "title": "Total number of artifacts",
       "type": "stat"
     },
     {
@@ -341,6 +367,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "Total used resources of a project",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -396,7 +423,7 @@
           "refId": "A"
         }
       ],
-      "title": "Project quota usage",
+      "title": "Quota usage",
       "type": "stat"
     },
     {
@@ -404,6 +431,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "Running status of Harbor components",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -500,6 +528,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "Total number of repositories in a project",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -591,7 +620,7 @@
           "refId": "A"
         }
       ],
-      "title": "Project repo total",
+      "title": "Total repositories in a project",
       "type": "timeseries"
     },
     {
@@ -599,6 +628,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "Total number of members in a project",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -687,7 +717,7 @@
           "refId": "A"
         }
       ],
-      "title": "Project members",
+      "title": "Total members in a project",
       "type": "timeseries"
     },
     {
@@ -695,7 +725,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "",
+      "description": "Total used resources of a project",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -822,7 +852,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "",
+      "description": "Total number of artifacts type in a project",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -949,6 +979,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "Number of images pulled in a project",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1036,7 +1067,7 @@
           "refId": "A"
         }
       ],
-      "title": "Artifact pulled",
+      "title": "Images pulled per project",
       "type": "timeseries"
     },
     {
@@ -4119,7 +4150,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "default",
           "value": "default"
         },
@@ -4146,5 +4177,7 @@
   },
   "timezone": "",
   "title": "Harbor",
-  "version": 1
+  "uid": "c51f4da2-e4a1-46cb-9856-46251a01e612",
+  "version": 2,
+  "weekStart": ""
 }

--- a/helmfile/charts/prometheus-alerts/templates/alerts/harbor.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/alerts/harbor.yaml
@@ -76,7 +76,7 @@ spec:
       labels:
         severity: medium
       annotations:
-        description: Total used storage is above the limit of
+        description: Total used storage is above the limit of {{ .Values.harbor.alerts.maxTotalStorageUsedGB }}GB
     - alert: 'Harbor p99 latency is higher than 10 seconds'
       expr: |
         histogram_quantile(0.99,  sum  (rate(registry_http_request_duration_seconds_bucket[30m]) )) > 10
@@ -100,5 +100,5 @@ spec:
       labels:
         severity: low
       annotations:
-        description: Total number of artifacts is above the limit of
+        description: Total number of artifacts is above the limit of {{ .Values.harbor.alerts.maxTotalArtifacts }}GB
 {{- end }}

--- a/helmfile/charts/prometheus-alerts/templates/alerts/harbor.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/alerts/harbor.yaml
@@ -1,0 +1,104 @@
+{{- if and .Values.defaultRules.create .Values.defaultRules.rules.harbor }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-alerts.fullname" .) "harbor" | trunc 63 | trimSuffix "-" }}
+  labels:
+    app: {{ template "prometheus-alerts.name" . }}
+{{ include "prometheus-alerts.labels" . | indent 4 }}
+{{- if .Values.defaultRules.alertLabels }}
+{{ toYaml .Values.defaultRules.alertLabels | indent 4 }}
+{{- end }}
+{{- if .Values.defaultRules.annotations }}
+  annotations:
+{{ toYaml .Values.defaultRules.annotations | indent 4 }}
+{{- end }}
+spec:
+  groups:
+  - name: harbor
+    rules:
+    - alert: 'Harbor Core Is Down'
+      expr: |
+        harbor_up{component="core"} == 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        description: Harbor Core Is Down
+    {{- if eq .Values.harbor.database.type "internal" }}
+    - alert: 'Harbor Database Is Down'
+      expr: |
+        harbor_up{component="database"} == 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        description: Harbor Database Is Down
+    {{- end }}
+    - alert: 'Harbor Registry Is Down'
+      expr: |
+        harbor_up{component="registry"} == 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        description: Harbor Registry Is Down
+    {{- if eq .Values.harbor.redis.type "internal" }}
+    - alert: 'Harbor Redis Is Down'
+      expr: |
+        harbor_up{component="redis"} == 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        description: Harbor Redis Is Down
+    {{- end }}
+    - alert: 'Harbor Trivy Is Down'
+      expr: |
+        harbor_up{component="trivy"} == 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        description: Harbor Trivy Is Down
+    - alert: 'Harbor JobService Is Down'
+      expr: |
+        harbor_up{component="jobservice"} == 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        description: Harbor JobService Is Down
+    - alert: 'Storage Usage Is Above the Limit'
+      expr: |
+        sum(harbor_project_quota_usage_byte) / (1024^3) > {{ .Values.harbor.alerts.maxTotalStorageUsedGB }}
+      for: 5m
+      labels:
+        severity: medium
+      annotations:
+        description: Total used storage is above the limit of
+    - alert: 'Harbor p99 latency is higher than 10 seconds'
+      expr: |
+        histogram_quantile(0.99,  sum  (rate(registry_http_request_duration_seconds_bucket[30m]) )) > 10
+      for: 5m
+      labels:
+        severity: low
+      annotations:
+        description: Harbor p99 latency is higher than 10 seconds
+    - alert: 'Harbor Error Rate is High'
+      expr: |
+        sum(rate(registry_http_requests_total{code=~"4..|5.."}[5m]))/sum(rate(registry_http_requests_total[5m])) > 0.15
+      for: 5m
+      labels:
+        severity: low
+      annotations:
+        description: Harbor Error Rate is High
+    - alert: 'Harbor Total Number of Artifacts is above the limit'
+      expr: |
+        sum(harbor_project_artifact_total) > {{ .Values.harbor.alerts.maxTotalArtifacts }}
+      for: 5m
+      labels:
+        severity: low
+      annotations:
+        description: Total number of artifacts is above the limit of
+{{- end }}

--- a/helmfile/charts/prometheus-alerts/values.yaml
+++ b/helmfile/charts/prometheus-alerts/values.yaml
@@ -77,7 +77,6 @@ defaultRules:
   ## Any labels to add to the recording rules
   # recordLabels:
   #   key: value
-
   rules:
     alertmanager: false
     blackbox: true
@@ -118,6 +117,7 @@ defaultRules:
     networkpolicies: true
     dns: true
     clusterApi: false
+    harbor: true
 
   appNamespacesTarget: ".*"
 
@@ -132,3 +132,12 @@ buckets:
   opensearch: set-me
   scFluentd: set-me
   thanos: set-me
+
+harbor:
+  database:
+    type: internal
+  redis:
+    type: internal
+  alerts:
+    maxTotalStorageUsedGB: 500
+    maxTotalArtifacts: 1000

--- a/helmfile/values/prometheus-alerts-sc.yaml.gotmpl
+++ b/helmfile/values/prometheus-alerts-sc.yaml.gotmpl
@@ -66,3 +66,10 @@ buckets:
   thanos: {{ .Values.objectStorage.buckets.thanos }}
 
 diskAlerts: {{ toYaml .Values.prometheus.diskAlerts | nindent 2 }}
+
+harbor:
+  database:
+    type: {{ .Values.harbor.database.type }}
+  redis:
+    type: {{ .Values.harbor.redis.type }}
+  alerts: {{ toYaml .Values.harbor.alerts | nindent 4 }}

--- a/helmfile/values/prometheus-user-alerts-wc.yaml.gotmpl
+++ b/helmfile/values/prometheus-user-alerts-wc.yaml.gotmpl
@@ -22,6 +22,7 @@ defaultRules:
     rookMonitor: {{ .Values.rookCeph.monitoring.enabled }}
     capacityManagementAlerts: {{ .Values.prometheus.capacityManagementAlerts.enabled }}
     networkpolicies: {{ .Values.networkPolicies.enableAlerting }}
+    harbor: false
 
 capacityManagementAlertsPersistentVolumeEnabled: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.enabled }}
 capacityManagementAlertsPersistentVolumeLimit: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.limit }}


### PR DESCRIPTION
**What this PR does / why we need it**: to add alerts for Harbor, including the possibility to alert when the total storage used of number of artefacts goes above threshold (configurable, default is 500GB with 1000)

**Add a screenshot or an example to illustrate the proposed solution:**
![image](https://github.com/elastisys/compliantkubernetes-apps/assets/77267293/6db32e05-f89b-44e3-bbf8-cb7d3af24e4c)


**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
