### PR TITLE
Allow per cluster upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,9 +426,16 @@ The former runs scripted configuration steps that do not change the state of the
 On unexpected failures the command will try to perform a rollback when possible to ensure that the environment continues to function.
 
 ```bash
-./bin/ck8s upgrade vX.Y prepare
-./bin/ck8s upgrade vX.Y apply
+./bin/ck8s upgrade both vX.Y prepare
+./bin/ck8s upgrade both vX.Y apply
 ```
+
+> [!NOTE]
+> It is possible to upgrade `wc` and `sc` clusters separately by replacing `both` when running the `upgrade` command, e.g. the following will only upgrade the workload cluster:
+> ```bash
+> ./bin/ck8s upgrade wc vX.Y prepare
+> ./bin/ck8s upgrade wc vX.Y apply
+> ```
 
 It is possible to upgrade from one minor version to the next regardless of patch versions (`vX.Y -> vX.Y+1`), and from one patch version to any later patch versions (`vX.Y.Z -> vX.Y.Z+N`).
 Version validation will require that you are on a release tag matching version specified in the command, and that your environment is at most one minor version behind.

--- a/bin/ck8s
+++ b/bin/ck8s
@@ -17,8 +17,8 @@ usage() {
     echo "  test <wc|sc> [--logging-enabled]                  test the applications" 1>&2
     echo "  dry-run <wc|sc> [--kubectl]                       runs helmfile diff" 1>&2
     echo "  fix-psp-violations <wc|sc>                        Checks and restarts pods that violates Pod Security Polices, applicable for new environments" 1>&2
-    echo "  upgrade <version-matching-migration> prepare      runs all prepare steps upgrading the configuration" 1>&2
-    echo "  upgrade <version-matching-migration> apply        runs all apply steps upgrading the environment" 1>&2
+    echo "  upgrade <wc|sc|both> <vX.Y> prepare               runs all prepare steps upgrading the configuration" 1>&2
+    echo "  upgrade <wc|sc|both> <vX.Y> apply                 runs all apply steps upgrading the environment" 1>&2
     echo "  team add-pgp <fp>                                 add a new PGP key to secrets" 1>&2
     echo "  team remove-pgp <fp>                              remove a PGP key from secrets and rotate the data encryption key" 1>&2
     # TODO: We might want to make this command less visible once we have proper
@@ -88,10 +88,11 @@ case "${1}" in
         "${here}/dry-run.bash" "${2}" "${KUBECTL}"
         ;;
     upgrade)
-        [[ "${2}" =~ ^(v[0-9]+\.[0-9]+)$ ]] || usage
-        [[ "${3}" =~ ^(prepare|apply)$ ]] || usage
+        [[ "${2}" =~ ^(wc|sc|both)$ ]] || usage
+        [[ "${3}" =~ ^(v[0-9]+\.[0-9]+)$ ]] || usage
+        [[ "${4}" =~ ^(prepare|apply)$ ]] || usage
         check_tools
-        "${here}/upgrade.bash" "${2}" "${3}"
+        "${here}/upgrade.bash" "${2}" "${3}" "${4}"
         ;;
     team)
         case "${2}" in

--- a/migration/template/README.md
+++ b/migration/template/README.md
@@ -65,7 +65,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     > *Done before maintenance window.*
 
     ```bash
-    ./bin/ck8s upgrade ${new_version} prepare
+    ./bin/ck8s upgrade both ${new_version} prepare
 
     # check if the netpol IPs need to be updated
     ./bin/ck8s update-ips both dry-run
@@ -73,12 +73,19 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ./bin/ck8s update-ips both apply
     ```
 
+    > [!NOTE]
+    > It is possible to upgrade `wc` and `sc` clusters separately by replacing `both` when running the `upgrade` command, e.g. the following will only upgrade the workload cluster:
+    > ```bash
+    > ./bin/ck8s upgrade wc ${new_version} prepare
+    > ./bin/ck8s upgrade wc ${new_version} apply
+    > ```
+
 1. Apply upgrade - *disruptive*
 
     > *Done during maintenance window.*
 
     ```bash
-    ./bin/ck8s upgrade ${new_version} apply
+    ./bin/ck8s upgrade both ${new_version} apply
     ```
 
 ## Manual method
@@ -92,6 +99,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ```bash
     git pull
     git switch -d ${new_version}.x
+    ```
+
+1. Set whether or not upgrade should be prepared for `both` clusters or for one of `sc` or `wc`:
+
+    ```bash
+    export CK8S_CLUSTER=<wc|sc|both>
     ```
 
 1. Update apps configuration:
@@ -112,6 +125,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 ### Apply upgrade - *disruptive*
 
 > *Done during maintenance window.*
+
+1. Set whether or not upgrade should be applied for `both` clusters or for one of `sc` or `wc`:
+
+    ```bash
+    export CK8S_CLUSTER=<wc|sc|both>
+    ```
 
 1. Rerun bootstrap:
 

--- a/migration/template/apply/00-template.sh
+++ b/migration/template/apply/00-template.sh
@@ -48,9 +48,23 @@ run() {
   execute)
     # Note: 00-template.sh will be skipped by the upgrade command
     log_info "no operation: this is a template"
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      log_info "operation on service cluster"
+    fi
+    if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+      log_info "operation on workload cluster"
+    fi
     ;;
   rollback)
     log_warn "rollback not implemented"
+
+    # if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+    #   log_info "rollback operation on service cluster"
+    # fi
+    # if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+    #   log_info "rollback operation on workload cluster"
+    # fi
     ;;
   *)
     log_fatal "usage: \"${0}\" <execute|rollback>"

--- a/migration/template/apply/20-bootstrap.sh
+++ b/migration/template/apply/20-bootstrap.sh
@@ -8,8 +8,12 @@ source "${ROOT}/scripts/migration/lib.sh"
 run() {
   case "${1:-}" in
   execute)
-    "${ROOT}/bin/ck8s" bootstrap sc
-    "${ROOT}/bin/ck8s" bootstrap wc
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      "${ROOT}/bin/ck8s" bootstrap sc
+    fi
+    if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+      "${ROOT}/bin/ck8s" bootstrap wc
+    fi
     ;;
   rollback)
     log_warn "rollback not implemented"

--- a/migration/template/apply/80-apply.sh
+++ b/migration/template/apply/80-apply.sh
@@ -23,16 +23,28 @@ run() {
     local -a filters
     local selector
 
-    filters=("${skipped[@]}" "${skipped_sc[@]}")
-    selector="${filters[*]:-"app!=null"}"
-    helmfile_upgrade sc "${selector// /,}"
-    filters=("${skipped[@]}" "${skipped_wc[@]}")
-    selector="${filters[*]:-"app!=null"}"
-    helmfile_upgrade wc "${selector// /,}"
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      filters=("${skipped[@]}" "${skipped_sc[@]}")
+      selector="${filters[*]:-"app!=null"}"
+      helmfile_upgrade sc "${selector// /,}"
+    fi
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+      filters=("${skipped[@]}" "${skipped_wc[@]}")
+      selector="${filters[*]:-"app!=null"}"
+      helmfile_upgrade wc "${selector// /,}"
+    fi
     ;;
 
   rollback)
     log_warn "rollback not implemented"
+
+    # if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+    #   log_info "rollback operation on service cluster"
+    # fi
+    # if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+    #   log_info "rollback operation on workload cluster"
+    # fi
     ;;
 
   *)

--- a/migration/template/prepare/00-template.sh
+++ b/migration/template/prepare/00-template.sh
@@ -22,3 +22,10 @@ source "${ROOT}/scripts/migration/lib.sh"
 
 # Note: 00-template.sh will be skipped by the upgrade command
 log_info "no operation: this is a template"
+
+if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+  log_info "operation on service cluster"
+fi
+if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+  log_info "operation on workload cluster"
+fi

--- a/migration/v0.34/README.md
+++ b/migration/v0.34/README.md
@@ -65,7 +65,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     > *Done before maintenance window.*
 
     ```bash
-    ./bin/ck8s upgrade v0.34 prepare
+    ./bin/ck8s upgrade both v0.34 prepare
 
     # check if the netpol IPs need to be updated
     ./bin/ck8s update-ips both dry-run
@@ -73,12 +73,19 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ./bin/ck8s update-ips both apply
     ```
 
+    > [!NOTE]
+    > It is possible to upgrade `wc` and `sc` clusters separately by replacing `both` when running the `upgrade` command, e.g. the following will only upgrade the workload cluster:
+    > ```bash
+    > ./bin/ck8s upgrade wc v0.34 prepare
+    > ./bin/ck8s upgrade wc v0.34 apply
+    > ```
+
 1. Apply upgrade - *disruptive*
 
     > *Done during maintenance window.*
 
     ```bash
-    ./bin/ck8s upgrade v0.34 apply
+    ./bin/ck8s upgrade both v0.34 apply
     ```
 
 ## Manual method
@@ -92,6 +99,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ```bash
     git pull
     git switch -d v0.34.x
+    ```
+
+1. Set whether or not upgrade should be prepared for `both` clusters or for one of `sc` or `wc`:
+
+    ```bash
+    export CK8S_CLUSTER=<wc|sc|both>
     ```
 
 1. Verify that no important resources are present in the `elastic-system` and `influxdb-prometheus` namespaces.
@@ -127,6 +140,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 ### Apply upgrade - *disruptive*
 
 > *Done during maintenance window.*
+
+1. Set whether or not upgrade should be applied for `both` clusters or for one of `sc` or `wc`:
+
+    ```bash
+    export CK8S_CLUSTER=<wc|sc|both>
+    ```
 
 1. Rerun bootstrap:
 

--- a/migration/v0.34/apply/00-template.sh
+++ b/migration/v0.34/apply/00-template.sh
@@ -48,9 +48,23 @@ run() {
   execute)
     # Note: 00-template.sh will be skipped by the upgrade command
     log_info "no operation: this is a template"
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      log_info "operation on service cluster"
+    fi
+    if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+      log_info "operation on workload cluster"
+    fi
     ;;
   rollback)
     log_warn "rollback not implemented"
+
+    # if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+    #   log_info "rollback operation on service cluster"
+    # fi
+    # if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+    #   log_info "rollback operation on workload cluster"
+    # fi
     ;;
   *)
     log_fatal "usage: \"${0}\" <execute|rollback>"

--- a/migration/v0.34/apply/11-prometheus-operator-crds.sh
+++ b/migration/v0.34/apply/11-prometheus-operator-crds.sh
@@ -8,38 +8,48 @@ source "${ROOT}/scripts/migration/lib.sh"
 run() {
   case "${1:-}" in
   execute)
-    for CLUSTER in sc wc; do
-      if [[ ! "$(helm_chart_version "$CLUSTER" monitoring kube-prometheus-stack)" = "49.2.0" ]]; then
+    clusters=("sc" "wc")
+    if [[ ! "${CK8S_CLUSTER}" = both ]]; then
+      clusters=("${CK8S_CLUSTER}")
+    fi
+
+    for CLUSTER in "${clusters[@]}"; do
+      if [[ ! "$(helm_chart_version "${CLUSTER}" monitoring kube-prometheus-stack)" = "49.2.0" ]]; then
         log_info "  - applying the prometheus-operator CRDs on $CLUSTER"
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-alertmanagers.yaml
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-podmonitors.yaml
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-probes.yaml
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-prometheuses.yaml
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-thanosrulers.yaml
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-scrapeconfigs.yaml
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-prometheusagents.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-alertmanagers.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-podmonitors.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-probes.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-prometheuses.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-thanosrulers.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-scrapeconfigs.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-prometheusagents.yaml
       else
         log_info "  - Skipping applying the prometheus-operator CRDs on $CLUSTER"
       fi
     done
     ;;
   rollback)
-    for CLUSTER in sc wc; do
-      if [[ ! "$(helm_chart_version "$CLUSTER" monitoring kube-prometheus-stack)" = "49.2.0" ]]; then
+    clusters=("sc" "wc")
+    if [[ ! "${CK8S_CLUSTER}" = both ]]; then
+      clusters=("${CK8S_CLUSTER}")
+    fi
+
+    for CLUSTER in "${clusters[@]}"; do
+      if [[ ! "$(helm_chart_version "${CLUSTER}" monitoring kube-prometheus-stack)" = "49.2.0" ]]; then
         log_info "  - rollback the prometheus-operator CRDs on $CLUSTER"
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
-        kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
-        kubectl_do $CLUSTER delete -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.67.1/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
-        kubectl_do $CLUSTER delete -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.67.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+        kubectl_do "${CLUSTER}" apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+        kubectl_do "${CLUSTER}" delete -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.67.1/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+        kubectl_do "${CLUSTER}" delete -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.67.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
       else
         log_info "  - Skipping rollbacking the prometheus-operator CRDs on $CLUSTER"
       fi

--- a/migration/v0.34/apply/20-bootstrap.sh
+++ b/migration/v0.34/apply/20-bootstrap.sh
@@ -8,8 +8,13 @@ source "${ROOT}/scripts/migration/lib.sh"
 run() {
   case "${1:-}" in
   execute)
-    "${ROOT}/bin/ck8s" bootstrap sc
-    "${ROOT}/bin/ck8s" bootstrap wc
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      "${ROOT}/bin/ck8s" bootstrap sc
+    fi
+    if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+      "${ROOT}/bin/ck8s" bootstrap wc
+    fi
     ;;
   rollback)
     log_warn "rollback not implemented"

--- a/migration/v0.34/apply/30-delete-obsolete-ns.sh
+++ b/migration/v0.34/apply/30-delete-obsolete-ns.sh
@@ -8,14 +8,19 @@ source "${ROOT}/scripts/migration/lib.sh"
 run() {
   case "${1:-}" in
   execute)
-    for NS in elastic-system influxdb-prometheus; do
-      if kubectl_do sc get namespace $NS >/dev/null 2>/dev/null; then
-        log_info "  - deleting unused namespace $NS in sc"
-        kubectl_do sc delete namespace $NS
-      else
-        log_info "  - skip deleting not present namespace $NS in sc"
-      fi
-    done
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      for NS in elastic-system influxdb-prometheus; do
+        if kubectl_do sc get namespace $NS >/dev/null 2>/dev/null; then
+          log_info "  - deleting unused namespace $NS in sc"
+          kubectl_do sc delete namespace $NS
+        else
+          log_info "  - skip deleting not present namespace $NS in sc"
+        fi
+      done
+    else
+      log_info "  - skipping workload cluster"
+    fi
     ;;
   rollback)
     log_warn "  - restoration of unused namespaces not implemented"

--- a/migration/v0.34/apply/80-apply.sh
+++ b/migration/v0.34/apply/80-apply.sh
@@ -23,12 +23,17 @@ run() {
     local -a filters
     local selector
 
-    filters=("${skipped[@]}" "${skipped_sc[@]}")
-    selector="${filters[*]:-"app!=null"}"
-    helmfile_upgrade sc "${selector// /,}"
-    filters=("${skipped[@]}" "${skipped_wc[@]}")
-    selector="${filters[*]:-"app!=null"}"
-    helmfile_upgrade wc "${selector// /,}"
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      filters=("${skipped[@]}" "${skipped_sc[@]}")
+      selector="${filters[*]:-"app!=null"}"
+      helmfile_upgrade sc "${selector// /,}"
+    fi
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+      filters=("${skipped[@]}" "${skipped_wc[@]}")
+      selector="${filters[*]:-"app!=null"}"
+      helmfile_upgrade wc "${selector// /,}"
+    fi
     ;;
 
   rollback)

--- a/migration/v0.34/prepare/00-template.sh
+++ b/migration/v0.34/prepare/00-template.sh
@@ -22,3 +22,10 @@ source "${ROOT}/scripts/migration/lib.sh"
 
 # Note: 00-template.sh will be skipped by the upgrade command
 log_info "no operation: this is a template"
+
+if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+  log_info "operation on service cluster"
+fi
+if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+  log_info "operation on workload cluster"
+fi

--- a/migration/v0.34/prepare/30-delete-obsolete-ns.sh
+++ b/migration/v0.34/prepare/30-delete-obsolete-ns.sh
@@ -6,13 +6,17 @@ ROOT="$(readlink -f "${HERE}/../../../")"
 # shellcheck source=scripts/migration/lib.sh
 source "${ROOT}/scripts/migration/lib.sh"
 
-for NS in elastic-system influxdb-prometheus; do
-  log_info "checking for resources in namespace $NS"
-  NS_RESOURCES="$(kubectl_do sc get all -n $NS 2>&1)"
-  if [[ "$NS_RESOURCES" == "No resources found in $NS namespace." ]]; then
-    log_info "$NS_RESOURCES - safe to delete"
-  else
-    log_warn "Resources found in namespace $NS, please verify that these are okay to delete before proceeding to apply"
-    echo "$NS_RESOURCES"
-  fi
-done
+if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+  for NS in elastic-system influxdb-prometheus; do
+    log_info "checking for resources in namespace $NS"
+    NS_RESOURCES="$(kubectl_do sc get all -n $NS 2>&1)"
+    if [[ "$NS_RESOURCES" == "No resources found in $NS namespace." ]]; then
+      log_info "$NS_RESOURCES - safe to delete"
+    else
+      log_warn "Resources found in namespace $NS, please verify that these are okay to delete before proceeding to apply"
+      echo "$NS_RESOURCES"
+    fi
+  done
+else
+  log_info "  - skipping for workload cluster"
+fi


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [ ] personal data beyond what is necessary for interacting with this pull request
> - [ ] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->


### Platform Administrator notice

This PR changes the number of arguments required to run the `upgrade` command, as you now have to specify the specific cluster, `sc`, `wc`, or `both` to apply to both clusters as the command did previously. The ck8s usage has been updated to clarify this:
```bash
➜ ./bin/ck8s                      
COMMANDS:
  ...
  upgrade <wc|sc|both> <vX.Y> prepare               runs all prepare steps upgrading the configuration
  upgrade <wc|sc|both> <vX.Y> apply                 runs all apply steps upgrading the environment
```

Migration templating have also been updated to support and clarify these changes.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
This PR allows for running the `upgrade` command for each cluster (`wc` and `sc`) separately, which is particularly useful for multi-workload cluster environments, or environments without workload clusters. Previously the `upgrade` command always applies for both `wc` and `sc`.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1472 

#### Additional information to reviewers
Note that this PR only fixes this for `upgrade apply`, as `upgrade prepare` requires more work as it uses the `init` command which currently does not support per cluster initialization (see [this issue](https://github.com/elastisys/compliantkubernetes-apps/issues/1777)).

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [x] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [x] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [x] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [x] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
