### PR TITLE
bin: upgrade prepare script fix

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - The Ingress test script to work with proxy-protocol, when used
 - Fixed the sops_validate_config function in `bin/common.bash` to better handle invalid pgp keys.
+- `scripts/migration/lib.sh` check_version function now asks if you want to use the specified nonstandard ck8sVersion.
 
 ### Updated
 


### PR DESCRIPTION
**What this PR does / why we need it**:
It throws an error message if the common-configs have different ck8sVersion values / It can be good to be able to delete the override common-config version so it won't throw a error in the upgrade apply part of the script.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1539

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
