### PR TITLE
Make deployment of Opensearch optional

### DIFF
--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -495,6 +495,7 @@ thanos:
       username: thanos
 
 opensearch:
+  enabled: true
   subdomain: opensearch
 
   indexPerNamespace: false

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -685,8 +685,6 @@ thanos:
     type: ""
 
 opensearch:
-  enabled: true
-
   # 'subdomain' and 'indexPerNamespace' is set in common-config.yaml
 
   clusterName: opensearch

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -685,6 +685,8 @@ thanos:
     type: ""
 
 opensearch:
+  enabled: true
+
   # 'subdomain' and 'indexPerNamespace' is set in common-config.yaml
 
   clusterName: opensearch

--- a/helmfile/14-podsecuritypolicies.yaml
+++ b/helmfile/14-podsecuritypolicies.yaml
@@ -92,6 +92,7 @@ releases:
       psp: opensearch
     chart: ./charts/gatekeeper/podsecuritypolicies
     version: 0.1.0
+    installed: {{ .Values.opensearch.enabled }}
     values:
       - values/podsecuritypolicies/service/opensearch.yaml.gotmpl
 {{- end }}

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -561,7 +561,7 @@ releases:
     app: fluentd
     component: fluentd-forwarder
   inherit: [ template: fluentd-elasticsearch ]
-  installed: {{ and .Values.opensearch.enabled .Values.fluentd.enabled }}
+  installed: {{ and (or .Values.opensearch.enabled .Values.fluentd.audit.enabled ) .Values.fluentd.enabled }}
   values:
   - values/fluentd/forwarder-common.yaml.gotmpl
   - values/fluentd/forwarder-service-cluster.yaml.gotmpl

--- a/helmfile/50-applications.yaml
+++ b/helmfile/50-applications.yaml
@@ -284,6 +284,7 @@ releases:
     group: opensearch
   chart: ./charts/opensearch/secrets
   version: 0.1.0
+  installed: {{ .Values.opensearch.enabled }}
   values:
   - values/opensearch/secrets.yaml.gotmpl
 
@@ -293,6 +294,7 @@ releases:
     app: opensearch-master
     group: opensearch
   inherit: [ template: opensearch ]
+  installed: {{ .Values.opensearch.enabled }}
   wait: true
   needs:
   {{- if .Values.opensearch.sso.enabled }}
@@ -309,7 +311,7 @@ releases:
     app: opensearch-data
     group: opensearch
   inherit: [ template: opensearch ]
-  installed: {{ .Values.opensearch.dataNode.dedicatedPods }}
+  installed: {{ and .Values.opensearch.enabled .Values.opensearch.dataNode.dedicatedPods }}
   wait: true
   needs:
   - opensearch-system/opensearch-master
@@ -323,7 +325,7 @@ releases:
     app: opensearch-client
     group: opensearch
   inherit: [ template: opensearch ]
-  installed: {{ .Values.opensearch.clientNode.dedicatedPods }}
+  installed: {{ and .Values.opensearch.enabled .Values.opensearch.clientNode.dedicatedPods }}
   wait: true
   needs:
   - opensearch-system/opensearch-master
@@ -337,6 +339,7 @@ releases:
     app: opensearch-dashboards
     group: opensearch
   inherit: [ template: opensearch-dashboards ]
+  installed: {{ .Values.opensearch.enabled }}
   wait: true
   needs:
   - opensearch-system/opensearch-master
@@ -350,7 +353,7 @@ releases:
     group: opensearch
   chart: ./charts/opensearch/backup
   version: 0.1.0
-  installed: {{ .Values.opensearch.snapshot.enabled }}
+  installed: {{ and .Values.opensearch.enabled .Values.opensearch.snapshot.enabled }}
   needs:
   - opensearch-system/opensearch-configurer
   values:
@@ -363,7 +366,7 @@ releases:
     group: opensearch
   chart: ./charts/opensearch/slm
   version: 0.1.0
-  installed: {{ .Values.opensearch.snapshot.enabled }}
+  installed: {{ and .Values.opensearch.enabled .Values.opensearch.snapshot.enabled }}
   needs:
   - opensearch-system/opensearch-configurer
   values:
@@ -376,7 +379,7 @@ releases:
     group: opensearch
   chart: ./charts/opensearch/curator
   version: 0.1.0
-  installed: {{ .Values.opensearch.curator.enabled }}
+  installed: {{ and .Values.opensearch.enabled .Values.opensearch.curator.enabled }}
   needs:
   - opensearch-system/opensearch-configurer
   values:
@@ -389,7 +392,7 @@ releases:
     group: opensearch
   chart: ./charts/opensearch/securityadmin
   version: 0.1.0
-  installed: {{ .Values.opensearch.securityadmin.enabled }}
+  installed: {{ and .Values.opensearch.enabled .Values.opensearch.securityadmin.enabled }}
   needs:
   - opensearch-system/opensearch-master
 {{- if .Values.opensearch.dataNode.dedicatedPods }}
@@ -408,6 +411,7 @@ releases:
     group: opensearch
   chart: ./charts/opensearch/configurer
   version: 0.1.0
+  installed: {{ .Values.opensearch.enabled }}
   needs:
   {{- if .Values.opensearch.securityadmin.enabled }}
   - opensearch-system/opensearch-securityadmin
@@ -557,7 +561,7 @@ releases:
     app: fluentd
     component: fluentd-forwarder
   inherit: [ template: fluentd-elasticsearch ]
-  installed: {{ .Values.fluentd.enabled }}
+  installed: {{ and .Values.opensearch.enabled .Values.fluentd.enabled }}
   values:
   - values/fluentd/forwarder-common.yaml.gotmpl
   - values/fluentd/forwarder-service-cluster.yaml.gotmpl

--- a/helmfile/charts/grafana-dashboards/files/welcome.md
+++ b/helmfile/charts/grafana-dashboards/files/welcome.md
@@ -31,7 +31,9 @@ In case you get lost, don't forget to check out the [public docs](https://elasti
 ## Web Portals
 
 - [grafana.{{ .Values.baseDomain }}](https://grafana.{{ .Values.baseDomain }})
+{{ if .Values.dashboard.opensearch }}
 - [opensearch.{{ .Values.baseDomain }}](https://opensearch.{{ .Values.baseDomain }})
+{{ end }}
 - [harbor.{{ .Values.baseDomain }}](https://harbor.{{ .Values.baseDomain }})
 
 ## Did you know?

--- a/helmfile/charts/networkpolicy/service-cluster/templates/ingress-nginx/controller.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/ingress-nginx/controller.yaml
@@ -115,6 +115,7 @@ spec:
               app.kubernetes.io/name: grafana
       ports:
         - port: 3000
+    {{- if .Values.opensearch.enabled }}
     - to:
         - namespaceSelector:
             matchLabels:
@@ -137,6 +138,7 @@ spec:
               {{- end }}
       ports:
         - port: 9200
+    {{- end }}
     - to:
         - namespaceSelector:
             matchLabels:

--- a/helmfile/values/fluentd/forwarder-workload-cluster.yaml.gotmpl
+++ b/helmfile/values/fluentd/forwarder-workload-cluster.yaml.gotmpl
@@ -1,3 +1,4 @@
+{{- if .Values.opensearch.enabled }}
 elasticsearch:
   outputType: "opensearch"
   logLevel: "info"
@@ -29,8 +30,10 @@ secret:
 - name: OUTPUT_PASSWORD
   secret_name: {{ .Release.Name }}-opensearch-credentials
   secret_key: password
+{{- end }}
 
 extraConfigMaps:
+{{- if .Values.opensearch.enabled }}
   opensearch-store.prop: |-
     @type "#{ENV['OUTPUT_TYPE']}"
     @log_level "#{ENV['OUTPUT_LOG_LEVEL']}"
@@ -52,6 +55,7 @@ extraConfigMaps:
     # custom
     include_timestamp true # defaults to false
     default_opensearch_version 2
+{{- end }}
 
   22-labels.conf: |-
     # Conditional labels
@@ -64,10 +68,12 @@ extraConfigMaps:
         @type relabel
         @label @AUDIT
       </store>
+      {{- if .Values.opensearch.enabled }}
       <store>
         @type relabel
         @label @STORE
       </store>
+      {{- end }}
     </match>
 
     # Split kubeaudit
@@ -77,10 +83,12 @@ extraConfigMaps:
         @type relabel
         @label @AUDIT
       </store>
+      {{- if .Values.opensearch.enabled }}
       <store>
         @type relabel
         @label @STORE
       </store>
+      {{- end }}
     </match>
 
     # Split kubernetes
@@ -90,18 +98,27 @@ extraConfigMaps:
         @type relabel
         @label @AUDIT
       </store>
+      {{- if .Values.opensearch.enabled }}
       <store>
         @type relabel
         @label @STORE
       </store>
+      {{- end }}
     </match>
     {{- end }}
 
+    {{- if .Values.opensearch.enabled }}
     # Relabel others
     <match **>
       @type relabel
       @label @STORE
     </match>
+    {{- else }}
+    # Discard others
+    <match **>
+      @type null
+    </match>
+    {{- end }}
 
 
   30-output.conf: |-
@@ -131,6 +148,7 @@ extraConfigMaps:
     </label>
     {{- end }}
 
+    {{- if .Values.opensearch.enabled }}
     <label @STORE>
       <match authlog.**>
         @id opensearch_authlog
@@ -193,3 +211,4 @@ extraConfigMaps:
         </buffer>
       </match>
     </label>
+    {{- end }}

--- a/helmfile/values/grafana/grafana-dashboards.yaml.gotmpl
+++ b/helmfile/values/grafana/grafana-dashboards.yaml.gotmpl
@@ -5,9 +5,12 @@ dashboard:
   extraVersions:
 {{- toYaml .Values.welcomingDashboard.extraVersions | nindent 2 }}
 {{ end }}
+  opensearch: {{ .Values.opensearch.enabled }}
 
 baseDomain: {{ .Values.global.baseDomain }}
+{{- if .Values.opensearch.enabled }}
 logEndpoint: https://{{ .Values.opensearch.dashboards.subdomain }}.{{ .Values.global.baseDomain }}
+{{- end }}
 
 disabledDashboards:
   {{- if not .Values.hnc.enabled }}
@@ -28,6 +31,9 @@ disabledDashboards:
   - vulnerability-dashboard
   - thanos-sidecar-dashboard
   - thanos-bucket-replicate-dashboard
+  {{- if not .Values.opensearch.enabled }}
+  - opensearch-dashboard
+  {{- end }}
 notDeveloperVisible:
   - hnc-dashboard
   - uptime-dashbord

--- a/helmfile/values/networkpolicy/service-cluster.yaml.gotmpl
+++ b/helmfile/values/networkpolicy/service-cluster.yaml.gotmpl
@@ -54,7 +54,7 @@ thanos:
   enabled: {{ .Values.networkPolicies.thanos.enabled }}
 
 opensearch:
-  enabled: {{ .Values.networkPolicies.opensearch.enabled }}
+  enabled: {{ and .Values.opensearch.enabled .Values.networkPolicies.opensearch.enabled }}
   data:
     enabled: {{ .Values.opensearch.dataNode.dedicatedPods }}
   client:


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [ ] personal data beyond what is necessary for interacting with this pull request
> - [ ] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice

Deploying Opensearch can now be disabled by setting `.opensearch.enabled=false` in `sc-config.yaml`

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
This introduces a flag that determines whether Opensearch is to be deployed in the service cluster, allowing it to _not_ be.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1370

#### Additional information to reviewers

#### Screenshots

Not an actual screenshot

```
# yq4 -i '.opensearch.enabled=false' $CK8S_CONFIG_PATH/common-config.yaml

DELETED RELEASES:
NAME
opensearch-curator
opensearch-configurer
opensearch-dashboards
opensearch-securityadmin
opensearch-master
opensearch-secrets
```

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [x] The change is disruptive (if you flip the flag)
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
