### PR TITLE
docs: update-ips command to use apply

### DIFF
--- a/bin/apps.bash
+++ b/bin/apps.bash
@@ -92,7 +92,7 @@ apps_wc() {
 #
 if [[ $1 == "wc" ]]; then
     if ! "${here}/update-ips.bash" "wc" "dry-run"; then
-        log_warning "Diff in wc config for network policy IPs, run 'ck8s update-ips wc update' to fix this issue."
+        log_warning "Diff in wc config for network policy IPs, run 'ck8s update-ips wc apply' to fix this issue."
 
         if ! ${CK8S_AUTO_APPROVE}; then
             log_warning_no_newline "Do you want to continue anyway? (y/N): "
@@ -106,7 +106,7 @@ if [[ $1 == "wc" ]]; then
     apps_wc "$2" "$3"
 elif [[ $1 == "sc" ]]; then
     if ! "${here}/update-ips.bash" "sc" "dry-run"; then
-        log_warning "Diff in sc config for network policy IPs, run 'ck8s update-ips sc update' to fix this issue."
+        log_warning "Diff in sc config for network policy IPs, run 'ck8s update-ips sc apply' to fix this issue."
 
         if ! ${CK8S_AUTO_APPROVE}; then
             log_warning_no_newline "Do you want to continue anyway? (y/N): "

--- a/migration/template/README.md
+++ b/migration/template/README.md
@@ -70,7 +70,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     # check if the netpol IPs need to be updated
     ./bin/ck8s update-ips both dry-run
     # if you agree with the changes apply
-    ./bin/ck8s update-ips both update
+    ./bin/ck8s update-ips both apply
     ```
 
 1. Apply upgrade - *disruptive*
@@ -106,7 +106,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     # check if the netpol IPs need to be updated
     ./bin/ck8s update-ips both dry-run
     # if you agree with the changes apply
-    ./bin/ck8s update-ips both update
+    ./bin/ck8s update-ips both apply
     ```
 
 ### Apply upgrade - *disruptive*

--- a/migration/v0.33/README.md
+++ b/migration/v0.33/README.md
@@ -112,7 +112,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     # check if the netpol IPs need to be updated
     ./bin/ck8s update-ips both dry-run
     # if you agree with the changes apply
-    ./bin/ck8s update-ips both update
+    ./bin/ck8s update-ips both apply
     ```
 
 1. Apply upgrade - *disruptive*
@@ -166,7 +166,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     # check if the netpol IPs need to be updated
     ./bin/ck8s update-ips both dry-run
     # if you agree with the changes apply
-    ./bin/ck8s update-ips both update
+    ./bin/ck8s update-ips both apply
     ```
 
 ### Apply upgrade - *disruptive*

--- a/migration/v0.34/README.md
+++ b/migration/v0.34/README.md
@@ -70,7 +70,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     # check if the netpol IPs need to be updated
     ./bin/ck8s update-ips both dry-run
     # if you agree with the changes apply
-    ./bin/ck8s update-ips both update
+    ./bin/ck8s update-ips both apply
     ```
 
 1. Apply upgrade - *disruptive*
@@ -121,7 +121,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     # check if the netpol IPs need to be updated
     ./bin/ck8s update-ips both dry-run
     # if you agree with the changes apply
-    ./bin/ck8s update-ips both update
+    ./bin/ck8s update-ips both apply
     ```
 
 ### Apply upgrade - *disruptive*


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [ ] personal data beyond what is necessary for interacting with this pull request
> - [ ] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [x] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
The migration steps for `update-ips` command had not been update to use `apply` instead of `update` (was changed [here](https://github.com/elastisys/compliantkubernetes-apps/pull/1582/files#diff-e2152e838d854d832a786626facd8174c460ba5ac8471bdaef3dab042b2b1ab1R39)). This PR updates the migration template as well as the migration documents for v0.33 and onwards.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
