### PR TITLE
apps: upgraded blackbox exporter to 8.2.0

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -27,5 +27,6 @@
 - Upgraded rclone-sync image app version from `v1.57.0` to `v1.63.0` chart version from `1.3.0` to `1.63.0`
 - Upgraded s3-exporter image app version from `0.4.0` to `0.5.0` chart version from `v0.4.0` to `0.5.0`
 - Upgraded kured image app version from `v1.12.1` to `v1.13.1` chart version from `4.4.1` to `4.5.1`
+- Upgraded blackbox exporter image app version from `v0.19.0` to `v0.24.0` chart version from `5.3.1` to `8.2.0`
 
 ### Removed

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -139,13 +139,13 @@ releases:
   version: 0.1.0
   installed: {{ .Values.calicoFelixMetrics.enabled }}
 
-# Prometheus blackboc exporter
+# Prometheus blackbox exporter
 - name: prometheus-blackbox-exporter
   namespace: monitoring
   labels:
     app: blackbox
   chart: ./upstream/prometheus-blackbox-exporter
-  version: 5.3.1
+  version: 8.2.0
   values:
 {{ if eq .Environment.Name "service_cluster" }}
   - values/prometheus-blackbox-exporter-sc.yaml.gotmpl

--- a/helmfile/upstream/prometheus-blackbox-exporter/Chart.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.19.0
+appVersion: v0.24.0
 description: Prometheus Blackbox Exporter
 home: https://github.com/prometheus/blackbox_exporter
 keywords:
@@ -20,4 +20,4 @@ sources:
 - https://github.com/prometheus/blackbox_exporter
 - https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-blackbox-exporter
 type: application
-version: 5.3.1
+version: 8.2.0

--- a/helmfile/upstream/prometheus-blackbox-exporter/README.md
+++ b/helmfile/upstream/prometheus-blackbox-exporter/README.md
@@ -11,14 +11,14 @@ This chart creates a Blackbox-Exporter deployment on a [Kubernetes](http://kuber
 - Kubernetes 1.8+ with Beta APIs enabled
 - Helm >= 3.0
 
-## Get Repo Info
+## Get Repository Info
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 ```
 
-_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+_See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
 ## Install Chart
 
@@ -47,6 +47,31 @@ helm upgrade [RELEASE_NAME] [CHART] --install
 ```
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+### To 8.0.0
+
+- The default image is set to `quay.io/prometheus/blackbox-exporter` instead `prom/blackbox-exporter`
+- `image.repository` is now split into `image.registry` and `image.repository`.
+  For the old behavior, set `image.registry` to an empty string and only use `image.repository`.
+
+### To 7.0.0
+
+This version introduces the `securityContext` and `podSecurityContext` and removes `allowICMP`option.
+
+All previous values are setup as default. In case that you want to enable previous functionality for `allowICMP` you need to explicit enabled with the following configuration:
+
+```yaml
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    add: ["NET_RAW"]
+```
+
+### To 6.0.0
+
+This version introduces the relabeling field for the ServiceMonitor.
+All values in the list `additionalRelabeling` will now appear under `relabelings` instead of `metricRelabelings`.
 
 ### To 5.0.0
 

--- a/helmfile/upstream/prometheus-blackbox-exporter/ci/icmp-values.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/ci/icmp-values.yaml
@@ -1,1 +1,0 @@
-allowIcmp: true

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/NOTES.txt
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/NOTES.txt
@@ -8,23 +8,24 @@ See https://github.com/prometheus/blackbox_exporter/ for how to configure Promet
   {{- end }}
 {{- end }}
 
-{{ if and .Values.ingress.className (semverCompare "<=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- $kubeVersion := include "prometheus-blackbox-exporter.kubeVersion" . -}}
+{{ if and .Values.ingress.className (semverCompare "<=1.18-0" $kubeVersion) }}
 You've set ".Values.ingressClassName" but it's not supported by your Kubernetes version!
 Therefore the option was not added and the old ingress annotation was set.
 {{ end }}
 
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "prometheus-blackbox-exporter.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export NODE_PORT=$(kubectl get --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "prometheus-blackbox-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "prometheus-blackbox-exporter.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "prometheus-blackbox-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+           You can watch the status of by running 'kubectl get --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} svc -w {{ include "prometheus-blackbox-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} {{ include "prometheus-blackbox-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "prometheus-blackbox-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  export POD_NAME=$(kubectl get pods --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} -l "app.kubernetes.io/name={{ include "prometheus-blackbox-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  kubectl --namespace {{ template "prometheus-blackbox-exporter.namespace" . }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/_helpers.tpl
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/_helpers.tpl
@@ -40,6 +40,12 @@ helm.sh/chart: {{ include "prometheus-blackbox-exporter.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.releaseLabel }}
+release: {{ .Release.Name }}
+{{- end }}
+{{- if .Values.commonLabels }}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -70,4 +76,28 @@ Return the appropriate apiVersion for rbac.
 {{- else -}}
 {{- print "rbac.authorization.k8s.io/v1beta1" -}}
 {{- end -}}
+{{- end -}}
+
+
+{{- define "prometheus-blackbox-exporter.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* Enable overriding Kubernetes version for some use cases */}}
+{{- define "prometheus-blackbox-exporter.kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
+{{- end -}}
+
+
+{{/*
+The image to use
+*/}}
+{{- define "prometheus-blackbox-exporter.image" -}}
+{{- with (.Values.global.imageRegistry | default .Values.image.registry) -}}{{ . }}/{{- end }}
+{{- .Values.image.repository -}}:{{- .Values.image.tag | default .Chart.AppVersion -}}
+{{- with .Values.image.digest -}}@{{ .}}{{- end -}}
 {{- end -}}

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/configmap.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: {{ if .Values.secretConfig -}} Secret {{- else -}} ConfigMap {{- end }}
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
     {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
 {{ if .Values.secretConfig -}} stringData: {{- else -}} data: {{- end }}

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/daemonset.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/daemonset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
     {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
 spec:
@@ -62,14 +63,12 @@ spec:
       {{- end }}
       containers:
         - name: blackbox-exporter
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ include "prometheus-blackbox-exporter.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
           securityContext:
-            readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}
-            runAsNonRoot: {{ .Values.runAsNonRoot  }}
-            {{- if .Values.runAsUser }}
-            runAsUser: {{ .Values.runAsUser }}
-            {{- end }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
           {{- range $key, $value := .Values.extraEnv }}
             - name: {{ $key }}

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
     {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
 spec:
@@ -27,17 +28,21 @@ spec:
     spec:
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       serviceAccountName: {{ template "prometheus-blackbox-exporter.serviceAccountName" . }}
-    {{- if .Values.nodeSelector }}
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.affinity }}
+    {{- with .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.tolerations }}
+    {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 6 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -60,6 +65,8 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
       {{- if .Values.extraInitContainers }}
       initContainers:
 {{ toYaml .Values.extraInitContainers | indent 8 }}
@@ -67,21 +74,14 @@ spec:
       containers:
         {{- if .Values.extraContainers }}
 {{ toYaml .Values.extraContainers | indent 8 }}
-        {{- end }}      
+        {{- end }}
         - name: blackbox-exporter
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ include "prometheus-blackbox-exporter.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
           securityContext:
-            readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}
-            {{- if .Values.allowIcmp }}
-            capabilities:
-              add: ["NET_RAW"]
-            {{- else }}
-            runAsNonRoot: {{ .Values.runAsNonRoot  }}
-              {{- if .Values.runAsUser }}
-            runAsUser: {{ .Values.runAsUser }}
-              {{- end }}
-            {{- end }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
           {{- range $key, $value := .Values.extraEnv }}
             - name: {{ $key }}
@@ -136,9 +136,9 @@ spec:
         {{- toYaml .Values.dnsConfig | nindent 8 }}
 {{- end }}
       volumes:
-    {{- if .Values.extraVolumes }}      
-{{ toYaml .Values.extraVolumes | indent 8 }}      
-    {{- end }}      
+    {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+    {{- end }}
         - name: config
 {{- if .Values.secretConfig }}
           secret:

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/extra-manifests.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/ingress.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/ingress.yaml
@@ -1,14 +1,15 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "prometheus-blackbox-exporter.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+{{- $kubeVersion := include "prometheus-blackbox-exporter.kubeVersion" . -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" $kubeVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
   {{- end }}
 {{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" $kubeVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.14-0" $kubeVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -16,14 +17,18 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
     {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
+    {{- if .Values.ingress.labels }}
+{{ toYaml .Values.ingress.labels | indent 4 }}
+    {{- end}}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" $kubeVersion) }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   {{- if .Values.ingress.tls }}
@@ -31,23 +36,23 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $ | quote }}
       http:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $kubeVersion) }}
             pathType: {{ .pathType }}
             {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              {{- if semverCompare ">=1.19-0" $kubeVersion }}
               service:
                 name: {{ $fullName }}
                 port:

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/networkpolicy.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/networkpolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
     {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}  
 spec:

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/poddisruptionbudget.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/poddisruptionbudget.yaml
@@ -1,8 +1,13 @@
 {{- if .Values.podDisruptionBudget -}}
+{{ if $.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+apiVersion: policy/v1
+{{- else -}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
     {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
 spec:

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/podsecuritypolicy.yaml
@@ -1,8 +1,9 @@
-{{- if .Values.pspEnabled }}
+{{- if and .Values.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}-psp
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
     {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
 spec:
@@ -33,7 +34,7 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}
-  {{- if .Values.allowIcmp }}
+  {{- if has "NET_RAW" .Values.securityContext.capabilities.add }}
   allowedCapabilities: 
   - NET_RAW
   {{- end }}

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/prometheusrule.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/prometheusrule.yaml
@@ -15,6 +15,6 @@ spec:
   {{- with .Values.prometheusRule.rules }}
   groups:
     - name: {{ template "prometheus-blackbox-exporter.name" $ }}
-      rules: {{ tpl (toYaml .) $ | nindent 8 }}
+      rules: {{ toYaml . | nindent 8 }}
   {{- end }}
 {{- end }}

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/role.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/role.yaml
@@ -1,10 +1,11 @@
-{{- if .Values.pspEnabled }}
+{{- if and .Values.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: Role
 metadata:
   labels:
     {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
 rules:
   - apiGroups:
     - policy

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/rolebinding.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/rolebinding.yaml
@@ -1,10 +1,11 @@
-{{- if .Values.pspEnabled }}
+{{- if and .Values.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: {{ template "rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   labels:
     {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/selfservicemonitor.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/selfservicemonitor.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.serviceMonitor.selfMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "prometheus-blackbox-exporter.fullname" $ }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" $ }}
+  labels:
+    {{- include "prometheus-blackbox-exporter.labels" $ | nindent 4 }}
+    {{- if .Values.serviceMonitor.selfMonitor.labels  }}
+    {{- toYaml (.Values.serviceMonitor.selfMonitor.labels) | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - path: {{ .Values.serviceMonitor.selfMonitor.path }}
+    interval: {{ .Values.serviceMonitor.selfMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.selfMonitor.scrapeTimeout }}
+    scheme: http
+
+{{- if .Values.serviceMonitor.selfMonitor.additionalRelabeling }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.selfMonitor.additionalRelabeling | indent 6 }}
+{{- end }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      {{- include "prometheus-blackbox-exporter.selectorLabels" $ | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ template "prometheus-blackbox-exporter.namespace" $ }}
+{{- end }}

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/service.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- toYaml .Values.service.annotations | nindent 4 }}
 {{- end }}
   name: {{ include "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
     {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
 {{- if .Values.service.labels }}

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/serviceaccount.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "prometheus-blackbox-exporter.serviceAccountName" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
     {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -5,6 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" $ }}-{{ .name }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" $ }}
   labels:
     {{- include "prometheus-blackbox-exporter.labels" $ | nindent 4 }}
     {{- if or $.Values.serviceMonitor.defaults.labels .labels }}
@@ -20,7 +21,7 @@ spec:
     {{- if $.Values.serviceMonitor.tlsConfig }}
     tlsConfig: {{ toYaml $.Values.serviceMonitor.tlsConfig | nindent 6 }}
     {{- end }}
-    path: "/probe"
+    path: {{ $.Values.serviceMonitor.path }}
     interval: {{ .interval | default $.Values.serviceMonitor.defaults.interval }}
     scrapeTimeout: {{ .scrapeTimeout | default $.Values.serviceMonitor.defaults.scrapeTimeout }}
     params:
@@ -28,21 +29,31 @@ spec:
       - {{ .module | default $.Values.serviceMonitor.defaults.module }}
       target:
       - {{ .url }}
+      {{- if .hostname }}
+      hostname:
+      - {{ .hostname }}
+      {{- end }}
     metricRelabelings:
-      - targetLabel: instance
+      - sourceLabels: [instance]
+        targetLabel: instance
         replacement: {{ .url }}
-      - targetLabel: target
+      - sourceLabels: [target]
+        targetLabel: target
         replacement: {{ .name }}
         {{- range $targetLabel, $replacement := .additionalMetricsRelabels | default $.Values.serviceMonitor.defaults.additionalMetricsRelabels }}
-      - targetLabel: {{ $targetLabel }}
-        replacement: {{ $replacement }}
+      - targetLabel: {{ $targetLabel | quote }}
+        replacement: {{ $replacement | quote }}
         {{- end }}
+{{- if concat (.additionalRelabeling | default list) $.Values.serviceMonitor.defaults.additionalRelabeling }}
+    relabelings:
+{{ toYaml (concat (.additionalRelabeling | default list) $.Values.serviceMonitor.defaults.additionalRelabeling) | indent 6 }}
+{{- end }}
   jobLabel: "{{ $.Release.Name }}"
   selector:
     matchLabels:
       {{- include "prometheus-blackbox-exporter.selectorLabels" $ | nindent 6 }}
   namespaceSelector:
     matchNames:
-      - {{ $.Release.Namespace }}
+      - {{ template "prometheus-blackbox-exporter.namespace" $ }}
 {{- end }}
 {{- end }}

--- a/helmfile/upstream/prometheus-blackbox-exporter/templates/verticalpodautoscaler.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/templates/verticalpodautoscaler.yaml
@@ -1,0 +1,44 @@
+{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1") (.Values.verticalPodAutoscaler.enabled) }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "prometheus-blackbox-exporter.fullname" . }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
+  labels:
+    {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.verticalPodAutoscaler.recommenders }}
+  recommenders:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  resourcePolicy:
+    containerPolicies:
+    - containerName: blackbox-exporter
+      {{- with .Values.verticalPodAutoscaler.controlledResources }}
+      controlledResources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.verticalPodAutoscaler.controlledValues }}
+      controlledValues: {{ .Values.verticalPodAutoscaler.controlledValues }}
+      {{- end }}
+      {{- if .Values.verticalPodAutoscaler.maxAllowed }}
+      maxAllowed:
+        {{ toYaml .Values.verticalPodAutoscaler.maxAllowed | nindent 8 }}
+      {{- end }}
+      {{- if .Values.verticalPodAutoscaler.minAllowed }}
+      minAllowed:
+        {{ toYaml .Values.verticalPodAutoscaler.minAllowed | nindent 8 }}
+      {{- end }}
+  targetRef:
+    apiVersion: apps/v1
+    {{- if (eq .Values.kind "DaemonSet") }}
+    kind: DaemonSet
+    {{- else }}
+    kind: Deployment
+    {{- end }}
+    name:  {{ template "prometheus-blackbox-exporter.fullname" . }}
+  {{- with .Values.verticalPodAutoscaler.updatePolicy }}
+  updatePolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helmfile/upstream/prometheus-blackbox-exporter/values.yaml
+++ b/helmfile/upstream/prometheus-blackbox-exporter/values.yaml
@@ -1,6 +1,21 @@
+global:
+  ## Global image registry to use if it needs to be overriden for some specific use cases (e.g local registries, custom images, ...)
+  ##
+  imageRegistry: ""
+
 restartPolicy: Always
 
 kind: Deployment
+
+## Override the namespace
+##
+namespaceOverride: ""
+
+# Override Kubernetes version if your distribution does not follow semver v2
+kubeVersionOverride: ""
+
+## set to true to add the release label so scraping of the servicemonitor with kube-prometheus-stack works out of the box
+releaseLabel: false
 
 podDisruptionBudget: {}
   # maxUnavailable: 0
@@ -67,9 +82,12 @@ strategy:
   type: RollingUpdate
 
 image:
-  repository: prom/blackbox-exporter
-  tag: v0.19.0
+  registry: quay.io
+  repository: prometheus/blackbox-exporter
+  # Overrides the image tag whose default is {{ printf "v%s" .Chart.AppVersion }}
+  tag: ""
   pullPolicy: IfNotPresent
+  digest: ""
 
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -78,24 +96,45 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
-## User to run blackbox-exporter container as
-runAsUser: 1000
-readOnlyRootFilesystem: true
-runAsNonRoot: true
+podSecurityContext: {}
+# fsGroup: 1000
+
+## User and Group to run blackbox-exporter container as
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+# Add NET_RAW to enable ICMP
+#    add: ["NET_RAW"]
 
 livenessProbe:
   httpGet:
-    path: /health
+    path: /-/healthy
     port: http
+  failureThreshold: 3
 
 readinessProbe:
   httpGet:
-    path: /health
+    path: /-/healthy
     port: http
 
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+## Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: failure-domain.beta.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+#       app.kubernetes.io/instance: jiralert
 
 # if the configuration is managed as secret outside the chart, using SealedSecret for example,
 # provide the name of the secret here. If secretConfig is set to true, configExistingSecretName will be ignored
@@ -133,8 +172,6 @@ extraSecretMounts: []
   #   readOnly: true
   #   defaultMode: 420
 
-allowIcmp: false
-
 resources: {}
   # limits:
   #   memory: 300Mi
@@ -168,10 +205,13 @@ serviceAccount:
 ingress:
   enabled: false
   className: ""
+  labels: {}
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
+    ## The host property on hosts and tls is passed through helm tpl function.
+    ## ref: https://helm.sh/docs/developing_charts/#using-the-tpl-function
     - host: chart-example.local
       paths:
         - path: /
@@ -201,33 +241,49 @@ replicas: 1
 
 serviceMonitor:
   ## If true, a ServiceMonitor CRD is created for a prometheus operator
-  ## https://github.com/coreos/prometheus-operator
+  ## https://github.com/coreos/prometheus-operator for blackbox-exporter itself
+  ##
+  selfMonitor:
+    enabled: false
+    additionalMetricsRelabels: {}
+    additionalRelabeling: []
+    labels: {}
+    path: /metrics
+    interval: 30s
+    scrapeTimeout: 30s
+
+  ## If true, a ServiceMonitor CRD is created for a prometheus operator
+  ## https://github.com/coreos/prometheus-operator for each target
   ##
   enabled: false
 
   # Default values that will be used for all ServiceMonitors created by `targets`
   defaults:
     additionalMetricsRelabels: {}
+    additionalRelabeling: []
     labels: {}
     interval: 30s
     scrapeTimeout: 30s
     module: http_2xx
   ## scheme: HTTP scheme to use for scraping. Can be used with `tlsConfig` for example if using istio mTLS.
   scheme: http
+  ## path: HTTP path. Needs to be adjusted, if web.route-prefix is set
+  path: "/probe"
   ## tlsConfig: TLS configuration to use when scraping the endpoint. For example if using istio mTLS.
   ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
   tlsConfig: {}
   bearerTokenFile:
 
   targets:
-
 #    - name: example                    # Human readable URL that will appear in Prometheus / AlertManager
 #      url: http://example.com/healthz  # The URL that blackbox will scrape
+#      hostname: example.com            # HTTP probes can accept an additional `hostname` parameter that will set `Host` header and TLS SNI
 #      labels: {}                       # Map of labels for ServiceMonitor. Overrides value set in `defaults`
 #      interval: 60s                    # Scraping interval. Overrides value set in `defaults`
 #      scrapeTimeout: 60s               # Scrape timeout. Overrides value set in `defaults`
 #      module: http_2xx                 # Module used for scraping. Overrides value set in `defaults`
 #      additionalMetricsRelabels: {}    # Map of metric labels and values to add
+#      additionalRelabeling: []         # List of metric relabeling actions to run
 
 ## Custom PrometheusRules to be defined
 ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
@@ -250,3 +306,47 @@ networkPolicy:
 ## These will be passed directly to the PodSpec of same.
 dnsPolicy:
 dnsConfig:
+
+# Extra manifests to deploy as an array
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #   labels:
+  #     name: prometheus-extra
+  #   data:
+  #     extra-data: "value"
+
+# global common labels, applied to all ressources
+commonLabels: {}
+
+# Enable vertical pod autoscaler support for prometheus-blackbox-exporter
+verticalPodAutoscaler:
+  enabled: false
+
+  # Recommender responsible for generating recommendation for the object.
+  # List should be empty (then the default recommender will generate the recommendation)
+  # or contain exactly one recommender.
+  # recommenders:
+  # - name: custom-recommender-performance
+
+  # List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory
+  controlledResources: []
+  # Specifies which resource values should be controlled: RequestsOnly or RequestsAndLimits.
+  # controlledValues: RequestsAndLimits
+
+  # Define the max allowed resources for the pod
+  maxAllowed: {}
+  # cpu: 200m
+  # memory: 100Mi
+  # Define the min allowed resources for the pod
+  minAllowed: {}
+  # cpu: 200m
+  # memory: 100Mi
+
+  updatePolicy:
+    # Specifies minimal number of replicas which need to be alive for VPA Updater to attempt pod eviction
+    # minReplicas: 1
+    # Specifies whether recommended updates are applied when a Pod is started and whether recommended updates
+    # are applied during the life of a Pod. Possible values are "Off", "Initial", "Recreate", and "Auto".
+    updateMode: Auto


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1230 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [ ] I upgraded no Chart.
  - [x] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
