### PR TITLE
apps sc: Added annotation to harbor ingress to fix timeout

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fixed the sops_validate_config function in `bin/common.bash` to better handle invalid pgp keys.
 - `scripts/migration/lib.sh` check_version function now asks if you want to use the specified nonstandard ck8sVersion.
 - Network policy for harbor notary server
+- Added some default annotations for harbor that will fix issues with not being able to upload larger images
 
 ### Updated
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -154,6 +154,11 @@ harbor:
   # The tolerations, affinity, and nodeSelector are applied to all harbor pods.
   tolerations: []
   nodeSelector: {}
+  ingress:
+    defaultAnnotations:
+      nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+      nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    additionalAnnotations: {}
   core:
     replicas: 1
     resources:

--- a/helmfile/values/harbor/harbor.yaml.gotmpl
+++ b/helmfile/values/harbor/harbor.yaml.gotmpl
@@ -14,9 +14,15 @@ expose:
   ingress:
     annotations:
       cert-manager.io/cluster-issuer: {{ .Values.global.issuer }}
-      {{ if and .Values.externalTrafficPolicy.local .Values.externalTrafficPolicy.whitelistRange.harbor }}
+      {{- if and .Values.externalTrafficPolicy.local .Values.externalTrafficPolicy.whitelistRange.harbor }}
       nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.externalTrafficPolicy.whitelistRange.harbor }}
-      {{ end }}
+      {{- end }}
+      {{- range $key, $value := .Values.harbor.ingress.defaultAnnotations }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- range $key, $value := .Values.harbor.ingress.additionalAnnotations }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
     hosts:
       core: {{ .Values.harbor.subdomain }}.{{ .Values.global.baseDomain }}
       notary: {{ .Values.harbor.notary.subdomain }}.{{ .Values.global.baseDomain }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This seems to fix the issue of larger image layers timing out and failing the push.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

Searching a bit on the issue of larger image layers that fail to upload I found a couple of suggestions to set these annotations/config. For example here:

https://github.com/goharbor/harbor/issues/16623#issuecomment-1084582967
https://github.com/goharbor/harbor/issues/9394#issuecomment-541598184

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [ ] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
