### PR TITLE
Added alerts for cluster api and updated its grafana dashboard

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -17,6 +17,7 @@
 - User alertmanager will re-use the secret if exists, instead of using the `"helm.sh/hook": pre-install` annotation
 - Memory limit for Thanos distributor increased to 700Mi
 - Reduced CPU requests for some components in the service cluster.
+- Reduced the information on the dashboard for Cluster-API at a glance, but added some hidden more detailed graphs
 
 ### Fixed
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added support for Swift in rclone-sync.
   - It is now possible to specify type (S3/Swift) per bucket.
 - Support for nftables backend in calico-accountant via config option `calicoAccountant.backend: nftables`
+- Added basic alerts for Cluster-API
 
 ### Changed
 

--- a/helmfile/charts/grafana-dashboards/dashboards/cluster-api-dashboard.json
+++ b/helmfile/charts/grafana-dashboards/dashboards/cluster-api-dashboard.json
@@ -23,8 +23,8 @@
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": 104,
+  "graphTooltip": 1,
+  "id": 106,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -103,8 +103,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 4,
+        "h": 4,
+        "w": 5,
         "x": 0,
         "y": 1
       },
@@ -123,7 +123,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.13",
+      "pluginVersion": "9.5.5",
       "targets": [
         {
           "datasource": {
@@ -131,7 +131,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "capi_cluster_status_phase{name=~\"$cluster\", phase=\"Provisioned\"} == 1 or\n(capi_cluster_status_phase{name=~\"$cluster\", phase=\"Provisioning\"} == 1) + 1 or\n(capi_cluster_status_phase{name=~\"$cluster\", phase=\"Pending\"} == 1) + 1 or\n(capi_cluster_status_phase{name=~\"$cluster\", phase=\"Unknown\"} == 1) + 1 or\n(capi_cluster_status_phase{name=~\"$cluster\", phase=\"Deleting\"} == 1) + 1 or\n(capi_cluster_status_phase{name=~\"$cluster\", phase=\"Failed\"} == 1) + 1",
+          "expr": "max(capi_cluster_status_phase{name=~\"$cluster\", phase=\"Provisioned\"} == 1 or\n(capi_cluster_status_phase{name=~\"$cluster\", phase=\"Provisioning\"} == 1) + 1 or\n(capi_cluster_status_phase{name=~\"$cluster\", phase=\"Pending\"} == 1) + 2 or\n(capi_cluster_status_phase{name=~\"$cluster\", phase=\"Unknown\"} == 1) + 3 or\n(capi_cluster_status_phase{name=~\"$cluster\", phase=\"Deleting\"} == 1) + 4 or\n(capi_cluster_status_phase{name=~\"$cluster\", phase=\"Failed\"} == 1) + 5) without (instance, pod)",
           "legendFormat": "{{status}}",
           "range": true,
           "refId": "A"
@@ -180,9 +180,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 4,
+        "h": 4,
+        "w": 3,
+        "x": 5,
         "y": 1
       },
       "id": 15,
@@ -200,7 +200,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.13",
+      "pluginVersion": "9.5.5",
       "targets": [
         {
           "datasource": {
@@ -208,7 +208,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "capi_cluster_spec_paused{name=~\"$cluster\"}",
+          "expr": "max(capi_cluster_spec_paused{name=~\"$cluster\"}) without (instance, pod)",
           "legendFormat": "{{status}}",
           "range": true,
           "refId": "A"
@@ -262,8 +262,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 4,
+        "h": 4,
+        "w": 3,
         "x": 8,
         "y": 1
       },
@@ -282,7 +282,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.13",
+      "pluginVersion": "9.5.5",
       "targets": [
         {
           "datasource": {
@@ -290,7 +290,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "capi_cluster_status_condition{name=~\"$cluster\", type=\"Ready\", status=\"True\"} == 1 or (capi_cluster_status_condition{name=~\"$cluster\", type=\"Ready\", status=\"Unknown\"} == 1) + 1 or (capi_cluster_status_condition{name=~\"$cluster\", type=\"Ready\", status=\"False\"} == 1) + 2",
+          "expr": "max(capi_cluster_status_condition{name=~\"$cluster\", type=\"Ready\", status=\"True\"} == 1 or (capi_cluster_status_condition{name=~\"$cluster\", type=\"Ready\", status=\"Unknown\"} == 1) + 1 or (capi_cluster_status_condition{name=~\"$cluster\", type=\"Ready\", status=\"False\"} == 1) + 2) without (instance, pod)",
           "legendFormat": "{{status}}",
           "range": true,
           "refId": "A"
@@ -344,9 +344,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 12,
+        "h": 4,
+        "w": 3,
+        "x": 11,
         "y": 1
       },
       "id": 11,
@@ -364,7 +364,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.13",
+      "pluginVersion": "9.5.5",
       "targets": [
         {
           "datasource": {
@@ -372,7 +372,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "capi_cluster_status_condition{name=~\"$cluster\", type=\"ControlPlaneInitialized\", status=\"True\"} == 1 or (capi_cluster_status_condition{name=~\"$cluster\", type=\"ControlPlaneInitialized\", status=\"Unknown\"} == 1) + 1 or (capi_cluster_status_condition{name=~\"$cluster\", type=\"ControlPlaneInitialized\", status=\"False\"} == 1) + 2",
+          "expr": "max(capi_cluster_status_condition{name=~\"$cluster\", type=\"ControlPlaneInitialized\", status=\"True\"} == 1 or (capi_cluster_status_condition{name=~\"$cluster\", type=\"ControlPlaneInitialized\", status=\"Unknown\"} == 1) + 1 or (capi_cluster_status_condition{name=~\"$cluster\", type=\"ControlPlaneInitialized\", status=\"False\"} == 1) + 2) without (instance, pod)",
           "legendFormat": "{{status}}",
           "range": true,
           "refId": "A"
@@ -426,9 +426,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 16,
+        "h": 4,
+        "w": 3,
+        "x": 14,
         "y": 1
       },
       "id": 12,
@@ -446,7 +446,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.13",
+      "pluginVersion": "9.5.5",
       "targets": [
         {
           "datasource": {
@@ -454,7 +454,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "capi_cluster_status_condition{name=~\"$cluster\", type=\"ControlPlaneReady\", status=\"True\"} == 1 or (capi_cluster_status_condition{name=~\"$cluster\", type=\"ControlPlaneReady\", status=\"Unknown\"} == 1) + 1 or (capi_cluster_status_condition{name=~\"$cluster\", type=\"ControlPlaneReady\", status=\"False\"} == 1) + 2",
+          "expr": "max(capi_cluster_status_condition{name=~\"$cluster\", type=\"ControlPlaneReady\", status=\"True\"} == 1 or (capi_cluster_status_condition{name=~\"$cluster\", type=\"ControlPlaneReady\", status=\"Unknown\"} == 1) + 1 or (capi_cluster_status_condition{name=~\"$cluster\", type=\"ControlPlaneReady\", status=\"False\"} == 1) + 2) without (instance, pod)",
           "legendFormat": "{{status}}",
           "range": true,
           "refId": "A"
@@ -508,9 +508,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 20,
+        "h": 4,
+        "w": 3,
+        "x": 17,
         "y": 1
       },
       "id": 13,
@@ -528,7 +528,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.13",
+      "pluginVersion": "9.5.5",
       "targets": [
         {
           "datasource": {
@@ -536,7 +536,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "capi_cluster_status_condition{name=~\"$cluster\", type=\"InfrastructureReady\", status=\"True\"} == 1 or (capi_cluster_status_condition{name=~\"$cluster\", type=\"InfrastructureReady\", status=\"Unknown\"} == 1) + 1 or (capi_cluster_status_condition{name=~\"$cluster\", type=\"InfrastructureReady\", status=\"False\"} == 1) + 2",
+          "expr": "max(capi_cluster_status_condition{name=~\"$cluster\", type=\"InfrastructureReady\", status=\"True\"} == 1 or (capi_cluster_status_condition{name=~\"$cluster\", type=\"InfrastructureReady\", status=\"Unknown\"} == 1) + 1 or (capi_cluster_status_condition{name=~\"$cluster\", type=\"InfrastructureReady\", status=\"False\"} == 1) + 2) without (instance, pod)",
           "legendFormat": "{{status}}",
           "range": true,
           "refId": "A"
@@ -569,10 +569,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 6,
+        "h": 5,
+        "w": 3,
         "x": 0,
-        "y": 7
+        "y": 5
       },
       "id": 16,
       "options": {
@@ -589,7 +589,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.13",
+      "pluginVersion": "9.5.5",
       "targets": [
         {
           "datasource": {
@@ -597,7 +597,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "capi_kubeadmcontrolplane_status_replicas{name=~\"${cluster}-control-plane\"}",
+          "expr": "avg(capi_kubeadmcontrolplane_status_replicas{name=~\"${cluster}-control-plane\"}) without (instance, pod)",
           "legendFormat": "{{cluster}}",
           "range": true,
           "refId": "A"
@@ -634,10 +634,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 6,
-        "y": 7
+        "h": 5,
+        "w": 3,
+        "x": 3,
+        "y": 5
       },
       "id": 17,
       "options": {
@@ -654,7 +654,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.13",
+      "pluginVersion": "9.5.5",
       "targets": [
         {
           "datasource": {
@@ -662,7 +662,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "capi_kubeadmcontrolplane_status_replicas_unavailable{name=~\"${cluster}-control-plane\"}",
+          "expr": "avg(capi_kubeadmcontrolplane_status_replicas_unavailable{name=~\"${cluster}-control-plane\"}) without (instance, pod)",
           "legendFormat": "{{cluster}}",
           "range": true,
           "refId": "A"
@@ -683,31 +683,73 @@
           },
           "custom": {
             "align": "auto",
-            "displayMode": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
             "inspect": false
           },
-          "mappings": [],
+          "mappings": [
+            {
+              "options": {
+                "Failed": {
+                  "color": "red",
+                  "index": 2
+                },
+                "Running": {
+                  "color": "green",
+                  "index": 0
+                },
+                "Unknown": {
+                  "color": "orange",
+                  "index": 1
+                }
+              },
+              "type": "value"
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "yellow",
                 "value": null
               }
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "phase"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 12,
-        "y": 7
+        "h": 7,
+        "w": 9,
+        "x": 6,
+        "y": 5
       },
       "id": 22,
       "options": {
+        "cellHeight": "sm",
         "footer": {
+          "countRows": false,
           "fields": "",
           "reducer": [
             "sum"
@@ -717,7 +759,7 @@
         "frameIndex": 5,
         "showHeader": true
       },
-      "pluginVersion": "9.3.13",
+      "pluginVersion": "9.5.5",
       "targets": [
         {
           "datasource": {
@@ -726,15 +768,15 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "capi_machine_status_condition{name=~\"${cluster}-control-plane.*\", type=\"Ready\"} == 1",
+          "expr": "capi_machinedeployment_status_phase{cluster_name=~\"$cluster\"} == 1",
           "format": "table",
           "instant": true,
-          "legendFormat": "{{name}}",
+          "legendFormat": "{{node_name}}",
           "range": false,
           "refId": "A"
         }
       ],
-      "title": "Control plane replicas",
+      "title": "Machine Deployment phase",
       "transformations": [
         {
           "id": "organize",
@@ -752,6 +794,442 @@
               "endpoint": true,
               "instance": true,
               "job": true,
+              "name": false,
+              "namespace": true,
+              "pod": true,
+              "receive": true,
+              "service": true,
+              "status": false,
+              "tenant_id": true,
+              "uid": true
+            },
+            "indexByName": {
+              "Time": 2,
+              "Value": 18,
+              "__name__": 19,
+              "cluster": 3,
+              "cluster_name": 4,
+              "container": 5,
+              "customresource_group": 6,
+              "customresource_kind": 7,
+              "customresource_version": 8,
+              "endpoint": 9,
+              "instance": 10,
+              "job": 11,
+              "name": 0,
+              "namespace": 12,
+              "phase": 1,
+              "pod": 13,
+              "receive": 14,
+              "service": 15,
+              "tenant_id": 16,
+              "uid": 17
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "Failed": {
+                  "color": "red",
+                  "index": 2
+                },
+                "Running": {
+                  "color": "green",
+                  "index": 0
+                },
+                "Unknown": {
+                  "color": "orange",
+                  "index": 1
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "phase"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 15,
+        "y": 5
+      },
+      "id": 71,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 5,
+        "showHeader": true
+      },
+      "pluginVersion": "9.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "capi_machine_status_phase{cluster_name=~\"$cluster\", phase!=\"Running\"} == 1",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{node_name}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Non running machine phase",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "cluster": true,
+              "cluster_name": true,
+              "container": true,
+              "customresource_group": true,
+              "customresource_kind": true,
+              "customresource_version": true,
+              "endpoint": true,
+              "instance": true,
+              "job": true,
+              "name": false,
+              "namespace": true,
+              "pod": true,
+              "receive": true,
+              "service": true,
+              "status": false,
+              "tenant_id": true,
+              "uid": true
+            },
+            "indexByName": {
+              "Time": 2,
+              "Value": 18,
+              "__name__": 19,
+              "cluster": 3,
+              "cluster_name": 4,
+              "container": 5,
+              "customresource_group": 6,
+              "customresource_kind": 7,
+              "customresource_version": 8,
+              "endpoint": 9,
+              "instance": 10,
+              "job": 11,
+              "name": 0,
+              "namespace": 12,
+              "phase": 1,
+              "pod": 13,
+              "receive": 14,
+              "service": 15,
+              "tenant_id": 16,
+              "uid": 17
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 70
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 10
+      },
+      "id": 108,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "9.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(capi_machinedeployment_status_replicas{cluster_name=~\"$cluster\"}) by (name)",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "B"
+        }
+      ],
+      "title": "Total control plane replicas",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "cluster": true,
+              "cluster_name": true,
+              "container": true,
+              "customresource_group": true,
+              "customresource_kind": true,
+              "customresource_version": true,
+              "endpoint": true,
+              "job": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "False": {
+                  "color": "red",
+                  "index": 2
+                },
+                "True": {
+                  "color": "green",
+                  "index": 0
+                },
+                "Unknown": {
+                  "color": "orange",
+                  "index": 1
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "type"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 300
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 9,
+        "x": 6,
+        "y": 12
+      },
+      "id": 38,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 5,
+        "showHeader": true
+      },
+      "pluginVersion": "9.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "(capi_machine_status_condition{cluster_name=~\"$cluster\", name!~\".*control-plane.*\", status!=\"True\"} == 1) * on (name) group_left(node_name) capi_machine_status_noderef",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{node_name}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "MachineDeployment replicas with non True conditions",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "cluster": true,
+              "cluster_name": true,
+              "container": true,
+              "customresource_group": true,
+              "customresource_kind": true,
+              "customresource_version": true,
+              "endpoint": true,
+              "instance": true,
+              "job": true,
+              "name": true,
               "namespace": true,
               "pod": true,
               "receive": true,
@@ -762,8 +1240,167 @@
             },
             "indexByName": {
               "Time": 3,
+              "Value": 4,
+              "node_name": 0,
+              "status": 2,
+              "type": 1
+            },
+            "renameByName": {
+              "node_name": "",
+              "type": ""
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "False": {
+                  "color": "red",
+                  "index": 2
+                },
+                "True": {
+                  "color": "green",
+                  "index": 0
+                },
+                "Unknown": {
+                  "color": "orange",
+                  "index": 1
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "type"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 300
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 9,
+        "x": 15,
+        "y": 12
+      },
+      "id": 39,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 5,
+        "showHeader": true
+      },
+      "pluginVersion": "9.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "(capi_machine_status_condition{name=~\"${cluster}-control-plane.*\", status!=\"True\"} == 1) * on (name) group_left(node_name) capi_machine_status_noderef",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{node_name}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Control plane replicas with non True conditions",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "cluster": true,
+              "cluster_name": true,
+              "container": true,
+              "customresource_group": true,
+              "customresource_kind": true,
+              "customresource_version": true,
+              "endpoint": true,
+              "instance": true,
+              "job": true,
+              "name": true,
+              "namespace": true,
+              "pod": true,
+              "receive": true,
+              "service": true,
+              "status": false,
+              "tenant_id": true,
+              "uid": true
+            },
+            "indexByName": {
+              "Time": 4,
               "Value": 20,
-              "__name__": 4,
               "cluster": 5,
               "cluster_name": 6,
               "container": 7,
@@ -773,8 +1410,9 @@
               "endpoint": 11,
               "instance": 12,
               "job": 13,
-              "name": 0,
+              "name": 3,
               "namespace": 14,
+              "node_name": 0,
               "pod": 15,
               "receive": 16,
               "service": 17,
@@ -788,6 +1426,338 @@
         }
       ],
       "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "#EAB839",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Unavailable"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto"
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 15
+      },
+      "id": 54,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "9.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(capi_machinedeployment_status_replicas_unavailable{cluster_name=~\"$cluster\"}) without (instance, pod)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{cluster}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Unavailable MachineDeployment replicas",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "cluster": true,
+              "cluster_name": true,
+              "container": true,
+              "customresource_group": true,
+              "customresource_kind": true,
+              "customresource_version": true,
+              "endpoint": true,
+              "job": true,
+              "namespace": true,
+              "receive": true,
+              "service": true,
+              "tenant_id": true,
+              "uid": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Unavailable"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "id": 128,
+      "panels": [],
+      "title": "Detailed graphs",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "id": 89,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(capi_kubeadmcontrolplane_status_replicas_unavailable{name=~\"${cluster}-control-plane\"}) without (instance, pod)",
+          "legendFormat": "{{cluster}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Unavailable control plane replicas",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "id": 70,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.13",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg((capi_machine_status_condition{cluster_name=~\"$cluster\", type=\"NodeHealthy\", status!=\"True\"} == 1)  * on (name) group_left(node_name) capi_machine_status_noderef) by (cluster_name, node_name, status)",
+          "hide": false,
+          "legendFormat": "{{cluster_name}}: {{node_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Non healthy machines",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -843,10 +1813,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
-        "w": 7,
+        "h": 11,
+        "w": 12,
         "x": 0,
-        "y": 13
+        "y": 54
       },
       "id": 21,
       "options": {
@@ -869,9 +1839,9 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "capi_machinedeployment_status_replicas{cluster_name=~\"$cluster\"}",
+          "expr": "avg(capi_machinedeployment_status_replicas{cluster_name=~\"$cluster\"}) without (instance, pod)",
           "hide": false,
-          "legendFormat": "{{name}}",
+          "legendFormat": "{{cluster_name}}: {{name}}",
           "range": true,
           "refId": "A"
         }
@@ -933,10 +1903,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
-        "w": 7,
-        "x": 7,
-        "y": 13
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 54
       },
       "id": 23,
       "options": {
@@ -959,136 +1929,19 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "capi_machinedeployment_status_replicas_unavailable{cluster_name=~\"$cluster\"}",
+          "expr": "avg(capi_machinedeployment_status_replicas_unavailable{cluster_name=~\"$cluster\"}) without (instance, pod)",
           "hide": false,
-          "legendFormat": "{{name}}",
+          "legendFormat": "{{cluster_name}}: {{name}}",
           "range": true,
           "refId": "A"
         }
       ],
       "title": "Unavailable MachineDeployment replicas",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "displayMode": "auto",
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 10,
-        "x": 14,
-        "y": 13
-      },
-      "id": 24,
-      "options": {
-        "footer": {
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "frameIndex": 5,
-        "showHeader": true
-      },
-      "pluginVersion": "9.3.13",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "capi_machine_status_condition{cluster_name=~\"$cluster\", name!~\".*control-plane.*\", type=\"Ready\"} == 1",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "{{name}}",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "MachineDeployment replicas",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Value": true,
-              "__name__": true,
-              "cluster": true,
-              "cluster_name": true,
-              "container": true,
-              "customresource_group": true,
-              "customresource_kind": true,
-              "customresource_version": true,
-              "endpoint": true,
-              "instance": true,
-              "job": true,
-              "namespace": true,
-              "pod": true,
-              "receive": true,
-              "service": true,
-              "status": false,
-              "tenant_id": true,
-              "uid": true
-            },
-            "indexByName": {
-              "Time": 3,
-              "Value": 20,
-              "__name__": 4,
-              "cluster": 5,
-              "cluster_name": 6,
-              "container": 7,
-              "customresource_group": 8,
-              "customresource_kind": 9,
-              "customresource_version": 10,
-              "endpoint": 11,
-              "instance": 12,
-              "job": 13,
-              "name": 0,
-              "namespace": 14,
-              "pod": 15,
-              "receive": 16,
-              "service": 17,
-              "status": 2,
-              "tenant_id": 18,
-              "type": 1,
-              "uid": 19
-            },
-            "renameByName": {}
-          }
-        }
-      ],
-      "type": "table"
     }
   ],
-  "schemaVersion": 37,
+  "refresh": "10s",
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1138,7 +1991,7 @@
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
         "type": "query"
       }
     ]
@@ -1151,6 +2004,6 @@
   "timezone": "",
   "title": "Cluster api",
   "uid": "xgfBZCUVk",
-  "version": 5,
+  "version": 6,
   "weekStart": ""
 }

--- a/helmfile/charts/prometheus-alerts/files/cluster-api.yaml
+++ b/helmfile/charts/prometheus-alerts/files/cluster-api.yaml
@@ -1,0 +1,152 @@
+- name: cluster-api-cluster
+  rules:
+    - alert: ClusterApiClusterIsPaused
+      annotations:
+        description: |
+          The cluster `{{ $labels.name }}` has been paused for 15 minutes
+        summary: |
+          The cluster `{{ $labels.name }}` has been paused for 15 minutes
+      labels:
+        rulesgroup: cluster-api
+        severity: warning
+      expr: |
+        sum(capi_cluster_spec_paused) by (name) != 0
+      for: 15m
+    - alert: ClusterApiClusterControlPlaneNotInitialized
+      annotations:
+        description: |
+          The cluster `{{ $labels.name }}` has an uninitialized control plane
+        summary: |
+          The cluster `{{ $labels.name }}` has an uninitialized control plane
+      labels:
+        rulesgroup: cluster-api
+        severity: warning
+      expr: |
+        sum(capi_cluster_status_condition{type="ControlPlaneInitialized", status="True"}) by (name) != 1
+      for: 15m
+    - alert: ClusterApiClusterNotReady
+      annotations:
+        description: |
+          The cluster `{{ $labels.name }}` is not ready
+        summary: |
+          The cluster `{{ $labels.name }}` is not ready
+      labels:
+        rulesgroup: cluster-api
+        severity: high
+      expr: |
+        sum(capi_cluster_status_condition{type="ControlPlaneReady", status="True"}) by (name) != 1
+      for: 5m
+    - alert: ClusterApiClusterInfrastructureNotReady
+      annotations:
+        description: |
+          The cluster `{{ $labels.name }}` infrastructur is not ready
+        summary: |
+          The cluster `{{ $labels.name }}` infrastructur is not ready
+      labels:
+        rulesgroup: cluster-api
+        severity: high
+      expr: |
+        sum(capi_cluster_status_condition{type="InfrastructureReady", status="True"}) by (name) != 1
+      for: 15m
+    - alert: ClusterApiClusterNotProvisionedState
+      annotations:
+        description: |
+          The cluster `{{ $labels.name }}` is not in a Provisioned state for more than 15 minutes, this can happen if the cluster is currently provisioning new nodes or replacing nodes.
+        summary: |
+          The cluster `{{ $labels.name }}` is not in a Provisioned state for more than 15 minutes
+      labels:
+        rulesgroup: cluster-api
+        severity: warning
+      expr: |
+        capi_cluster_status_phase{phase!="Provisioned"} == 1
+      for: 15m
+    - alert: ClusterApiClusterNotProvisionedState
+      annotations:
+        description: |
+          The cluster `{{ $labels.name }}` is not in a Provisioned state for more than 1 hour, this can happen if the cluster is currently provisioning new nodes or replacing nodes.
+        summary: |
+          The cluster `{{ $labels.name }}` is not in a Provisioned state for more than 1 hour
+      labels:
+        rulesgroup: cluster-api
+        severity: high
+      expr: |
+        capi_cluster_status_phase{phase!="Provisioned"} == 1
+      for: 60m
+- name: cluster-api-kubeadm-control-plane
+  rules:
+    - alert: ClusterApiKubeadmControlPlaneNotFullyReady
+      annotations:
+        description: |
+          The cluster `{{ $labels.cluster_name }}` has a control plane `{{ $labels.name }}` that has some not ready nodes.
+        summary: |
+          The cluster `{{ $labels.cluster_name }}` has a control plane `{{ $labels.name }}` that has some not ready nodes.
+      labels:
+        rulesgroup: cluster-api
+        severity: warning
+      expr: |
+        sum(capi_kubeadmcontrolplane_status_replicas_ready / capi_kubeadmcontrolplane_status_replicas) by (cluster_name, name) != 1
+      for: 10m
+    - alert: ClusterApiKubeadmControlPlaneCloseToMajorityNotReady
+      annotations:
+        description: |
+          The cluster `{{ $labels.cluster_name }}` has a control plane `{{ $labels.name }}` with one node from having majority of its nodes not ready.
+        summary: |
+          The cluster `{{ $labels.cluster_name }}` has a control plane `{{ $labels.name }}` with one node from having majority of its nodes not ready.
+      labels:
+        rulesgroup: cluster-api
+        severity: warning
+      expr: |
+        sum(capi_kubeadmcontrolplane_status_replicas_ready / capi_kubeadmcontrolplane_status_replicas) by (cluster_name, name) < 0.5
+      for: 10m
+    - alert: ClusterApiKubeadmControlPlaneMajorityNotReady
+      annotations:
+        description: |
+          The cluster `{{ $labels.cluster_name }}` has a control plane `{{ $labels.name }}` that have majority of its nodes not ready.
+        summary: |
+          The cluster `{{ $labels.cluster_name }}` has a control plane `{{ $labels.name }}` that have majority of its nodes not ready.
+      labels:
+        rulesgroup: cluster-api
+        severity: high
+      expr: |
+        sum(capi_kubeadmcontrolplane_status_replicas_ready / capi_kubeadmcontrolplane_status_replicas) by (cluster_name, name) < 0.5
+      for: 2m
+- name: cluster-api-machine-deployment
+  rules:
+    - alert: ClusterApiMachineDeploymentNotFullyReady
+      annotations:
+        description: |
+          The cluster `{{ $labels.cluster_name }}` has a machine deployment `{{ $labels.name }}` that has some not ready nodes.
+        summary: |
+          The cluster `{{ $labels.cluster_name }}` has a machine deployment `{{ $labels.name }}` that has some not ready nodes.
+      labels:
+        rulesgroup: cluster-api
+        severity: warning
+      expr: |
+        sum(capi_machinedeployment_status_replicas_ready / capi_machinedeployment_status_replicas) by (cluster_name, name) != 1
+      for: 15m
+    - alert: ClusterApiMachineDeploymentMajorityNotReady
+      annotations:
+        description: |
+          The cluster `{{ $labels.cluster_name }}` has a machine deployment `{{ $labels.name }}` that have majority of its nodes not ready.
+        summary: |
+          The cluster `{{ $labels.cluster_name }}` has a machine deployment `{{ $labels.name }}` that have majority of its nodes not ready.
+      labels:
+        rulesgroup: cluster-api
+        severity: high
+      expr: |
+        sum(capi_machinedeployment_status_replicas_ready / capi_machinedeployment_status_replicas) by (cluster_name, name) < 0.5
+      for: 2m
+- name: cluster-api-machine
+  rules:
+    - alert: ClusterApiMachineConditionNotTrue
+      annotations:
+        description: |
+          The cluster `{{ $labels.cluster_name }}` has a machine `{{ $labels.node_name }}` that has the condition `{{ $labels.type }}` set to `{{ $labels.status }}`
+        summary: |
+          The cluster `{{ $labels.cluster_name }}` has a machine `{{ $labels.node_name }}` that has the condition `{{ $labels.type }}` set to `{{ $labels.status }}`
+      labels:
+        rulesgroup: cluster-api
+        severity: warning
+      expr: |
+        sum((capi_machine_status_condition{status!="True"}) * on (name) group_left(node_name) sum(capi_machine_status_noderef) by (name, node_name)) by (cluster_name, node_name, type, status) > 0
+      for: 15m

--- a/helmfile/charts/prometheus-alerts/templates/alerts/cluster-api.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/alerts/cluster-api.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.defaultRules.create .Values.defaultRules.rules.clusterApi }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-alerts.fullname" .) "cluster-api" | trunc 63 | trimSuffix "-" }}
+  labels:
+    app: {{ template "prometheus-alerts.name" . }}
+    {{- include "prometheus-alerts.labels" . | nindent 4 }}
+    {{- with .Values.defaultRules.alertLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.defaultRules.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  groups:
+    {{- .Files.Get "files/cluster-api.yaml" | nindent 4 }}
+{{- end }}

--- a/helmfile/charts/prometheus-alerts/values.yaml
+++ b/helmfile/charts/prometheus-alerts/values.yaml
@@ -117,6 +117,7 @@ defaultRules:
     configReloaders: true
     networkpolicies: true
     dns: true
+    clusterApi: false
 
   appNamespacesTarget: ".*"
 

--- a/helmfile/values/prometheus-alerts-sc.yaml.gotmpl
+++ b/helmfile/values/prometheus-alerts-sc.yaml.gotmpl
@@ -33,6 +33,7 @@ defaultRules:
     backupStatus: true
     dailyChecks: true
     networkpolicies: {{ .Values.networkPolicies.enableAlerting }}
+    clusterApi: {{ .Values.global.clusterApi }}
 
   {{- if and .Values.thanos.enabled .Values.thanos.ruler.enabled }}
   thanos:


### PR DESCRIPTION
**What this PR does / why we need it**:



**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes elastisys/ck8s-cluster-api#42

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

Main panels for each cluster:

![screenshot_2023-08-01-144318](https://github.com/elastisys/compliantkubernetes-apps/assets/2071713/57b0013c-c052-4ae9-9518-d1029203ea7b)

One (hidden by default) row of more detailed graphs that works both with all clusters and for one specific one:
![screenshot_2023-08-01-144332](https://github.com/elastisys/compliantkubernetes-apps/assets/2071713/ac7da776-6c99-461b-8810-ba89bd730863)


**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [ ] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
