### PR TITLE
apps:Replace elastisys/curl-jq:latest

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -11,6 +11,7 @@
 - Moved `rclone-sync` from `kube-system` to its own namespace.
 - Moved all the kube-prometheus-stack Grafana dashboards to `grafana-dashboards` chart
 - Separated node and PV `capacityManagementAlerts` limit configuration
+- Replaced image `elastisys/curl-jq:latest` with `ghcr.io/elastisys/curl-jq:1.0.0`.
 
 ### Fixed
 

--- a/helmfile/charts/harbor/init-harbor/templates/init-harbor-job.yaml
+++ b/helmfile/charts/harbor/init-harbor/templates/init-harbor-job.yaml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: run
-          image: elastisys/curl-jq:latest
+          image: ghcr.io/elastisys/curl-jq:1.0.0
           command: ['/bin/sh', '/scripts/init-harbor.sh']
           env:
             - name: ENDPOINT

--- a/helmfile/charts/opensearch/configurer/values.yaml
+++ b/helmfile/charts/opensearch/configurer/values.yaml
@@ -1,5 +1,5 @@
 
-image: elastisys/curl-jq:latest
+image: ghcr.io/elastisys/curl-jq:1.0.0
 
 dashboard:
   ck8sVersion: ""

--- a/helmfile/values/falco/falco-common.yaml.gotmpl
+++ b/helmfile/values/falco/falco-common.yaml.gotmpl
@@ -82,7 +82,7 @@ customRules:
             docker.io/bitnami/fluentd,
             docker.io/bitnami/kubectl,
             docker.io/elastisys/calico-accountant,
-            docker.io/elastisys/curl-jq,
+            ghcr.io/elastisys/curl-jq,
             docker.io/library/rabbitmq,
             docker.io/openpolicyagent/gatekeeper,
             docker.io/openpolicyagent/gatekeeper-crds,
@@ -210,7 +210,7 @@ customRules:
     - macro: user_known_package_manager_in_container
       condition: (
           container.image.repository in (
-            docker.io/elastisys/curl-jq,
+            ghcr.io/elastisys/curl-jq,
             ghcr.io/elastisys/fluentd,
             registry.k8s.io/dns/k8s-dns-node-cache
           ) or
@@ -268,7 +268,7 @@ customRules:
             registry.k8s.io/kube-proxy,
             registry.opensource.zalan.do/acid/spilo-14
           ) or (
-            container.image.repository=docker.io/elastisys/curl-jq and k8s.pod.name startswith opensearch-
+            container.image.repository=ghcr.io/elastisys/curl-jq and k8s.pod.name startswith opensearch-
           )
         )
     - macro: allowed_clear_log_files

--- a/helmfile/values/opensearch/common.yaml.gotmpl
+++ b/helmfile/values/opensearch/common.yaml.gotmpl
@@ -108,7 +108,7 @@ extraEnvs:
 # However this relies on the unsafe sysctl to be allowed in kubelet, which it is not by default.
 extraInitContainers:
   - name: init-sysctl
-    image: elastisys/curl-jq:latest
+    image: ghcr.io/elastisys/curl-jq:1.0.0
     command:
       - sysctl
       - -w


### PR DESCRIPTION
**What this PR does / why we need it:**

<!-- use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged-->
**Which issue this PR fixes:** fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer:**

**Add a screenshot or an example to illustrate the proposed solution:**

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The pods logs do not show any errors
- Network Policy checks:
  - [ ] The `NetworkPolicy Dashboard` doesn't show any dropped packages
- Gatekeeper PSPs checks:
  - [ ] Gatekeeper PSPs do not block the pods from starting after the change
- Falco checks:
  - [ ] No Falco alerts are generated by the change
- Is this changeset backwards compatible for existing clusters? Applying:
  - [ ] Is completely transparent, will not impact the workload in any way.
  - [ ] Requires running a migration script.
  - [ ] Will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] Will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).

**Pipeline config** *(if applicable)*
If you change some config options (e.g. add/rename variable or change the default value) you may need to update the config used by the pipeline in `pipeline/config`.

<!--
Here are the commit prefixes and comments on when to use them:
all: (things that touch on more than one of the areas below, or don't fit any of them)
apps: (changes to the applications running in both/all clusters)
apps sc: (changes to applications in the service cluster)
apps wc: (changes to applications in the workload cluster)
docs: (documentation)
tests: (test related changes)
pipeline: (the pipeline)
config: (configuration, e.g. add/remove/rename a parameter, this is not for changes to the default values for an application that would go into `apps [sc/wc]`)
bin: (changes to binaries or scripts used manage ck8s)
release: (anything release related)

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
