### PR TITLE
apps sc: move rclone from kube-system

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Moved `rclone-sync` from `kube-system` to its own namespace.
+
 ### Fixed
 
 ### Updated

--- a/bootstrap/namespaces/helmfile/values/namespaces-sc.yaml.gotmpl
+++ b/bootstrap/namespaces/helmfile/values/namespaces-sc.yaml.gotmpl
@@ -66,5 +66,12 @@ namespaces:
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/enforce: restricted
     pod-security.kubernetes.io/warn: restricted
+{{ if .Values.objectStorage.sync.enabled }}
+- name: rclone
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+{{ end }}
 commonLabels:
   owner: operator

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -616,7 +616,7 @@ releases:
   - values/fluentd/log-manager.yaml.gotmpl
 
 - name: rclone-sync
-  namespace: kube-system
+  namespace: rclone
   labels:
     app: rclone-sync
   chart: ./charts/rclone-sync

--- a/helmfile/charts/networkpolicy/service-cluster/templates/rclone-sync.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/rclone-sync.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: allow-rclone-sync
-  namespace: kube-system
+  namespace: rclone
 spec:
   policyTypes:
     - Egress

--- a/helmfile/charts/rclone-sync/templates/cronjob.yaml
+++ b/helmfile/charts/rclone-sync/templates/cronjob.yaml
@@ -44,6 +44,13 @@ spec:
               volumeMounts:
                 - name: {{ $.Chart.Name }}-config
                   mountPath: /home/rclone/.config/rclone/
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                seccompProfile:
+                  type: "RuntimeDefault"
+                capabilities:
+                  drop: ["ALL"]
           volumes:
             - name: {{ $.Chart.Name }}-config
               secret:

--- a/migration/v0.33/README.md
+++ b/migration/v0.33/README.md
@@ -1,0 +1,167 @@
+# Upgrade to v0.33.x
+
+> **Warning**: Upgrade only supported from v0.32.x.
+
+<!--
+Notice to developers on writing migration steps:
+
+- Migration steps:
+  - are written per minor version and placed in a subdirectory of the migration directory with the name `vX.Y/`,
+  - are written to be idempotent and usable no matter which patch version you are upgrading from and to,
+  - are documented in this document to be able to run them manually,
+  - are divided into prepare and apply steps:
+    - Prepare steps:
+      - are placed in the `prepare/` directory,
+      - may **only** modify the configuration of the environment,
+      - may **not** modify the state of the environment,
+      - steps are run in order of their names use two digit prefixes.
+    - Apply steps:
+      - are placed in the `apply/` directory,
+      - may **only** modify the state of the environment,
+      - may **not** modify the configuration of the environment,
+      - are run in order of their names use two digit prefixes,
+      - are run with the argument `execute` on upgrade and should return 1 on failure and 2 on successful internal rollback,
+      - are rerun with the argument `rollback` on execute failure and should return 1 on failure.
+
+For prepare the init step is given.
+For apply the bootstrap and the apply steps are given, it is expected that releases upgraded in custom steps are excluded from the apply step.
+
+Upgrades of components that are dependent on each other should be done within the same snippet to easily manage the upgrade to a working state and to be able to rollback to a working state.
+
+Steps should use the `scripts/migration/lib.sh` which will provide helper functions, see the file for available helper functions.
+This script expects the `ROOT` environment variable to be set pointing to the root of the repository.
+As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
+-->
+
+## Prerequisites
+
+> **Warning**: Any `rclone-sync` job running during the upgrade will be terminated
+
+- [ ] Suspend any `rclone-sync` jobs that are scheduled to run during the upgrade;
+- [ ] Notify the users (if any) before the upgrade starts;
+- [ ] Check if there are any pending changes to the environment;
+- [ ] Check the state of the environment, pods, nodes and backup jobs:
+
+    ```bash
+    ./bin/ck8s test sc|wc
+    ./bin/ck8s test sc|wc cert-manager
+    ./bin/ck8s test sc|wc ingress
+    ./bin/ck8s test sc opensearch
+    ./bin/ck8s test wc hnc
+    ./bin/ck8s ops kubectl sc|wc get pods -A -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-false:status.containerStatuses[*].ready,REASON:status.containerStatuses[*].state.terminated.reason | grep false | grep -v Completed
+    ./bin/ck8s ops kubectl sc|wc get nodes
+    ./bin/ck8s ops kubectl sc|wc get jobs -A
+    ./bin/ck8s ops helm sc|wc list -A --all
+    velero get backup
+    ```
+
+- [ ] Silence the notifications for the alerts. e.g you can use [alertmanager silences](https://prometheus.io/docs/alerting/latest/alertmanager/#silences);
+
+## Automatic method
+
+1. Pull the latest changes and switch to the correct branch:
+
+    ```bash
+    git pull
+    git switch -d v0.33.x
+    ```
+
+1. Prepare upgrade - *non-disruptive*
+
+    > *Done before maintenance window.*
+
+    ```bash
+    ./bin/ck8s upgrade v0.33 prepare
+
+    # check if the netpol IPs need to be updated
+    ./bin/ck8s update-ips both dry-run
+    # if you agree with the changes apply
+    ./bin/ck8s update-ips both update
+    ```
+
+1. Apply upgrade - *disruptive*
+
+    > *Done during maintenance window.*
+
+    ```bash
+    ./bin/ck8s upgrade v0.33 apply
+    ```
+
+## Manual method
+
+### Prepare upgrade - *non-disruptive*
+
+> *Done before maintenance window.*
+
+1. Pull the latest changes and switch to the correct branch:
+
+    ```bash
+    git pull
+    git switch -d v0.33.x
+    ```
+
+1. Update apps configuration:
+
+    This will take a backup into `backups/` before modifying any files.
+
+    ```bash
+    ./bin/ck8s init
+    # or
+    ./migration/v0.33/prepare/50-init.sh
+
+    # check if the netpol IPs need to be updated
+    ./bin/ck8s update-ips both dry-run
+    # if you agree with the changes apply
+    ./bin/ck8s update-ips both update
+    ```
+
+### Apply upgrade - *disruptive*
+
+> *Done during maintenance window.*
+
+1. Rerun bootstrap:
+
+    ```bash
+    ./bin/ck8s bootstrap {sc|wc}
+    # or
+    ./migration/v0.33/apply/20-bootstrap.sh execute
+    ```
+
+1. Move `rclone-sync` from `kube-system`:
+
+    ```bash
+    ./migration/v0.32/apply/40-rclone.sh execute
+    ```
+
+1. Upgrade applications:
+
+    ```bash
+    ./bin/ck8s apply {sc|wc}
+    # or
+    ./migration/v0.33/apply/80-apply.sh execute
+    ```
+
+## Postrequisite:
+
+- [ ] Unsuspend any `rclone-sync` jobs that were suspended before the upgrade;
+- [ ] Check the state of the environment, pods and nodes:
+
+    ```bash
+    ./bin/ck8s test sc|wc
+    ./bin/ck8s test sc|wc cert-manager
+    ./bin/ck8s test sc|wc ingress
+    ./bin/ck8s test sc opensearch
+    ./bin/ck8s test wc hnc
+    ./bin/ck8s ops kubectl sc|wc get pods -A -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-false:status.containerStatuses[*].ready,REASON:status.containerStatuses[*].state.terminated.reason | grep false | grep -v Completed
+    ./bin/ck8s ops kubectl sc|wc get nodes
+    ./bin/ck8s ops helm sc|wc list -A --all
+    ```
+
+- [ ] Enable the notifications for the alerts;
+- [ ] Notify the users (if any) when the upgrade is complete;
+
+> **_Note:_** Additionally it is good to check:
+
+- if any alerts generated by the upgrade didn't close;
+- if you can login to Grafana, Opensearch or Harbor;
+- you can see fresh metrics and logs.

--- a/migration/v0.33/apply/00-template.sh
+++ b/migration/v0.33/apply/00-template.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+# functions currently available in the library:
+#   - logging:
+#     - log_info(_no_newline) <message>
+#     - log_warn(_no_newline) <message>
+#     - log_error(_no_newline) <message>
+#     - log_fatal <message> # this will call "exit 1"
+#
+#   - kubectl
+#     # Use kubectl with kubeconfig set
+#     - kubectl_do <sc|wc> <kubectl args...>
+#     # Perform kubectl delete, will not cause errors if the resource is missing
+#     - kubectl_delete <sc|wc> <resource> <namespace> <name>
+#
+#   - helm
+#     # Use helm with kubeconfig set
+#     - helm_do <sc|wc> <helm args...>
+#     # Checks if a release is installed
+#     - helm_installed <sc|wc> <namespace> <release>
+#     # Uninstalls a release if it is installed
+#     - helm_uninstall <sc|wc> <namespace> <release>
+#
+#   - helmfile
+#     # Use helmfile with kubeconfig set
+#     - helmfile_do <sc|wc> <helmfile args...>
+#     # For selector args all will be prefixed with "-l"
+#     # List releases matching the selector
+#     - helmfile_list <sc|wc> <selectors...>
+#     # Apply releases matching the selector
+#     - helmfile_apply <sc|wc> <selectors...>
+#     # Check for changes on releases matching the selector
+#     - helmfile_change <sc|wc> <selectors...>
+#     # Destroy releases matching the selector
+#     - helmfile_destroy <sc|wc> <selectors...>
+#     # Replaces the releases matching the selector, performing destroy and apply on each release individually
+#     - helmfile_replace <sc|wc> <selectors...>
+#     # Upgrades the releases matching the selector, performing automatic rollback on failure set "CK8S_ROLLBACK=false" to disable
+#     - helmfile_upgrade <sc|wc> <selectors...>
+
+run() {
+  case "${1:-}" in
+  execute)
+    # Note: 00-template.sh will be skipped by the upgrade command
+    log_info "no operation: this is a template"
+    ;;
+  rollback)
+    log_warn "rollback not implemented"
+    ;;
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.33/apply/20-bootstrap.sh
+++ b/migration/v0.33/apply/20-bootstrap.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+run() {
+  case "${1:-}" in
+  execute)
+    "${ROOT}/bin/ck8s" bootstrap sc
+    "${ROOT}/bin/ck8s" bootstrap wc
+    ;;
+  rollback)
+    log_warn "rollback not implemented"
+    ;;
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.33/apply/40-rclone.sh
+++ b/migration/v0.33/apply/40-rclone.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+run() {
+  case "${1:-}" in
+  execute)
+    log_info "Removing old rclone-sync cronjobs"
+    old_cronjobs=$(kubectl_do sc get cronjobs.batch -n kube-system -l app=rclone-sync --output=jsonpath={.items..metadata.name})
+    for cronjob in $old_cronjobs; do
+      kubectl_delete sc cronjobs.batch kube-system "$cronjob"
+    done
+    helmfile_apply sc app=rclone-sync
+    ;;
+  rollback)
+    log_warn "rollback not implemented"
+    ;;
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.33/apply/80-apply.sh
+++ b/migration/v0.33/apply/80-apply.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+# Add selector filters if covered by other snippets.
+# Example: "app!=something"
+declare -a skipped
+skipped=(
+)
+declare -a skipped_sc
+skipped_sc=(
+  "app!=rclone-sync"
+)
+declare -a skipped_wc
+skipped_wc=(
+)
+
+run() {
+  case "${1:-}" in
+  execute)
+    local -a filters
+    local selector
+
+    filters=("${skipped[@]}" "${skipped_sc[@]}")
+    selector="${filters[*]:-"app!=null"}"
+    helmfile_upgrade sc "${selector// /,}"
+    filters=("${skipped[@]}" "${skipped_wc[@]}")
+    selector="${filters[*]:-"app!=null"}"
+    helmfile_upgrade wc "${selector// /,}"
+    ;;
+
+  rollback)
+    log_warn "rollback not implemented"
+    ;;
+
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.33/prepare/00-template.sh
+++ b/migration/v0.33/prepare/00-template.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+# functions currently available in the library:
+#   - logging:
+#     - log_info(_no_newline) <message>
+#     - log_warn(_no_newline) <message>
+#     - log_error(_no_newline) <message>
+#     - log_fatal <message> # this will call "exit 1"
+#
+#  - yq:
+#     - yq_null <common|sc|wc> <target>
+#     - yq_copy <common|sc|wc> <source> <destination>
+#     - yq_move <common|sc|wc> <source> <destination>
+#     - yq_remove <common|sc|wc> <target>
+#     - yq_add <common|sc|wc> <target> <destination> <value>
+
+# Note: 00-template.sh will be skipped by the upgrade command
+log_info "no operation: this is a template"

--- a/migration/v0.33/prepare/50-init.sh
+++ b/migration/v0.33/prepare/50-init.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+"${ROOT}/bin/ck8s" init


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR moves rclone from kube-system to its own namespace.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1544 

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [x] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

