### PR TITLE
apps: separate capacity alert limits for pv

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Moved `rclone-sync` from `kube-system` to its own namespace.
 - Moved all the kube-prometheus-stack Grafana dashboards to `grafana-dashboards` chart
+- Separated node and PV `capacityManagementAlerts` limit configuration
 
 ### Fixed
 

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -352,6 +352,9 @@ prometheus:
   capacityManagementAlerts:
     enabled: true
     disklimit: 75
+    persistentVolume:
+      enabled: true
+      limit: 75
     usagelimit: 95
     ## for each cpu and memory add the node pattern for which you want to create an alert
     requestlimit:

--- a/helmfile/charts/prometheus-alerts/templates/alerts/cluster-capacity-management-alerts.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/alerts/cluster-capacity-management-alerts.yaml
@@ -33,13 +33,15 @@ spec:
       for: 1h
       labels:
         severity: warning
-    - alert: PersistentVolume{{.Values.capacityManagementAlertsDiskLimit}}PercentInThreeDays
+    {{- if .Values.capacityManagementAlertsPersistentVolumeEnabled }}
+    - alert: PersistentVolume{{.Values.capacityManagementAlertsPersistentVolumeLimit}}PercentInThreeDays
       annotations:
-        message: The PersistentVolume claimed by {{`{{ $labels.persistentvolumeclaim }}`}} in Namespace {{`{{ $labels.namespace }}`}} will go over {{.Values.capacityManagementAlertsDiskLimit}} in three days.
-      expr: predict_linear(kubelet_volume_stats_available_bytes[24h], 3*24*60*60) <= (kubelet_volume_stats_capacity_bytes*(1-{{ .Values.capacityManagementAlertsDiskLimit }}/100))
+        message: The PersistentVolume claimed by {{`{{ $labels.persistentvolumeclaim }}`}} in Namespace {{`{{ $labels.namespace }}`}} will go over {{.Values.capacityManagementAlertsPersistentVolumeLimit}} in three days.
+      expr: predict_linear(kubelet_volume_stats_available_bytes[24h], 3*24*60*60) <= (kubelet_volume_stats_capacity_bytes*(1-{{ .Values.capacityManagementAlertsPersistentVolumeLimit }}/100))
       for: 5m
       labels:
         severity: warning
+    {{- end }}
     - alert: Memory{{.Values.capacityManagementAlertsUsageLimit}}PercentInThreeDays
       annotations:
         message: Memory usage in Cluster {{`{{ $labels.cluster }}`}} Instance {{`{{ $labels.instance }}`}} is predicted to go over {{.Values.capacityManagementAlertsUsageLimit}}% within the next 3 days at current use rate.

--- a/helmfile/values/prometheus-alerts-sc.yaml.gotmpl
+++ b/helmfile/values/prometheus-alerts-sc.yaml.gotmpl
@@ -41,6 +41,8 @@ defaultRules:
       evaluate_prometheus: "1"
   {{- end }}
 
+capacityManagementAlertsPersistentVolumeEnabled: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.enabled }}
+capacityManagementAlertsPersistentVolumeLimit: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.limit }}
 capacityManagementAlertsDiskLimit: {{ .Values.prometheus.capacityManagementAlerts.disklimit }}
 capacityManagementAlertsUsageLimit: {{ .Values.prometheus.capacityManagementAlerts.usagelimit }}
 capacityManagementAlertsRequestLimit: {{ toYaml .Values.prometheus.capacityManagementAlerts.requestlimit | nindent 2 }}

--- a/helmfile/values/prometheus-user-alerts-wc.yaml.gotmpl
+++ b/helmfile/values/prometheus-user-alerts-wc.yaml.gotmpl
@@ -23,6 +23,8 @@ defaultRules:
     capacityManagementAlerts: {{ .Values.prometheus.capacityManagementAlerts.enabled }}
     networkpolicies: {{ .Values.networkPolicies.enableAlerting }}
 
+capacityManagementAlertsPersistentVolumeEnabled: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.enabled }}
+capacityManagementAlertsPersistentVolumeLimit: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.limit }}
 capacityManagementAlertsDiskLimit: {{ .Values.prometheus.capacityManagementAlerts.disklimit }}
 capacityManagementAlertsUsageLimit: {{ .Values.prometheus.capacityManagementAlerts.usagelimit }}
 capacityManagementAlertsRequestLimit:

--- a/migration/v0.33/README.md
+++ b/migration/v0.33/README.md
@@ -108,6 +108,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
   ./migration/v0.33/prepare/07-move-to-common-for-cross-cluster-probe.sh
   ```
 
+1. Check if `.prometheus.capacityManagementAlerts.disklimit` needs to be copied:
+
+    ```bash
+    ./migration/v0.33/prepare/10-copy-capacity-alert-disklimit.sh
+    ```
+
 1. Update apps configuration:
 
     This will take a backup into `backups/` before modifying any files.

--- a/migration/v0.33/prepare/10-copy-capacity-alert-disklimit.sh
+++ b/migration/v0.33/prepare/10-copy-capacity-alert-disklimit.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+log_info "- checking if .prometheus.capacityManagementAlerts.disklimit needs to be copied"
+
+yq_copy common .prometheus.capacityManagementAlerts.disklimit .prometheus.capacityManagementAlerts.persistentVolume.limit
+yq_copy sc .prometheus.capacityManagementAlerts.disklimit .prometheus.capacityManagementAlerts.persistentVolume.limit
+yq_copy wc .prometheus.capacityManagementAlerts.disklimit .prometheus.capacityManagementAlerts.persistentVolume.limit


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR separates limit configurations for node disk and PVC capacity alerts, as well as allowing PVC capacity alerts to be disabled.

_Reason:_ When using NFS and the [nfs-provisioner](https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner) for provisioning Persistent Volumes, the metrics used for measuring PVCs shows the total capacity & usage of the entire NFS volume instead of the capacity of each PVC. As a result, we'd like to be able to turn off PVC capacity notifications and handle them individually.

<!-- use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged-->
**Which issue this PR fixes:** fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer:**

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Metrics checks:
  - [X] The metrics are still exposed and present in Grafana after the change
  - [X] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [X] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [X] The pods logs do not show any errors
- Network Policy checks:
  - [X] The `NetworkPolicy Dashboard` doesn't show any dropped packages
- Gatekeeper PSPs checks:
  - [X] Gatekeeper PSPs do not block the pods from starting after the change
- Falco checks:
  - [X] No Falco alerts are generated by the change
- Is this changeset backwards compatible for existing clusters? Applying:
  - [X] Is completely transparent, will not impact the workload in any way.
  - [X] Requires running a migration script.
  - [ ] Will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] Will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
- Chart checklist (pick exactly one):
  - [X] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
