### PR TITLE
apps sc: netpol fix for harbor notary server

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -23,6 +23,7 @@
 - The Ingress test script to work with proxy-protocol, when used
 - Fixed the sops_validate_config function in `bin/common.bash` to better handle invalid pgp keys.
 - `scripts/migration/lib.sh` check_version function now asks if you want to use the specified nonstandard ck8sVersion.
+- Network policy for harbor notary server
 
 ### Updated
 

--- a/helmfile/values/networkpolicies/service/harbor.yaml.gotmpl
+++ b/helmfile/values/networkpolicies/service/harbor.yaml.gotmpl
@@ -265,6 +265,9 @@ policies:
               component: core
             ports:
               - tcp: 4443
+        - rule: ingress-rule-ingress
+          ports:
+            - tcp: 4443
       egress:
         - rule: egress-rule-dns
         - rule: egress-rule-harbor-database


### PR DESCRIPTION
**What this PR does / why we need it**: when the harbor notary certificates were renewed we saw some packets dropped
seems that harbor notary server needed an ingress rules for ingress-nginx

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
