### PR TITLE
Add some initial disk performance alerts

### DIFF
--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -416,6 +416,8 @@ prometheus:
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: DoNotSchedule
+  diskAlerts:
+    perf: true
 
 dex:
   replicaCount: 2

--- a/helmfile.d/charts/prometheus-alerts/files/disk-perf.yaml
+++ b/helmfile.d/charts/prometheus-alerts/files/disk-perf.yaml
@@ -1,0 +1,46 @@
+groups:
+  - name: disk-performance
+    rules:
+      - alert: DiskReadWaitTimeHigh
+        annotations:
+          description: Disk {{ $labels.device }} Wait Time on {{ $labels.instance }} is {{ $value }}, check the workload
+          summary: Disk {{ $labels.device }} Wait Time is high on {{ $labels.instance }}
+          severity_level: warning
+          storage_type: local
+        expr: |
+          (
+          rate(node_disk_read_time_seconds_total{job="node-exporter"}[1m])
+          /
+          rate(node_disk_reads_completed_total{job="node-exporter"}[1m])
+          ) > 0.01
+        for: 10m
+        labels:
+          severity: warning
+      - alert: DiskWriteWaitTimeHigh
+        annotations:
+          description: Disk {{ $labels.device }} Wait Time on {{ $labels.instance }} is {{ $value }}, check the workload
+          summary: Disk {{ $labels.device }} Wait Time is high on {{ $labels.instance }}
+          severity_level: warning
+          storage_type: local
+        expr: |
+          (
+          rate(node_disk_write_time_seconds_total{job="node-exporter"}[1m])
+          /
+          rate(node_disk_writes_completed_total{job="node-exporter"}[1m])
+          ) > 0.1
+        for: 10m
+        labels:
+          severity: warning
+      - alert: DiskQueueSizeHigh
+        annotations:
+          description: Disk {{ $labels.device }} Queue Size on {{ $labels.instance }} is {{ $value }}, check the workload
+          summary: Disk {{ $labels.device }} has very large Queue Size on {{ $labels.instance }}
+          severity_level: warning
+          storage_type: local
+        expr: |
+          (
+          rate(node_disk_io_time_weighted_seconds_total{job="node-exporter"}[1m])
+          ) > 0.5
+        for: 10m
+        labels:
+          severity: warning

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/disk-perf.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/disk-perf.yaml
@@ -1,0 +1,23 @@
+# Based on https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
+{{- if .Values.diskAlerts.perf }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-alerts.fullname" .) "disk-perf" | trunc 63 | trimSuffix "-" }}
+  namespace: "monitoring"
+  labels:
+    app: {{ template "prometheus-alerts.name" . }}
+{{ include "prometheus-alerts.labels" . | indent 4 }}
+{{- if .Values.defaultRules.alertLabels }}
+{{ toYaml .Values.defaultRules.alertLabels | indent 4 }}
+{{- end }}
+{{- if .Values.defaultRules.annotations }}
+  annotations:
+{{ toYaml .Values.defaultRules.annotations | indent 4 }}
+{{- end }}
+spec:
+  # The rules contain templates for prometheus, which breaks helm if trying
+  # to render them. We have to either escape them or (as we do here) include
+  # them without going through the template rendering.
+  {{- .Files.Get "files/disk-perf.yaml" | nindent 2}}
+{{- end }}

--- a/helmfile.d/charts/prometheus-alerts/values.yaml
+++ b/helmfile.d/charts/prometheus-alerts/values.yaml
@@ -67,6 +67,7 @@ diskAlerts:
     #        node: "" # Node to filter out from pattern matching
     #        disk: "" # Disk to filter out from pattern matching
     space: []
+  perf: false
 
 defaultRules:
   create: true


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [ ] personal data beyond what is necessary for interacting with this pull request
> - [ ] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1302

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
