### PR TITLE
apps sc & wc: Fixed the csi-upcloud networkpolicy template

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Refer to Grafana, OpenSearch and Harbor as Web Portals in Grafana and OpenSearch welcome dashboards
+- Fixed the `csi-upcloud` Network Policy template.
 
 ### Updated
 

--- a/helmfile/charts/networkpolicy/common/templates/kube-system/csi-upcloud.yaml
+++ b/helmfile/charts/networkpolicy/common/templates/kube-system/csi-upcloud.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.kubeSystem.enabled }}
+{{- if and .Values.kubeSystem.enabled .Values.kubeSystem.upcloud.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:


### PR DESCRIPTION
**What this PR does / why we need it:** During DR exercise we found there is upcloud cs-controller netpols in the cluera environment. This fixes the issue .
Before:
```
NAME                                  POD-SELECTOR                            AGE
allow-coredns                         k8s-app=kube-dns                        41d
allow-csi-cinder-controller-plugin    app=csi-cinder-controllerplugin         41d
allow-csi-upcloud-controller-plugin   app=csi-upcloud-controller              41d
allow-dns-autoscaler                  k8s-app=dns-autoscaler                  41d
allow-metrics-server                  app.kubernetes.io/name=metrics-server   41d
allow-snapshot-controller             app=snapshot-controller                 41d

```
After:

```
NAME                                 POD-SELECTOR                            AGE
allow-coredns                        k8s-app=kube-dns                        41d
allow-csi-cinder-controller-plugin   app=csi-cinder-controllerplugin         41d
allow-dns-autoscaler                 k8s-app=dns-autoscaler                  41d
allow-metrics-server                 app.kubernetes.io/name=metrics-server   41d
allow-snapshot-controller            app=snapshot-controller                 41d
```

<!-- use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged-->
**Which issue this PR fixes:** fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer:**

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The pods logs do not show any errors
- Network Policy checks:
  - [x] The `NetworkPolicy Dashboard` doesn't show any dropped packages
- Gatekeeper PSPs checks:
  - [ ] Gatekeeper PSPs do not block the pods from starting after the change
- Falco checks:
  - [ ] No Falco alerts are generated by the change
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] Is completely transparent, will not impact the workload in any way.
  - [ ] Requires running a migration script.
  - [ ] Will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] Will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
