### PR TITLE
apps sc & wc: Increased the default proxy-buffer-size to 8k

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -13,6 +13,7 @@
 - Separated node and PV `capacityManagementAlerts` limit configuration
 - Replaced image `elastisys/curl-jq:latest` with `ghcr.io/elastisys/curl-jq:1.0.0`.
 - Only mutate pods on create to prevent them from getting stuck
+- Increased the default `proxy-buffer-size` setting in ingress-nginx to `8k`.
 
 ### Fixed
 

--- a/helmfile/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile/values/ingress-nginx.yaml.gotmpl
@@ -13,6 +13,7 @@ controller:
     disable-ipv6-dns: "true"
     proxy-body-size: "200m"
     client-body-buffer-size: "256k"
+    proxy-buffer-size: "8k"
     {{ if and .Values.externalTrafficPolicy.local .Values.externalTrafficPolicy.whitelistRange.global }}
     whitelist-source-range: {{ .Values.externalTrafficPolicy.whitelistRange.global }}
     {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it:** Increased the default proxy-buffer-size to 8k to fix the `502 Gateway error`

<!-- use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged-->
**Which issue this PR fixes:** fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer:**

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The pods logs do not show any errors
- Network Policy checks:
  - [x] The `NetworkPolicy Dashboard` doesn't show any dropped packages
- Gatekeeper PSPs checks:
  - [x] Gatekeeper PSPs do not block the pods from starting after the change
- Falco checks:
  - [x] No Falco alerts are generated by the change
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] Is completely transparent, will not impact the workload in any way.
  - [ ] Requires running a migration script.
  - [ ] Will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] Will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
