### PR TITLE
apps: configure trailing dots(grafana) and ndots for pods

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -6,6 +6,8 @@
   - It is now possible to specify type (S3/Swift) per bucket.
 - Support for nftables backend in calico-accountant via config option `calicoAccountant.backend: nftables`
 - Added basic alerts for Cluster-API
+- Added support to turn off trailing dots for grafana.
+- Added gatekeeper mutation to enable changing ndots for any specified pod/podgroup or clusterwide.
 
 ### Changed
 

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -680,6 +680,14 @@ opa:
       enabled: true
       ttlSeconds: 604800
 
+    ndots:
+      enabled: false
+      ndotAmount: 3
+      labelSelector:
+        # None for clusterwide effect or one for each pod or podgroup to be effected by this mutation.
+        matchLabels:
+          # labelkey: labelvalue
+
   controllerManager:
     resources:
       requests:

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -108,6 +108,7 @@ grafana:
       allowedDomains:
         - set-me
     viewersCanEdit: true
+    trailingDots: true
     sidecar:
       resources:
         requests:
@@ -139,6 +140,7 @@ grafana:
         - set-me
         - example.com
     viewersCanEdit: true
+    trailingDots: true
     sidecar:
       resources:
         requests:

--- a/helmfile/charts/gatekeeper/mutations/templates/ndot-amount-dns-policy.yaml
+++ b/helmfile/charts/gatekeeper/mutations/templates/ndot-amount-dns-policy.yaml
@@ -1,0 +1,42 @@
+{{- define "ndots-mutation" }}
+---
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  {{- if .mutationLabelValue }}
+  name: ndot-amount-dns-policy-{{ .mutationLabelValue }}
+  {{- else }}
+  name: ndot-amount-dns-policy
+  {{- end }}
+spec:
+  applyTo:
+    - groups: [""]
+      kinds: ["Pod"]
+      versions: ["v1"]
+  match:
+    scope: Namespaced
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Pod"]
+    {{- if .mutationLabelValue }}
+    labelSelector:
+      matchLabels:
+        {{ .mutationLabelKey }}: {{ .mutationLabelValue }}
+    {{- end }}
+  location: "spec.dnsConfig"
+  parameters:
+    assign:
+      value:
+        options:
+        - name: ndots
+          value: "{{ .Values.ndots.ndotAmount }}"
+{{- end }}
+{{- if $.Values.ndots.enabled }}
+{{- if gt (len ($.Values.ndots | dig "labelSelector" "matchLabels" dict)) 0 }}
+{{- range $key, $val := .Values.ndots.labelSelector.matchLabels }}
+{{- include "ndots-mutation" (mustMergeOverwrite (dict "mutationLabelKey" $key "mutationLabelValue" $val) $) }}
+{{- end }}
+{{- else }}
+{{- include "ndots-mutation" $ }}
+{{- end }}
+{{- end }}

--- a/helmfile/charts/gatekeeper/mutations/values.yaml
+++ b/helmfile/charts/gatekeeper/mutations/values.yaml
@@ -1,3 +1,10 @@
 jobTTL:
   enabled: true
   ttlSeconds: 604800
+
+ndots:
+  enabled: true
+  ndotAmount: 3
+  labelSelector:
+    matchLabels:
+      # labelkey: labelvalue

--- a/helmfile/charts/grafana-dashboards/values.yaml
+++ b/helmfile/charts/grafana-dashboards/values.yaml
@@ -4,7 +4,7 @@
 #   {{ .Values.labelKey }}: nameOfDashboard
 labelKey: grafana_dashboard
 
-# We use the value for the "lablekey" to separate the ops and user dashboards in Grafana.
+# We use the value for the "labelkey" to separate the ops and user dashboards in Grafana.
 # ops Grafana will load all ConfigMaps regardless of the "labelkey" value
 # user Grafana will load only the ConfigMaps that have the value for "labelkey" set to 1. Set "user_visible" to "true" for this.
 

--- a/helmfile/values/gatekeeper/mutations.yaml.gotmpl
+++ b/helmfile/values/gatekeeper/mutations.yaml.gotmpl
@@ -1,3 +1,11 @@
 jobTTL:
   enabled: {{ .Values.opa.mutations.jobTTL.enabled }}
   ttlSeconds: {{ .Values.opa.mutations.jobTTL.ttlSeconds }}
+
+ndots:
+  enabled: {{ .Values.opa.mutations.ndots.enabled }}
+  ndotAmount: {{ .Values.opa.mutations.ndots.ndotAmount }}
+  labelSelector:
+    matchLabels: {{ range $key, $val := .Values.opa.mutations.ndots.labelSelector.matchLabels }}
+      {{ $key }}: {{ $val }}
+      {{- end }}

--- a/helmfile/values/grafana/grafana-dashboards.yaml.gotmpl
+++ b/helmfile/values/grafana/grafana-dashboards.yaml.gotmpl
@@ -1,5 +1,5 @@
 
-# We use the value for the "lablekey" to separate the ops and user dashboards in Grafana.
+# We use the value for the "labelkey" to separate the ops and user dashboards in Grafana.
 # ops Grafana will load all ConfigMaps regardless of the "labelkey" value
 # user Grafana will load only the ConfigMaps that have the value for "labelkey" set to 1. Set "user_visible" to "true" for this.
 

--- a/helmfile/values/grafana/grafana-ops.yaml.gotmpl
+++ b/helmfile/values/grafana/grafana-ops.yaml.gotmpl
@@ -77,6 +77,11 @@ datasources:
     {{- end }}
     {{- end }}
 
+{{ $trailingDot := "" }}
+{{- if .Values.grafana.ops.trailingDots }}
+{{ $trailingDot = "." }}
+{{- end }}
+
 grafana.ini:
   server:
     root_url: https://{{ .Values.grafana.ops.subdomain }}.{{ .Values.global.opsDomain }}
@@ -90,9 +95,9 @@ grafana.ini:
     client_id: grafana-ops
     client_secret: {{ .Values.grafana.opsClientSecret }}
     scopes: {{ .Values.grafana.ops.oidc.scopes }}
-    auth_url: https://{{ .Values.dex.subdomain }}.{{ .Values.global.baseDomain }}./auth
-    token_url: http://dex.dex.svc.cluster.local.:5556/token
-    api_url: http://dex.dex.svc.cluster.local.:5556/api
+    auth_url: https://{{ .Values.dex.subdomain }}.{{ .Values.global.baseDomain }}{{ $trailingDot }}/auth
+    token_url: http://dex.dex.svc.cluster.local{{ $trailingDot }}:5556/token
+    api_url: http://dex.dex.svc.cluster.local{{ $trailingDot }}:5556/api
     allowed_domains: {{ join " " .Values.grafana.ops.oidc.allowedDomains }}
     allow_sign_up: true
     tls_skip_verify_insecure: {{ not .Values.global.verifyTls }}

--- a/helmfile/values/grafana/grafana-user.yaml.gotmpl
+++ b/helmfile/values/grafana/grafana-user.yaml.gotmpl
@@ -77,6 +77,10 @@ datasources:
     {{- end }}
     {{- end }}
 
+{{ $trailingDot := "" }}
+{{- if .Values.grafana.user.trailingDots }}
+{{ $trailingDot = "." }}
+{{- end }}
 
 grafana.ini:
   server:
@@ -90,9 +94,9 @@ grafana.ini:
     client_id: grafana
     client_secret: {{ .Values.grafana.clientSecret }}
     scopes: {{ .Values.grafana.user.oidc.scopes }}
-    auth_url: https://{{ .Values.dex.subdomain }}.{{ .Values.global.baseDomain }}./auth
-    token_url: http://dex.dex.svc.cluster.local.:5556/token
-    api_url: http://dex.dex.svc.cluster.local.:5556/api
+    auth_url: https://{{ .Values.dex.subdomain }}.{{ .Values.global.baseDomain }}{{ $trailingDot }}/auth
+    token_url: http://dex.dex.svc.cluster.local{{ $trailingDot }}:5556/token
+    api_url: http://dex.dex.svc.cluster.local{{ $trailingDot }}:5556/api
     allowed_domains: {{ join " " .Values.grafana.user.oidc.allowedDomains }}
     allow_sign_up: true
     tls_skip_verify_insecure: {{ not .Values.global.verifyTls }}


### PR DESCRIPTION
**What this PR does / why we need it**:
We can now choose if grafana needs to have trailing dots and a gatekeeper mutation that makes pods have the specified amount of ndots if enabled.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1671

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
