### PR TITLE
apps: Allow calico-accountant drop and execute in Falco

### DIFF
--- a/helmfile/values/falco/falco-common.yaml.gotmpl
+++ b/helmfile/values/falco/falco-common.yaml.gotmpl
@@ -307,6 +307,10 @@ customRules:
     - list: known_binaries_to_read_environment_variables_from_proc_files
       append: true
       items: [systemd-run, rook, udevadm]
+    - list: known_drop_and_execute_containers
+      append: true
+      items:
+        - ghcr.io/elastisys/calico-accountant # when .calicoAccountant.backend = nftables
 falcosidekick:
   enabled: {{ .Values.falco.alerts.enabled }}
   config:


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Exempt calico-accountant from drop and execute rule in Falco.
As it is expected when it runs with the nftables backend.

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Network Policy checks:
  - [x] Any changed pod is covered by Network Policies
  - [x] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [x] Any changed pod is covered by Pod Security Admission
  - [x] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [x] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [x] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
