### PR TITLE
apps: update gatekeeper violation messages

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changed
 
 - Changed the alert `KubeContainerOOMKilled` threshold.
+- Changed Gatekeeper violation messages to be more informative.
 
 ### Fixed
 

--- a/helmfile/charts/gatekeeper/constraints/templates/disallow-tag/constraint.yaml
+++ b/helmfile/charts/gatekeeper/constraints/templates/disallow-tag/constraint.yaml
@@ -2,7 +2,7 @@
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sDisallowedTags
 metadata:
-  name: container-image-must-not-have-disallowed-tags
+  name: elastisys-container-image-must-not-have-disallowed-tags
 spec:
   enforcementAction: {{ .Values.disallowedTags.enforcementAction }}
   match:

--- a/helmfile/charts/gatekeeper/constraints/templates/image-registry/constraint.yaml
+++ b/helmfile/charts/gatekeeper/constraints/templates/image-registry/constraint.yaml
@@ -2,7 +2,7 @@
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sAllowedRepos
 metadata:
-  name: require-harbor-repo
+  name: elastisys-require-harbor-registry
 spec:
   enforcementAction: {{ .Values.restrictImageRegistry.enforcementAction }}
   match:

--- a/helmfile/charts/gatekeeper/constraints/templates/networkpolicies/constraint.yaml
+++ b/helmfile/charts/gatekeeper/constraints/templates/networkpolicies/constraint.yaml
@@ -2,7 +2,7 @@
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sRequireNetworkPolicy
 metadata:
-  name: require-networkpolicy
+  name: elastisys-require-networkpolicy
 spec:
   enforcementAction: {{ .Values.requireNetworkpolicies.enforcementAction }}
   match:

--- a/helmfile/charts/gatekeeper/constraints/templates/resource-requests/constraint.yaml
+++ b/helmfile/charts/gatekeeper/constraints/templates/resource-requests/constraint.yaml
@@ -2,7 +2,7 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: K8sResourceRequests
 metadata:
-  name: require-resource-requests
+  name: elastisys-require-resource-requests
 spec:
   enforcementAction: {{ .Values.requireResourceRequests.enforcementAction }}
   match:

--- a/helmfile/charts/gatekeeper/constraints/templates/user-crds/constraint.yaml
+++ b/helmfile/charts/gatekeeper/constraints/templates/user-crds/constraint.yaml
@@ -2,7 +2,7 @@
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sUserCRDs
 metadata:
-  name: allowed-user-crds
+  name: elastisys-allowed-user-crds
 spec:
   enforcementAction: {{ .Values.allowUserCRDs.enforcementAction }}
   match:

--- a/helmfile/charts/gatekeeper/templates/policies/disallow-tag.rego
+++ b/helmfile/charts/gatekeeper/templates/policies/disallow-tag.rego
@@ -7,7 +7,7 @@ violation[{"msg": msg}] {
 
     tags := [forbid | tag = input.parameters.tags[_] ; forbid = endswith(container.image, concat(":", ["", tag]))]
     any(tags)
-    msg := sprintf("container <%v> uses a disallowed tag <%v>; disallowed tags are %v", [container.name, container.image, input.parameters.tags])
+    msg := sprintf("The container named <%v> uses the :latest tag. Elastisys Compliant Kubernetes requires all images to have explicit tags. Read more at https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-no-latest-tag/", [container.name])
 }
 
 violation[{"msg": msg}] {
@@ -16,7 +16,7 @@ violation[{"msg": msg}] {
 
     tag := [contains(container.image, ":")]
     not all(tag)
-    msg := sprintf("container <%v> didn't specify an image tag <%v>", [container.name, container.image])
+    msg := sprintf("The container named <%v> didn't specify an image tag. Elastisys Compliant Kubernetes requires all images to have tags to avoid the implicit :latest tag. Read more at https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-no-latest-tag/", [container.name])
 }
 
 # Get containers for "Pods"
@@ -53,7 +53,7 @@ violation[{"msg": msg}] {
 
     tags := [forbid | tag = input.parameters.tags[_] ; forbid = endswith(container.image, concat(":", ["", tag]))]
     any(tags)
-    msg := sprintf("container <%v> uses a disallowed tag <%v>; disallowed tags are %v", [container.name, container.image, input.parameters.tags])
+    msg := sprintf("The container named <%v> uses the :latest tag. Elastisys Compliant Kubernetes requires all images to have explicit tags. Read more at https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-no-latest-tag/", [container.name])
 }
 
 violation[{"msg": msg}] {
@@ -62,7 +62,7 @@ violation[{"msg": msg}] {
 
     tag := [contains(container.image, ":")]
     not all(tag)
-    msg := sprintf("container <%v> didn't specify an image tag <%v>", [container.name, container.image])
+    msg := sprintf("The container named <%v> didn't specify an image tag. Elastisys Compliant Kubernetes requires all images to have tags to avoid the implicit :latest tag. Read more at https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-no-latest-tag/", [container.name])
 }
 
 # Get init containers for "Pods"

--- a/helmfile/charts/gatekeeper/templates/policies/image-registry.rego
+++ b/helmfile/charts/gatekeeper/templates/policies/image-registry.rego
@@ -7,7 +7,7 @@ violation[{"msg": msg}] {
 
     satisfied := [good | repo = input.parameters.repos[_] ; good = startswith(container.image, repo)]
     not any(satisfied)
-    msg := sprintf("container %q has an invalid image repo %q, allowed repos are %v", [container.name, container.image, input.parameters.repos])
+    msg := sprintf("The container named <%v> does not have an allowed image registry <%v>, allowed registries are <%v>. Elastisys Compliant Kubernetes requires that all images come from trusted registries. Read more at https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-trusted-registries/", [container.name, container.image, input.parameters.repos])
 }
 
 # Get containers for "Pods"
@@ -44,7 +44,7 @@ violation[{"msg": msg}] {
 
     satisfied := [good | repo = input.parameters.repos[_] ; good = startswith(container.image, repo)]
     not any(satisfied)
-    msg := sprintf("initContainer %q has an invalid image repo %q, allowed repos are %v", [container.name, container.image, input.parameters.repos])
+    msg := sprintf("The initContainer named <%v> does not have an allowed image registry <%v>, allowed registries are <%v>. Elastisys Compliant Kubernetes requires that all images come from trusted registries. Read more at https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-trusted-registries/", [container.name, container.image, input.parameters.repos])
 }
 
 # Get init containers for "Pods"

--- a/helmfile/charts/gatekeeper/templates/policies/network-policies.rego
+++ b/helmfile/charts/gatekeeper/templates/policies/network-policies.rego
@@ -5,7 +5,7 @@ violation[{"msg": msg}] {
 
     res = [x | x := allChecks(data.inventory.namespace[namespace]["networking.k8s.io/v1"]["NetworkPolicy"][_])]
     all(res) #all networkpolicies failed to match
-    msg := sprintf("No matching networkpolicy found", [])
+    msg := sprintf("No matching networkpolicy found. Elastisys Compliant Kubernetes requires that all pods are targeted by NetworkPolicies. Read more at https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-networkpolicies/", [])
 }
 
 #Check one networkpolicy, returns true if it does not match

--- a/helmfile/charts/gatekeeper/templates/policies/resource-requests.rego
+++ b/helmfile/charts/gatekeeper/templates/policies/resource-requests.rego
@@ -4,21 +4,21 @@ package k8sresourcerequests
 violation[{"msg": msg}] {
     container := get_containers[_]
     not container.resources.requests
-    msg := sprintf("Container %q has no resource requests", [container.name])
+    msg := sprintf("The container named <%v> has no resource requests. Elastisys Compliant Kubernetes requires resource requests to be set for all containers. Read more at https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-resources/", [container.name])
 }
 
 # violation if CPU REQUESTS is missing.
 violation[{"msg": msg}] {
     container := get_containers[_]
     missing(container.resources.requests, "cpu")
-    msg := sprintf("Container %q has no cpu request", [container.name])
+    msg := sprintf("The container <%v> has no cpu request. Elastisys Compliant Kubernetes requires resource requests to be set for all containers. Read more at https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-resources/", [container.name])
 }
 
 # violation if MEMORY REQUESTS is missing.
 violation[{"msg": msg}] {
     container := get_containers[_]
     missing(container.resources.requests, "memory")
-    msg := sprintf("Container %q has no memory request", [container.name])
+    msg := sprintf("The container <%v> has no memory request. Elastisys Compliant Kubernetes requires resource requests to be set for all containers. Read more at https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-resources/", [container.name])
 }
 
 # Get containers for "Pods"


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Updated the Gatekeeper violation messages and added an `elastisys-` prefix to the policies. Also re-worded from `repo` to `registry` to be consistent with the docs.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1748 

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [x] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [x] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
