### PR TITLE
apps: upgraded kured to 1.13.1

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -25,5 +25,6 @@
 - Upgraded compliantkubernetes-apps-log-manager image to a later `ubuntu:rolling` and chart version to `0.2.0`
 - Upgraded rclone-sync image app version from `v1.57.0` to `v1.63.0` chart version from `1.3.0` to `1.63.0`
 - Upgraded s3-exporter image app version from `0.4.0` to `0.5.0` chart version from `v0.4.0` to `0.5.0`
+- Upgraded kured image app version from `v1.12.1` to `v1.13.1` chart version from `4.4.1` to `4.5.1`
 
 ### Removed

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -29,7 +29,7 @@ releases:
   labels:
     app: kured
   chart: ./upstream/kured
-  version: 4.4.1
+  version: 4.5.1
   installed: {{ .Values.kured.enabled }}
   values:
   - values/kured.yaml.gotmpl

--- a/helmfile/upstream/kured/Chart.yaml
+++ b/helmfile/upstream/kured/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.12.1
+appVersion: 1.13.1
 description: A Helm chart for kured
 home: https://github.com/kubereboot/kured
 icon: https://raw.githubusercontent.com/kubereboot/website/main/static/img/kured.png
@@ -11,4 +11,4 @@ maintainers:
 name: kured
 sources:
 - https://github.com/kubereboot/kured
-version: 4.4.1
+version: 4.5.1

--- a/helmfile/upstream/kured/README.md
+++ b/helmfile/upstream/kured/README.md
@@ -64,7 +64,7 @@ The following changes have been made compared to the stable chart:
 | Config                                  | Description                                                                 | Default                   |
 | ------                                  | -----------                                                                 | -------                   |
 | `image.repository`                      | Image repository                                                            | `ghcr.io/kubereboot/kured`|
-| `image.tag`                             | Image tag                                                                   | `1.12.1`                  |
+| `image.tag`                             | Image tag                                                                   | `1.13.1`                  |
 | `image.pullPolicy`                      | Image pull policy                                                           | `IfNotPresent`            |
 | `image.pullSecrets`                     | Image pull secrets                                                          | `[]`                      |
 | `updateStrategy`                        | Daemonset update strategy                                                   | `RollingUpdate`           |
@@ -126,7 +126,7 @@ The following changes have been made compared to the stable chart:
 | `tolerations`           | Tolerations to apply to the daemonset (eg to allow running on master)                       | `[{"key": "node-role.kubernetes.io/control-plane", "effect": "NoSchedule"}]` for Kubernetes 1.24.0 and greater, otherwise `[{"key": "node-role.kubernetes.io/master", "effect": "NoSchedule"}]`|
 | `affinity`              | Affinity for the daemonset (ie, restrict which nodes kured runs on)                         | `{}`                      |
 | `hostNetwork`           | Pod uses the host network instead of the cluster network                                    | `true`                    |
-| `nodeSelector`          | Node Selector for the daemonset (ie, restrict which nodes kured runs on)                    | `{}`                      |
+| `nodeSelector`          | Node Selector for the daemonset (ie, restrict which nodes kured runs on)                    | `{ "kubernetes.io/os": "linux" }` |
 | `volumeMounts`          | Maps of volumes mount to mount                                                              | `{}`                      |
 | `volumes`               | Maps of volumes to mount                                                                    | `{}`                      |
 | `initContainers`        | Define initContainers for DaemonSet                                                         | `{}`                      |

--- a/helmfile/upstream/kured/values.yaml
+++ b/helmfile/upstream/kured/values.yaml
@@ -97,7 +97,8 @@ tolerations: []
 
 affinity: {}
 
-nodeSelector: {}
+nodeSelector:
+  kubernetes.io/os: linux
 
 volumeMounts: []
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1489 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [ ] I upgraded no Chart.
  - [x] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
