### PR TITLE
tests: test script all at once option

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Extra component versions can be added in the Welcome dashboard via config
 - Probes from WC to SC to monitor how well clusters reach each other
+- Added so `bin/ck8s test` components can be used all at once in a cluster.
 
 ### Changed
 

--- a/bin/test.bash
+++ b/bin/test.bash
@@ -38,28 +38,43 @@ test_apps_wc() {
 function sc_help() {
     printf "%s\n" "[Usage]: test sc [target] [ARGUMENTS]"
     printf "%s\n" "List of targets:"
+    printf "\t%-23s %s\n" "apps" "Apps checks"
     printf "\t%-23s %s\n" "opensearch" "Open search checks"
     printf "\t%-23s %s\n" "cert-manager" "Cert Manager checks"
     printf "\t%-23s %s\n" "ingress" "Ingress checks"
-    printf "%s\n" "[NOTE] If no target is specified, the default sc apps tests will be executed."
-    printf "%s\n" "[NOTE] Logging can be enabled for the sc apps tests by using the --logging-enabled flag."
+    printf "%s\n" "[NOTE] If no target is specified, all of them will be executed."
+    printf "%s\n" "[NOTE] Logging can be enabled for test sc and test sc apps by using the --logging-enabled flag."
 }
 
 function wc_help() {
     printf "%s\n" "[Usage]: test wc [target] [ARGUMENTS]"
     printf "%s\n" "List of targets:"
+    printf "\t%-23s %s\n" "apps" "Apps checks"
     printf "\t%-23s %s\n" "cert-manager" "Cert Manager checks"
     printf "\t%-23s %s\n" "ingress" "Ingress checks"
     printf "\t%-23s %s\n" "hnc" "HNC checks"
-    printf "%s\n" "[NOTE] If no target is specified, the default wc apps tests will be executed."
-    printf "%s\n" "[NOTE] Logging can be enabled for wc apps tests by using the --logging-enabled flag."
+    printf "%s\n" "[NOTE] If no target is specified, all of them will be executed."
+    printf "%s\n" "[NOTE] Logging can be enabled for test wc and test wc apps by using the --logging-enabled flag."
 }
 
 function sc() {
     if [[ ${#} == 0 ]] || [[ ${#} == 1 && ${1} == "--logging-enabled" ]]; then
-        test_apps_sc "${@}"
+        set +e
+        test_apps_sc "${@:1}"
+        set -e
+        log_info "Testing opensearch\n"
+        sc_opensearch_checks
+        echo
+        log_info "Testing cert-manager\n"
+        sc_cert_manager_checks
+        echo
+        log_info "Testing ingress\n"
+        sc_ingress_checks
     else
         case ${1} in
+        apps)
+            test_apps_sc "${@:2}"
+            ;;
         opensearch)
             sc_opensearch_checks "${@:2}"
             ;;
@@ -84,9 +99,23 @@ function sc() {
 
 function wc() {
     if [[ ${#} == 0 ]] || [[ ${#} == 1 && ${1} == "--logging-enabled" ]]; then
-        test_apps_wc "${@}"
+        set +e
+        test_apps_wc "${@:1}"
+        set -e
+        log_info "Testing cert-manager\n"
+        wc_cert_manager_checks
+        echo
+        log_info "Testing ingress\n"
+        wc_ingress_checks
+        echo
+        log_info "Testing hnc\n"
+        wc_hnc_checks
+
     else
         case ${1} in
+        apps)
+            test_apps_wc "${@:2}"
+            ;;
         cert-manager)
             wc_cert_manager_checks "${@:2}"
             ;;

--- a/migration/template/README.md
+++ b/migration/template/README.md
@@ -42,10 +42,6 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
     ```bash
     ./bin/ck8s test sc|wc
-    ./bin/ck8s test sc|wc cert-manager
-    ./bin/ck8s test sc|wc ingress
-    ./bin/ck8s test sc opensearch
-    ./bin/ck8s test wc hnc
     ./bin/ck8s ops kubectl sc|wc get pods -A -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-false:status.containerStatuses[*].ready,REASON:status.containerStatuses[*].state.terminated.reason | grep false | grep -v Completed
     ./bin/ck8s ops kubectl sc|wc get nodes
     ./bin/ck8s ops kubectl sc|wc get jobs -A
@@ -139,10 +135,6 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
     ```bash
     ./bin/ck8s test sc|wc
-    ./bin/ck8s test sc|wc cert-manager
-    ./bin/ck8s test sc|wc ingress
-    ./bin/ck8s test sc opensearch
-    ./bin/ck8s test wc hnc
     ./bin/ck8s ops kubectl sc|wc get pods -A -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-false:status.containerStatuses[*].ready,REASON:status.containerStatuses[*].state.terminated.reason | grep false | grep -v Completed
     ./bin/ck8s ops kubectl sc|wc get nodes
     ./bin/ck8s ops helm sc|wc list -A --all

--- a/pipeline/test/services/funcs.sh
+++ b/pipeline/test/services/funcs.sh
@@ -102,7 +102,7 @@ function resourceReplicaCompare() {
 
         if [[ "${activeResourceStatus}" == "${desiredResourceStatus}" ]]; then
             echo -e "\tready ✔"; SUCCESSES=$((SUCCESSES+1))
-            if [ -n "$LOGGING" ]; then
+            if [ "$LOGGING" == "--logging-enabled" ]; then
               writeLog "${namespace}" "${resourceName}" "Pod"
               writeLog "${namespace}" "${resourceName}" "${kind}"
               writeEvent "${namespace}" "${resourceName}" "Pod"
@@ -118,7 +118,7 @@ function resourceReplicaCompare() {
 
     echo -e "\tready ❌"; FAILURES=$((FAILURES+1))
     DEBUG_OUTPUT+=$(kubectl get "${kind}" -n "${namespace}" "${resourceName}" -o json)
-    if [ -n "$LOGGING" ]; then
+    if [  "$LOGGING" == "--logging-enabled" ]; then
       writeLog "${namespace}" "${resourceName}" "Pod"
       writeLog "${namespace}" "${resourceName}" "${kind}"
       writeEvent "${namespace}" "${resourceName}" "Pod"
@@ -138,7 +138,7 @@ function testStatefulsetStatusByPods {
         if ! kubectl wait -n "$1" --for=condition=ready pod "$POD_NAME" --timeout=60s > /dev/null; then
             echo -n -e "\tnot ready ❌"; FAILURES=$((FAILURES+1))
             DEBUG_OUTPUT+="$(kubectl get statefulset -n "$1" "$2" -o json)"
-            if [ -n "$LOGGING" ]; then
+            if [ "$LOGGING" == "--logging-enabled" ]; then
               writeLog "${1}" "${2}" "Pod"
               writeLog "${1}" "${2}" "${kind}"
               writeEvent "${1}" "${2}" "Pod"
@@ -160,7 +160,7 @@ function testJobStatus {
       echo -n -e "\tnot completed ❌"; FAILURES=$((FAILURES+1))
       DEBUG_OUTPUT+=$(kubectl get -n "$1" job "$2" -o json)
     fi
-    if [ -n "$LOGGING" ]; then
+    if [ "$LOGGING" == "--logging-enabled" ]; then
       logJob "${1}" "${2}"
     fi
 }

--- a/pipeline/test/services/service-cluster/testCertManager.sh
+++ b/pipeline/test/services/service-cluster/testCertManager.sh
@@ -21,7 +21,7 @@ function sc_cert_manager_checks() {
         check_sc_certmanager_cluster_issuers
         check_sc_certmanager_apps_certificates
         check_sc_certmanager_challenges
-        exit 0
+        return
     fi
     while [[ ${#} -gt 0 ]]; do
         case ${1} in

--- a/pipeline/test/services/service-cluster/testIngress.sh
+++ b/pipeline/test/services/service-cluster/testIngress.sh
@@ -17,7 +17,7 @@ function sc_ingress_checks() {
     if [[ ${#} == 0 ]]; then
         echo "Running all checks ..."
         check_sc_ingress_health
-        exit 0
+        return
     fi
     while [[ ${#} -gt 0 ]]; do
         case ${1} in

--- a/pipeline/test/services/service-cluster/testOpensearch.sh
+++ b/pipeline/test/services/service-cluster/testOpensearch.sh
@@ -40,7 +40,7 @@ function sc_opensearch_checks() {
         check_opensearch_ism
         check_object_store_access
         check_fluentd_connection
-        exit 0
+        return
     fi
     while [[ ${#} -gt 0 ]]; do
         case ${1} in

--- a/pipeline/test/services/service-cluster/testPodsReady.sh
+++ b/pipeline/test/services/service-cluster/testPodsReady.sh
@@ -236,7 +236,7 @@ for cronjob in "${cronjobs[@]}"; do
     namespace="${arr[0]}"
     name="${arr[1]}"
     echo -n -e "\n${name}\t"
-    if testResourceExistence cronjob "${namespace}" "${name}" && [ -n "$LOGGING" ]; then
+    if testResourceExistence cronjob "${namespace}" "${name}" && [ "$LOGGING" == "--logging-enabled" ]; then
         logCronJob "${namespace}" "${name}"
     fi
 done

--- a/pipeline/test/services/test-sc.sh
+++ b/pipeline/test/services/test-sc.sh
@@ -7,7 +7,7 @@ if [[ ! -f $1 ]];then
     exit 1
 fi
 export CONFIG_FILE=$1
-LOGGING="${2:-}"
+LOGGING="${3:-$2}"
 SUCCESSES=0
 FAILURES=0
 DEBUG_OUTPUT=("")
@@ -29,7 +29,7 @@ source "${SCRIPTS_PATH}"/service-cluster/testPrometheusTargets.sh
 echo -e "\nSuccesses: $SUCCESSES"
 echo "Failures: $FAILURES"
 
-if [ $FAILURES -gt 0 ] && [ -n "$LOGGING" ]
+if [ $FAILURES -gt 0 ] && [ "$LOGGING" == "--logging-enabled" ]
 then
     echo "Something failed"
     echo

--- a/pipeline/test/services/test-wc.sh
+++ b/pipeline/test/services/test-wc.sh
@@ -7,7 +7,7 @@ if [[ ! -f $1 ]];then
 fi
 
 export CONFIG_FILE=$1
-LOGGING="${2:-}"
+LOGGING="${3:-$2}"
 SUCCESSES=0
 FAILURES=0
 DEBUG_OUTPUT=("")
@@ -28,7 +28,7 @@ source "${SCRIPTS_PATH}"/workload-cluster/testUserRbac.sh
 echo -e "\nSuccesses: $SUCCESSES"
 echo "Failures: $FAILURES"
 
-if [ $FAILURES -gt 0 ] && [ -n "$LOGGING" ]
+if [ $FAILURES -gt 0 ] && [ "$LOGGING" == "--logging-enabled" ]
 then
     echo "Something failed"
     echo

--- a/pipeline/test/services/workload-cluster/testCertManager.sh
+++ b/pipeline/test/services/workload-cluster/testCertManager.sh
@@ -21,7 +21,7 @@ function wc_cert_manager_checks() {
         check_wc_certmanager_cluster_issuers
         check_wc_certmanager_apps_certificates
         check_wc_certmanager_challenges
-        exit 0
+        return
     fi
     while [[ ${#} -gt 0 ]]; do
         case ${1} in

--- a/pipeline/test/services/workload-cluster/testHNC.sh
+++ b/pipeline/test/services/workload-cluster/testHNC.sh
@@ -19,7 +19,7 @@ function wc_hnc_checks() {
         echo "Running all checks ..."
         check_wc_hnc_creation_removal
         check_wc_hnc_system_namespaces
-        exit 0
+        return
     fi
     while [[ ${#} -gt 0 ]]; do
         case ${1} in

--- a/pipeline/test/services/workload-cluster/testIngress.sh
+++ b/pipeline/test/services/workload-cluster/testIngress.sh
@@ -17,7 +17,7 @@ function wc_ingress_checks() {
     if [[ ${#} == 0 ]]; then
         echo "Running all checks ..."
         check_wc_ingress_health
-        exit 0
+        return
     fi
     while [[ ${#} -gt 0 ]]; do
         case ${1} in


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes it more efficient if one is going to test all components.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: fixes #1565

**Special notes for reviewer**:
Do we want the all option to be able to use the *--logging-enabled*? because thats only for one component of the many that it tests.

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] is completely transparent, will not impact the workload in any way.
  - [ ] requires running a migration script.
  - [ ] will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] requires draining and/or replacing nodes.
  - [ ] will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
  - [ ] will break the cluster.
        I.e. full cluster migration is required.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
