### PR TITLE
apps: upgrade ingress-nginx controller to 1.8.4 and chart to 4.7.3

### DIFF
--- a/helmfile/upstream/index.yaml
+++ b/helmfile/upstream/index.yaml
@@ -49,7 +49,7 @@ charts:
 
   kubereboot/kured: 4.5.1
 
-  kubernetes-ingress-nginx/ingress-nginx: 4.7.0
+  kubernetes-ingress-nginx/ingress-nginx: 4.7.3
   kubernetes-metrics-server/metrics-server: 3.10.0
 
   open-policy-agent-gatekeeper/gatekeeper: 3.11.0

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/Chart.yaml
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/Chart.yaml
@@ -1,11 +1,9 @@
 annotations:
   artifacthub.io/changes: |
-    - "helm: Fix opentelemetry module installation for daemonset (#9792)"
-    - "Update charts/* to keep project name display aligned (#9931)"
-    - "Update Ingress-Nginx version controller-v1.8.0"
+    - "Update Ingress-Nginx version controller-v1.8.4"
   artifacthub.io/prerelease: "false"
 apiVersion: v2
-appVersion: 1.8.0
+appVersion: 1.8.4
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and
   load balancer
 home: https://github.com/kubernetes/ingress-nginx
@@ -21,4 +19,4 @@ maintainers:
 name: ingress-nginx
 sources:
 - https://github.com/kubernetes/ingress-nginx
-version: 4.7.0
+version: 4.7.3

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/README.md
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/README.md
@@ -2,7 +2,7 @@
 
 [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 
-![Version: 4.7.0](https://img.shields.io/badge/Version-4.7.0-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 4.7.3](https://img.shields.io/badge/Version-4.7.3-informational?style=flat-square) ![AppVersion: 1.8.4](https://img.shields.io/badge/AppVersion-1.8.4-informational?style=flat-square)
 
 To use, add `ingressClassName: nginx` spec field or the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
 
@@ -143,8 +143,10 @@ controller:
     internal:
       enabled: true
       annotations:
-        # Create internal ELB
-        service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+        # Create internal NLB
+        service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+        # Create internal ELB(Deprecated)
+        # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
         # Any other annotation can be declared here.
 ```
 
@@ -186,6 +188,8 @@ controller:
         service.beta.kubernetes.io/oci-load-balancer-internal: "true"
         # Any other annotation can be declared here.
 ```
+
+The load balancer annotations of more cloud service providers can be found: [Internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer).
 
 An use case for this scenario is having a split-view DNS setup where the public zone CNAME records point to the external balancer URL while the private zone CNAME records point to the internal balancer URL. This way, you only need one ingress kubernetes object.
 
@@ -248,11 +252,11 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.admissionWebhooks.networkPolicyEnabled | bool | `false` |  |
 | controller.admissionWebhooks.objectSelector | object | `{}` |  |
 | controller.admissionWebhooks.patch.enabled | bool | `true` |  |
-| controller.admissionWebhooks.patch.image.digest | string | `"sha256:543c40fd093964bc9ab509d3e791f9989963021f1e9e4c9c7b6700b02bfb227b"` |  |
+| controller.admissionWebhooks.patch.image.digest | string | `"sha256:a7943503b45d552785aa3b5e457f169a5661fb94d82b8a3373bcd9ebaf9aac80"` |  |
 | controller.admissionWebhooks.patch.image.image | string | `"ingress-nginx/kube-webhook-certgen"` |  |
 | controller.admissionWebhooks.patch.image.pullPolicy | string | `"IfNotPresent"` |  |
 | controller.admissionWebhooks.patch.image.registry | string | `"registry.k8s.io"` |  |
-| controller.admissionWebhooks.patch.image.tag | string | `"v20230407"` |  |
+| controller.admissionWebhooks.patch.image.tag | string | `"v20231011-8b53cabe0"` |  |
 | controller.admissionWebhooks.patch.labels | object | `{}` | Labels to be added to patch job resources |
 | controller.admissionWebhooks.patch.nodeSelector."kubernetes.io/os" | string | `"linux"` |  |
 | controller.admissionWebhooks.patch.podAnnotations | object | `{}` |  |
@@ -309,13 +313,13 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.hostname | object | `{}` | Optionally customize the pod hostname. |
 | controller.image.allowPrivilegeEscalation | bool | `true` |  |
 | controller.image.chroot | bool | `false` |  |
-| controller.image.digest | string | `"sha256:744ae2afd433a395eeb13dc03d3313facba92e96ad71d9feaafc85925493fee3"` |  |
-| controller.image.digestChroot | string | `"sha256:a45e41cd2b7670adf829759878f512d4208d0aec1869dae593a0fecd09a5e49e"` |  |
+| controller.image.digest | string | `"sha256:8d8ddf32b83ca3e74bd5f66369fa60d85353e18ff55fa7691b321aa4716f5ba9"` |  |
+| controller.image.digestChroot | string | `"sha256:76100ab4c1b3cdc2697dd26492ba42c6519e99c5df1bc839ac5d6444a2c58d17"` |  |
 | controller.image.image | string | `"ingress-nginx/controller"` |  |
 | controller.image.pullPolicy | string | `"IfNotPresent"` |  |
 | controller.image.registry | string | `"registry.k8s.io"` |  |
 | controller.image.runAsUser | int | `101` |  |
-| controller.image.tag | string | `"v1.8.0"` |  |
+| controller.image.tag | string | `"v1.8.4"` |  |
 | controller.ingressClass | string | `"nginx"` | For backwards compatibility with ingress.class annotation, use ingressClass. Algorithm is as follows, first ingressClassName is considered, if not present, controller looks for ingress.class annotation |
 | controller.ingressClassByName | bool | `false` | Process IngressClass per name (additionally as per spec.controller). |
 | controller.ingressClassResource.controllerValue | string | `"k8s.io/ingress-nginx"` | Controller-value of the controller that is processing this ingressClass |
@@ -352,7 +356,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.metrics.prometheusRule.enabled | bool | `false` |  |
 | controller.metrics.prometheusRule.rules | list | `[]` |  |
 | controller.metrics.service.annotations | object | `{}` |  |
-| controller.metrics.service.externalIPs | list | `[]` | List of IP addresses at which the stats-exporter service is available # Ref: https://kubernetes.io/docs/user-guide/services/#external-ips # |
+| controller.metrics.service.externalIPs | list | `[]` | List of IP addresses at which the stats-exporter service is available # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips # |
 | controller.metrics.service.labels | object | `{}` | Labels to be added to the metrics service resource |
 | controller.metrics.service.loadBalancerSourceRanges | list | `[]` |  |
 | controller.metrics.service.servicePort | int | `10254` |  |
@@ -368,10 +372,10 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.minAvailable | int | `1` | Minimum available pods set in PodDisruptionBudget. Define either 'minAvailable' or 'maxUnavailable', never both. |
 | controller.minReadySeconds | int | `0` | `minReadySeconds` to avoid killing pods before we are ready # |
 | controller.name | string | `"controller"` |  |
-| controller.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for controller pod assignment # Ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
+| controller.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for controller pod assignment # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/ # |
 | controller.opentelemetry.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
 | controller.opentelemetry.enabled | bool | `false` |  |
-| controller.opentelemetry.image | string | `"registry.k8s.io/ingress-nginx/opentelemetry:v20230527@sha256:fd7ec835f31b7b37187238eb4fdad4438806e69f413a203796263131f4f02ed0"` |  |
+| controller.opentelemetry.image | string | `"registry.k8s.io/ingress-nginx/opentelemetry:v20230721-3e2062ee5@sha256:13bee3f5223883d3ca62fee7309ad02d22ec00ff0d7033e3e9aca7a9f60fd472"` |  |
 | controller.podAnnotations | object | `{}` | Annotations to be added to controller pods # |
 | controller.podLabels | object | `{}` | Labels to add to the pod container metadata |
 | controller.podSecurityContext | object | `{}` | Security Context policies for controller pods |
@@ -395,21 +399,23 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.scope.enabled | bool | `false` | Enable 'scope' or not |
 | controller.scope.namespace | string | `""` | Namespace to limit the controller to; defaults to $(POD_NAMESPACE) |
 | controller.scope.namespaceSelector | string | `""` | When scope.enabled == false, instead of watching all namespaces, we watching namespaces whose labels only match with namespaceSelector. Format like foo=bar. Defaults to empty, means watching all namespaces. |
-| controller.service.annotations | object | `{}` |  |
+| controller.service.annotations | object | `{}` | Annotations are mandatory for the load balancer to come up. Varies with the cloud service. Values passed through helm tpl engine. |
 | controller.service.appProtocol | bool | `true` | If enabled is adding an appProtocol option for Kubernetes service. An appProtocol field replacing annotations that were using for setting a backend protocol. Here is an example for AWS: service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http It allows choosing the protocol for each backend specified in the Kubernetes service. See the following GitHub issue for more details about the purpose: https://github.com/kubernetes/kubernetes/issues/40244 Will be ignored for Kubernetes versions older than 1.20 # |
 | controller.service.enableHttp | bool | `true` |  |
 | controller.service.enableHttps | bool | `true` |  |
 | controller.service.enabled | bool | `true` |  |
 | controller.service.external.enabled | bool | `true` |  |
-| controller.service.externalIPs | list | `[]` | List of IP addresses at which the controller services are available # Ref: https://kubernetes.io/docs/user-guide/services/#external-ips # |
-| controller.service.internal.annotations | object | `{}` | Annotations are mandatory for the load balancer to come up. Varies with the cloud service. |
+| controller.service.externalIPs | list | `[]` | List of IP addresses at which the controller services are available # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips # |
+| controller.service.internal.annotations | object | `{}` | Annotations are mandatory for the load balancer to come up. Varies with the cloud service. Values passed through helm tpl engine. |
 | controller.service.internal.enabled | bool | `false` | Enables an additional internal load balancer (besides the external one). |
+| controller.service.internal.loadBalancerIP | string | `""` | Used by cloud providers to connect the resulting internal LoadBalancer to a pre-existing static IP. Make sure to add to the service the needed annotation to specify the subnet which the static IP belongs to. For instance, `networking.gke.io/internal-load-balancer-subnet` for GCP and `service.beta.kubernetes.io/aws-load-balancer-subnets` for AWS. |
 | controller.service.internal.loadBalancerSourceRanges | list | `[]` | Restrict access For LoadBalancer service. Defaults to 0.0.0.0/0. |
 | controller.service.internal.ports | object | `{}` | Custom port mapping for internal service |
 | controller.service.internal.targetPorts | object | `{}` | Custom target port mapping for internal service |
 | controller.service.ipFamilies | list | `["IPv4"]` | List of IP families (e.g. IPv4, IPv6) assigned to the service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. # Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/ |
 | controller.service.ipFamilyPolicy | string | `"SingleStack"` | Represents the dual-stack-ness requested or required by this Service. Possible values are SingleStack, PreferDualStack or RequireDualStack. The ipFamilies and clusterIPs fields depend on the value of this field. # Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/ |
 | controller.service.labels | object | `{}` |  |
+| controller.service.loadBalancerClass | string | `""` | Used by cloud providers to select a load balancer implementation other than the cloud provider default. https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class |
 | controller.service.loadBalancerIP | string | `""` | Used by cloud providers to connect the resulting `LoadBalancer` to a pre-existing static IP according to https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer |
 | controller.service.loadBalancerSourceRanges | list | `[]` |  |
 | controller.service.nodePorts.http | string | `""` |  |
@@ -463,7 +469,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | defaultBackend.minAvailable | int | `1` |  |
 | defaultBackend.minReadySeconds | int | `0` | `minReadySeconds` to avoid killing pods before we are ready # |
 | defaultBackend.name | string | `"defaultbackend"` |  |
-| defaultBackend.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for default backend pod assignment # Ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
+| defaultBackend.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for default backend pod assignment # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/ # |
 | defaultBackend.podAnnotations | object | `{}` | Annotations to be added to default backend pods # |
 | defaultBackend.podLabels | object | `{}` | Labels to add to the pod container metadata |
 | defaultBackend.podSecurityContext | object | `{}` | Security Context policies for controller pods See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for notes on enabling and using sysctls # |
@@ -477,7 +483,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | defaultBackend.replicaCount | int | `1` |  |
 | defaultBackend.resources | object | `{}` |  |
 | defaultBackend.service.annotations | object | `{}` |  |
-| defaultBackend.service.externalIPs | list | `[]` | List of IP addresses at which the default backend service is available # Ref: https://kubernetes.io/docs/user-guide/services/#external-ips # |
+| defaultBackend.service.externalIPs | list | `[]` | List of IP addresses at which the default backend service is available # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips # |
 | defaultBackend.service.loadBalancerSourceRanges | list | `[]` |  |
 | defaultBackend.service.servicePort | int | `80` |  |
 | defaultBackend.service.type | string | `"ClusterIP"` |  |

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/README.md.gotmpl
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/README.md.gotmpl
@@ -140,8 +140,10 @@ controller:
     internal:
       enabled: true
       annotations:
-        # Create internal ELB
-        service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+        # Create internal NLB
+        service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+        # Create internal ELB(Deprecated)
+        # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
         # Any other annotation can be declared here.
 ```
 
@@ -183,6 +185,8 @@ controller:
         service.beta.kubernetes.io/oci-load-balancer-internal: "true"
         # Any other annotation can be declared here.
 ```
+
+The load balancer annotations of more cloud service providers can be found: [Internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer).
 
 An use case for this scenario is having a split-view DNS setup where the public zone CNAME records point to the external balancer URL while the private zone CNAME records point to the internal balancer URL. This way, you only need one ingress kubernetes object.
 

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog.md.gotmpl
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog.md.gotmpl
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### {{  .NewHelmChartVersion }}
+{{ with .HelmUpdates }}
+{{ range . }}* {{ . }}
+{{ end }}{{ end }}
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-{{ .PreviousHelmChartVersion }}...helm-chart-{{ .NewHelmChartVersion }}

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/Changelog-4.5.2.md
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/Changelog-4.5.2.md
@@ -1,0 +1,13 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.5.2
+
+* add lint on chart before release (#9570)
+* ci: remove setup-helm step (#9404)
+* feat(helm): Optionally use cert-manager instead admission patch (#9279)
+* run helm release on main only and when the chart/value changes only (#9290)
+* Update Ingress-Nginx version controller-v1.6.4
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.4.3...helm-chart-4.5.2

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/Changelog-4.6.0.md
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/Changelog-4.6.0.md
@@ -1,0 +1,24 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.5.3
+
+* docs(helm): fix value key in readme for enabling certManager (#9640)
+* Upgrade alpine 3.17.2
+* Upgrade golang 1.20
+* Drop testing/support for Kubernetes 1.23
+* docs(helm): fix value key in readme for enabling certManager (#9640)
+* Update Ingress-Nginx version controller-v1.7.0
+* feat: OpenTelemetry module integration (#9062)
+* canary-weight-total annotation ignored in rule backends (#9729)
+* fix controller psp's volume config (#9740)
+* Fix several Helm YAML issues with extraModules and extraInitContainers (#9709)
+* Chart: Drop `controller.headers`, rework DH param secret. (#9659)
+* Deployment/DaemonSet: Label pods using `ingress-nginx.labels`. (#9732)
+* HPA: autoscaling/v2beta1 deprecated, bump apiVersion to v2 for defaultBackend (#9731)
+* Fix incorrect annotation name in upstream hashing configuration (#9617)
+
+* Update Ingress-Nginx version controller-v1.7.0
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.5.2...helm-chart-4.6.0

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/Changelog-4.6.1.md
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/Changelog-4.6.1.md
@@ -1,0 +1,11 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.6.1
+
+* [helm] Support custom port configuration for internal service (#9846)
+* Adding resource type to default HPA configuration to resolve issues with Terraform helm chart usage (#9803)
+* Update Ingress-Nginx version controller-v1.7.1
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.6.0...helm-chart-4.6.1

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/Changelog-4.7.0.md
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/Changelog-4.7.0.md
@@ -1,0 +1,14 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.7.0
+
+* helm: Fix opentelemetry module installation for daemonset (#9792)
+* Update charts/* to keep project name display aligned (#9931)
+* HPA: Use capabilites & align manifests. (#9521)
+* PodDisruptionBudget spec logic update (#9904)
+* add option for annotations in PodDisruptionBudget (#9843)
+* Update Ingress-Nginx version controller-v1.8.0
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.6.1...helm-chart-4.7.0

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/Changelog-4.7.1.md
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/Changelog-4.7.1.md
@@ -1,0 +1,12 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.7.1
+
+* Added a doc line to the missing helm value service.internal.loadBalancerIP (#9406)
+* feat(helm): Add loadBalancerClass (#9562)
+* added helmshowvalues example (#10019)
+* Update Ingress-Nginx version controller-v1.8.1
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.7.0...helm-chart-4.7.1

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/Changelog-4.7.2.md
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/Changelog-4.7.2.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.7.2
+
+* Update Ingress-Nginx version controller-v1.8.2
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.7.1...helm-chart-4.7.2

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/Changelog-4.7.3.md
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/Changelog-4.7.3.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.7.3
+
+* Update Ingress-Nginx version controller-v1.8.4
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.7.3...helm-chart-4.7.3

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/_helpers.tpl
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/_helpers.tpl
@@ -201,8 +201,12 @@ Extra modules.
 
 - name: {{ .name }}
   image: {{ .image }}
+  {{- if .distroless | default false }}
+  command: ['/init_module']
+  {{- else }}
   command: ['sh', '-c', '/usr/local/bin/init_module.sh']
-  {{- if (.containerSecurityContext) }}
+  {{- end }}
+  {{- if .containerSecurityContext }}
   securityContext: {{ .containerSecurityContext | toYaml | nindent 4 }}
   {{- end }}
   volumeMounts:

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-deployment.yaml
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-deployment.yaml
@@ -190,7 +190,7 @@ spec:
       {{- end }}
       {{- if .Values.controller.opentelemetry.enabled}}
           {{ $otelContainerSecurityContext := $.Values.controller.opentelemetry.containerSecurityContext | default $.Values.controller.containerSecurityContext }}
-          {{- include "extraModules" (dict "name" "opentelemetry" "image" .Values.controller.opentelemetry.image "containerSecurityContext" $otelContainerSecurityContext) | nindent 8}}
+          {{- include "extraModules" (dict "name" "opentelemetry" "image" .Values.controller.opentelemetry.image "containerSecurityContext" $otelContainerSecurityContext "distroless" true) | nindent 8}}
       {{- end}}
     {{- end }}
     {{- if .Values.controller.hostNetwork }}

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-hpa.yaml
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-hpa.yaml
@@ -21,18 +21,18 @@ spec:
   minReplicas: {{ .Values.controller.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
   metrics:
-  {{- with .Values.controller.autoscaling.targetCPUUtilizationPercentage }}
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ . }}
-  {{- end }}
   {{- with .Values.controller.autoscaling.targetMemoryUtilizationPercentage }}
   - type: Resource
     resource:
       name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.controller.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
       target:
         type: Utilization
         averageUtilization: {{ . }}

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-keda.yaml
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-keda.yaml
@@ -25,6 +25,11 @@ spec:
   cooldownPeriod: {{ .Values.controller.keda.cooldownPeriod }}
   minReplicaCount: {{ .Values.controller.keda.minReplicas }}
   maxReplicaCount: {{ .Values.controller.keda.maxReplicas }}
+{{- with .Values.controller.keda.fallback }}
+  fallback:
+    failureThreshold: {{ .failureThreshold | default 3 }}
+    replicas: {{ .replicas | default $.Values.controller.keda.maxReplicas }}
+{{- end }}
   triggers:
 {{- with .Values.controller.keda.triggers }}
 {{ toYaml . | indent 2 }}

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-service-internal.yaml
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-service-internal.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   annotations:
   {{- range $key, $value := .Values.controller.service.internal.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{ $key }}: {{ tpl ($value | toString) $ | quote }}
   {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-service.yaml
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   annotations:
   {{- range $key, $value := .Values.controller.service.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{ $key }}: {{ tpl ($value | toString) $ | quote }}
   {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
@@ -27,6 +27,9 @@ spec:
 {{- end }}
 {{- if .Values.controller.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{ toYaml .Values.controller.service.loadBalancerSourceRanges | nindent 4 }}
+{{- end }}
+{{- if .Values.controller.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.controller.service.loadBalancerClass }}
 {{- end }}
 {{- if .Values.controller.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.controller.service.externalTrafficPolicy }}

--- a/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/values.yaml
+++ b/helmfile/upstream/kubernetes-ingress-nginx/ingress-nginx/values.yaml
@@ -23,9 +23,9 @@ controller:
     ## for backwards compatibility consider setting the full image url via the repository value below
     ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
     ## repository:
-    tag: "v1.8.0"
-    digest: sha256:744ae2afd433a395eeb13dc03d3313facba92e96ad71d9feaafc85925493fee3
-    digestChroot: sha256:a45e41cd2b7670adf829759878f512d4208d0aec1869dae593a0fecd09a5e49e
+    tag: "v1.8.4"
+    digest: sha256:8d8ddf32b83ca3e74bd5f66369fa60d85353e18ff55fa7691b321aa4716f5ba9
+    digestChroot: sha256:76100ab4c1b3cdc2697dd26492ba42c6519e99c5df1bc839ac5d6444a2c58d17
     pullPolicy: IfNotPresent
     # www-data -> uid 101
     runAsUser: 101
@@ -257,7 +257,7 @@ controller:
   ##
   terminationGracePeriodSeconds: 300
   # -- Node labels for controller pod assignment
-  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
   ##
   nodeSelector:
     kubernetes.io/os: linux
@@ -368,6 +368,9 @@ controller:
     maxReplicas: 11
     pollingInterval: 30
     cooldownPeriod: 300
+    # fallback:
+    #   failureThreshold: 3
+    #   replicas: 11
     restoreToOriginalReplicaCount: false
     scaledObject:
       annotations: {}
@@ -412,17 +415,20 @@ controller:
     # Will be ignored for Kubernetes versions older than 1.20
     ##
     appProtocol: true
+    # -- Annotations are mandatory for the load balancer to come up. Varies with the cloud service. Values passed through helm tpl engine.
     annotations: {}
     labels: {}
     # clusterIP: ""
 
     # -- List of IP addresses at which the controller services are available
-    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
     ##
     externalIPs: []
     # -- Used by cloud providers to connect the resulting `LoadBalancer` to a pre-existing static IP according to https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
+    # -- Used by cloud providers to select a load balancer implementation other than the cloud provider default. https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
+    loadBalancerClass: ""
     enableHttp: true
     enableHttps: true
     ## Set external traffic policy to: "Local" to preserve source IP on providers supporting it.
@@ -471,10 +477,10 @@ controller:
     internal:
       # -- Enables an additional internal load balancer (besides the external one).
       enabled: false
-      # -- Annotations are mandatory for the load balancer to come up. Varies with the cloud service.
+      # -- Annotations are mandatory for the load balancer to come up. Varies with the cloud service. Values passed through helm tpl engine.
       annotations: {}
-      # loadBalancerIP: ""
-
+      # -- Used by cloud providers to connect the resulting internal LoadBalancer to a pre-existing static IP. Make sure to add to the service the needed annotation to specify the subnet which the static IP belongs to. For instance, `networking.gke.io/internal-load-balancer-subnet` for GCP and `service.beta.kubernetes.io/aws-load-balancer-subnets` for AWS.
+      loadBalancerIP: ""
       # -- Restrict access For LoadBalancer service. Defaults to 0.0.0.0/0.
       loadBalancerSourceRanges: []
       ## Set external traffic policy to: "Local" to preserve source IP on
@@ -547,7 +553,7 @@ controller:
 
   opentelemetry:
     enabled: false
-    image: registry.k8s.io/ingress-nginx/opentelemetry:v20230527@sha256:fd7ec835f31b7b37187238eb4fdad4438806e69f413a203796263131f4f02ed0
+    image: registry.k8s.io/ingress-nginx/opentelemetry:v20230721-3e2062ee5@sha256:13bee3f5223883d3ca62fee7309ad02d22ec00ff0d7033e3e9aca7a9f60fd472
     containerSecurityContext:
       allowPrivilegeEscalation: false
   admissionWebhooks:
@@ -609,8 +615,8 @@ controller:
         ## for backwards compatibility consider setting the full image url via the repository value below
         ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
         ## repository:
-        tag: v20230407
-        digest: sha256:543c40fd093964bc9ab509d3e791f9989963021f1e9e4c9c7b6700b02bfb227b
+        tag: v20231011-8b53cabe0
+        digest: sha256:a7943503b45d552785aa3b5e457f169a5661fb94d82b8a3373bcd9ebaf9aac80
         pullPolicy: IfNotPresent
       # -- Provide a priority class name to the webhook patching job
       ##
@@ -652,7 +658,7 @@ controller:
       # clusterIP: ""
 
       # -- List of IP addresses at which the stats-exporter service is available
-      ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+      ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
       ##
       externalIPs: []
       # loadBalancerIP: ""
@@ -810,7 +816,7 @@ defaultBackend:
   #  key: value
 
   # -- Node labels for default backend pod assignment
-  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
   ##
   nodeSelector:
     kubernetes.io/os: linux
@@ -849,7 +855,7 @@ defaultBackend:
     # clusterIP: ""
 
     # -- List of IP addresses at which the default backend service is available
-    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
     ##
     externalIPs: []
     # loadBalancerIP: ""


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [x] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

### Security notice
New curl release (CVE-2023-38545 and CVE-2023-38546)
New Go release (https://github.com/advisories/GHSA-qppj-fm5r-hxr3 and https://github.com/advisories/GHSA-4374-p667-p6c8)
Fix for HTTP/2 Rapid Reset Attack [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)

### What does this PR do / why do we need this PR?

To apply the latest patch release and fix a couple of CVEs.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1820 

#### Additional information to reviewers

The relevant changelogs:
- https://github.com/kubernetes/ingress-nginx/blob/main/changelog/Changelog-1.8.1.md
- https://github.com/kubernetes/ingress-nginx/blob/main/changelog/Changelog-1.8.2.md

#### Screenshots
NA

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Network Policy checks:
  - [x] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [x] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [x] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [x] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
