### PR TITLE
apps: fluentd-forwarder set metrics scrape interval to 30s

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -19,6 +19,7 @@
 - Memory limit for Thanos distributor increased to 700Mi
 - Reduced CPU requests for some components in the service cluster.
 - Reduced the information on the dashboard for Cluster-API at a glance, but added some hidden more detailed graphs
+- Scrape interval for fluentd-forwarder is increased from 10s to 30s
 
 ### Fixed
 

--- a/helmfile/values/fluentd/forwarder-common.yaml.gotmpl
+++ b/helmfile/values/fluentd/forwarder-common.yaml.gotmpl
@@ -11,6 +11,7 @@ serviceMonitor:
   enabled: true
   # Seems like it is double templated so the end result yields an empty string ""
   jobLabel: '""'
+  interval: 30s
 
 prometheusRule:
   enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**: 10s scrape interval seems to be unnecessary for fluentd-forwarder pods so I increased it to the Prometheus default, 30s

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
