### PR TITLE
apps wc: Removed the label from kube-system namespace

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Fixed
 
+- Removed the label `admission.gatekeeper.sh/ignore: "true"` from `kube-system` namespace.
+
 ### Updated
 
 ### Removed

--- a/bootstrap/namespaces/helmfile/values/namespaces-wc.yaml.gotmpl
+++ b/bootstrap/namespaces/helmfile/values/namespaces-wc.yaml.gotmpl
@@ -19,8 +19,6 @@ namespaces:
 - name: kube-node-lease
 - name: kube-public
 - name: kube-system
-  labels:
-    admission.gatekeeper.sh/ignore: "true"
 - name: monitoring
   labels:
     pod-security.kubernetes.io/audit: privileged


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

### What kind of PR is this?
Since we already have the label `owner=operator` and so removed the label `admission.gatekeeper.sh/ignore: "true"` from `kube-system` namespace as it was interfering with the gatekeeper from `bootstrap` script.
Found the error when running the apps version `0.31.2`
```
namespace/hnc-system unchanged
namespace/alertmanager unchanged
Error from server (Only exempt namespace can have the admission.gatekeeper.sh/ignore label): error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"labels\":{\"admission.gatekeeper.sh/ignore\":\"true\",\"owner\":\"operator\"},\"name\":\"kube-system\"}}\n"},"labels":{"admission.gatekeeper.sh/ignore":"true","name":null,"owner":"operator"}}}
to:
Resource: "/v1, Resource=namespaces", GroupVersionKind: "/v1, Kind=Namespace"
Name: "kube-system", Namespace: ""
for: "STDIN": admission webhook "check-ignore-label.gatekeeper.sh" denied the request: Only exempt namespace can have the admission.gatekeeper.sh/ignore label
```

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Critical security fixes should be marked with `kind/security`
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR -->
- Fixes #

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
