### PR TITLE
apps wc: disable some of the user alerts managed by the platform admin

### DIFF
--- a/helmfile/charts/prometheus-alerts/values.yaml
+++ b/helmfile/charts/prometheus-alerts/values.yaml
@@ -85,9 +85,6 @@ defaultRules:
     general: true
     hnc: false
     k8s: true
-    kubeApiserverAvailability: true
-    kubePrometheusGeneral: true
-    kubePrometheusNodeRecording: true
     kubeStateMetrics: true
     kubelet: true
     kubernetesApps: true
@@ -109,11 +106,7 @@ defaultRules:
     dailyChecks: false
     fluentd: true
     missingMetrics: true
-    kubeSchedulerAlerting: true
-    kubeSchedulerRecording: true
     kubeProxy: true
-    kubeControllerManager: true
-    configReloaders: true
     networkpolicies: true
     dns: true
     clusterApi: false

--- a/helmfile/values/prometheus-user-alerts-wc.yaml.gotmpl
+++ b/helmfile/values/prometheus-user-alerts-wc.yaml.gotmpl
@@ -14,15 +14,24 @@ defaultRules:
   # labels:
   #   cluster: workload
   rules:
-    opensearch: false
-    falcoAlerts: false # falco alerts will come from falco sidekick
     alertmanager: {{ .Values.user.alertmanager.enabled }}
     # Rook is handled by the cluster operators. Users would normally not care
     # about these alerts, but we have no other way of gathering them currently.
     rookMonitor: {{ .Values.rookCeph.monitoring.enabled }}
     capacityManagementAlerts: {{ .Values.prometheus.capacityManagementAlerts.enabled }}
     networkpolicies: {{ .Values.networkPolicies.enableAlerting }}
+    # handled by the platform administrator
+    opensearch: false
+    falcoAlerts: false # falco alerts will come from falco sidekick
     harbor: false
+    missingMetrics: false # not useful for wc
+    dns: false
+    kubeProxy: false
+    prometheusOperator: false
+    network: false
+    kubernetesSystem: false
+    kubeStateMetrics: false
+
 
 capacityManagementAlertsPersistentVolumeEnabled: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.enabled }}
 capacityManagementAlertsPersistentVolumeLimit: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.limit }}


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [x] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
As for some alerts only the platform admin can take action I do not see them necessary to be seen by the developer, by default.
I propose to disable this alerts for wc:
- prometheus-alerts/templates/alerts/prometheus-operator.yaml
- prometheus-alerts/templates/alerts/node-network.yaml
- prometheus-alerts/templates/alerts/missing-metrics-rules.yaml
- prometheus-alerts/templates/alerts/kubernetes-system-kubelet.yaml
- prometheus-alerts/templates/alerts/kubernetes-system-apiserver.yaml
- prometheus-alerts/templates/alerts/kubernetes-system.yaml
- prometheus-alerts/templates/alerts/kube-state-metrics.yaml
- prometheus-alerts/templates/alerts/kubernetes-system-kube-proxy.yaml
- prometheus-alerts/templates/alerts/coredns.yaml

Let me know if you thinks the developer would benefit from any of these alerts.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Network Policy checks:
  - [x] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [x] Any changed pod is covered by Pod Security Admission
  - [x] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [x] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [x] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
