### PR TITLE
tests: Add e2e tests for Grafana Dex logins

### DIFF
--- a/tests/end-to-end/grafana-admin.cy.js
+++ b/tests/end-to-end/grafana-admin.cy.js
@@ -21,4 +21,42 @@ describe("grafana admin", function() {
     cy.contains("Home")
       .should("exist")
   })
+
+  it("has configured data sources", function() {
+    cy.contains("Sign in with dex")
+      .click()
+
+    cy.dexStaticLogin()
+
+    cy.get("button[aria-label=\"Toggle menu\"]")
+      .click()
+
+    cy.contains("Latest from the blog")
+      .parent()
+      .parent()
+      .contains("Loading")
+      .should("not.exist")
+
+    cy.contains("Connections")
+      .click()
+    cy.contains("Data sources")
+      .click()
+
+    cy.contains("prometheus-sc")
+      .should("exist")
+    cy.contains("Thanos All")
+      .should("exist")
+      .parent()
+      .contains("default")
+      .should("exist")
+    cy.contains("Thanos SC Only")
+      .should("exist")
+    cy.yqDigParse("sc", ".global.clustersMonitoring")
+      .then(clusters => {
+        for (const cluster of clusters) {
+          cy.contains(`Thanos ${cluster} only`)
+            .should("exist")
+        }
+      })
+  })
 })

--- a/tests/end-to-end/grafana-admin.cy.js
+++ b/tests/end-to-end/grafana-admin.cy.js
@@ -1,0 +1,24 @@
+describe("grafana admin", function() {
+  beforeEach(function() {
+    // Cypress does not like trailing dots
+    cy.yqDig("sc", ".grafana.ops.trailingDots")
+      .should("not.equal", "true")
+
+    cy.yq("sc", "\"https://\" + .grafana.ops.subdomain + \".\" + .global.opsDomain")
+      .should("not.be.empty")
+      .then(cy.visit)
+  })
+
+  it("can login via dex with static user", function() {
+    cy.url()
+      .should("include", "/login")
+
+    cy.contains("Sign in with dex")
+      .click()
+
+    cy.dexStaticLogin()
+
+    cy.contains("Home")
+      .should("exist")
+  })
+})

--- a/tests/end-to-end/grafana-dashboards-discovery.bats
+++ b/tests/end-to-end/grafana-dashboards-discovery.bats
@@ -14,7 +14,7 @@ grafana_logs() {
     kubectl -n monitoring logs "deployment/${1}" grafana | grep 'level=error' | sed -rn 's#.*dashboards/(.+) error="(.+)"#error: \1: \2#p' | sort -u
 }
 
-@test "grafana admin - can discover dashboards" {
+@test "grafana admin can discover dashboards" {
   with_kubeconfig "sc"
 
   run grafana_sc_dashboard_logs ops-grafana
@@ -26,7 +26,7 @@ grafana_logs() {
   done
 }
 
-@test "grafana admin - can load dashboards without error" {
+@test "grafana admin can load dashboards without error" {
   with_kubeconfig "sc"
 
   run grafana_logs ops-grafana
@@ -34,7 +34,7 @@ grafana_logs() {
   refute_output
 }
 
-@test "grafana dev - can discover dashboards" {
+@test "grafana dev can discover dashboards" {
   with_kubeconfig "sc"
 
   run grafana_sc_dashboard_logs user-grafana
@@ -46,7 +46,7 @@ grafana_logs() {
   done
 }
 
-@test "grafana dev - can load dashboards without error" {
+@test "grafana dev can load dashboards without error" {
   with_kubeconfig "sc"
 
   run grafana_logs user-grafana

--- a/tests/end-to-end/grafana-dev.cy.js
+++ b/tests/end-to-end/grafana-dev.cy.js
@@ -21,4 +21,27 @@ describe("grafana dev", function() {
     cy.contains("Home")
       .should("exist")
   })
+
+  it("has configured data sources", function() {
+    cy.contains("Sign in with dex")
+      .click()
+
+    cy.dexStaticLogin()
+
+    cy.get("button[aria-label=\"Toggle menu\"]")
+      .click()
+
+    cy.contains("Connections")
+      .click()
+    cy.contains("Data sources")
+      .click()
+
+    cy.contains("Service Cluster")
+      .should("exist")
+    cy.contains("Workload Cluster")
+      .should("exist")
+      .parent()
+      .contains("default")
+      .should("exist")
+  })
 })

--- a/tests/end-to-end/grafana-dev.cy.js
+++ b/tests/end-to-end/grafana-dev.cy.js
@@ -1,0 +1,24 @@
+describe("grafana dev", function() {
+  beforeEach(function() {
+    // Cypress does not like trailing dots
+    cy.yqDig("sc", ".grafana.user.trailingDots")
+      .should("not.equal", "true")
+
+    cy.yq("sc", "\"https://\" + .grafana.user.subdomain + \".\" + .global.baseDomain")
+      .should("not.be.empty")
+      .then(cy.visit)
+  })
+
+  it("can login via dex with static user", function() {
+    cy.url()
+      .should("include", "/login")
+
+    cy.contains("Sign in with dex")
+      .click()
+
+    cy.dexStaticLogin()
+
+    cy.contains("Home")
+      .should("exist")
+  })
+})


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Tests login to Grafana using Dex static user.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes https://github.com/elastisys/ck8s-ops/issues/1841

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
