### PR TITLE
apps wc: Allow HNC without HA mode in netpol

### DIFF
--- a/helmfile/values/networkpolicies/workload/hnc.yaml.gotmpl
+++ b/helmfile/values/networkpolicies/workload/hnc.yaml.gotmpl
@@ -5,22 +5,29 @@ policies:
       egress: {}
       ingress: {}
 
+    controller-manager:
+      podSelectorLabels:
+        app.kubernetes.io/component: hnc-controller-manager
+      egress:
+        - rule: egress-rule-apiserver
+      ingress:
+        {{- if not .Values.hnc.ha }}
+        - rule: ingress-rule-apiserver
+          ports:
+            - tcp: 9443
+        {{- end }}
+        - rule: ingress-rule-prometheus
+          ports:
+            - tcp: 8080
+
+    {{- if .Values.hnc.ha }}
     webhook:
       podSelectorLabels:
         app.kubernetes.io/component: hnc-webhook
+      egress:
+        - rule: egress-rule-apiserver
       ingress:
         - rule: ingress-rule-apiserver
           ports:
             - tcp: 9443
-      egress:
-        - rule: egress-rule-apiserver
-
-    controller-manager:
-      podSelectorLabels:
-        app.kubernetes.io/component: hnc-controller-manager
-      ingress:
-        - rule: ingress-rule-prometheus
-          ports:
-            - tcp: 8080
-      egress:
-        - rule: egress-rule-apiserver
+    {{- end }}


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Found that the netpols were blocking if HNC wasn't in HA mode, and I reordered things to better match how they get templated.

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Network Policy checks:
  - [x] Any changed pod is covered by Network Policies
  - [x] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
