### PR TITLE
sc apps: way to include more component versions in welcome dasboard

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- Extra component versions can be added in the Welcome dashboard via config
+
 ### Changed
 
 - Moved `rclone-sync` from `kube-system` to its own namespace.

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -1141,6 +1141,17 @@ welcomingDashboard:
   extraTextGrafana: ""
   # For newline in Opensearch dashboard use format "\\\\n"
   extraTextOpensearch: ""
+  extraVersions: []
+  #- name: Stuffs
+  #  version: v0.30.4
+  #  releasenotes: https://elastisys.io/compliantkubernetes/release-notes/
+  #- name: Dex
+  #  version: "v2.37"
+  #  subdomain: dex
+  #- name: Postgres
+  #  version: "11"
+  #  url: https://www.postgresql.org/
+  #  releasenotes: https://elastisys.io/compliantkubernetes/release-notes/#postgres
 
 # Network policies for service cluster
 networkPolicies:

--- a/helmfile/charts/grafana-dashboards/dashboards/welcome-dashboard.json
+++ b/helmfile/charts/grafana-dashboards/dashboards/welcome-dashboard.json
@@ -1,65 +1,65 @@
 {
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": "-- Grafana --",
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "target": {
-            "limit": 100,
-            "matchAny": false,
-            "tags": [],
-            "type": "dashboard"
-          },
-          "type": "dashboard"
-        }
-      ]
-    },
-    "description": "Welcoming Dashboard",
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "graphTooltip": 0,
-    "id": 46,
-    "links": [],
-    "liveNow": false,
-    "panels": [
+  "annotations": {
+    "list": [
       {
-        "description": "Home dashboard",
-        "gridPos": {
-          "h": 25,
-          "w": 24,
-          "x": 0,
-          "y": 0
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
         },
-        "id": 2,
-        "options": {
-          "content": "<<markdownstring>>",
-          "mode": "markdown"
-        },
-        "pluginVersion": "8.4.7",
-        "title": "Welcome",
-        "type": "text"
+        "type": "dashboard"
       }
-    ],
-    "schemaVersion": 35,
-    "style": "dark",
-    "tags": [],
-    "templating": {
-      "list": []
-    },
-    "time": {
-      "from": "now-6h",
-      "to": "now"
-    },
-    "timepicker": {
-      "hidden": true
-    },
-    "timezone": "",
-    "title": "Welcome to Compliant Kubernetes",
-    "uid": "xI0OiXQnk",
-    "version": 3,
-    "weekStart": ""
-  }
+    ]
+  },
+  "description": "Welcoming Dashboard",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 46,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "description": "Home dashboard",
+      "gridPos": {
+        "h": 32,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "content": "<<markdownstring>>",
+        "mode": "markdown"
+      },
+      "pluginVersion": "8.4.7",
+      "title": "Welcome",
+      "type": "text"
+    }
+  ],
+  "schemaVersion": 35,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "hidden": true
+  },
+  "timezone": "",
+  "title": "Welcome to Compliant Kubernetes",
+  "uid": "xI0OiXQnk",
+  "version": 3,
+  "weekStart": ""
+}

--- a/helmfile/charts/grafana-dashboards/files/welcome.md
+++ b/helmfile/charts/grafana-dashboards/files/welcome.md
@@ -26,6 +26,13 @@ In case you get lost, don't forget to check out the [public docs](https://elasti
 
 - Apps: **{{ .Values.dashboard.ck8sVersion }}** - [Release Notes](https://elastisys.io/compliantkubernetes/release-notes/)
 
+{{ $baseDomain := .Values.baseDomain }}
+{{ range .Values.dashboard.extraVersions }}
+
+- {{ if .url }}[{{ .name }}]({{ .url }}){{ else if .subdomain }}[{{ .name }}](https://{{ .subdomain }}.{{ $baseDomain }}/){{ else }}{{ .name }}{{ end }}{{ if .version }}: **{{ .version }}**{{ end }}{{ if .releasenotes }} - [Release Notes]({{ .releasenotes }}){{ end }}
+
+{{ end }}
+
 ## Web Portals
 
 - [grafana.{{ .Values.baseDomain }}](https://grafana.{{ .Values.baseDomain }})

--- a/helmfile/charts/grafana-dashboards/values.yaml
+++ b/helmfile/charts/grafana-dashboards/values.yaml
@@ -14,6 +14,14 @@ labelKey: grafana_dashboard
 dashboard:
   ck8sVersion: ""
   extraTextGrafana: ""
+  extraVersions: []
+  # - name: The Example Software
+  #   version: "1.7.3"
+  #   url: https://the-software.example/
+  #   # OR
+  #   subdomain: subdomain
+  #   # becomes https://subdomain.{{ baseDomain }}/
+  #   releasenotes: https://https://elastisys.io/compliantkubernetes/release-notes/#example
 
 baseDomain: ""
 

--- a/helmfile/values/grafana/grafana-dashboards.yaml.gotmpl
+++ b/helmfile/values/grafana/grafana-dashboards.yaml.gotmpl
@@ -9,6 +9,10 @@
 dashboard:
   ck8sVersion: {{ .Values.global.ck8sVersion }}
   extraTextGrafana: {{ .Values.welcomingDashboard.extraTextGrafana }}
+{{ if .Values.welcomingDashboard.extraVersions }}
+  extraVersions:
+{{- toYaml .Values.welcomingDashboard.extraVersions | nindent 2 }}
+{{ end }}
 
 baseDomain: {{ .Values.global.baseDomain }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a way to list additional components, optionally with a link and/or referencing a release notes URL, see #1290

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1290

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

When looking at the diff, enable "Hide whitespace", changes to the dashboard.json is mostly indentation.

Adds `welcomingDashboard.extraVersions`, a list of entries. Each entry requires at least a `name` property. The corresponding version may be specified in `version`.  To link to a component that is available on a subdomain of `baseDomain`, set `subdomain` to that subdomain. An exact URL can be specified (instead of `subdomain`) using the `url` property. Release notes can be referenced by the `releasenotes` property.

Example:
``` yaml
welcomingDashboard:
  extraTextGrafana: Lorem ipsum etc
  extraVersions:
    - name: Additional Component
      version: v1.3.37
      releasenotes: https://www.example.com/
    - name: Grafana
      version: v10
      subdomain: grafana
    - name: Internal Component
      version: v3.141592
```

**Add a screenshot or an example to illustrate the proposed solution:**

![image](https://github.com/elastisys/compliantkubernetes-apps/assets/197474/9d8d4b4d-65ac-478e-995e-c4e53b01a491)


**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [x] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [ ] I upgraded no Chart.
  - [x] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
