### PR TITLE
Update sops URLs to account for it moving to a new github organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The apps are installed using a combination of helm charts and manifests with the
 - [helm-diff](https://github.com/databus23/helm-diff) (tested with 3.5.0)
 - [helm-secrets](https://github.com/futuresimple/helm-secrets) (tested with 3.12.0)
 - [jq](https://github.com/stedolan/jq) (tested with jq-1.6)
-- [sops](https://github.com/mozilla/sops) (tested with 3.7.3)
+- [sops](https://github.com/getsops/sops) (tested with 3.7.3)
 - [s3cmd](https://s3tools.org/s3cmd) available directly in Ubuntus repositories (tested with 2.0.1)
 - [yq4](https://github.com/mikefarah/yq) (tested with 4.26.1)
 - [pwgen](https://sourceforge.net/projects/pwgen/) available directly in Ubuntus repositories (tested with 2.08)
@@ -85,7 +85,7 @@ See [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ### :closed_lock_with_key: PGP :closed_lock_with_key:
 
-Configuration secrets in ck8s are encrypted using [SOPS](https://github.com/mozilla/sops).
+Configuration secrets in ck8s are encrypted using [SOPS](https://github.com/getsops/sops).
 We currently only support using PGP when encrypting secrets.
 Because of this, before you can start using ck8s, you need to generate your own PGP key:
 

--- a/bin/common.bash
+++ b/bin/common.bash
@@ -469,7 +469,7 @@ sops_encrypt_stdin() {
 
 # Encrypt a file in place.
 sops_encrypt() {
-    # https://github.com/mozilla/sops/issues/460
+    # https://github.com/getsops/sops/issues/460
     if sops_check "${1}"; then
         log_info "Already encrypted ${1}"
         return
@@ -487,7 +487,7 @@ sops_decrypt_verify() {
         exit 1
     fi
 
-    # https://github.com/mozilla/sops/issues/460
+    # https://github.com/getsops/sops/issues/460
     if ! sops_check "${1}"; then
         log_error "NOT ENCRYPTED: ${1}"
         exit 1

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -25,7 +25,7 @@ RUN wget --progress=dot:giga "https://github.com/yannh/kubeconform/releases/down
 # sops
 # NOTE: This needs to be installed before the helm-secrets plugin.
 ENV SOPS_VERSION="3.7.3"
-RUN wget --progress=dot:giga "https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux" && \
+RUN wget --progress=dot:giga "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux" && \
     install -Tm 755 "sops-v${SOPS_VERSION}.linux" /usr/local/bin/sops && \
     rm "sops-v${SOPS_VERSION}.linux"
 

--- a/roles/get-requirements.yaml
+++ b/roles/get-requirements.yaml
@@ -28,7 +28,7 @@
         dest: "{{ install_path }}/jq"
       - command: sops
         version: "{{ sops_version }}"
-        url: https://github.com/mozilla/sops/releases/download/v{{ sops_version }}/sops-v{{ sops_version }}.linux
+        url: https://github.com/getsops/sops/releases/download/v{{ sops_version }}/sops-v{{ sops_version }}.linux
         dest: "{{ install_path }}/sops"
       - command: yq
         version: "{{ yq_version }}"


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [ ] personal data beyond what is necessary for interacting with this pull request
> - [ ] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [x] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

[Sops is now a CNCF Sandbox project](https://github.com/getsops/sops/releases/tag/v3.8.0) and has moved out of the Mozilla github organization to its own, https://github.com/getsops
All old URLs still work for now but redirect to the new ones. 

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [x] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
