### PR TITLE
Crssnd/grafana expose additional configs

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added so `bin/ck8s test` components can be used all at once in a cluster.
 - Alerts for Harbor
 - The possibility to configure plugins and additional datasources for Grafana
+- The possibility to add or overwrite `grafana.ini` configuration
 
 ### Changed
 

--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -6,6 +6,7 @@
 - Probes from WC to SC to monitor how well clusters reach each other
 - Added so `bin/ck8s test` components can be used all at once in a cluster.
 - Alerts for Harbor
+- The possibility to configure plugins and additional datasources for Grafana
 
 ### Changed
 

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -86,12 +86,12 @@ falco:
     hostPort: http://alertmanager-operated.monitoring:9093
 
 grafana:
-  ops:
+  ops: &grafanadefaults
     # subdomain moved to common-config
     resources:
       requests:
         cpu: 50m
-        memory: 60Mi
+        memory: 80Mi
       limits:
         cpu: 100m
         memory: 160Mi
@@ -101,9 +101,9 @@ grafana:
     oidc:
       enabled: true
       userGroups:
-        grafanaAdmin: grafana_admin   # maps to grafana role admin
-        grafanaEditor: grafana_editor # maps to grafana role editor
-        grafanaViewer: grafana_viewer # maps to grafana role viewer
+        grafanaAdmin: grafana_admin    # maps to grafana role admin
+        grafanaEditor: grafana_editor  # maps to grafana role editor
+        grafanaViewer: grafana_viewer  # maps to grafana role viewer
       scopes: openid profile email groups
       allowedDomains:
         - set-me
@@ -117,38 +117,18 @@ grafana:
         limits:
           cpu: 50m
           memory: 100Mi
+    plugins: []  # this will require adding the correct IP/range and port to .networkPolicies.monitoring.grafana.externalDashboardProvider
+    # if the datasource require a secrets, you can set that in secrets.yaml under .grafana.{ops|user}.envRenderSecret
+    # the correct IP/range and port should be added to .networkPolicies.monitoring.grafana.externalDataSources
+    additionalDatasources: {}
+    additionalConfigValues: {}
+    # additionalConfigValues: |-
+    #   dataproxy:
+    #     timeout: 600
   user:
     enabled: true
     # subdomain moved to common-config
-    resources:
-      limits:
-        cpu: 100m
-        memory: 160Mi
-      requests:
-        cpu: 50m
-        memory: 80Mi
-    tolerations: []
-    affinity: {}
-    nodeSelector: {}
-    oidc:
-      scopes: profile email openid groups
-      userGroups:
-        grafanaAdmin: grafana_admin   # maps to grafana role admin
-        grafanaEditor: grafana_editor # maps to grafana role editor
-        grafanaViewer: grafana_viewer # maps to grafana role viewer
-      allowedDomains:
-        - set-me
-        - example.com
-    viewersCanEdit: true
-    trailingDots: true
-    sidecar:
-      resources:
-        requests:
-          cpu: 10m
-          memory: 80Mi
-        limits:
-          cpu: 50m
-          memory: 100Mi
+    <<: *grafanadefaults
 
 harbor:
   # the enabled property moved to common-config

--- a/config/secrets/sc-secrets.yaml
+++ b/config/secrets/sc-secrets.yaml
@@ -29,6 +29,10 @@ grafana:
   password: somelongsecret
   clientSecret: somelongsecret
   opsClientSecret: somelongsecret
+  ops:
+    envRenderSecret: []
+  user:
+    envRenderSecret: []
 harbor:
   password: somelongsecret
   clientSecret: somelongsecret

--- a/helmfile/values/grafana/grafana-ops.yaml.gotmpl
+++ b/helmfile/values/grafana/grafana-ops.yaml.gotmpl
@@ -116,6 +116,9 @@ grafana.ini:
     {{- end }}
   users:
     viewers_can_edit: {{ .Values.grafana.ops.viewersCanEdit }}
+  {{- if .Values.grafana.ops.additionalConfigValues }}
+  {{ .Values.grafana.ops.additionalConfigValues | nindent 2 }}
+  {{- end }}
 
 resources: {{- toYaml .Values.grafana.ops.resources | nindent 4 }}
 tolerations: {{- toYaml .Values.grafana.ops.tolerations | nindent 4 }}

--- a/helmfile/values/grafana/grafana-ops.yaml.gotmpl
+++ b/helmfile/values/grafana/grafana-ops.yaml.gotmpl
@@ -20,10 +20,21 @@ sidecar:
     labelValue: "" # should be set to "" to load all dashboards, regardless of the label value
   resources: {{- toYaml .Values.grafana.ops.sidecar.resources | nindent 6 }}
 
+{{- if .Values.grafana.ops.envRenderSecret }}
+envRenderSecret: {{- toYaml .Values.grafana.ops.envRenderSecret | nindent 2 }}
+{{- end }}
+
+{{- if .Values.grafana.ops.plugins }}
+plugins: {{- toYaml .Values.grafana.ops.plugins | nindent 2 }}
+{{- end }}
+
 datasources:
   datasources.yaml:
     apiVersion: 1
     datasources:
+    {{- if .Values.grafana.ops.additionalDatasources }}
+    {{- toYaml .Values.grafana.ops.additionalDatasources | nindent 4 }}
+    {{- end }}
     - name: prometheus-sc
       access: proxy
       basicAuth: false

--- a/helmfile/values/grafana/grafana-user.yaml.gotmpl
+++ b/helmfile/values/grafana/grafana-user.yaml.gotmpl
@@ -21,10 +21,21 @@ sidecar:
     labelValue: "1"
   resources: {{- toYaml .Values.grafana.user.sidecar.resources | nindent 6 }}
 
+{{- if .Values.grafana.user.envRenderSecret }}
+envRenderSecret: {{- toYaml .Values.grafana.user.envRenderSecret | nindent 2 }}
+{{- end }}
+
+{{- if .Values.grafana.user.plugins }}
+plugins: {{- toYaml .Values.grafana.user.plugins | nindent 2 }}
+{{- end }}
+
 datasources:
   datasources.yaml:
     apiVersion: 1
     datasources:
+    {{- if .Values.grafana.user.additionalDatasources }}
+    {{- toYaml .Values.grafana.user.additionalDatasources | nindent 4 }}
+    {{- end }}
     {{- if and .Values.thanos.enabled .Values.thanos.query.enabled }}
     - name: "Service Cluster"
       access: proxy

--- a/helmfile/values/grafana/grafana-user.yaml.gotmpl
+++ b/helmfile/values/grafana/grafana-user.yaml.gotmpl
@@ -112,6 +112,9 @@ grafana.ini:
     viewers_can_edit: {{ .Values.grafana.user.viewersCanEdit }}
   dashboards:
     default_home_dashboard_path: /tmp/dashboards/welcome-dashboard.json
+  {{- if .Values.grafana.user.additionalConfigValues }}
+  {{ .Values.grafana.user.additionalConfigValues | nindent 2 }}
+  {{- end }}
 
 # Velero backup
 


### PR DESCRIPTION
**What this PR does / why we need it:** to add the possibility to add plugins, datasources and additional configs in Grafana

**Special notes for reviewer:**
- I do not know if I should create a separate netpol key for the plugins, now it is shared with `externalDashboardProvider`

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The pods logs do not show any errors
- Network Policy checks:
  - [x] The `NetworkPolicy Dashboard` doesn't show any dropped packages
- Gatekeeper PSPs checks:
  - [x] Gatekeeper PSPs do not block the pods from starting after the change
- Falco checks:
  - [x] No Falco alerts are generated by the change
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] Is completely transparent, will not impact the workload in any way.
  - [ ] Requires running a migration script.
  - [ ] Will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] Will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
