### PR TITLE
apps wc: Skip installing fluentd example resources if disabled

### DIFF
--- a/scripts/deploy-wc.sh
+++ b/scripts/deploy-wc.sh
@@ -19,21 +19,25 @@ INTERACTIVE=${1:-""}
 # Add example resources.
 # We use `create` here instead of `apply` to avoid overwriting any changes the
 # user may have done.
-if [ "$(kubectl get configmap fluentd-extra-config -n fluentd)" ] ; then
-  echo "fluentd-extra-config ConfigMap already in place. Ignoring."
+if ! kubectl get ns fluentd > /dev/null; then
+  echo "fluentd namespace missing, skipping installing fluentd example resources."
 else
-  echo "Creating fluentd-extra-config ConfigMap"
-  kubectl create -f "${SCRIPTS_PATH}/../manifests/examples/fluentd/fluentd-extra-config.yaml"
+  if kubectl get configmap fluentd-extra-config -n fluentd > /dev/null; then
+    echo "fluentd-extra-config ConfigMap already in place. Ignoring."
+  else
+    echo "Creating fluentd-extra-config ConfigMap"
+    kubectl create -f "${SCRIPTS_PATH}/../manifests/examples/fluentd/fluentd-extra-config.yaml"
+  fi
+
+  if kubectl get configmap fluentd-extra-plugins -n fluentd > /dev/null ; then
+    echo "fluentd-extra-plugins ConfigMap already in place. Ignoring."
+  else
+    echo "Creating fluentd-extra-plugins ConfigMap"
+    kubectl create -f "${SCRIPTS_PATH}/../manifests/examples/fluentd/fluentd-extra-plugins.yaml"
+  fi
 fi
 
-if [ "$(kubectl get configmap fluentd-extra-plugins -n fluentd)" ] ; then
-  echo "fluentd-extra-plugins ConfigMap already in place. Ignoring."
-else
-  echo "Creating fluentd-extra-plugins ConfigMap"
-  kubectl create -f "${SCRIPTS_PATH}/../manifests/examples/fluentd/fluentd-extra-plugins.yaml"
-fi
-
-if [ "$(kubectl get clusterrolebinding extra-user-view)" ] ; then
+if kubectl get clusterrolebinding extra-user-view > /dev/null; then
   echo "extra-user-view ClusterRoleBinding already in place. Ignoring."
 else
   echo "Creating extra-user-view ClusterRoleBinding"


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [ ] personal data beyond what is necessary for interacting with this pull request
> - [ ] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->

The `fluentd` namespace is not created during bootstrap if `fluentd.enabled = false` but the Fluentd "example resources" are still created which errors. This fixes that.

Alternatively I could remove the "example resources" as they seem pretty out of place. Does anyone know if they are being used somehow?

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
