### PR TITLE
pipeline: added proxy-protocol support for ingress tests

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Fixed
 
+- The Ingress test script to work with proxy-protocol, when used
+
 ### Updated
 
 - Upgraded Grafana chart version to `6.57.4` and app version to `9.5.5`

--- a/pipeline/test/services/workload-cluster/testIngress.sh
+++ b/pipeline/test/services/workload-cluster/testIngress.sh
@@ -39,13 +39,19 @@ function check_wc_ingress_health() {
 
     desired_replicas=$(kubectl get daemonset -n ingress-nginx ingress-nginx-controller -ojson | jq ".status.desiredNumberScheduled | tonumber")
     ready_replicas=$(kubectl get daemonset -n ingress-nginx ingress-nginx-controller -ojson | jq ".status.numberReady | tonumber")
+    has_proxy_protocol=$(kubectl get configmap -n ingress-nginx ingress-nginx-controller -oyaml | yq4 '.data.use-proxy-protocol')
 
     diff=$((desired_replicas - ready_replicas))
     if [[ $desired_replicas -eq $ready_replicas ]]; then
         read -r -a pods <<<"$(kubectl get pods -n ingress-nginx -ojson | jq -r '.items[].metadata.name' | tr '\n' ' ')"
         for pod in "${pods[@]}"; do
             if [[ "$pod" =~ ingress-nginx-controller* ]]; then
-                res=$(kubectl -n ingress-nginx exec -it "$pod" -- curl --retry 3 -w "%{http_code}" -o /dev/null -sk https://localhost/healthz)
+                extra_flags=""
+                if "${has_proxy_protocol}"; then
+                  extra_flags="--haproxy-protocol"
+                fi
+                # shellcheck disable=SC2086
+                res=$(kubectl -n ingress-nginx exec -it "$pod" -- curl --retry 3 ${extra_flags} -w "%{http_code}" -o /dev/null -sk https://localhost/healthz)
                 if [[ "$res" != "200" ]]; then
                     no_error=false
                     debug_msg+="[ERROR] The following nginx pod $pod is not healthy\n"


### PR DESCRIPTION
**What this PR does / why we need it**: added proxy-protocol support for the testIngress scripts

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1469 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
