### PR TITLE
apps sc: thanos receiver out-of-order bug fix

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - Broken link in v0.30 migration instructions
+- Fixed thanos ingesting out-of-order error.
 
 ### Updated
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -601,6 +601,9 @@ thanos:
     # standalone: Single instance of receiver.
     mode: dual-mode
 
+    # Can only be used if thanos.compactor.verticalCompaction is set to true
+    outOfOrderTimeWindow: 600s
+
     # Retention for the metrics in the receiver
     tsdbRetention: 15d
 
@@ -629,6 +632,8 @@ thanos:
     retentionResolutionRaw: 30d
     retentionResolution5m: 90d
     retentionResolution1h: 0s
+
+    verticalCompaction: false
 
     # Deduplication of metrics in long term storage
     # receiverReplicas: Deduplicate results from multiple receivers, simpler dedup

--- a/helmfile/values/thanos/receiver.yaml.gotmpl
+++ b/helmfile/values/thanos/receiver.yaml.gotmpl
@@ -13,12 +13,14 @@ compactor:
   retentionResolution5m: {{ .Values.thanos.compactor.retentionResolution5m }}
   retentionResolution1h: {{ .Values.thanos.compactor.retentionResolution1h }}
 
-  {{- if eq .Values.thanos.compactor.deduplication "receiverReplicas" }}
   extraFlags:
+  {{- if eq .Values.thanos.compactor.verticalCompaction true }}
+    - --compact.enable-vertical-compaction
+  {{- end }}
+  {{- if eq .Values.thanos.compactor.deduplication "receiverReplicas" }}
     - --deduplication.func=
     - --deduplication.replica-label=replica
   {{- else if eq .Values.thanos.compactor.deduplication "prometheusReplicas" }}
-  extraFlags:
     - --deduplication.func=penalty
     - --deduplication.replica-label=replica
     - --deduplication.replica-label=prometheus_replica
@@ -44,6 +46,10 @@ receive:
 
   mode: {{ .Values.thanos.receiver.mode }}
 
+  {{- if eq .Values.thanos.compactor.verticalCompaction true }}
+  extraFlags:
+    - --tsdb.out-of-order.time-window={{ .Values.thanos.receiver.outOfOrderTimeWindow }}
+  {{- end }}
   # extraFlags:
   #   - "--receive.tenant-label-name=\"cluster\""
 


### PR DESCRIPTION
**What this PR does / why we need it**:
It fixes thanos ingesting out-of-order by making a window of time where a thanos receiver pod does not drop metrics on a restart instead so long as its within the time limit it just pick up the metrics again.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1637

**Special notes for reviewer**:
Do we want it to have a setting so that it can be enabled/disabled and or make --tsdb.out-of-order.time-window= adjustable from sc-config?

**Checklist:**
- [x] kind/bug

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
