### PR TITLE
migration: added snippet to run update-ips

### DIFF
--- a/migration/template/README.md
+++ b/migration/template/README.md
@@ -69,6 +69,11 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
     ```bash
     ./bin/ck8s upgrade ${new_version} prepare
+
+    # check if the netpol IPs need to be updated
+    ./bin/ck8s update-ips both dry-run
+    # if you agree with the changes apply
+    ./bin/ck8s update-ips both update
     ```
 
 1. Apply upgrade - *disruptive*
@@ -100,6 +105,11 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ./bin/ck8s init
     # or
     ./migration/${new_version}/prepare/50-init.sh
+
+    # check if the netpol IPs need to be updated
+    ./bin/ck8s update-ips both dry-run
+    # if you agree with the changes apply
+    ./bin/ck8s update-ips both update
     ```
 
 ### Apply upgrade - *disruptive*

--- a/migration/v0.31/README.md
+++ b/migration/v0.31/README.md
@@ -69,6 +69,11 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
     ```bash
     ./bin/ck8s upgrade v0.31 prepare
+
+    # check if the netpol IPs need to be updated
+    ./bin/ck8s update-ips both dry-run
+    # if you agree with the changes apply
+    ./bin/ck8s update-ips both update
     ```
 
 1. Apply upgrade - *disruptive*
@@ -148,6 +153,11 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ./bin/ck8s helmfile sc -l app=opensearch-configurer destroy
     # or
     ./migration/v0.31/apply/11-remove-opensearch-configurer.sh execute
+
+    # check if the netpol IPs need to be updated
+    ./bin/ck8s update-ips both dry-run
+    # if you agree with the changes apply
+    ./bin/ck8s update-ips both update
     ```
 
 1. Update HNC namespace labels:

--- a/migration/v0.32/README.md
+++ b/migration/v0.32/README.md
@@ -69,6 +69,11 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
     ```bash
     ./bin/ck8s upgrade v0.32 prepare
+
+    # check if the netpol IPs need to be updated
+    ./bin/ck8s update-ips both dry-run
+    # if you agree with the changes apply
+    ./bin/ck8s update-ips both update
     ```
 
 1. Apply upgrade - *disruptive*
@@ -106,6 +111,11 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ./bin/ck8s init
     # or
     ./migration/v0.32/prepare/50-init.sh
+
+    # check if the netpol IPs need to be updated
+    ./bin/ck8s update-ips both dry-run
+    # if you agree with the changes apply
+    ./bin/ck8s update-ips both update
     ```
 
 > **Note**: Calico Accountant now supports nftables as a backend for network policy rules which is used by default in Ubuntu 22.04 and newer.


### PR DESCRIPTION
**What this PR does / why we need it**: to update the netpol IPs before the maintenance 
for a more more automated method to run this script is created [this issue](https://github.com/elastisys/compliantkubernetes-apps/issues/1698) 

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
