### PR TITLE
End-to-end tests for Harbor API

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,4 @@
 common/bats
+common/docs
 node_modules
 **.gen.bats

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -64,7 +64,7 @@ $(all:.bats=): %: %.bats
 	@echo --- bats $*.bats
 	@bats -r $*.bats
 
-dep: dep-bats common/bats/assert common/bats/detik common/bats/support dep-npm node_modules
+dep: dep-bats common/bats/assert common/bats/detik common/bats/support common/docs dep-npm node_modules
 
 dep-bats:
 ifndef found_bats
@@ -88,17 +88,22 @@ endif
 
 common/bats/assert:
 	@echo --- git clone github.com/bats-core/bats-assert
-	@git clone https://github.com/bats-core/bats-assert.git common/bats/assert
+	@git clone --depth 1 https://github.com/bats-core/bats-assert.git common/bats/assert
 	@echo
 
 common/bats/detik:
 	@echo --- git clone github.com/bats-core/bats-detik
-	@git clone https://github.com/bats-core/bats-detik.git common/bats/detik
+	@git clone --depth 1 https://github.com/bats-core/bats-detik.git common/bats/detik
 	@echo
 
 common/bats/support:
 	@echo --- git clone github.com/bats-core/bats-support
-	@git clone https://github.com/bats-core/bats-support.git common/bats/support
+	@git clone --depth 1 https://github.com/bats-core/bats-support.git common/bats/support
+	@echo
+
+common/docs:
+	@echo --- git clone github.com/elastisys/compliantkubernetes
+	@git clone --depth 1 https://github.com/elastisys/compliantkubernetes.git common/docs
 	@echo
 
 node_modules:
@@ -125,6 +130,8 @@ clean: clean-dep clean-gen
 clean-dep:
 	@echo rm common/bats
 	@rm -rf common/bats
+	@echo rm common/docs
+	@rm -rf common/docs
 	@echo rm node_modules
 	@rm -rf node_modules
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,6 +8,9 @@ Tests implemented with `cypress` can and will be integrated into the `bats` test
 > [!note]
 > All instructions assume that you are standing in the `tests/` directory.
 
+> [!warning]
+> Known issue that tests requiring use of `docker` or `podman` cannot run within the test container.
+
 ### Usage with Makefile
 
 > [!note]

--- a/tests/common/lib/harbor.bash
+++ b/tests/common/lib/harbor.bash
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+
+# Helpers for interacting with Harbor:
+# - harbor.load_env [slug]                                                      - setup variables to have unique names for each test suite
+# - harbor.setup_user_demo_image                                                - setup user demo image from the public docs repo
+# - harbor.setup_project                                                        - setup project and robot for test suites
+# - harbor.teardown_project                                                     - teardown project and robot for test suites
+# - harbor.get [resource/path] <args...>                                        - curl with args to do get requests
+# - harbor.post [resource/path] [json data] <args...>                           - curl with args to do post requests
+# - harbor.delete [resource/path] <args...>                                     - curl with args to do delete requests
+# - harbor.get_current_user                                                     - get current user information
+# - harbor.create_project [project]                                             - create new project
+# - harbor.delete_project [project]                                             - delete project, must not have repositories
+# - harbor.get_robots [project]                                                 - get robots within a project
+# - harbor.create_robot [project] [robot]                                       - create a robot within a project
+# - harbor.delete_robot [robot-id]                                              - delete a robot by id
+# - harbor.get_repositories [project]                                           - get repositories within a project
+# - harbor.delete repositories [project] [repository]                           - delete a repository within a project
+# - harbor.get_artefact_vulnerabilities [project] [repository] [artefact]       - get vulnerabilities for an artefact
+# - harbor.create_artefact_vulnerability_scan [project] [repository] [artefact] - create a vulnerability scan for an artefact
+
+harbor.load_env() {
+  if [[ -z "${1:-}" ]]; then
+    log_fatal "usage: harbor.load_env [slug]"
+  fi
+
+  harbor_endpoint="$(yq sc '.harbor.subdomain + "." + .global.baseDomain')"
+  export harbor_endpoint
+
+  harbor_username="admin"
+  export harbor_username
+
+  harbor_password="$(yq_secret ".harbor.password")"
+  export harbor_password
+
+  export harbor_project="end-to-end-${1:-"user-demo"}-project"
+  export harbor_robot="end-to-end-${1:-"user-demo"}-robot"
+  export harbor_robot_fullname="robot\$${harbor_project}+${harbor_robot}"
+  export harbor_robot_id_path="/tmp/compliantkubernetes-apps-end-to-end-${1:-"user-demo"}-robot-id"
+  export harbor_robot_secret_path="/tmp/compliantkubernetes-apps-end-to-end-${1:-"user-demo"}-robot-secret"
+}
+
+# Expects a project to be setup with harbor.setup_project
+harbor.setup_user_demo_image() {
+  export docs_path="${ROOT}/tests/common/docs"
+
+  export user_demo="${docs_path}/user-demo/"
+  export user_demo_image="${harbor_endpoint}/${harbor_project}/user-demo:test"
+
+  docker build "${user_demo}" -t "${user_demo_image}"
+  docker push "${user_demo_image}"
+}
+
+# Expects variables to be set with harbor.load_env
+harbor.setup_project() {
+  local output
+
+  harbor.create_project "${harbor_project}"
+  output="$(harbor.create_robot "${harbor_project}" "${harbor_robot}")"
+
+  jq -r .id <<< "${output}" > "${harbor_robot_id_path}"
+  jq -r .secret <<< "${output}" > "${harbor_robot_secret_path}"
+
+  docker login --username "${harbor_robot_fullname}" --password-stdin "${harbor_endpoint}" < "${harbor_robot_secret_path}"
+}
+
+# Expects variables to be set with harbor.load_env
+harbor.teardown_project() {
+  # Allow failure
+  docker logout "${harbor_endpoint}" || true
+
+  readarray -t robots < <(harbor.get_robots "${harbor_project}" | jq -r '.[].id')
+  if [[ -n "${robots[*]}" ]]; then
+    for robot in "${robots[@]}"; do
+      harbor.delete_robot "${harbor_project}" "${robot}"
+    done
+  fi
+
+  rm -f "${harbor_robot_id_path}" "${harbor_robot_secret_path}"
+
+  readarray -t repositories < <(harbor.get_repositories "${harbor_project}" | jq -r '.[].name')
+  if [[ -n "${repositories[*]}" ]]; then
+    for repository in "${repositories[@]}"; do
+      harbor.delete_repository "${harbor_project}" "${repository#"${harbor_project}/"}"
+    done
+  fi
+
+  harbor.delete_project "${harbor_project}"
+}
+
+harbor.get() {
+  if [[ "${#}" -lt 1 ]]; then
+    log_fatal "usage: harbor.get [resource/path] <additional curl args...>"
+  fi
+
+  curl -s -u "${harbor_username}:${harbor_password}" "https://${harbor_endpoint}/api/v2.0/${1}" -H "accept: application/json" "${@:2}"
+}
+
+harbor.post() {
+  if [[ "${#}" -lt 1 ]]; then
+    log_fatal "usage: harbor.post [resource/path] [json data] <additional curl args...>"
+  fi
+
+  curl -s -u "${harbor_username}:${harbor_password}" "https://${harbor_endpoint}/api/v2.0/${1}" -H "accept: application/json" -H "content-type: application/json" -d "${2}" "${@:3}"
+}
+
+harbor.delete() {
+  if [[ "${#}" -lt 1 ]]; then
+    log_fatal "usage: harbor.delete [resource/path] <additional curl args...>"
+  fi
+
+  curl -s -u "${harbor_username}:${harbor_password}" -X DELETE "https://${harbor_endpoint}/api/v2.0/${1}" -H "accept: application/json" "${@:2}"
+}
+
+harbor.get_current_user() {
+  harbor.get users/current
+}
+
+harbor.create_project() {
+  if [[ "${#}" -lt 1 ]]; then
+    log_fatal "usage: harbor.create_project [project]"
+  fi
+
+  data="$(jq -cn --arg name "${1}" '
+    {
+      "project_name": $name
+    }
+  ')"
+
+  harbor.post projects "${data}"
+}
+
+harbor.delete_project() {
+  if [[ "${#}" -lt 1 ]]; then
+    log_fatal "usage: harbor.delete_project [project]"
+  fi
+
+  harbor.delete "projects/${1}"
+}
+
+harbor.get_robots() {
+  if [[ "${#}" -lt 1 ]]; then
+    log.fatal "usage: harbor.get_robots [project]"
+  fi
+
+  harbor.get "projects/${1}/robots"
+}
+
+harbor.create_robot() {
+  if [[ "${#}" -lt 2 ]]; then
+    log.fatal "usage: harbor.create_robot [project] [robot]"
+  fi
+
+  data="$(jq -cn --arg namespace "${1}" --arg name "${2}" '
+    {
+      "name": $name,
+      "level": "project",
+      "permissions": [
+        {
+          "access": [
+            {
+              "action": "*",
+              "resource": "*"
+            }
+          ],
+          "kind": "project",
+          "namespace": $namespace
+        }
+      ]
+    }
+  ')"
+
+  harbor.post "robots" "${data}"
+}
+
+harbor.delete_robot() {
+  if [[ "${#}" -lt 1 ]]; then
+    log.fatal "usage: harbor.delete_robot [robot-id]"
+  fi
+
+  harbor.delete "robots/${1}"
+}
+
+harbor.get_repositories() {
+  if [[ "${#}" -lt 1 ]]; then
+    log.fatal "usage: harbor.get_repositories [project]"
+  fi
+
+  harbor.get "projects/${1}/repositories"
+}
+
+harbor.delete_repository() {
+  if [[ "${#}" -lt 2 ]]; then
+    log.fatal "usage: harbor.delete_repository [project] [repository]"
+  fi
+
+  harbor.delete "projects/${1}/repositories/${2}"
+}
+
+harbor.get_artefact_vulnerabilities() {
+  if [[ "${#}" -lt 3 ]]; then
+    log.fatal "usage: harbor.get_artefact_vulnerabilities [project] [repository] [artefact]"
+  fi
+
+  harbor.get "projects/${1}/repositories/${2}/artifacts/${3}/additions/vulnerabilities" \
+    -H "x-accept-vulnerabilities: application/vnd.security.vulnerability.report; version=1.1, application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0"
+}
+
+harbor.create_artefact_vulnerability_scan() {
+  if [[ "${#}" -lt 3 ]]; then
+    log.fatal "usage: harbor.create_artefact_vulnerability_scan [project] [repository] [artefact]"
+  fi
+
+  harbor.post "projects/${1}/repositories/${2}/artifacts/${3}/scan" ""
+}

--- a/tests/end-to-end/gatekeeper-policies.bats
+++ b/tests/end-to-end/gatekeeper-policies.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+# Tests Gatekeeper policies
+
+# Setup user-demo image
+setup_file() {
+  load "../common/lib"
+  load "../common/lib/harbor"
+
+  common_setup
+
+  harbor.load_env gatekeeper-policies
+  harbor.setup_project
+  harbor.setup_user_demo_image
+
+  export user_demo_image
+}
+
+setup() {
+  load "../common/lib"
+
+  common_setup
+}
+
+@test "gatekeeper policies has prepared image" {
+  docker pull "${user_demo_image}"
+}
+
+# Teardown user-demo image
+teardown_file() {
+  load "../common/lib"
+  load "../common/lib/harbor"
+
+  common_setup
+
+  harbor.teardown_project
+}

--- a/tests/end-to-end/harbor-api.bats
+++ b/tests/end-to-end/harbor-api.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+
+# Test using Harbor via the API
+
+setup_file() {
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../common/lib"
+  load "../common/lib/harbor"
+
+  common_setup
+
+  harbor.load_env "harbor-api"
+
+  export harbor_endpoint
+  export harbor_project
+  export harbor_robot
+  export harbor_robot_fullname
+  export harbor_robot_id_path
+  export harbor_robot_secret_path
+}
+
+teardown_file() {
+  harbor.teardown_project
+}
+
+setup() {
+  load "../common/lib"
+  load "../common/lib/harbor"
+
+  common_setup
+}
+
+@test "harbor api can authenticate" {
+  run harbor.get_current_user
+
+  assert_line --regexp ".*\"username\":\"admin\".*"
+  assert_success
+}
+
+@test "harbor api can create project" {
+  run harbor.create_project "${harbor_project}"
+
+  refute_output
+  assert_success
+}
+
+@test "harbor api can create robot account" {
+  run harbor.create_robot "${harbor_project}" "${harbor_robot}"
+
+  assert_line --regexp ".*\"name\":\"robot.*"
+  assert_success
+
+  jq -r .id <<< "${output}" > "${harbor_robot_id_path}"
+  jq -r .secret <<< "${output}" > "${harbor_robot_secret_path}"
+}
+
+@test "harbor api can authenticate with robot account" {
+  run docker login "${harbor_endpoint}" --username "${harbor_robot_fullname}" --password-stdin < "${harbor_robot_secret_path}"
+
+  assert_line --regexp "Login Succeeded"
+  assert_success
+}
+
+@test "harbor api can push image with robot account" {
+  docker pull docker.io/library/busybox
+  docker tag docker.io/library/busybox "${harbor_endpoint}/${harbor_project}/busybox:latest"
+  docker push "${harbor_endpoint}/${harbor_project}/busybox:latest"
+}
+
+@test "harbor api can pull image with robot account" {
+  docker rmi docker.io/library/busybox
+  docker rmi "${harbor_endpoint}/${harbor_project}/busybox:latest"
+  docker pull "${harbor_endpoint}/${harbor_project}/busybox:latest"
+  docker tag "${harbor_endpoint}/${harbor_project}/busybox:latest" "docker.io/library/busybox"
+  docker rmi "${harbor_endpoint}/${harbor_project}/busybox:latest"
+}
+
+@test "harbor api can scan image with robot account" {
+  run harbor.create_artefact_vulnerability_scan "${harbor_project}" "busybox" "latest"
+
+  refute_output
+  assert_success
+
+  for each in $(seq 30); do
+    echo "${each} try" >&2
+
+    run harbor.get_artefact_vulnerabilities "${harbor_project}" "busybox" "latest"
+
+    assert_success
+
+    if [[ "${output}" != "{}" ]]; then
+      break
+    fi
+
+    sleep 1
+  done
+
+  refute_line --regexp ".*errors.*"
+}
+
+@test "harbor api can unauthenticate with robot account" {
+  docker logout "${harbor_endpoint}"
+}
+
+@test "harbor api can delete robot account" {
+  read -r harbor_robot_id < "${harbor_robot_id_path}"
+
+  run harbor.delete_robot "${harbor_robot_id}"
+
+  refute_output
+  assert_success
+
+  rm -f "${harbor_robot_id_path}" "${harbor_robot_secret_path}"
+}
+
+@test "harbor api can delete repository" {
+  run harbor.delete_repository "${harbor_project}" "busybox"
+
+  refute_output
+  assert_success
+}
+
+@test "harbor api can delete project" {
+  run harbor.delete_project "${harbor_project}"
+
+  refute_output
+  assert_success
+}


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
I'm not entirely happy with the execution of these tests, and I'm thinking of reworking them a bit.

I would like the setup of the user-demo image to be a one liner and that practically all that needs can create it's own project/repository/robot to ensure that each test suite has a fresh and predictable environment, and that each test suite can be run independently.
And having it as a before all files may prevent the specific harbor tests to tell what goes wrong.

The clone of the docs repo may be allowed to be a before all files since it will be relatively static.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes https://github.com/elastisys/ck8s-ops/issues/1849

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
