### PR TITLE
config: more templating for gatekeeper

### DIFF
--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -730,6 +730,10 @@ opa:
       limits:
         cpu: 300m
         memory: 300Mi
+    affinity: {}
+    tolerations: []
+    nodeSelector: {kubernetes.io/os: linux}
+    topologySpreadConstraints: []
 
   audit:
     resources:
@@ -739,9 +743,28 @@ opa:
       limits:
         cpu: 500m
         memory: 300Mi
+    affinity: {}
+    tolerations: []
+    nodeSelector: {kubernetes.io/os: linux}
 
-  # how often gatekeeper audits kubernetes resources, in seconds
+    # Enable for audit pod to use cache instead of disk
+    writeToRAMDisk: false
+
+  # How often gatekeeper audits kubernetes resources, in seconds
   auditIntervalSeconds: 600
+
+  # A lower chunk size can reduce memory consumption of the auditing Pod
+  # but can increase the number of requests to the Kubernetes API server
+  auditChunkSize: 500
+
+  # Enable audit informer cache instead of requesting resources from Kubernetes API
+  auditFromCache: false
+
+  # The maximum number of audit violations reported on a constraint
+  constraintViolationsLimit: 20
+
+  validatingWebhookTimeoutSeconds: 5
+  mutatingWebhookTimeoutSeconds: 5
 
   ## Enable rule that requires pods to come from
   ## the image registry defined by "URL".

--- a/helmfile/values/gatekeeper/gatekeeper.yaml.gotmpl
+++ b/helmfile/values/gatekeeper/gatekeeper.yaml.gotmpl
@@ -1,7 +1,7 @@
 validatingWebhookFailurePolicy: Fail
-validatingWebhookTimeoutSeconds: 5
+validatingWebhookTimeoutSeconds: {{ .Values.opa.validatingWebhookTimeoutSeconds }}
 mutatingWebhookFailurePolicy: Fail
-mutatingWebhookTimeoutSeconds: 5
+mutatingWebhookTimeoutSeconds: {{ .Values.opa.mutatingWebhookTimeoutSeconds }}
 
 validatingWebhookCustomRules:
   - apiGroups:
@@ -86,13 +86,26 @@ mutatingWebhookCustomRules:
       - nodes/proxy
       - hierarchyconfiguration
 
-auditInterval: {{ .Values.opa.auditIntervalSeconds }}
 auditMatchKindOnly: true
+
+auditChunkSize: {{ .Values.opa.auditChunkSize }}
+auditFromCache: {{ .Values.opa.auditFromCache }}
+auditInterval: {{ .Values.opa.auditIntervalSeconds }}
+constraintViolationsLimit: {{ .Values.opa.constraintViolationsLimit }}
 
 controllerManager:
   resources: {{- toYaml .Values.opa.controllerManager.resources | nindent 4  }}
+  affinity: {{- toYaml .Values.opa.controllerManager.affinity | nindent 4  }}
+  nodeSelector: {{- toYaml .Values.opa.controllerManager.nodeSelector | nindent 4  }}
+  tolerations: {{- toYaml .Values.opa.controllerManager.tolerations | nindent 4  }}
+  topologySpreadConstraints: {{- toYaml .Values.opa.controllerManager.topologySpreadConstraints | nindent 4  }}
+
 audit:
   resources: {{- toYaml .Values.opa.audit.resources | nindent 4  }}
+  affinity: {{- toYaml .Values.opa.audit.affinity | nindent 4  }}
+  nodeSelector: {{- toYaml .Values.opa.audit.nodeSelector | nindent 4  }}
+  tolerations: {{- toYaml .Values.opa.audit.tolerations | nindent 4  }}
+  writeToRAMDisk: {{- toYaml .Values.opa.audit.writeToRAMDisk  | nindent 4  }}
 
 postInstall:
   probeWebhook:


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [ ] personal data beyond what is necessary for interacting with this pull request
> - [ ] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
This PR provides additional configuration through config files, making it possible to tune different parameters of gatekeeper `controllerManager` and `audit` pods.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1072 

#### Additional information to reviewers
The `controllerManager` already has [affinity](https://github.com/elastisys/compliantkubernetes-apps/blob/1651f30df8a1d1eb4a98c576cf91a321c06e5d17/helmfile/upstream/open-policy-agent-gatekeeper/gatekeeper/values.yaml#L149-L160) configured in the upstream `values.yaml` file, keeping it empty in `common-config.yaml` does not seem to override the upstream configuration, but it does reduce clarity for the reader not having it set in `common-config.yaml`.

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [x] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [x] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
