### PR TITLE
apps wc: make packets dropped less senastive

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- Increased window for `FrequentPacketsDroppedFromWorkload` and `FrequentPacketsDroppedToWorkload` alerts
+  - To make it less sensitive to semi-consistent blocked network traffic.
+
 ### Fixed
 
 ### Updated

--- a/helmfile/charts/prometheus-alerts/templates/alerts/packets-dropped.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/alerts/packets-dropped.yaml
@@ -22,7 +22,7 @@ spec:
         description: Number of packets dropped to workload {{ "{{ $labels.exported_pod }}" }} in namespace {{ "{{ $labels.pod_namespace }}" }}, because no policies matched them
         summary: Number of packets dropped to workload in {{ "{{ $labels.cluster }}" }} cluster
       expr: |
-        increase(no_policy_drop_counter{type="tw"}[1m]) > 0
+        increase(no_policy_drop_counter{type="tw"}[15m]) > 0
       for: 5m
       labels:
         severity: warning
@@ -46,7 +46,7 @@ spec:
         description: Number of packets dropped from workload {{ "{{ $labels.exported_pod }}" }} in namespace {{ "{{ $labels.pod_namespace }}" }}, because no policies matched them
         summary: Number of packets dropped from workload in {{ "{{ $labels.cluster }}" }} cluster
       expr: |
-        increase(no_policy_drop_counter{type="fw"}[1m]) > 0
+        increase(no_policy_drop_counter{type="fw"}[15m]) > 0
       for: 5m
       labels:
         severity: warning


### PR DESCRIPTION
**What this PR does / why we need it**:

Make FrequentPacketsDroppedFromWorkload less sensative

**Which issue this PR fixes**: fixes #1643 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
