### PR TITLE
migration: Delete namespaces obsolete since v0.20

### DIFF
--- a/migration/v0.34/README.md
+++ b/migration/v0.34/README.md
@@ -94,6 +94,21 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     git switch -d v0.34.x
     ```
 
+1. Verify that no important resources are present in the `elastic-system` and `influxdb-prometheus` namespaces.
+
+    ``` bash
+    ./migration/v0.34/prepare/30-delete-obsolete-ns.sh
+    ```
+
+    Expected output:
+
+    ```
+    No resources found in elastic-system namespace.
+    No resources found in influxdb-prometheus namespace.
+    ```
+
+    If resources _are_ present, verify that they are not something important.
+
 1. Update apps configuration:
 
     This will take a backup into `backups/` before modifying any files.
@@ -125,6 +140,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
     ```bash
     ./migration/v0.30/apply/11-prometheus-operator-crds.sh execute
+    ```
+
+1. Delete obsolete namespaces:
+
+    ```bash
+    ./migration/v0.34/apply/30-delete-obsolete-ns.sh execute
     ```
 
 1. Upgrade applications:

--- a/migration/v0.34/apply/30-delete-obsolete-ns.sh
+++ b/migration/v0.34/apply/30-delete-obsolete-ns.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+run() {
+  case "${1:-}" in
+  execute)
+    for NS in elastic-system influxdb-prometheus; do
+      if kubectl_do sc get namespace $NS >/dev/null 2>/dev/null; then
+        log_info "  - deleting unused namespace $NS in sc"
+        kubectl_do sc delete namespace $NS
+      else
+        log_info "  - skip deleting not present namespace $NS in sc"
+      fi
+    done
+    ;;
+  rollback)
+    log_warn "  - restoration of unused namespaces not implemented"
+    ;;
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.34/prepare/30-delete-obsolete-ns.sh
+++ b/migration/v0.34/prepare/30-delete-obsolete-ns.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+for NS in elastic-system influxdb-prometheus; do
+  log_info "checking for resources in namespace $NS"
+  NS_RESOURCES="$(kubectl_do sc get all -n $NS 2>&1)"
+  if [[ "$NS_RESOURCES" == "No resources found in $NS namespace." ]]; then
+    log_info "$NS_RESOURCES - safe to delete"
+  else
+    log_warn "Resources found in namespace $NS, please verify that these are okay to delete before proceeding to apply"
+    echo "$NS_RESOURCES"
+  fi
+done


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [ ] personal data beyond what is necessary for interacting with this pull request
> - [ ] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [x] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
**_Removes_** namespaces that have been obsolete since v0.20, namely:

- `elastic-system`
- `influxdb-prometheus`

Rollback not implemented because the namespaces have been obsolete so long, plus this wouldn't restore any resources in the deleted namespaces anyway, so restoring them on their own seems of little value.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1585

#### Additional information to reviewers

#### Screenshots

#### Testing done

1. ran migration against cluster without the namespaces in question, script should handle this gracefully
2. created both namespaces
3. ran migration again, observed that it claimed to have deleted the namespaces
4. observed that `kubectl get namespace` lists neither namespace, in either cluster

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [x] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
