### PR TITLE
Probe public SC endpoints from WC

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Extra component versions can be added in the Welcome dashboard via config
+- Probes from WC to SC to monitor how well clusters reach each other
 
 ### Changed
 

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -169,6 +169,12 @@ falco:
     affinity: {}
     nodeSelector: {}
 
+grafana:
+  ops:
+    subdomain: grafana
+  user:
+    subdomain: grafana
+
 fluentd:
   audit:
     enabled: false
@@ -247,6 +253,11 @@ fluentd:
     livenessThresholdSeconds: 900
     stuckThresholdSeconds: 1200
 
+harbor:
+  enabled: true
+  subdomain: harbor
+  notary:
+    subdomain: notary.harbor
 
 ## Hierarchical namespace controller configuration.
 hnc:
@@ -450,6 +461,9 @@ prometheus:
               node: ""
               disk: ""
 
+dex:
+  subdomain: dex
+
 thanos:
   # Enables Thanos components.
   # If this isn't set, no components will be deployed
@@ -470,6 +484,9 @@ opensearch:
   subdomain: opensearch
 
   indexPerNamespace: false
+
+  dashboards:
+    subdomain: opensearch
 
 ## Set external traffic policy to: "Local" to preserve source IP on
 ## providers supporting it

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -87,7 +87,7 @@ falco:
 
 grafana:
   ops:
-    subdomain: grafana
+    # subdomain moved to common-config
     resources:
       requests:
         cpu: 50m
@@ -119,7 +119,7 @@ grafana:
           memory: 100Mi
   user:
     enabled: true
-    subdomain: grafana
+    # subdomain moved to common-config
     resources:
       limits:
         cpu: 100m
@@ -151,8 +151,8 @@ grafana:
           memory: 100Mi
 
 harbor:
-  enabled: true
-  subdomain: harbor
+  # the enabled property moved to common-config
+  # subdomain moved to common-config
   # The tolerations, affinity, and nodeSelector are applied to all harbor pods.
   tolerations: []
   nodeSelector: {}
@@ -315,7 +315,7 @@ harbor:
 
   notary:
     replicas: 1
-    subdomain: notary.harbor
+    # subdomain moved to common-config
     resources:
       requests:
         cpu: 20m
@@ -479,7 +479,7 @@ prometheus:
 
 dex:
   replicaCount: 2
-  subdomain: dex
+  # subdomain moved to common-config
   additionalKubeloginRedirects: []
   enableStaticLogin: true
   serviceMonitor:
@@ -708,7 +708,7 @@ opensearch:
   createIndices: true
 
   dashboards:
-    subdomain: opensearch
+    # subdomain moved to common-config
     # Note SSO is enabled via `opensearch.sso.enabled`
     resources:
       requests:

--- a/helmfile/values/prometheus-blackbox-exporter-wc.yaml.gotmpl
+++ b/helmfile/values/prometheus-blackbox-exporter-wc.yaml.gotmpl
@@ -66,3 +66,33 @@ serviceMonitor:
       scrapeTimeout: 30s
       module: http_2xx
     {{- end }}
+
+    - name: sc-dex
+      url: https://{{ .Values.dex.subdomain }}.{{ .Values.global.baseDomain }}/healthz
+      interval: 60s
+      scrapeTimeout: 30s
+      module: http_2xx
+    {{- if .Values.harbor.enabled }}
+    - name: sc-harbor
+      url: https://{{ .Values.harbor.subdomain }}.{{ .Values.global.baseDomain }}/api/v2.0/ping
+      interval: 60s
+      scrapeTimeout: 30s
+      module: http_2xx
+    {{- end }}
+    - name: sc-user-grafana
+      url: https://{{ .Values.grafana.user.subdomain }}.{{ .Values.global.baseDomain }}/api/health
+      interval: 60s
+      scrapeTimeout: 30s
+      module: http_2xx
+    - name: sc-opensearch-ops
+      url: https://{{ .Values.opensearch.subdomain }}.{{ .Values.global.opsDomain }}
+      interval: 60s
+      scrapeTimeout: 30s
+      module: http_401
+    {{- if and .Values.thanos.enabled .Values.thanos.receiver.enabled }}
+    - name: sc-thanos-recv-ops
+      url: https://{{ .Values.thanos.receiver.subdomain }}.{{ .Values.global.opsDomain }}
+      interval: 60s
+      scrapeTimeout: 30s
+      module: http_401
+    {{- end }}

--- a/migration/v0.33/README.md
+++ b/migration/v0.33/README.md
@@ -102,6 +102,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     git switch -d v0.33.x
     ```
 
+1. Move subdomain and enabled settings to the common config file:
+
+  ```bash
+  ./migration/v0.33/prepare/07-move-to-common-for-cross-cluster-probe.sh
+  ```
+
 1. Update apps configuration:
 
     This will take a backup into `backups/` before modifying any files.

--- a/migration/v0.33/prepare/07-move-to-common-for-cross-cluster-probe.sh
+++ b/migration/v0.33/prepare/07-move-to-common-for-cross-cluster-probe.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+log_info "- move subdomain values to common"
+
+for field in grafana.ops grafana.user harbor harbor.notary dex opensearch.dashboards; do
+  if ! yq_null sc ".${field}.subdomain" && yq_null common ".${field}.subdomain" ; then
+    yq_move_to_file sc ".${field}.subdomain" common ".${field}.subdomain"
+  fi
+done
+
+log_info "- move harbor enabled to common"
+
+if ! yq_null sc ".harbor.enabled" && yq_null common ".harbor.enabled" ; then
+  yq_move_to_file sc ".harbor.enabled" common ".harbor.enabled"
+fi

--- a/scripts/migration/yq.sh
+++ b/scripts/migration/yq.sh
@@ -38,6 +38,19 @@ yq_move() {
   fi
 }
 
+yq_move_to_file() {
+  if [[ "${#}" -lt 4 ]] || [[ ! "${1}" =~ ^(common|sc|wc)$ ]] || [[ ! "${3}" =~ ^(common|sc|wc)$ ]]; then
+    log_fatal "usage: yq_move_to_file <common|sc|wc> <source> <common|sc|wc> <destination>"
+  fi
+
+  if ! yq_null "${1}" "${2}"; then
+    log_info "  - move: ${1} ${2} to ${4} ${3}"
+    yq4 -oj -I0 "${2}" "${CK8S_CONFIG_PATH}/${1}-config.yaml" |
+    yq4 -i "${4} = load(\"/dev/stdin\")" "${CK8S_CONFIG_PATH}/${3}-config.yaml"
+    yq4 -i "del(${2})" "${CK8S_CONFIG_PATH}/${1}-config.yaml"
+  fi
+}
+
 yq_add() {
   if [[ "${#}" -lt 3 ]] || [[ ! "${1}" =~ ^(common|sc|wc)$ ]]; then
     log_fatal "usage: yq_add <common|sc|wc> <destination> <value>"


### PR DESCRIPTION
**What this PR does / why we need it**: to monitor how well WC can communicate with SC

**Which issue this PR fixes**: fixes #1437

**Special notes for reviewer**: Depends on Blackbox Exporter dashboard added in https://github.com/elastisys/compliantkubernetes-apps/pull/1542

**Add a screenshot or an example to illustrate the proposed solution:**
![image](https://github.com/elastisys/compliantkubernetes-apps/assets/197474/c2d5616a-3abc-4dd3-8d2e-298fd223c190)

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [ ] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [x] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
