### PR TITLE
apps sc: rclone sync changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         exclude: ^helmfile/upstream/|^CHANGELOG.md$|^WIP-CHANGELOG.md$|^helmfile/charts/grafana-dashboards/files/welcome.md$|^helmfile/charts/opensearch/configurer/files/dashboards-resources/welcome.md$|^images/elasticsearch-curator/README.md
         args:
           - -r
-          - ~MD013,~MD024,~MD026,~MD028,~MD034
+          - ~MD013,~MD024,~MD026,~MD028,~MD034,~MD033
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.4

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -18,6 +18,7 @@
 - Only mutate pods on create to prevent them from getting stuck
 - Increased the default `proxy-buffer-size` setting in ingress-nginx to `8k`.
 - The Grafana dashboard for Harbor to show the total number of artifacts and storage used per project
+- If sync is enabled and swift is used for Harbor or Thanos then the sync job will automatically use swift
 
 ### Fixed
 

--- a/bin/update-ips.bash
+++ b/bin/update-ips.bash
@@ -394,6 +394,8 @@ fi
 ## Add destination object storage ips for rclone sync to sc config
 if [ "$(yq_dig 'sc' '.objectStorage.sync.enabled' 'false')" == "true" ]; then
     if [ "$(yq_dig 'sc' '.networkPolicies.rcloneSync.enabled' 'false')" == "true" ]; then
+        check_harbor="$(yq_dig 'sc' '.harbor.persistence.type' 'false')"
+        check_thanos="$(yq_dig 'sc' '.thanos.objectStorage.type' 'false')"
         destination=$(yq4 '.objectStorage.sync.buckets.[].destinationType' "${config["override_sc"]}")
         destinationSwift=false
         destinationS3=false
@@ -404,6 +406,10 @@ if [ "$(yq_dig 'sc' '.objectStorage.sync.enabled' 'false')" == "true" ]; then
             destinationS3=true
           fi
         done
+        if [ "$check_harbor" == "swift" ] || [ "$check_thanos" == "swift" ]; then
+            destinationSwift=true
+        fi
+
         ifNull=""
         S3_ENDPOINT_DST="$(yq_dig 'sc' '.objectStorage.sync.s3.regionEndpoint' "" | sed 's/https\?:\/\///' | sed 's/[:\/].*//')"
         S3_PORT_DST="$(yq_dig 'sc' '.objectStorage.sync.s3.regionEndpoint' "" | sed 's/https\?:\/\///' | sed 's/[A-Za-z.0-9-]*:\?//' | sed 's/\/.*//')"
@@ -411,7 +417,7 @@ if [ "$(yq_dig 'sc' '.objectStorage.sync.enabled' 'false')" == "true" ]; then
         SWIFT_ENDPOINT_DST="$(yq_dig 'sc' '.objectStorage.sync.swift.authUrl' "" | sed 's/https\?:\/\///' | sed 's/[:\/].*//')"
         SWIFT_PORT_DST="$(yq_dig 'sc' '.objectStorage.sync.swift.authUrl' "" | sed 's/https\?:\/\///' | sed 's/[A-Za-z.0-9-]*:\?//' | sed 's/\/.*//')"
 
-        if { [ "$destinationS3" == "true" ] && [ "$destinationSwift" != "true" ]; } || { [ "$destinationS3" != "true" ] && [ "$destinationSwift" != "true" ] && [ "$(yq_dig 'sc' '.objectStorage.sync.type' 's3')" == "s3" ]; }; then
+        if { [ "$destinationS3" == "true" ] && [ "$destinationSwift" != "true" ]; } || { [ "$destinationS3" != "true" ] && [ "$destinationSwift" != "true" ] && [ "$(yq_dig 'sc' '.objectStorage.sync.destinationType' 's3')" == "s3" ]; }; then
             if [ -z "${S3_ENDPOINT_DST}" ]; then
                 log_error "No destination S3 endpoint for rclone sync found, check your sc-config.yaml"
                 exit 1
@@ -435,7 +441,7 @@ if [ "$(yq_dig 'sc' '.objectStorage.sync.enabled' 'false')" == "true" ]; then
             fi
             ifNull=true
         fi
-        if { [ "$destinationSwift" == "true" ] && [ "$destinationS3" != "true" ]; } || { [ "$destinationS3" != "true" ] && [ "$destinationSwift" != "true" ] && [ "$(yq_dig 'sc' '.objectStorage.sync.type' 'swift')" == "swift" ]; }; then
+        if { [ "$destinationSwift" == "true" ] && [ "$destinationS3" != "true" ]; } || { [ "$destinationS3" != "true" ] && [ "$destinationSwift" != "true" ] && [ "$(yq_dig 'sc' '.objectStorage.sync.desinationType' 'swift')" == "swift" ]; }; then
             if [ -z "${SWIFT_ENDPOINT_DST}" ]; then
                 log_error "No destination Swift endpoint for rclone sync found, check your sc-config.yaml"
                 exit 1
@@ -460,9 +466,8 @@ if [ "$(yq_dig 'sc' '.objectStorage.sync.enabled' 'false')" == "true" ]; then
             checkIfDiffAndUpdateDNSIPs "${SWIFT_ENDPOINT_DST}" ".networkPolicies.rcloneSync.destinationObjectStorageSwift.ips" "${config["override_sc"]}"
             checkIfDiffAndUpdatePorts ".networkPolicies.rcloneSync.destinationObjectStorageSwift.ports" "${config["override_sc"]}" "$SWIFT_PORT_DST"
             ifNull=true
-
         fi
-        if { [ "$destinationSwift" == "true" ] && [ "$destinationS3" == "true" ]; } || [ -z "$ifNull" ] && { [ "$(yq_dig 'sc' '.objectStorage.sync.type' 'swift')" == "swift" ] || [ "$(yq_dig 'sc' '.objectStorage.sync.type' 's3')" == "s3" ]; }; then
+        if { [ "$destinationSwift" == "true" ] && [ "$destinationS3" == "true" ]; } || [ -z "$ifNull" ] && { [ "$(yq_dig 'sc' '.objectStorage.sync.destinationType' 'swift')" == "swift" ] || [ "$(yq_dig 'sc' '.objectStorage.sync.destinationType' 's3')" == "s3" ]; }; then
             if [ -z "${S3_ENDPOINT_DST}" ]; then
                 log_error "No destination S3 endpoint for rclone sync found, check your sc-config.yaml"
                 exit 1

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -1248,7 +1248,7 @@ networkPolicies:
         - 443
     destinationObjectStorageSwift:
       ips:
-        - "set-me-if-objectStorage.sync.enabled-type-is-swift-or-habor-thanos-use-swift"
+        - "set-me-if-objectStorage.sync.enabled-type-is-swift-or-harbor-thanos-use-swift"
       ports:
         - 5000
     secondaryUrl:

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -32,8 +32,8 @@ objectStorage:
     enabled: false
     # dryrun: false
 
-    ## Options are 's3 and swift'. If Harbor or Thanos are using swift then we will automatically use swift for the sync, regardless of the value set for type.
-    #
+    ## Only 's3' is currently supported for `.objectStorage.sync.destinationType` as not all default buckets applications have swift support.
+    ## If Harbor or Thanos are using swift then we will automatically use swift for the sync, regardless of the value set for type.
     destinationType: s3
     # secondaryUrl: set-me if regionEndpoint and or authUrl does not have all the relevant ips and or ports used for rclone-sync networkpolicy.
     # s3:

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -32,8 +32,9 @@ objectStorage:
     enabled: false
     # dryrun: false
 
-    ## Options are 's3 and swift'
-    type: none
+    ## Options are 's3 and swift'. If Harbor or Thanos are using swift then we will automatically use swift for the sync, regardless of the value set for type.
+    #
+    destinationType: s3
     # secondaryUrl: set-me if regionEndpoint and or authUrl does not have all the relevant ips and or ports used for rclone-sync networkpolicy.
     # s3:
     #   region: set-me
@@ -45,6 +46,7 @@ objectStorage:
     # swift:
     #   authUrl: set-me
     #   region: set-me
+    #   projectName: set-me
     ## Sync all buckets under 'objectStorage.buckets'
     ## These will be appended to 'buckets' using the same name from source as destination, and the default schedule.
     syncDefaultBuckets: false
@@ -1141,17 +1143,19 @@ welcomingDashboard:
 networkPolicies:
   global:
     objectStorageSwift:
-      ips: [] # - set-me-if-enabled
-      ports: [] # - set-me-if-enabled
+      ips:
+        - "set-me-if-enabled"
+      ports:
+        - 5000
     scApiserver:
       # usually private ip of control-plane nodes
       ips:
-        - set-me
+        - "set-me"
       port: 6443
     scNodes:
       # ip of all nodes in the cluster for internal communication
       ips:
-        - set-me
+        - "set-me"
   harbor:
     enabled: true
     # For replication, added to core and jobservice
@@ -1238,14 +1242,20 @@ networkPolicies:
   rcloneSync:
     enabled: true
     destinationObjectStorageS3:
-      ips: [] # - "set-me-if-objectStorage.sync.enabled-and-type-is-s3"
-      ports: [] # - 443
+      ips:
+        - "set-me-if-objectStorage.sync.enabled-and-type-is-s3"
+      ports:
+        - 443
     destinationObjectStorageSwift:
-      ips: [] # - "set-me-if-objectStorage.sync.enabled-and-type-is-swift"
-      ports: [] # - 443
+      ips:
+        - "set-me-if-objectStorage.sync.enabled-type-is-swift-or-habor-thanos-use-swift"
+      ports:
+        - 5000
     secondaryUrl:
-      ips: [] # - "set-me-if-secondaryUrl-has-a-url"
-      ports: [] # - 443
+      ips:
+        - "set-me-if-secondaryUrl-has-an-url"
+      ports:
+        - 443
   s3Exporter:
     enabled: true
 
@@ -1260,7 +1270,7 @@ networkPolicies:
   ingressNginx:
     ingressOverride:
       ips:
-      - set-me-if-enabled
+        - "set-me-if-enabled"
   dex:
     enabled: true
     # Ip to connector, e.g. Google, LDAP, ...

--- a/config/secrets/sc-secrets.yaml
+++ b/config/secrets/sc-secrets.yaml
@@ -18,8 +18,10 @@ objectStorage: {}
   #     accessKey: "set-me"
   #     secretKey: "set-me"
   #   swift:
-  #     applicationCredentialID: "set-me"
+  #     applicationCredentialID: "set-me" #  application credentials are preferred over username and password, but both are currently supported
   #     applicationCredentialSecret: "set-me"
+  #     username: "set-me"
+  #     password: "set-me"
   #   encrypt:
   #     password: "set-me" # generate with `pwgen 32 1`
   #     salt: "set-me" # generate with `pwgen 32 1`

--- a/helmfile/charts/networkpolicy/service-cluster/templates/rclone-sync.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/rclone-sync.yaml
@@ -16,25 +16,14 @@ spec:
           protocol: UDP
         - port: 53
           protocol: TCP
-    {{- if and .Values.rcloneSync.sourceObjectStorage.ips .Values.rcloneSync.sourceObjectStorage.ports }}
+    {{- if and .Values.rcloneSync.objectStorage.ips .Values.rcloneSync.objectStorage.ports }}
     - to:
-        {{- range .Values.rcloneSync.sourceObjectStorage.ips | uniq }}
+        {{- range .Values.rcloneSync.objectStorage.ips | uniq }}
         - ipBlock:
             cidr: {{ . }}
         {{- end }}
       ports:
-        {{- range .Values.rcloneSync.sourceObjectStorage.ports | uniq }}
-        - port: {{ . }}
-        {{- end }}
-    {{- end }}
-    {{- if and .Values.rcloneSync.destinationObjectStorage.ips .Values.rcloneSync.destinationObjectStorage.ports }}
-    - to:
-        {{- range .Values.rcloneSync.destinationObjectStorage.ips | uniq }}
-        - ipBlock:
-            cidr: {{ . }}
-        {{- end }}
-      ports:
-        {{- range .Values.rcloneSync.destinationObjectStorage.ports | uniq }}
+        {{- range .Values.rcloneSync.objectStorage.ports | uniq }}
         - port: {{ . }}
         {{- end }}
     {{- end }}

--- a/helmfile/charts/networkpolicy/service-cluster/templates/rclone-sync.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/rclone-sync.yaml
@@ -16,14 +16,14 @@ spec:
           protocol: UDP
         - port: 53
           protocol: TCP
-    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
+    {{- if and .Values.rcloneSync.sourceObjectStorage.ips .Values.rcloneSync.sourceObjectStorage.ports }}
     - to:
-        {{- range .Values.global.objectStorage.ips | uniq }}
+        {{- range .Values.rcloneSync.sourceObjectStorage.ips | uniq }}
         - ipBlock:
             cidr: {{ . }}
         {{- end }}
       ports:
-        {{- range .Values.global.objectStorage.ports | uniq }}
+        {{- range .Values.rcloneSync.sourceObjectStorage.ports | uniq }}
         - port: {{ . }}
         {{- end }}
     {{- end }}

--- a/helmfile/charts/rclone-sync/files/rclone.conf
+++ b/helmfile/charts/rclone-sync/files/rclone.conf
@@ -12,10 +12,16 @@ v2_auth = {{ .s3.v2Auth | default false }}
 {{- end }}
 
 {{- if eq .type "swift" }}
+{{- if and (get .swift "applicationCredentialID") (get .swift "applicationCredentialSecret") }}
 application_credential_id = {{ .swift.applicationCredentialID }}
 application_credential_secret = {{ .swift.applicationCredentialSecret }}
+{{- else }}
+user = {{.swift.username }}
+key = {{.swift.password }}
+{{- end }}
 auth = {{ .swift.authUrl }}
 region = {{ .swift.region }}
+tenant = {{ .swift.tenant }}
 {{- end }}
 {{- end }}
 
@@ -24,7 +30,7 @@ region = {{ .swift.region }}
 
 [{{ $.Values.config.encrypt.name }}-{{ .destination }}]
 type = crypt
-remote = {{ $.Values.config.destination.name }}:{{ .destination }}
+remote = dest-{{ .destinationType }}:{{ .destination }}
 password = {{ $.Values.config.encrypt.password }}
 password2 = {{ $.Values.config.encrypt.salt }}
 {{- if not $.Values.config.encrypt.directoryNames }}

--- a/helmfile/values/networkpolicy/service-cluster.yaml.gotmpl
+++ b/helmfile/values/networkpolicy/service-cluster.yaml.gotmpl
@@ -1,3 +1,20 @@
+{{ $sourceSwift := "" }}
+{{ $destinationSwift := "" }}
+
+{{- range .Values.objectStorage.sync.buckets }}
+  {{- if hasKey . "sourceType" }}
+  {{- if eq .sourceType "swift" }}
+  {{ $sourceSwift = "true" }}
+  {{- end }}
+  {{- end }}
+
+  {{- if hasKey . "destinationType" }}
+  {{- if eq .destinationType "swift" }}
+  {{ $destinationSwift = "true" }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+
 global:
   scApiserver:
     ips: {{- toYaml .Values.networkPolicies.global.scApiserver.ips | nindent 6 }}
@@ -9,12 +26,6 @@ global:
   wcIngress:
     ips: {{- toYaml .Values.networkPolicies.global.wcIngress.ips | nindent 6 }}
   objectStorage:
-  {{ $sourceSwift := "" }}
-  {{- range .Values.objectStorage.sync.buckets }}
-  {{- if or (eq (get "sourceType" "" .) "swift") (and (ne (get "sourceType" "" .) "s3") (eq $.Values.objectStorage.type "swift") ) }}
-  {{ $sourceSwift = "true" }}
-  {{- end }}
-  {{- end }}
     ips:
       {{- toYaml .Values.networkPolicies.global.objectStorage.ips | nindent 6 }}
       {{- if and (or (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") ($sourceSwift)) (.Values.networkPolicies.global.objectStorageSwift.ips) }}
@@ -79,7 +90,7 @@ rcloneSync:
       {{- if eq .Values.objectStorage.sync.destinationType "s3" }}
       {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorageS3.ips | nindent 6 }}
       {{- end }}
-      {{- if or (eq .Values.objectStorage.sync.destinationType "swift") (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") }}
+      {{- if or (eq .Values.objectStorage.sync.destinationType "swift") (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") ($destinationSwift) }}
       {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorageSwift.ips | nindent 6 }}
       {{- end }}
       {{- if hasKey .Values.objectStorage.sync "secondaryUrl" }}
@@ -89,7 +100,7 @@ rcloneSync:
       {{- if eq .Values.objectStorage.sync.destinationType "s3" }}
       {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorageS3.ports | nindent 6 }}
       {{- end }}
-      {{- if or (eq .Values.objectStorage.sync.destinationType "swift") (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") }}
+      {{- if or (eq .Values.objectStorage.sync.destinationType "swift") (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") ($destinationSwift) }}
       {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorageSwift.ports | nindent 6 }}
       {{- end }}
       {{- if hasKey .Values.objectStorage.sync "secondaryUrl" }}

--- a/helmfile/values/networkpolicy/service-cluster.yaml.gotmpl
+++ b/helmfile/values/networkpolicy/service-cluster.yaml.gotmpl
@@ -68,49 +68,77 @@ fluentd:
 
 rcloneSync:
   enabled: {{ and .Values.objectStorage.sync.enabled .Values.networkPolicies.rcloneSync.enabled }}
-{{ $sourceSwift := "" }}
-{{ $destinationSwift := "" }}
 
-{{- range .Values.objectStorage.sync.buckets }}
-  {{- if hasKey . "sourceType" }}
-  {{- if eq .sourceType "swift" }}
-  {{ $sourceSwift = "true" }}
-  {{- end }}
+  {{ $sourceS3 := "" }}
+  {{ $sourceSwift := "" }}
+  {{ $destinationS3 := "" }}
+  {{ $destinationSwift := "" }}
+
+  {{- if or (eq .Values.thanos.objectStorage.type "swift") (eq .Values.harbor.persistence.type "swift") }}
+    {{ $sourceSwift = "true" }}
+    {{ $destinationSwift = "true" }}
   {{- end }}
 
-  {{- if hasKey . "destinationType" }}
-  {{- if eq .destinationType "swift" }}
-  {{ $destinationSwift = "true" }}
+  {{- if .Values.objectStorage.sync.syncDefaultBuckets }}
+    {{- if eq .Values.objectStorage.type "s3" }}
+    {{ $sourceS3 = "true" }}
+    {{- end }}
+    {{- if eq $.Values.objectStorage.sync.destinationType "s3" }}
+    {{ $destinationS3 := "true" }}
+    {{- else if eq $.Values.objectStorage.sync.destinationType "swift" }}
+    {{ $sourceSwift = "true" }}
+    {{- end }}
+  {{- end }}
+
+  {{- if .Values.objectStorage.sync.buckets }}
+  {{- range .Values.objectStorage.sync.buckets }}
+    {{- if not (hasKey . "sourceType") }}
+    {{- $_ := set . "sourceType" $.Values.objectStorage.type }}
+    {{- end }}
+    {{- if eq .sourceType "s3" }}
+    {{ $sourceS3 = "true" }}
+    {{- else if eq .sourceType "swift" }}
+    {{ $sourceSwift = "true" }}
+    {{- end }}
+
+    {{- if not (hasKey . "destinationType") }}
+    {{- $_ := set . "destinationType" $.Values.objectStorage.sync.destinationType }}
+    {{- end }}
+    {{- if eq .destinationType "s3" }}
+    {{ $destinationS3 = "true" }}
+    {{- else if eq .destinationType "swift" }}
+    {{ $destinationSwift = "true" }}
+    {{- end }}
   {{- end }}
   {{- end }}
-{{- end }}
-  sourceObjectStorage:
+  objectStorage:
     ips:
+      {{- if $sourceS3 }}
       {{- toYaml .Values.networkPolicies.global.objectStorage.ips | nindent 6 }}
-      {{- if or (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") ($sourceSwift) }}
+      {{- end }}
+      {{- if $sourceSwift }}
       {{- toYaml .Values.networkPolicies.global.objectStorageSwift.ips | nindent 6 }}
       {{- end }}
-    ports:
-      {{- toYaml .Values.networkPolicies.global.objectStorage.ports | nindent 6 }}
-      {{- if or (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") ($sourceSwift) }}
-      {{- toYaml .Values.networkPolicies.global.objectStorageSwift.ports | nindent 6 }}
-      {{- end }}
-  destinationObjectStorage:
-    ips:
-      {{- if eq .Values.objectStorage.sync.destinationType "s3" }}
+      {{- if $destinationS3 }}
       {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorageS3.ips | nindent 6 }}
       {{- end }}
-      {{- if or (eq .Values.objectStorage.sync.destinationType "swift") (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") ($destinationSwift) }}
+      {{- if $destinationSwift }}
       {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorageSwift.ips | nindent 6 }}
       {{- end }}
       {{- if hasKey .Values.objectStorage.sync "secondaryUrl" }}
       {{- toYaml .Values.networkPolicies.rcloneSync.secondaryUrl.ips | nindent 6 }}
       {{- end }}
     ports:
-      {{- if eq .Values.objectStorage.sync.destinationType "s3" }}
+      {{- if $sourceS3 }}
+      {{- toYaml .Values.networkPolicies.global.objectStorage.ports | nindent 6 }}
+      {{- end }}
+      {{- if $sourceSwift }}
+      {{- toYaml .Values.networkPolicies.global.objectStorageSwift.ports | nindent 6 }}
+      {{- end }}
+      {{- if $destinationS3 }}
       {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorageS3.ports | nindent 6 }}
       {{- end }}
-      {{- if or (eq .Values.objectStorage.sync.destinationType "swift") (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") ($destinationSwift) }}
+      {{- if $destinationSwift }}
       {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorageSwift.ports | nindent 6 }}
       {{- end }}
       {{- if hasKey .Values.objectStorage.sync "secondaryUrl" }}

--- a/helmfile/values/networkpolicy/service-cluster.yaml.gotmpl
+++ b/helmfile/values/networkpolicy/service-cluster.yaml.gotmpl
@@ -74,7 +74,6 @@ fluentd:
 
 rcloneSync:
   enabled: {{ and .Values.objectStorage.sync.enabled .Values.networkPolicies.rcloneSync.enabled }}
-  {{- if and .Values.objectStorage.sync.enabled .Values.networkPolicies.rcloneSync.enabled }}
   destinationObjectStorage:
     ips:
       {{- if eq .Values.objectStorage.sync.destinationType "s3" }}

--- a/helmfile/values/networkpolicy/service-cluster.yaml.gotmpl
+++ b/helmfile/values/networkpolicy/service-cluster.yaml.gotmpl
@@ -1,20 +1,3 @@
-{{ $sourceSwift := "" }}
-{{ $destinationSwift := "" }}
-
-{{- range .Values.objectStorage.sync.buckets }}
-  {{- if hasKey . "sourceType" }}
-  {{- if eq .sourceType "swift" }}
-  {{ $sourceSwift = "true" }}
-  {{- end }}
-  {{- end }}
-
-  {{- if hasKey . "destinationType" }}
-  {{- if eq .destinationType "swift" }}
-  {{ $destinationSwift = "true" }}
-  {{- end }}
-  {{- end }}
-{{- end }}
-
 global:
   scApiserver:
     ips: {{- toYaml .Values.networkPolicies.global.scApiserver.ips | nindent 6 }}
@@ -28,12 +11,12 @@ global:
   objectStorage:
     ips:
       {{- toYaml .Values.networkPolicies.global.objectStorage.ips | nindent 6 }}
-      {{- if and (or (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") ($sourceSwift)) (.Values.networkPolicies.global.objectStorageSwift.ips) }}
+      {{- if and (or (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift")) (.Values.networkPolicies.global.objectStorageSwift.ips) }}
       {{- toYaml .Values.networkPolicies.global.objectStorageSwift.ips | nindent 6 }}
       {{- end }}
     ports:
       {{- toYaml .Values.networkPolicies.global.objectStorage.ports | nindent 6 }}
-      {{- if and (or (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") ($sourceSwift)) (.Values.networkPolicies.global.objectStorageSwift.ports) }}
+      {{- if and (or (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift")) (.Values.networkPolicies.global.objectStorageSwift.ports) }}
       {{- toYaml .Values.networkPolicies.global.objectStorageSwift.ports | nindent 6 }}
       {{- end }}
   externalLoadBalancer: {{ .Values.networkPolicies.global.externalLoadBalancer }}
@@ -85,6 +68,33 @@ fluentd:
 
 rcloneSync:
   enabled: {{ and .Values.objectStorage.sync.enabled .Values.networkPolicies.rcloneSync.enabled }}
+{{ $sourceSwift := "" }}
+{{ $destinationSwift := "" }}
+
+{{- range .Values.objectStorage.sync.buckets }}
+  {{- if hasKey . "sourceType" }}
+  {{- if eq .sourceType "swift" }}
+  {{ $sourceSwift = "true" }}
+  {{- end }}
+  {{- end }}
+
+  {{- if hasKey . "destinationType" }}
+  {{- if eq .destinationType "swift" }}
+  {{ $destinationSwift = "true" }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+  sourceObjectStorage:
+    ips:
+      {{- toYaml .Values.networkPolicies.global.objectStorage.ips | nindent 6 }}
+      {{- if or (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") ($sourceSwift) }}
+      {{- toYaml .Values.networkPolicies.global.objectStorageSwift.ips | nindent 6 }}
+      {{- end }}
+    ports:
+      {{- toYaml .Values.networkPolicies.global.objectStorage.ports | nindent 6 }}
+      {{- if or (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") ($sourceSwift) }}
+      {{- toYaml .Values.networkPolicies.global.objectStorageSwift.ports | nindent 6 }}
+      {{- end }}
   destinationObjectStorage:
     ips:
       {{- if eq .Values.objectStorage.sync.destinationType "s3" }}

--- a/helmfile/values/networkpolicy/service-cluster.yaml.gotmpl
+++ b/helmfile/values/networkpolicy/service-cluster.yaml.gotmpl
@@ -77,26 +77,25 @@ rcloneSync:
   {{- if and .Values.objectStorage.sync.enabled .Values.networkPolicies.rcloneSync.enabled }}
   destinationObjectStorage:
     ips:
-      {{- if and (hasKey .Values.objectStorage.sync.s3 "regionEndpoint" ) (.Values.objectStorage.sync.s3.regionEndpoint) (.Values.networkPolicies.rcloneSync.destinationObjectStorageS3.ips) }}
+      {{- if eq .Values.objectStorage.sync.destinationType "s3" }}
       {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorageS3.ips | nindent 6 }}
       {{- end }}
-      {{- if and (hasKey .Values.objectStorage.sync.swift "authUrl" ) (.Values.objectStorage.sync.swift.authUrl) (.Values.networkPolicies.rcloneSync.destinationObjectStorageSwift.ips) }}
+      {{- if or (eq .Values.objectStorage.sync.destinationType "swift") (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") }}
       {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorageSwift.ips | nindent 6 }}
       {{- end }}
-      {{- if and (hasKey .Values.objectStorage.sync "secondaryUrl" ) (.Values.objectStorage.sync.secondaryUrl) (.Values.networkPolicies.rcloneSync.secondaryUrl.ips) }}
+      {{- if hasKey .Values.objectStorage.sync "secondaryUrl" }}
       {{- toYaml .Values.networkPolicies.rcloneSync.secondaryUrl.ips | nindent 6 }}
       {{- end }}
     ports:
-      {{- if and (hasKey .Values.objectStorage.sync.s3 "regionEndpoint" ) (.Values.objectStorage.sync.s3.regionEndpoint) (.Values.networkPolicies.rcloneSync.destinationObjectStorageS3.ports) }}
+      {{- if eq .Values.objectStorage.sync.destinationType "s3" }}
       {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorageS3.ports | nindent 6 }}
       {{- end }}
-      {{- if and (hasKey .Values.objectStorage.sync.swift "authUrl" ) (.Values.objectStorage.sync.swift.authUrl) (.Values.networkPolicies.rcloneSync.destinationObjectStorageSwift.ports) }}
+      {{- if or (eq .Values.objectStorage.sync.destinationType "swift") (eq .Values.harbor.persistence.type "swift") (eq .Values.thanos.objectStorage.type "swift") }}
       {{- toYaml .Values.networkPolicies.rcloneSync.destinationObjectStorageSwift.ports | nindent 6 }}
       {{- end }}
-      {{- if and (hasKey .Values.objectStorage.sync "secondaryUrl" ) (.Values.objectStorage.sync.secondaryUrl) (.Values.networkPolicies.rcloneSync.secondaryUrl.ports) }}
+      {{- if hasKey .Values.objectStorage.sync "secondaryUrl" }}
       {{- toYaml .Values.networkPolicies.rcloneSync.secondaryUrl.ports | nindent 6 }}
       {{- end }}
-  {{- end }}
 
 s3Exporter:
   enabled: {{ and (eq .Values.objectStorage.type "s3") (and .Values.s3Exporter.enabled .Values.networkPolicies.s3Exporter.enabled) }}

--- a/helmfile/values/rclone-sync.yaml.gotmpl
+++ b/helmfile/values/rclone-sync.yaml.gotmpl
@@ -98,7 +98,7 @@ config:
       {{- end }}
   {{- end }}
 
-  {{- if or $destinationSwift ($.Values.objectStorage.sync.destinationType "swift") }}
+  {{- if or $destinationSwift (eq $.Values.objectStorage.sync.destinationType "swift") }}
   {{- $swift := .Values.objectStorage.sync | getOrNil "swift" | required "Swift destination enabled for rclone but not configured!" }}
   - name: dest-swift
     type: swift

--- a/helmfile/values/rclone-sync.yaml.gotmpl
+++ b/helmfile/values/rclone-sync.yaml.gotmpl
@@ -1,10 +1,6 @@
-{{- range .Values.objectStorage.sync.buckets }}
-{{- if or (and (ne (get "sourceType" "s3" .) "s3") (ne (get "sourceType" "swift" .) "swift") ) (and (ne $.Values.objectStorage.type "s3") (ne $.Values.objectStorage.type "swift") ) }}
-{{- fail "rclone-sync only supports using s3 and swift on source ends" }}
-{{- end }}
-{{- if or (and (ne (get "destinationType" "s3" .) "s3") (ne (get "destinationType" "swift" .) "swift") ) (and (ne $.Values.objectStorage.sync.type "s3") (ne $.Values.objectStorage.sync.type "swift") ) }}
-{{- fail "rclone-sync only supports using s3 and swift on destination ends" }}
-{{- end }}
+{{- $valid := list "s3" "swift" }}
+{{- if not (and (eq $.Values.objectStorage.type "s3") (has $.Values.objectStorage.sync.destinationType $valid)) }}
+{{- fail "rclone-sync only supports using s3 and swift for source and destination" }}
 {{- end }}
 
 {{- if not (or .Values.objectStorage.sync.syncDefaultBuckets .Values.objectStorage.sync.buckets) }}
@@ -20,23 +16,43 @@ config:
 {{ $sourceSwift := "" }}
 {{ $destinationS3 := "" }}
 {{ $destinationSwift := "" }}
+{{ $swiftEnabled := list }}
+
+{{- if eq .Values.thanos.objectStorage.type "swift" }}
+  {{ $swiftEnabled = append $swiftEnabled .Values.objectStorage.buckets.thanos }}
+  {{ $sourceSwift = "true" }}
+  {{ $destinationSwift = "true" }}
+{{- end }}
+{{- if eq .Values.harbor.persistence.type "swift" }}
+  {{ $swiftEnabled = append $swiftEnabled .Values.objectStorage.buckets.harbor }}
+  {{ $sourceSwift = "true" }}
+  {{ $destinationSwift = "true" }}
+{{- end }}
 
 {{- range .Values.objectStorage.sync.buckets }}
-{{- if or (eq (get "sourceType" "" .) "s3") (and (ne (get "sourceType" "" .) "swift") (eq $.Values.objectStorage.type "s3") ) }}
-{{ $sourceS3 = "true" }}
-{{- else if or (eq (get "sourceType" "" .) "swift") (and (ne (get "sourceType" "" .) "s3") (eq $.Values.objectStorage.type "swift") ) }}
-{{ $sourceSwift = "true" }}
-{{- end }}
+  {{- if hasKey . "sourceType" }}
+  {{- if eq .sourceType "s3" }}
+  {{ $sourceS3 = "true" }}
+  {{- else if eq .sourceType "swift" }}
+  {{ $sourceSwift = "true" }}
+  {{- else }}
+  {{- fail "rclone-sync custom buckets only support s3 and swift for sourceType" }}
+  {{- end }}
+  {{- end }}
 
-{{- if or (eq (get "destinationType" "" .) "s3") (and (ne (get "destinationType" "" .) "swift") (eq $.Values.objectStorage.sync.type "s3") ) }}
-{{ $destinationS3 = "true" }}
-{{- else if or (eq (get "destinationType" "" .) "swift") (and (ne (get "destinationType" "" .) "s3") (eq $.Values.objectStorage.sync.type "swift") ) }}
-{{ $destinationSwift = "true" }}
-{{- end }}
+  {{- if hasKey . "destinationType" }}
+  {{- if eq .destinationType "s3" }}
+  {{ $destinationS3 = "true" }}
+  {{- else if eq .destinationType "swift" }}
+  {{ $destinationSwift = "true" }}
+  {{- else }}
+  {{- fail "rclone-sync custom buckets only support s3 and swift for destinationType" }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 
   source:
-  {{- if $sourceS3 }}
+  {{- if or $sourceS3 (eq $.Values.objectStorage.type "s3") }}
   - name: src-s3
     type: s3
     s3:
@@ -51,17 +67,24 @@ config:
   {{- end }}
 
   {{- if $sourceSwift }}
+  {{- $swift := .Values.objectStorage | getOrNil "swift" | required "Swift source enabled for rclone but not configured!" }}
   - name: src-swift
     type: swift
     swift:
-      applicationCredentialID: {{ .Values.objectStorage.swift.applicationCredentialID }}
-      applicationCredentialSecret: {{ .Values.objectStorage.swift.applicationCredentialSecret }}
-      authUrl: {{ .Values.objectStorage.swift.authUrl }}
-      region: {{ .Values.objectStorage.swift.region }}
+      {{- if getOrNil "applicationCredentialID" $swift }}
+      applicationCredentialID: {{ $swift.applicationCredentialID }}
+      applicationCredentialSecret: {{ $swift.applicationCredentialSecret }}
+      {{- else }}
+      username: {{ $swift.username | quote }}
+      password: {{ $swift.password | quote }}
+      {{- end }}
+      authUrl: {{ $swift.authUrl }}
+      region: {{ $swift.region }}
+      tenant: {{ $swift.projectName }}
   {{- end }}
 
   destination:
-  {{- if $destinationS3 }}
+  {{- if or $destinationS3 (eq $.Values.objectStorage.sync.destinationType "s3") }}
   - name: dest-s3
     type: s3
     s3:
@@ -70,9 +93,26 @@ config:
       region: {{ .Values.objectStorage.sync.s3.region }}
       regionEndpoint: {{ .Values.objectStorage.sync.s3.regionEndpoint }}
       forcePathStyle: {{ .Values.objectStorage.sync.s3.forcePathStyle }}
-    {{- if hasKey .Values.objectStorage.sync.s3 "v2Auth" }}
+      {{- if hasKey .Values.objectStorage.sync.s3 "v2Auth" }}
       v2Auth: {{ .Values.objectStorage.sync.s3.v2Auth }}
-    {{- end }}
+      {{- end }}
+  {{- end }}
+
+  {{- if or $destinationSwift ($.Values.objectStorage.sync.destinationType "swift") }}
+  {{- $swift := .Values.objectStorage.sync | getOrNil "swift" | required "Swift destination enabled for rclone but not configured!" }}
+  - name: dest-swift
+    type: swift
+    swift:
+      {{- if getOrNil "applicationCredentialID" $swift }}
+      applicationCredentialID: {{ $swift.applicationCredentialID }}
+      applicationCredentialSecret: {{ $swift.applicationCredentialSecret }}
+      {{- else }}
+      username: {{ $swift.username | quote }}
+      password: {{ $swift.password | quote }}
+      {{- end }}
+      authUrl: {{ $swift.authUrl }}
+      region: {{ $swift.region }}
+      tenant: {{ $swift.projectName }}
   {{- end }}
   {{- if $destinationSwift }}
   - name: dest-swift
@@ -101,8 +141,17 @@ defaultSchedule: {{ .Values.objectStorage.sync.defaultSchedule }}
 buckets:
 {{- if .Values.objectStorage.sync.syncDefaultBuckets }}
   {{- range (values .Values.objectStorage.buckets | sortAlpha) }}
+  {{- if has . $swiftEnabled }}
   - source: {{ . }}
     destination: {{ . }}
+    sourceType: swift
+    destinationType: swift
+  {{- else }}
+  - source: {{ . }}
+    destination: {{ . }}
+    sourceType: {{ $.Values.objectStorage.type }}
+    destinationType: {{ $.Values.objectStorage.sync.destinationType }}
+  {{- end }}
   {{- end }}
 {{- end }}
 {{- if .Values.objectStorage.sync.buckets }}
@@ -117,7 +166,7 @@ buckets:
     schedule: {{ .schedule | quote }}
     {{- end }}
     sourceType: {{ . | dig "sourceType" $.Values.objectStorage.type }}
-    destinationType: {{ . | dig "destinationType" $.Values.objectStorage.sync.type }}
+    destinationType: {{ . | dig "destinationType" $.Values.objectStorage.sync.destinationType }}
   {{- end }}
 {{- end }}
 

--- a/helmfile/values/rclone-sync.yaml.gotmpl
+++ b/helmfile/values/rclone-sync.yaml.gotmpl
@@ -29,8 +29,21 @@ config:
   {{ $destinationSwift = "true" }}
 {{- end }}
 
+{{- if .Values.objectStorage.sync.syncDefaultBuckets }}
+  {{- if eq .Values.objectStorage.type "s3" }}
+  {{ $sourceS3 = "true" }}
+  {{- end }}
+  {{- if eq $.Values.objectStorage.sync.destinationType "s3" }}
+  {{ $destinationS3 = "true" }}
+  {{- else if eq $.Values.objectStorage.sync.destinationType "swift" }}
+  {{ $destinationSwift = "true" }}
+  {{- end }}
+{{- end }}
+
 {{- range .Values.objectStorage.sync.buckets }}
-  {{- if hasKey . "sourceType" }}
+  {{- if not (hasKey . "sourceType") }}
+  {{- $_ := set . "sourceType" $.Values.objectStorage.type }}
+  {{- end }}
   {{- if eq .sourceType "s3" }}
   {{ $sourceS3 = "true" }}
   {{- else if eq .sourceType "swift" }}
@@ -38,9 +51,10 @@ config:
   {{- else }}
   {{- fail "rclone-sync custom buckets only support s3 and swift for sourceType" }}
   {{- end }}
-  {{- end }}
 
-  {{- if hasKey . "destinationType" }}
+  {{- if not (hasKey . "destinationType") }}
+  {{- $_ := set . "destinationType" $.Values.objectStorage.sync.destinationType }}
+  {{- end }}
   {{- if eq .destinationType "s3" }}
   {{ $destinationS3 = "true" }}
   {{- else if eq .destinationType "swift" }}
@@ -48,11 +62,10 @@ config:
   {{- else }}
   {{- fail "rclone-sync custom buckets only support s3 and swift for destinationType" }}
   {{- end }}
-  {{- end }}
 {{- end }}
 
   source:
-  {{- if or $sourceS3 (eq $.Values.objectStorage.type "s3") }}
+  {{- if $sourceS3 }}
   - name: src-s3
     type: s3
     s3:
@@ -84,7 +97,7 @@ config:
   {{- end }}
 
   destination:
-  {{- if or $destinationS3 (eq $.Values.objectStorage.sync.destinationType "s3") }}
+  {{- if $destinationS3 }}
   - name: dest-s3
     type: s3
     s3:
@@ -98,7 +111,7 @@ config:
       {{- end }}
   {{- end }}
 
-  {{- if or $destinationSwift (eq $.Values.objectStorage.sync.destinationType "swift") }}
+  {{- if $destinationSwift }}
   {{- $swift := .Values.objectStorage.sync | getOrNil "swift" | required "Swift destination enabled for rclone but not configured!" }}
   - name: dest-swift
     type: swift

--- a/helmfile/values/rclone-sync.yaml.gotmpl
+++ b/helmfile/values/rclone-sync.yaml.gotmpl
@@ -114,15 +114,6 @@ config:
       region: {{ $swift.region }}
       tenant: {{ $swift.projectName }}
   {{- end }}
-  {{- if $destinationSwift }}
-  - name: dest-swift
-    type: swift
-    swift:
-      applicationCredentialID: {{ .Values.objectStorage.sync.swift.applicationCredentialID }}
-      applicationCredentialSecret: {{ .Values.objectStorage.sync.swift.applicationCredentialSecret }}
-      authUrl: {{ .Values.objectStorage.sync.swift.authUrl }}
-      region: {{ .Values.objectStorage.sync.swift.region }}
-  {{- end }}
 
   encrypt:
   {{- if .Values.objectStorage.sync.encrypt.enabled }}

--- a/migration/v0.32/README.md
+++ b/migration/v0.32/README.md
@@ -48,8 +48,8 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
     sops ${CK8S_CONFIG_PATH}/secrets.yaml
 
-    objectStorage.swift.applicationCredentialID
-    objectStorage.swift.applicationCredentialSecret
+    # set objectStorage.swift.applicationCredentialID in secrets.yaml
+    # set objectStorage.swift.applicationCredentialSecret in secrets.yaml
     ```
 
     </details>
@@ -64,8 +64,8 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
     sops ${CK8S_CONFIG_PATH}/secrets.yaml
 
-    objectStorage.sync.swift.applicationCredentialID
-    objectStorage.sync.swift.applicationCredentialSecret
+    # set objectStorage.sync.swift.applicationCredentialID in secrets.yaml
+    # set objectStorage.sync.swift.applicationCredentialSecret in secrets.yaml
     ```
 
     </details>

--- a/migration/v0.32/README.md
+++ b/migration/v0.32/README.md
@@ -36,12 +36,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
 ## Prerequisites
 
-- If `.objectStorage.sync.enabled: true` and `.thanos.objectStorage.type: swift` or `.harbor.persistence.type: swift` then the rclone jobs will automatically use swift for source and destination buckets. You will need to create the application credentials for swift and add them into the `secrets.yaml`:
+- If `.objectStorage.sync.enabled: true` and `.thanos.objectStorage.type: swift` or `.harbor.persistence.type: swift` then the rclone jobs will automatically use swift for Thanos and/or Harbor source and destination buckets. You will need to create the application credentials for swift and add them into the `secrets.yaml`:
 
     <details><summary>Create source application credentials</summary>
 
     ```bash
-    source ${CK8S_CONFIG_PATH}/openrc.sh
+    source ${CK8S_CONFIG_PATH}/<source-openrc>.sh
     source <(sops -d ${CK8S_CONFIG_PATH}/secret/<source-env-openstack-user>.sh)
 
     openstack application credential create <env-name>-swift
@@ -57,7 +57,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     <details><summary>Create destination application credentials</summary>
 
     ```bash
-    source ${CK8S_CONFIG_PATH}/openrc.sh
+    source ${CK8S_CONFIG_PATH}/<destination-openrc>.sh
     source <(sops -d ${CK8S_CONFIG_PATH}/secret/<destination-env-openstack-user>.sh)
 
     openstack application credential create <env-name>-swift

--- a/migration/v0.32/README.md
+++ b/migration/v0.32/README.md
@@ -36,6 +36,40 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
 ## Prerequisites
 
+- If `.objectStorage.sync.enabled: true` and `.thanos.objectStorage.type: swift` or `.harbor.persistence.type: swift` then the rclone jobs will automatically use swift for source and destination buckets. You will need to create the application credentials for swift and add them into the `secrets.yaml`:
+
+    <details><summary>Create source application credentials</summary>
+
+    ```bash
+    source ${CK8S_CONFIG_PATH}/openrc.sh
+    source <(sops -d ${CK8S_CONFIG_PATH}/secret/<source-env-openstack-user>.sh)
+
+    openstack application credential create <env-name>-swift
+
+    sops ${CK8S_CONFIG_PATH}/secrets.yaml
+
+    objectStorage.swift.applicationCredentialID
+    objectStorage.swift.applicationCredentialSecret
+    ```
+
+    </details>
+
+    <details><summary>Create destination application credentials</summary>
+
+    ```bash
+    source ${CK8S_CONFIG_PATH}/openrc.sh
+    source <(sops -d ${CK8S_CONFIG_PATH}/secret/<destination-env-openstack-user>.sh)
+
+    openstack application credential create <env-name>-swift
+
+    sops ${CK8S_CONFIG_PATH}/secrets.yaml
+
+    objectStorage.sync.swift.applicationCredentialID
+    objectStorage.sync.swift.applicationCredentialSecret
+    ```
+
+    </details>
+
 - [ ] Notify the users (if any) before the upgrade starts;
 - [ ] Check if there are any pending changes to the environment;
 - [ ] Check the state of the environment, pods, nodes and backup jobs:
@@ -102,6 +136,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
     ```bash
     ./migration/v0.32/prepare/10-thanos-distrib-memory-limit.sh
+    ```
+
+1. Rename the key `.objectStorage.sync.type` to `objectStorage.sync.destinationType`
+
+    ```bash
+    ./migration/v0.32/prepare/20-sync-type-new-key-name.sh
     ```
 
 1. Update rclone sync networkPolicy name:

--- a/migration/v0.32/README.md
+++ b/migration/v0.32/README.md
@@ -36,7 +36,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
 ## Prerequisites
 
-- If `.objectStorage.sync.enabled: true` and `.thanos.objectStorage.type: swift` or `.harbor.persistence.type: swift` then the rclone jobs will automatically use swift for Thanos and/or Harbor source and destination buckets. You will need to create the application credentials for swift and add them into the `secrets.yaml`:
+- If `.objectStorage.sync.enabled: true` and `.objectStorage.sync.syncDefaultBuckets: true` and `.thanos.objectStorage.type: swift` or `.harbor.persistence.type: swift` then the rclone jobs will automatically use swift for Thanos and/or Harbor source and destination buckets. You will need to create the application credentials for swift and add them into the `secrets.yaml`:
 
     <details><summary>Create source application credentials</summary>
 

--- a/migration/v0.32/prepare/20-sync-type-new-key-name.sh
+++ b/migration/v0.32/prepare/20-sync-type-new-key-name.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+log_info " - move .sync.type to .sync.destinationType"
+yq_move sc .objectStorage.sync.type .objectStorage.sync.destinationType

--- a/migration/v0.33/README.md
+++ b/migration/v0.33/README.md
@@ -36,6 +36,40 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
 ## Prerequisites
 
+- If `.objectStorage.sync.enabled: true` and `.objectStorage.sync.syncDefaultBuckets: true` and `.thanos.objectStorage.type: swift` or `.harbor.persistence.type: swift` then the rclone jobs will automatically use swift for Thanos and/or Harbor source and destination buckets. You will need to create the application credentials for swift and add them into the `secrets.yaml`:
+
+    <details><summary>Create source application credentials</summary>
+
+    ```bash
+    source ${CK8S_CONFIG_PATH}/<source-openrc>.sh
+    source <(sops -d ${CK8S_CONFIG_PATH}/secret/<source-env-openstack-user>.sh)
+
+    openstack application credential create <env-name>-swift
+
+    sops ${CK8S_CONFIG_PATH}/secrets.yaml
+
+    # set objectStorage.swift.applicationCredentialID in secrets.yaml
+    # set objectStorage.swift.applicationCredentialSecret in secrets.yaml
+    ```
+
+    </details>
+
+    <details><summary>Create destination application credentials</summary>
+
+    ```bash
+    source ${CK8S_CONFIG_PATH}/<destination-openrc>.sh
+    source <(sops -d ${CK8S_CONFIG_PATH}/secret/<destination-env-openstack-user>.sh)
+
+    openstack application credential create <env-name>-swift
+
+    sops ${CK8S_CONFIG_PATH}/secrets.yaml
+
+    # set objectStorage.sync.swift.applicationCredentialID in secrets.yaml
+    # set objectStorage.sync.swift.applicationCredentialSecret in secrets.yaml
+    ```
+
+    </details>
+
 > [!WARNING]
 > Any `rclone-sync` job running during the upgrade will be terminated
 
@@ -112,6 +146,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
     ```bash
     ./migration/v0.33/prepare/10-copy-capacity-alert-disklimit.sh
+    ```
+
+1. Rename the key `.objectStorage.sync.type` to `objectStorage.sync.destinationType`
+
+    ```bash
+    ./migration/v0.33/prepare/20-sync-type-new-key-name.sh
     ```
 
 1. Update apps configuration:

--- a/migration/v0.33/prepare/20-sync-type-new-key-name.sh
+++ b/migration/v0.33/prepare/20-sync-type-new-key-name.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+log_info " - move .sync.type to .sync.destinationType"
+yq_move sc .objectStorage.sync.type .objectStorage.sync.destinationType

--- a/scripts/migration/lib.sh
+++ b/scripts/migration/lib.sh
@@ -129,6 +129,19 @@ config_validate() {
           pass="false"
       fi
     done
+
+    sync_enabled=$(yq4 '.objectStorage.sync.enabled' <<< "${CONFIG["${1}"]}")
+    if [[ "${1}" = "sc" ]] && [[ "${sync_enabled}" = "true" ]]; then
+      log_info "checking sync swift"
+
+      check_harbor="$(yq4 '.harbor.persistence.type' <<< "${CONFIG["${1}"]}")"
+      check_thanos="$(yq4 '.thanos.objectStorage.type' <<< "${CONFIG["${1}"]}")"
+      check_sync_swift="$(yq4 '.objectStorage.sync.swift' <<< "${CONFIG["${1}"]}")"
+
+      if { [[ "${check_harbor}" = "swift" ]] || [[ "${check_thanos}" = "swift" ]]; } && [[ "${check_sync_swift}" = "null" ]]; then
+        log_error "error: swift is enabled for Harbor/Thanos, but .objectStorage.sync is missing swift configuration"
+      fi
+    fi
     ;;
 
   *)

--- a/scripts/migration/lib.sh
+++ b/scripts/migration/lib.sh
@@ -131,7 +131,8 @@ config_validate() {
     done
 
     sync_enabled=$(yq4 '.objectStorage.sync.enabled' <<< "${CONFIG["${1}"]}")
-    if [[ "${1}" = "sc" ]] && [[ "${sync_enabled}" = "true" ]]; then
+    sync_default_enabled=$(yq4 '.objectStorage.sync.syncDefaultBuckets' <<< "${CONFIG["${1}"]}")
+    if [[ "${1}" = "sc" ]] && [[ "${sync_enabled}" = "true" ]] && [[ "${sync_default_enabled}" = "true" ]]; then
       log_info "checking sync swift"
 
       check_harbor="$(yq4 '.harbor.persistence.type' <<< "${CONFIG["${1}"]}")"


### PR DESCRIPTION
**What this PR does / why we need it:** rcone sync config apply to the default buckets and enable rclone sync with swift if swift is anebled

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [x] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The pods logs do not show any errors
- Network Policy checks:
  - [ ] The `NetworkPolicy Dashboard` doesn't show any dropped packages
- Gatekeeper PSPs checks:
  - [ ] Gatekeeper PSPs do not block the pods from starting after the change
- Falco checks:
  - [ ] No Falco alerts are generated by the change
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] Is completely transparent, will not impact the workload in any way.
  - [x] Requires running a migration script.
  - [ ] Will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] Will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
- Chart checklist (pick exactly one):
  - [ ] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [x] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
