### PR TITLE
apps: falco-exporter chart v0.9.6

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,13 @@
+### Release notes
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Updated
+
+- Upgraded falco-exporter chart version to `v0.9.6` and app version to `v0.8.3`
+
+### Removed

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -187,7 +187,7 @@ releases:
   labels:
     app: falco-exporter
   chart: ./upstream/falco-exporter
-  version: 0.9.0
+  version: 0.9.6
   installed: {{ .Values.falco.enabled }}
   values:
     - values/falco/falco-exporter.yaml.gotmpl

--- a/helmfile/upstream/falco-exporter/CHANGELOG.md
+++ b/helmfile/upstream/falco-exporter/CHANGELOG.md
@@ -3,6 +3,43 @@
 This file documents all notable changes to `falco-exporter` Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.9.6
+
+### Minor Changes
+
+* Bump falco-exporter to v0.8.3
+
+## v0.9.5
+
+### Minor Changes
+
+* Removed unnecessary capabilities from security context
+* Setted filesystem on read-only
+
+## v0.9.4
+
+### Minor Changes
+
+* Add options to configure readiness/liveness probe values
+
+## v0.9.3
+
+### Minor Changes
+
+* Bump falco-exporter to v0.8.2
+
+## v0.9.2
+
+### Minor Changes
+
+* Add option to place Grafana dashboard in a folder
+
+## v0.9.1
+
+### Minor Changes
+
+* Fix PSP allowed host path prefix to match grpc socket path change.
+
 ## v0.8.3
 
 ### Major Changes

--- a/helmfile/upstream/falco-exporter/Chart.yaml
+++ b/helmfile/upstream/falco-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.8.0
+appVersion: 0.8.3
 description: Prometheus Metrics Exporter for Falco output events
 keywords:
 - monitoring
@@ -15,4 +15,4 @@ name: falco-exporter
 sources:
 - https://github.com/falcosecurity/falco-exporter
 type: application
-version: 0.9.0
+version: 0.9.6

--- a/helmfile/upstream/falco-exporter/README.md
+++ b/helmfile/upstream/falco-exporter/README.md
@@ -49,7 +49,7 @@ The following table lists the main configurable parameters of the chart and thei
 | ------------------------------------------------ | ------------------------------------------------------------------------------------------------ | ---------------------------------- |
 | `image.registry`                                 | The image registry to pull from                                                                  | `docker.io`                        |
 | `image.repository`                               | The image repository to pull from                                                                | `falcosecurity/falco-exporter`     |
-| `image.tag`                                      | The image tag to pull                                                                            | `0.6.0`                            |
+| `image.tag`                                      | The image tag to pull                                                                            | `0.8.3`                            |
 | `image.pullPolicy`                               | The image pull policy                                                                            | `IfNotPresent`                     |
 | `falco.grpcUnixSocketPath`                       | Unix socket path for connecting to a Falco gRPC server                                           | `unix:///var/run/falco/falco.sock` |
 | `falco.grpcTimeout`                              | gRPC connection timeout                                                                          | `2m`                               |
@@ -60,12 +60,21 @@ The following table lists the main configurable parameters of the chart and thei
 | `serviceMonitor.interval`                        | Specify a user defined interval for the Service Monitor                                          | `""`                               |
 | `serviceMonitor.scrapeTimeout`                   | Specify a user defined scrape timeout for the Service Monitor                                    | `""`                               |
 | `grafanaDashboard.enabled`                       | Enable the falco security dashboard, see https://github.com/falcosecurity/falco-exporter#grafana | `false`                            |
+| `grafanaDashboard.folder`                        | The grafana folder to deplay the dashboard in                                                    |     `""`                                 |
 | `grafanaDashboard.namespace`                     | The namespace to deploy the dashboard configmap in                                               | `default`                          |
 | `grafanaDashboard.prometheusDatasourceName`      | The prometheus datasource name to be used for the dashboard                                      | `Prometheus`                       |
 | `scc.create`                                     | Create OpenShift's Security Context Constraint                                                   | `true`                             |
 | `service.mTLS.enabled`                           | Enable falco-exporter server Mutual TLS feature                                                  | `false`                            |
 | `prometheusRules.enabled`                        | Enable the creation of falco-exporter PrometheusRules                                            | `false`                            |
-| `daemonset.podLabels`                            | Customized Daemonset pod labels                                                                  | `{}`
+| `daemonset.podLabels`                            | Customized Daemonset pod labels                                                                  | `{}`                               |
+| `healthChecks.livenessProbe.probesPort`          | Liveness probes port                                                                             | `19376`                            |
+| `healthChecks.readinessProbe.probesPort`         | Readiness probes port                                                                            | `19376`                            |
+| `healthChecks.livenessProbe.initialDelaySeconds` | Number of seconds before performing the first liveness probe                                     | `60`                               |
+| `healthChecks.readinessProbe.initialDelaySeconds`| Number of seconds before performing the first readiness probe                                    | `30`                               |
+| `healthChecks.livenessProbe.timeoutSeconds`      | Number of seconds after which the liveness probe times out                                       | `5`                                |
+| `healthChecks.readinessProbe.timeoutSeconds`     | Number of seconds after which the readiness probe times out                                      | `5`                                |
+| `healthChecks.livenessProbe.periodSeconds`       | Time interval in seconds to perform the liveness probe                                           | `15`                               |
+| `healthChecks.readinessProbe.periodSeconds`      | Time interval in seconds to perform the readiness probe                                          | `15`                               |
 
 Please, refer to [values.yaml](./values.yaml) for the full list of configurable parameters.
 

--- a/helmfile/upstream/falco-exporter/templates/daemonset.yaml
+++ b/helmfile/upstream/falco-exporter/templates/daemonset.yaml
@@ -59,13 +59,19 @@ spec:
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           livenessProbe:
+            initialDelaySeconds: {{ .Values.healthChecks.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.healthChecks.livenessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.healthChecks.livenessProbe.periodSeconds }}          
             httpGet:
               path: /liveness
-              port: {{ .Values.probesPort }}
+              port: {{ .Values.healthChecks.livenessProbe.probesPort }}
           readinessProbe:
+            initialDelaySeconds: {{ .Values.healthChecks.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.healthChecks.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.healthChecks.readinessProbe.periodSeconds }}
             httpGet:
               path: /readiness
-              port: {{ .Values.probesPort }}
+              port: {{ .Values.healthChecks.readinessProbe.probesPort }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/helmfile/upstream/falco-exporter/templates/grafana-dashboard.yaml
+++ b/helmfile/upstream/falco-exporter/templates/grafana-dashboard.yaml
@@ -302,6 +302,10 @@ kind: ConfigMap
 metadata:
   labels:
     grafana_dashboard: "1"
+  {{- if .Values.grafanaDashboard.folder }}
+  annotations:
+    k8s-sidecar-target-directory: /tmp/dashboards/{{ .Values.grafanaDashboard.folder }}
+  {{- end }}
   name: grafana-falco
   {{- if .Values.grafanaDashboard.namespace }}
   namespace: {{ .Values.grafanaDashboard.namespace }}

--- a/helmfile/upstream/falco-exporter/templates/podsecuritypolicy.yaml
+++ b/helmfile/upstream/falco-exporter/templates/podsecuritypolicy.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   allowPrivilegeEscalation: false
   allowedHostPaths:
-  - pathPrefix: "/var/run/falco"
+  - pathPrefix: "/run/falco"
     readOnly: true
   fsGroup:
     rule: RunAsAny

--- a/helmfile/upstream/falco-exporter/values.yaml
+++ b/helmfile/upstream/falco-exporter/values.yaml
@@ -16,13 +16,30 @@ service:
   mTLS:
     enabled: false
 
-# /readiness and /liveness probes port
-probesPort: 19376
+healthChecks:
+  livenessProbe:
+    # liveness probes port
+    probesPort: 19376
+    # -- Tells the kubelet that it should wait X seconds before performing the first probe.
+    initialDelaySeconds: 60
+    # -- Number of seconds after which the probe times out.
+    timeoutSeconds: 5
+    # -- Specifies that the kubelet should perform the check every x seconds.
+    periodSeconds: 15
+  readinessProbe:
+    # readiness probes port
+    probesPort: 19376
+    # -- Tells the kubelet that it should wait X seconds before performing the first probe.
+    initialDelaySeconds: 30
+    # -- Number of seconds after which the probe times out.
+    timeoutSeconds: 5
+    # -- Specifies that the kubelet should perform the check every x seconds.
+    periodSeconds: 15
 
 image:
   registry: docker.io
   repository: falcosecurity/falco-exporter
-  tag: 0.8.0
+  tag: 0.8.3
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -71,13 +88,14 @@ daemonset:
   podLabels: {}
 
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  privileged: false
+  seccompProfile:
+    type: RuntimeDefault
 
 resources:
   {}
@@ -113,6 +131,7 @@ serviceMonitor:
 
 grafanaDashboard:
   enabled: false
+  folder:
   namespace: default
   prometheusDatasourceName: Prometheus
 scc:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
fixes #1488 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [ ] I upgraded no Chart.
  - [x] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
