### PR TITLE
apps sc: reduced cpu requests for some components

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -16,6 +16,7 @@
 - The `score.sh` script now presents results in either structured yaml or machine readable csv
 - User alertmanager will re-use the secret if exists, instead of using the `"helm.sh/hook": pre-install` annotation
 - Memory limit for Thanos distributor increased to 700Mi
+- Reduced CPU requests for some components in the service cluster.
 
 ### Fixed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -158,7 +158,7 @@ harbor:
     replicas: 1
     resources:
       requests:
-        cpu: 125m
+        cpu: 100m
         memory: 250Mi
       limits:
         cpu: 250m
@@ -185,7 +185,7 @@ harbor:
       resources:
         requests:
           memory: 512Mi
-          cpu: 250m
+          cpu: 100m
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -224,7 +224,7 @@ harbor:
         size: 1Gi
     resources:
       requests:
-        cpu: 125m
+        cpu: 50m
         memory: 125Mi
       limits:
         cpu: 250m
@@ -259,7 +259,7 @@ harbor:
     controller:
       resources:
         requests:
-          cpu: 125m
+          cpu: 10m
           memory: 125Mi
         limits:
           cpu: 250m
@@ -311,7 +311,7 @@ harbor:
     subdomain: notary.harbor
     resources:
       requests:
-        cpu: 125m
+        cpu: 20m
         memory: 125Mi
       limits:
         cpu: 250m
@@ -333,7 +333,7 @@ harbor:
   notarySigner:
     resources:
       requests:
-        cpu: 125m
+        cpu: 20m
         memory: 125Mi
       limits:
         cpu: 250m
@@ -356,7 +356,7 @@ harbor:
     replicas: 1
     resources:
       requests:
-        cpu: 125m
+        cpu: 50m
         memory: 125Mi
       limits:
         cpu: 250m
@@ -381,7 +381,7 @@ harbor:
       size: 5Gi
     resources:
       requests:
-        cpu: 125m
+        cpu: 50m
         memory: 263Mi
       limits:
         cpu: 400m
@@ -584,6 +584,14 @@ thanos:
       limits:
         cpu: 300m
         memory: 100Mi
+    configReloader:
+      resources:
+        limits:
+          cpu: 100m
+          memory: 50Mi
+        requests:
+          cpu: 10m
+          memory: 50Mi
 
     # With our configuration of rules, thanos ruler has no recording rules so it should be fine without persistence.
     persistence:
@@ -985,6 +993,11 @@ opa:
   disallowedTags:
     enabled: false
 
+  controllerManager:
+    resources:
+      requests:
+        cpu: 30m
+
 fluentd:
   enabled: true
 
@@ -1012,6 +1025,11 @@ fluentd:
       enabled: true
       schedule: 0 21 * * *
       days: 7
+
+  aggregator:
+    resources:
+      requests:
+        cpu: 150m
 
   forwarder:
     buffer:

--- a/helmfile/values/thanos/receiver.yaml.gotmpl
+++ b/helmfile/values/thanos/receiver.yaml.gotmpl
@@ -123,13 +123,7 @@ ruler:
           fieldRef:
             apiVersion: v1
             fieldPath: metadata.name
-      resources:
-        limits:
-          cpu: 100m
-          memory: 50Mi
-        requests:
-          cpu: 100m
-          memory: 50Mi
+      resources: {{- toYaml .Values.thanos.ruler.configReloader.resources | nindent 8 }}
       securityContext:
         runAsNonRoot: true
         runAsGroup: 65534


### PR DESCRIPTION
**What this PR does / why we need it**: Reduced CPU requests for some components in SC after looking into how much CPU actually is utilized.

**Which issue this PR fixes**: fixes elastisys/ck8s-ops#4334

**Special notes for reviewer**: I found that for environments with 5x 2c worker nodes in SC, four of the nodes would have 90+% CPU requests and one node would be significantly lower (~40%), so these reductions are not urgently necessary but should be good to have regardless. If we want to try to ensure that the workload is spread out more evenly, we should consider prioritizing this task: https://github.com/elastisys/compliantkubernetes-apps/issues/1336

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [X] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [X] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
