### PR TITLE
apps sc & wc: Modified the FluentdQueueLength/FluentdOutputError/FluentdRetry alert expression

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -17,6 +17,8 @@
 
 - Changed the alert `KubeContainerOOMKilled` threshold.
 - Changed Gatekeeper violation messages to be more informative.
+- Modified the `FluentdQueueLength` prometheus alert condition to calculate the rate of change of the `fluentd_status_buffer_queue_length` metric from `5m` to `15m` and sustain the condition from `1m` to `5m`.
+- Modified the `FluentdOutputError` & `FluentdRetry` prometheus alert condition to evaluate based on specific labels combination of `pod`, `cluster`, and `service`.
 
 ### Fixed
 

--- a/helmfile/charts/prometheus-alerts/templates/alerts/fluentd.yaml
+++ b/helmfile/charts/prometheus-alerts/templates/alerts/fluentd.yaml
@@ -36,14 +36,14 @@ spec:
         summary: fluentd cannot be scraped
         description: Prometheus could not scrape {{ "{{ $labels.job }}" }} for more than 30 minutes
     - alert: FluentdQueueLength
-      expr: rate(fluentd_status_buffer_queue_length[5m]) > 0.3
-      for: 1m
+      expr: rate(fluentd_status_buffer_queue_length[15m]) > 0.3
+      for: 5m
       labels:
         service: fluentd
         severity: warning
       annotations:
         summary: fluentd node are failing
-        description: In the last 5 minutes, fluentd queues increased 30%. Current value is {{ "{{ $value }}" }}
+        description: In the last 15 minutes, fluentd queues increased 30%. Current value is {{ "{{ $value }}" }}
     - alert: FluentdQueueLength
       expr: rate(fluentd_status_buffer_queue_length[5m]) > 0.5
       for: 1m
@@ -84,7 +84,7 @@ spec:
         summary: fluentd records count are critical
         description: In the last 5m, records counts increased 3 times, comparing to the latest 15 min.
     - alert: FluentdRetry
-      expr: increase(fluentd_status_retry_count[10m]) > 0
+      expr: sum(increase(fluentd_status_retry_count[10m])) by (pod, cluster, service) > 0
       for: 30m
       labels:
         service: fluentd
@@ -93,7 +93,7 @@ spec:
         description: Fluentd retry count has been  {{ "{{ $value }}" }} for the last 10 minutes
         summary: Fluentd retry count has been  {{ "{{ $value }}" }} for the last 10 minutes
     - alert: FluentdOutputError
-      expr: increase(fluentd_output_status_num_errors[10m]) > 0
+      expr: sum(increase(fluentd_output_status_num_errors[10m])) by (pod, cluster, service) > 0
       for: 30m
       labels:
         service: fluentd


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

### What kind of PR is this?
- Modified the `FluentdQueueLength` prometheus alert condition to calculate the rate of change of the `fluentd_status_buffer_queue_length` metric from `5m` to `15m` and sustain the condition from `1m` to `5m`.
- Modified the `FluentdOutputError` & `FluentdRetry` prometheus alert condition to evaluate based on specific labels combination of `pod`, `cluster`, and `service`.

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Critical security fixes should be marked with `kind/security`
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR -->
- Fixes #

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
