### PR TITLE
apps sc: add security context for the curl-jq images

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -23,6 +23,7 @@
 
 - Refer to Grafana, OpenSearch and Harbor as Web Portals in Grafana and OpenSearch welcome dashboards
 - Fixed the `csi-upcloud` Network Policy template.
+- Pods that are using `curl-jq` image security context
 
 ### Updated
 

--- a/helmfile/charts/harbor/init-harbor/files/init.sh
+++ b/helmfile/charts/harbor/init-harbor/files/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 validate_harbor() {

--- a/helmfile/charts/harbor/init-harbor/templates/init-harbor-job.yaml
+++ b/helmfile/charts/harbor/init-harbor/templates/init-harbor-job.yaml
@@ -12,10 +12,15 @@ spec:
         release: {{ .Release.Name }}
     spec:
       restartPolicy: OnFailure
+      securityContext:
+        runAsUser: 10000
+        fsGroup: 10000
       containers:
         - name: run
           image: ghcr.io/elastisys/curl-jq:1.0.0
-          command: ['/bin/sh', '/scripts/init-harbor.sh']
+          command: ['/bin/bash', '/scripts/init-harbor.sh']
+          securityContext:
+            runAsUser: 10000
           env:
             - name: ENDPOINT
               value: {{ .Values.endpoint }}

--- a/helmfile/charts/opensearch/configurer/files/configurer.sh
+++ b/helmfile/charts/opensearch/configurer/files/configurer.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # TODO
 # ----

--- a/helmfile/charts/opensearch/configurer/templates/job.yaml
+++ b/helmfile/charts/opensearch/configurer/templates/job.yaml
@@ -28,10 +28,15 @@ spec:
       {{- if .Values.affinity }}
       affinity: {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
+      securityContext:
+        runAsUser: 10000
+        fsGroup: 10000
       containers:
       - name: opensearch-configurer
         image: {{ .Values.image }}
-        command: ['/bin/sh', '/files/configurer.sh']
+        command: ['/bin/bash', '/files/configurer.sh']
+        securityContext:
+          runAsUser: 10000
         volumeMounts:
         - name: files
           mountPath: /files


### PR DESCRIPTION
**What this PR does / why we need it:** Seems that when we replaced the curl-jq images some pods started to fail

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/compliantkubernetes-apps/blob/main/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [x] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The pods logs do not show any errors
- Network Policy checks:
  - [x] The `NetworkPolicy Dashboard` doesn't show any dropped packages
- Gatekeeper PSPs checks:
  - [x] Gatekeeper PSPs do not block the pods from starting after the change
- Falco checks:
  - [x] No Falco alerts are generated by the change
- Is this changeset backwards compatible for existing clusters? Applying:
  - [x] Is completely transparent, will not impact the workload in any way.
  - [ ] Requires running a migration script.
  - [ ] Will create noticeable cluster degradation.
        E.g. logs or metrics are not being collected or Kubernetes API server
        will not be responding while upgrading.
  - [ ] Will change any APIs.
        E.g. removes or changes any CK8S config options or Kubernetes APIs.
- Chart checklist (pick exactly one):
  - [x] I upgraded no Chart.
  - [ ] I upgraded a Chart and determined that no migration steps are needed.
  - [ ] I upgraded a Chart and added [migration steps](https://github.com/elastisys/compliantkubernetes-apps/blob/main/migration).
