### PR TITLE
apps sc: increase the default memeory limit for thanos distributor

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added secret as a volumetype for osdprepare jobs
 - The `score.sh` script now presents results in either structured yaml or machine readable csv
 - User alertmanager will re-use the secret if exists, instead of using the `"helm.sh/hook": pre-install` annotation
+- Memory limit for Thanos distributor increased to 700Mi
 
 ### Fixed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -559,7 +559,7 @@ thanos:
         memory: 100Mi
       limits:
         cpu: 1000m
-        memory: 400Mi
+        memory: 700Mi
 
   ruler:
     # Enables the ruler component

--- a/migration/v0.31/README.md
+++ b/migration/v0.31/README.md
@@ -116,6 +116,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ./migration/v0.31/prepare/05-increase-maxbodysize-chunklimitsize.sh
     ```
 
+1. Increase the memory limit for Thanos receiveDistributor
+
+    ```bash
+    ./migration/v0.31/prepare/10-thanos-distrib-memory-limit.sh
+    ```
+
 1. Move thanos replication factor
 
     ```bash

--- a/migration/v0.31/prepare/10-thanos-distrib-memory-limit.sh
+++ b/migration/v0.31/prepare/10-thanos-distrib-memory-limit.sh
@@ -8,11 +8,11 @@ source "${ROOT}/scripts/migration/lib.sh"
 
 if ! yq_null sc .thanos.receiveDistributor.resources.limits.memory; then
   log_info "- check if thanos distributor memory limit is less than 700Mi"
-  size=$(yq4 '.thanos.receiveDistributor.resources.limits.memory | sub("Mi","")' "${CK8S_CONFIG_PATH}/sc-config.yaml")
-  if ((size < 700)); then
+  size=$(yq4 '.thanos.receiveDistributor.resources.limits.memory | select(. == "*Mi") | sub("Mi","")' "${CK8S_CONFIG_PATH}/sc-config.yaml")
+  if [ -n "$size" ] && ((size < 700)); then
     log_info "- increase the thanos distributor memory limit to 700Mi"
     yq4 -i '.thanos.receiveDistributor.resources.limits.memory = "700Mi"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
   else
-    log_info "- thanos distributor memory limit is $size, will not update it"
+    log_info "- thanos distributor memory limit is greater or equal with 700Mi, will not update it"
   fi
 fi

--- a/migration/v0.31/prepare/10-thanos-distrib-memory-limit.sh
+++ b/migration/v0.31/prepare/10-thanos-distrib-memory-limit.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+if ! yq_null sc .thanos.receiveDistributor.resources.limits.memory; then
+  log_info "- check if thanos distributor memory limit is less than 700Mi"
+  size=$(yq4 '.thanos.receiveDistributor.resources.limits.memory | sub("Mi","")' "${CK8S_CONFIG_PATH}/sc-config.yaml")
+  if ((size < 700)); then
+    log_info "- increase the thanos distributor memory limit to 700Mi"
+    yq4 -i '.thanos.receiveDistributor.resources.limits.memory = "700Mi"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
+  else
+    log_info "- thanos distributor memory limit is $size, will not update it"
+  fi
+fi

--- a/migration/v0.32/README.md
+++ b/migration/v0.32/README.md
@@ -92,6 +92,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     git switch -d v0.32.x
     ```
 
+1. Increase the memory limit for Thanos receiveDistributor
+
+    ```bash
+    ./migration/v0.32/prepare/10-thanos-distrib-memory-limit.sh
+    ```
+
 1. Update apps configuration:
 
     This will take a backup into `backups/` before modifying any files.

--- a/migration/v0.32/prepare/10-thanos-distrib-memory-limit.sh
+++ b/migration/v0.32/prepare/10-thanos-distrib-memory-limit.sh
@@ -8,11 +8,11 @@ source "${ROOT}/scripts/migration/lib.sh"
 
 if ! yq_null sc .thanos.receiveDistributor.resources.limits.memory; then
   log_info "- check if thanos distributor memory limit is less than 700Mi"
-  size=$(yq4 '.thanos.receiveDistributor.resources.limits.memory | sub("Mi","")' "${CK8S_CONFIG_PATH}/sc-config.yaml")
-  if ((size < 700)); then
+  size=$(yq4 '.thanos.receiveDistributor.resources.limits.memory | select(. == "*Mi") | sub("Mi","")' "${CK8S_CONFIG_PATH}/sc-config.yaml")
+  if [ -n "$size" ] && ((size < 700)); then
     log_info "- increase the thanos distributor memory limit to 700Mi"
     yq4 -i '.thanos.receiveDistributor.resources.limits.memory = "700Mi"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
   else
-    log_info "- thanos distributor memory limit is $size, will not update it"
+    log_info "- thanos distributor memory limit is greater or equal with 700Mi, will not update it"
   fi
 fi

--- a/migration/v0.32/prepare/10-thanos-distrib-memory-limit.sh
+++ b/migration/v0.32/prepare/10-thanos-distrib-memory-limit.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+if ! yq_null sc .thanos.receiveDistributor.resources.limits.memory; then
+  log_info "- check if thanos distributor memory limit is less than 700Mi"
+  size=$(yq4 '.thanos.receiveDistributor.resources.limits.memory | sub("Mi","")' "${CK8S_CONFIG_PATH}/sc-config.yaml")
+  if ((size < 700)); then
+    log_info "- increase the thanos distributor memory limit to 700Mi"
+    yq4 -i '.thanos.receiveDistributor.resources.limits.memory = "700Mi"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
+  else
+    log_info "- thanos distributor memory limit is $size, will not update it"
+  fi
+fi


### PR DESCRIPTION
**What this PR does / why we need it**: after upgrading some env to apps v0.31 I noticed that one common problem was thanos distributor going into a crash loop due to OOMkilled

I increased the limit to avoid that.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

