### PR TITLE
apps sc: rclone-sync migration script

### DIFF
--- a/migration/v0.32/README.md
+++ b/migration/v0.32/README.md
@@ -103,6 +103,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ./migration/v0.32/prepare/10-thanos-distrib-memory-limit.sh
     ```
 
+1. Update rclone sync networkPolicy name:
+
+    ```bash
+    ./migration/v0.32/prepare/30-rclone-sync-name-change.sh
+    ```
+
 1. Update apps configuration:
 
     This will take a backup into `backups/` before modifying any files.

--- a/migration/v0.32/prepare/30-rclone-sync-netpol-name-change.sh
+++ b/migration/v0.32/prepare/30-rclone-sync-netpol-name-change.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+log_info "- check if the rclone-sync networkPolicy exists in sc-config"
+if ! yq_null sc .networkPolicies.rcloneSync.destinationObjectStorage; then
+  log_info "- changing rclone-sync networkPolicy name to destinationObjectStorageS3"
+  yq4 -i 'with(.networkPolicies.rcloneSync; with_entries(.key |= . + "S3" ))' "${CK8S_CONFIG_PATH}/sc-config.yaml"
+else
+  log_info "- no changes necessary"
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a migration script this [comment](https://github.com/elastisys/compliantkubernetes-apps/commit/c3ab16683791208dac4165ed13fc14c1b98f9147#r123797404) brought awareness to needing.

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] is completely transparent, will not impact the workload in any way.
  - [x] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
