### PR TITLE
migration: add version check before applying crds

### DIFF
--- a/migration/v0.34/apply/11-prometheus-operator-crds.sh
+++ b/migration/v0.34/apply/11-prometheus-operator-crds.sh
@@ -9,32 +9,40 @@ run() {
   case "${1:-}" in
   execute)
     for CLUSTER in sc wc; do
-      log_info "  - applying the prometheus-operator CRDs on $CLUSTER"
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-alertmanagers.yaml
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-podmonitors.yaml
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-probes.yaml
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-prometheuses.yaml
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-thanosrulers.yaml
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-scrapeconfigs.yaml
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-prometheusagents.yaml
+      if [[ ! "$(helm_chart_version "$CLUSTER" monitoring kube-prometheus-stack)" = "49.2.0" ]]; then
+        log_info "  - applying the prometheus-operator CRDs on $CLUSTER"
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-alertmanagers.yaml
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-podmonitors.yaml
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-probes.yaml
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-prometheuses.yaml
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-thanosrulers.yaml
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-scrapeconfigs.yaml
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f "${ROOT}"/helmfile/upstream/prometheus-community/kube-prometheus-stack/charts/crds/crds/crd-prometheusagents.yaml
+      else
+        log_info "  - Skipping applying the prometheus-operator CRDs on $CLUSTER"
+      fi
     done
     ;;
   rollback)
     for CLUSTER in sc wc; do
-      log_info "  - rollback the prometheus-operator CRDs on $CLUSTER"
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
-      kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
-      kubectl_do $CLUSTER delete -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.67.1/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
-      kubectl_do $CLUSTER delete -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.67.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+      if [[ ! "$(helm_chart_version "$CLUSTER" monitoring kube-prometheus-stack)" = "49.2.0" ]]; then
+        log_info "  - rollback the prometheus-operator CRDs on $CLUSTER"
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+        kubectl_do $CLUSTER apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.63.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+        kubectl_do $CLUSTER delete -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.67.1/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+        kubectl_do $CLUSTER delete -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.67.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml
+      else
+        log_info "  - Skipping rollbacking the prometheus-operator CRDs on $CLUSTER"
+      fi
     done
     ;;
   *)

--- a/roles/get-requirements.yaml
+++ b/roles/get-requirements.yaml
@@ -3,7 +3,7 @@
   vars:
     install_path: /usr/local/bin
     install_user: "{{ lookup('env','USER') }}"
-    kubectl_version: 1.24.4
+    kubectl_version: 1.26.9
     helm_version: 3.8.0
     helmfile_version: 0.154.0
     helmdiff_version: 3.5.0


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Checks the installed chart version of `kube-prometheus-stack` before applying CRDs to avoid repeated work. Unfortunately `kubectl diff` takes as long as just applying the CRDs so that approach doesn't work. Also bumped the `kubectl` dependency to the latest patch on `1.26` as we are on `1.26.5` in the latest kubespray release.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1779 

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
