### PR TITLE
apps sc: grafana user values file

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Grafana user values rendering was failing when whitelistRange was enabled, because of the missing of `annotations` key
+
 ### Updated
 
 - Upgraded falco-exporter chart version to `v0.9.6` and app version to `v0.8.3`

--- a/helmfile/values/grafana/grafana-user.yaml.gotmpl
+++ b/helmfile/values/grafana/grafana-user.yaml.gotmpl
@@ -2,6 +2,7 @@ adminPassword: {{ .Values.user.grafanaPassword }}
 
 ingress:
   {{ if and .Values.externalTrafficPolicy.local .Values.externalTrafficPolicy.whitelistRange.userGrafana }}
+  annotations:
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.externalTrafficPolicy.whitelistRange.userGrafana }}
   {{ end }}
   hosts:


### PR DESCRIPTION
**What this PR does / why we need it**: the user grafana values file rendering fails during apply when `whitelistRange` is enabled, because the annotations key for ingress was missing

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
