### PR TITLE
Allow per cluster init

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -156,7 +156,7 @@ jobs:
         CK8S_ENVIRONMENT_NAME: pipeline-exoscale
         CK8S_CLOUD_PROVIDER: exoscale
         CK8S_FLAVOR: dev
-      run: ./apps/bin/ck8s init
+      run: ./apps/bin/ck8s init both
       id: initialize-apps
 
     - name: Create buckets

--- a/README.md
+++ b/README.md
@@ -148,8 +148,15 @@ Assuming you already have everything needed to install the apps, this is what yo
     See [compliantkubernetes.io](https://compliantkubernetes.io/) if you are uncertain about what order you should do things in.
 
     ```bash
-    ./bin/ck8s init
+    ./bin/ck8s init both
     ```
+
+    > [!NOTE]
+    > It is possible to initialize `wc` and `sc` clusters separately by replacing `both` when running the `init` command:
+    > ```bash
+    > ./bin/ck8s init wc
+    > ./bin/ck8s init sc
+    > ```
 
 1. Edit the configuration files that have been initialized in the configuration path.
     Make sure that the `objectStorage` values are set in `common-config.yaml` or `sc-config.yaml` and `wc-config.yaml`, as well as required credentials in `secrets.yaml` according to your `objectStorage.type`.

--- a/bin/ck8s
+++ b/bin/ck8s
@@ -10,7 +10,7 @@ source "${here}/common.bash"
 
 usage() {
     echo "COMMANDS:" 1>&2
-    echo "  init [--generate-new-secrets]                     initialize the config path" 1>&2
+    echo "  init <wc|sc|both> [--generate-new-secrets]        initialize the config path" 1>&2
     echo "  bootstrap <wc|sc>                                 bootstrap the cluster" 1>&2
     echo "  apps <wc|sc> [--sync] [--skip-template-validate]  deploy the applications" 1>&2
     echo "  apply <wc|sc> [--sync] [--skip-template-validate] bootstrap and apps" 1>&2
@@ -58,7 +58,9 @@ done
 
 case "${1}" in
     init)
+        [[ "${2}" =~ ^(wc|sc|both)$ ]] || usage
         check_tools
+        export CK8S_CLUSTER="${2}"
         "${here}/init.bash" "${GEN_NEW_SECRETS}"
         ;;
     bootstrap)
@@ -92,7 +94,8 @@ case "${1}" in
         [[ "${3}" =~ ^(v[0-9]+\.[0-9]+)$ ]] || usage
         [[ "${4}" =~ ^(prepare|apply)$ ]] || usage
         check_tools
-        "${here}/upgrade.bash" "${2}" "${3}" "${4}"
+        export CK8S_CLUSTER="${2}"
+        "${here}/upgrade.bash" "${3}" "${4}"
         ;;
     team)
         case "${2}" in
@@ -159,7 +162,10 @@ case "${1}" in
         "${here}/update-ips.bash" "${2}" "${3}"
         ;;
     fix-psp-violations)
-        "${here}/fix-psp-violations.bash" "${2}"
+        [[ "${2}" =~ ^(wc|sc)$ ]] || usage
+        check_tools
+        export CK8S_CLUSTER="${2}"
+        "${here}/fix-psp-violations.bash"
         ;;
     clean)
         "${here}/clean.bash" "${2}"

--- a/bin/fix-psp-violations.bash
+++ b/bin/fix-psp-violations.bash
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 
-usage() {
-    echo "Usage: fix-psp-violoations <wc|sc>" >&2
-    exit 1
-}
+: "${CK8S_CLUSTER:?Missing CK8S_CLUSTER}"
 
 ROOT="$(readlink -f "$(dirname "${0}")/../")"
 
@@ -17,10 +14,9 @@ exempt_namepsaces=("rook-ceph")
 function set_violating_resources() {
   results_mult_uniq=""
   results=()
-  cluster="$1"
 
   # Get violations for PSPs
-  violations=$(kubectl_do "$cluster" get constraints -o yaml | yq4 '[.items[] | select(.kind == "K8sPSP*") | .status.violations[]]')
+  violations=$(kubectl_do "${CK8S_CLUSTER}" get constraints -o yaml | yq4 '[.items[] | select(.kind == "K8sPSP*") | .status.violations[]]')
 
   # Build array of maps with relevant information
   resources=$(echo "$violations" | yq4 '.[] |[{"name": .name, "namespace": .namespace}]' | yq4 'unique_by(.name,.namespace)')
@@ -32,7 +28,7 @@ function set_violating_resources() {
     namespace=$(echo "$resource" | yq4 e '.namespace')
     pod_name=$(echo "$resource" | yq4 e '.name')
 
-    owner_reference=$(kubectl_do "$cluster" -n "$namespace" get pod "$pod_name" --ignore-not-found=true -oyaml | yq4 '.metadata.ownerReferences.[0]')
+    owner_reference=$(kubectl_do "${CK8S_CLUSTER}" -n "$namespace" get pod "$pod_name" --ignore-not-found=true -oyaml | yq4 '.metadata.ownerReferences.[0]')
 
     # Skip standalone Pods and stale references
     if [ "$owner_reference" = "null" ] || [ -z "$owner_reference" ]; then continue; fi
@@ -45,7 +41,7 @@ function set_violating_resources() {
 
     # Get owner of ReplicaSets
     if [ "$owner_kind" == "ReplicaSet" ]; then
-      owner_reference=$(kubectl_do "$cluster" -n "$namespace" get rs "$owner_name" --ignore-not-found=true -oyaml | yq4 '.metadata.ownerReferences.[0]')
+      owner_reference=$(kubectl_do "${CK8S_CLUSTER}" -n "$namespace" get rs "$owner_name" --ignore-not-found=true -oyaml | yq4 '.metadata.ownerReferences.[0]')
 
       # Skip standalone ReplicaSets and stale references
       if [ "$owner_reference" = "null" ] || [ -z "$owner_reference" ]; then continue; fi
@@ -63,15 +59,13 @@ function set_violating_resources() {
 
 function is_customer_namespace() {
   namespace="$1"
-  cluster="$2"
-  operator_ns_regex="^($(kubectl_do "$cluster" get ns -l owner=operator '-ojsonpath={.items[*].metadata.name}' | sed 's/ /|/g'))$"
+  operator_ns_regex="^($(kubectl_do "${CK8S_CLUSTER}" get ns -l owner=operator '-ojsonpath={.items[*].metadata.name}' | sed 's/ /|/g'))$"
 
   if [[ "$namespace" =~ $operator_ns_regex  ]]; then return 1; fi
 }
 
 function restart_violating_resources() {
   IFS=$'\n'
-  cluster="$1"
   # shellcheck disable=SC2128
   for entry in $results_mult_uniq; do
     kind=$(echo "$entry" | yq4 .kind)
@@ -79,22 +73,17 @@ function restart_violating_resources() {
     namespace=$(echo "$entry" | yq4 .namespace)
 
     # shellcheck disable=SC2076
-    if [[ "${exempt_namepsaces[*]}" =~ "${namespace}" ]] || is_customer_namespace "$namespace" "$cluster"; then
-      log_warn "$kind/$name in $namespace for cluster $cluster requires manual restart"
+    if [[ "${exempt_namepsaces[*]}" =~ "${namespace}" ]] || is_customer_namespace "$namespace"; then
+      log_warn "$kind/$name in $namespace for cluster ${CK8S_CLUSTER} requires manual restart"
     else
-      if [[ -n "$(kubectl_do "$cluster" get "$kind" "$name" -n "$namespace" --ignore-not-found=true -oname)" ]]; then
-        log_info "Will trigger a rollout restart of $kind/$name in $namespace for cluster $cluster"
-        kubectl_do "$cluster" rollout restart "$kind" "$name" -n "$namespace"
+      if [[ -n "$(kubectl_do "${CK8S_CLUSTER}" get "$kind" "$name" -n "$namespace" --ignore-not-found=true -oname)" ]]; then
+        log_info "Will trigger a rollout restart of $kind/$name in $namespace for cluster ${CK8S_CLUSTER}"
+        kubectl_do "${CK8S_CLUSTER}" rollout restart "$kind" "$name" -n "$namespace"
       fi
     fi
 
   done
 }
 
-cluster="${1}"
-
-if [[ $cluster != "wc" && $cluster != "sc" ]]; then
-    usage
-fi
-set_violating_resources "$cluster"
-restart_violating_resources "$cluster"
+set_violating_resources
+restart_violating_resources

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -5,9 +5,12 @@
 # some defaults where applicable.
 # It's not to be executed on its own but rather via `ck8s init`.
 
+: "${CK8S_CLUSTER:?Missing CK8S_CLUSTER}"
+
 set -eu -o pipefail
 
 here="$(dirname "$(readlink -f "$0")")"
+
 # shellcheck source=bin/common.bash
 source "${here}/common.bash"
 
@@ -102,7 +105,7 @@ generate_default_config() {
         exit 1
     fi
 
-    default_config=$1
+    default_config="${1}"
     if [ -f "${default_config}" ]; then
         backup_file "${default_config}" default
     else
@@ -124,9 +127,9 @@ generate_default_config() {
 # Usage: set_storage_class <config-file>
 # baremetal support is experimental, keep as separate case until stable
 set_storage_class() {
-    file=$1
+    file="${1}"
     if [[ ! -f "${file}" ]]; then
-        log_error "ERROR: invalid file - $file"
+        log_error "ERROR: invalid file - ${file}"
         exit 1
     fi
     case ${CK8S_CLOUD_PROVIDER} in
@@ -161,9 +164,9 @@ set_storage_class() {
 # Usage: set_object_storage <config-file>
 # baremetal support is experimental, keep as separate case until stable
 set_object_storage() {
-    file=$1
+    file="${1}"
     if [[ ! -f "${file}" ]]; then
-        log_error "ERROR: invalid file - $file"
+        log_error "ERROR: invalid file - ${file}"
         exit 1
     fi
     case ${CK8S_CLOUD_PROVIDER} in
@@ -192,9 +195,9 @@ set_object_storage() {
 # Usage: set_nginx_config <config-file>
 # baremetal support is experimental, keep as separate case until stable
 set_nginx_config() {
-    file=$1
+    file="${1}"
     if [[ ! -f "${file}" ]]; then
-        log_error "ERROR: invalid file - $file"
+        log_error "ERROR: invalid file - ${file}"
         exit 1
     fi
     case ${CK8S_CLOUD_PROVIDER} in
@@ -235,27 +238,27 @@ set_nginx_config() {
             ;;
     esac
 
-    replace_set_me "$1" '.ingressNginx.controller.config.useProxyProtocol' "${use_proxy_protocol}"
-    replace_set_me "$1" '.ingressNginx.controller.useHostPort' "${use_host_port}"
-    replace_set_me "$1" '.ingressNginx.controller.service.enabled' "${service_enabled}"
-    replace_set_me "$1" '.networkPolicies.global.externalLoadBalancer' "${external_load_balancer}"
-    replace_set_me "$1" '.networkPolicies.global.ingressUsingHostNetwork' "${ingress_using_host_network}"
+    replace_set_me "${file}" '.ingressNginx.controller.config.useProxyProtocol' "${use_proxy_protocol}"
+    replace_set_me "${file}" '.ingressNginx.controller.useHostPort' "${use_host_port}"
+    replace_set_me "${file}" '.ingressNginx.controller.service.enabled' "${service_enabled}"
+    replace_set_me "${file}" '.networkPolicies.global.externalLoadBalancer' "${external_load_balancer}"
+    replace_set_me "${file}" '.networkPolicies.global.ingressUsingHostNetwork' "${ingress_using_host_network}"
 
     if [ "${service_enabled}" = 'false' ]; then
         replace_set_me "${file}" '.ingressNginx.controller.service.type' '"set-me-if-ingressNginx.controller.service.enabled"'
         replace_set_me "${file}" '.ingressNginx.controller.service.annotations' '"set-me-if-ingressNginx.controller.service.enabled"'
     else
-        replace_set_me "$1" '.ingressNginx.controller.service.type' "\"${service_type}\""
-        replace_set_me "$1" '.ingressNginx.controller.service.annotations' "\"${service_annotations}\""
+        replace_set_me "${file}" '.ingressNginx.controller.service.type' "\"${service_type}\""
+        replace_set_me "${file}" '.ingressNginx.controller.service.annotations' "\"${service_annotations}\""
     fi
 }
 
 # Usage: set_fluentd_config <config-file>
 # baremetal support is experimental, keep as separate case until stable
 set_fluentd_config() {
-    file=$1
+    file="${1}"
     if [[ ! -f "${file}" ]]; then
-        log_error "ERROR: invalid file - $file"
+        log_error "ERROR: invalid file - ${file}"
         exit 1
     fi
     case ${CK8S_CLOUD_PROVIDER} in
@@ -277,9 +280,9 @@ set_fluentd_config() {
 
 # Usage: set_s3bucketalertscount_config <config-file>
 set_s3bucketalertscount_config() {
-    file=$1
+    file="${1}"
     if [[ ! -f "${file}" ]]; then
-        log_error "ERROR: invalid file - $file"
+        log_error "ERROR: invalid file - ${file}"
         exit 1
     fi
     case ${CK8S_CLOUD_PROVIDER} in
@@ -300,7 +303,7 @@ set_s3bucketalertscount_config() {
 # Usage: set_harbor_config <config-file>
 # baremetal support is experimental, keep as separate case until stable
 set_harbor_config() {
-    file=$1
+    file="${1}"
     if [[ ! -f "${file}" ]]; then
         log_error "ERROR: invalid file - ${file}"
         exit 1
@@ -342,7 +345,7 @@ set_harbor_config() {
 }
 
 update_monitoring() {
-    file=$1
+    file="${1}"
     if [[ ! -f "${file}" ]]; then
         log_error "ERROR: invalid file - ${file}"
         exit 1
@@ -355,7 +358,7 @@ update_monitoring() {
     esac
 }
 update_psp_netpol() {
-    file=$1
+    file="${1}"
     if [[ ! -f "${file}" ]]; then
         log_error "ERROR: invalid file - ${file}"
         exit 1
@@ -375,7 +378,7 @@ update_config() {
         exit 1
     fi
 
-    override_config=$1
+    override_config="${1}"
     config_name=$(echo "${override_config}" | sed -r 's/.*\///' | sed -r 's/-config.yaml//')
 
     if [ -f "${override_config}" ]; then
@@ -434,8 +437,8 @@ update_secrets() {
         log_error "ERROR: number of args in update_secrets must be 2. #=[$#]"
         exit 1
     fi
-    file=$1
-    generate_new_secrets=$2
+    file="${1}"
+    generate_new_secrets="${2}"
 
     tmpfile=$(mktemp)
     append_trap "rm ${tmpfile}" EXIT
@@ -444,7 +447,7 @@ update_secrets() {
 
     generate_secrets "${tmpfile}"
 
-    if [[ -f $file ]]; then
+    if [[ -f "${file}" ]]; then
         sops_decrypt "${file}"
         yq4 --inplace '... comments=""' "${tmpfile}"
         yq4 eval-all --inplace --prettyPrint 'select(fi == 0) * select(fi == 1)' "${tmpfile}" "${file}"
@@ -464,7 +467,7 @@ generate_secrets() {
         log_error "ERROR: number of args in generate_secrets must be 1. #=[$#]"
         exit 1
     fi
-    tmpfile=$1
+    tmpfile="${1}"
 
     # https://unix.stackexchange.com/questions/307994/compute-bcrypt-hash-from-command-line
 
@@ -523,8 +526,9 @@ generate_secrets() {
 
 # Usage: backup_file <file> [sufix]
 backup_file() {
-    if [ ! -f "$1" ]; then
-        log_error "ERROR: args in backup_file must be a file. [$1]"
+    file="${1}"
+    if [ ! -f "${file}" ]; then
+        log_error "ERROR: args in backup_file must be a file. [${file}]"
     fi
 
     if [ ! -d "${backup_config_path}" ]; then
@@ -532,14 +536,14 @@ backup_file() {
     fi
 
     if [ ${#} -gt 1 ]; then
-        backup_name=$(echo "$1" | sed "s/.*\///" | sed "s/-config.yaml/-$2-$(date +%y%m%d%H%M%S).yaml/")
+        backup_name=$(echo "${file}" | sed "s/.*\///" | sed "s/-config.yaml/-$2-$(date +%y%m%d%H%M%S).yaml/")
     else
-        backup_name=$(echo "$1" | sed "s/.*\///" | sed "s/.yaml/-$(date +%y%m%d%H%M%S).yaml/")
+        backup_name=$(echo "${file}" | sed "s/.*\///" | sed "s/.yaml/-$(date +%y%m%d%H%M%S).yaml/")
     fi
 
     log_info "Creating backup ${backup_config_path}/${backup_name}"
 
-    cp "$1" "${backup_config_path}/${backup_name}"
+    cp "${file}" "${backup_config_path}/${backup_name}"
 }
 
 log_info "Initializing CK8S configuration for $CK8S_ENVIRONMENT_NAME with $CK8S_CLOUD_PROVIDER:$CK8S_FLAVOR"
@@ -569,19 +573,23 @@ update_monitoring       "${config[default_common]}"
 update_psp_netpol       "${config[default_common]}"
 update_config           "${config[override_common]}"
 
-generate_default_config        "${config[default_sc]}"
-set_fluentd_config             "${config[default_sc]}"
-set_harbor_config              "${config[default_sc]}"
-set_s3bucketalertscount_config "${config[default_sc]}"
-update_config                  "${config[override_sc]}"
+if [[ "${CK8S_CLUSTER:-}" =~ ^(sc|both)$ ]]; then
+  generate_default_config        "${config[default_sc]}"
+  set_fluentd_config             "${config[default_sc]}"
+  set_harbor_config              "${config[default_sc]}"
+  set_s3bucketalertscount_config "${config[default_sc]}"
+  update_config                  "${config[override_sc]}"
+fi
 
-generate_default_config "${config[default_wc]}"
-update_config           "${config[override_wc]}"
+if [[ "${CK8S_CLUSTER:-}" =~ ^(wc|both)$ ]]; then
+  generate_default_config "${config[default_wc]}"
+  update_config           "${config[override_wc]}"
+fi
 
 gen_new_secrets=true
 if [ -f "${secrets[secrets_file]}" ]; then
     backup_file "${secrets[secrets_file]}"
-    if [ ${#} -gt 0 ] && [ "$1" = "--generate-new-secrets" ]; then
+    if [ ${#} -gt 0 ] && [ "${1}" = "--generate-new-secrets" ]; then
         log_info "Updating and generating new secrets"
     else
         log_info "Updating secrets"
@@ -597,6 +605,10 @@ log_info "Config initialized"
 
 log_info "Time to edit the following files:"
 log_info "${config[override_common]}"
-log_info "${config[override_sc]}"
-log_info "${config[override_wc]}"
+if [[ "${CK8S_CLUSTER:-}" =~ ^(sc|both)$ ]]; then
+  log_info "${config[override_sc]}"
+fi
+if [[ "${CK8S_CLUSTER:-}" =~ ^(wc|both)$ ]]; then
+  log_info "${config[override_wc]}"
+fi
 log_info "${secrets[secrets_file]}"

--- a/bin/upgrade.bash
+++ b/bin/upgrade.bash
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
+: "${CK8S_CLUSTER:?Missing CK8S_CLUSTER}"
+
 here="$(readlink -f "$(dirname "${0}")")"
 
 ROOT="$(readlink -f "${here}/../")"
 
 CK8S_STACK="$(basename "$0")"
 export CK8S_STACK
-export CK8S_CLUSTER="${1}"
 
 # shellcheck source=scripts/migration/lib.sh
 CK8S_ROOT_SCRIPT="true" source "${ROOT}/scripts/migration/lib.sh"
@@ -134,8 +135,8 @@ usage() {
 }
 
 main() {
-  local version="${2}"
-  local action="${3}"
+  local version="${1}"
+  local action="${2}"
 
   local pass="true"
   for dir in "" "prepare" "apply"; do

--- a/migration/template/README.md
+++ b/migration/template/README.md
@@ -112,14 +112,14 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     This will take a backup into `backups/` before modifying any files.
 
     ```bash
-    ./bin/ck8s init
+    ./bin/ck8s init ${CK8S_CLUSTER}
     # or
     ./migration/${new_version}/prepare/50-init.sh
 
     # check if the netpol IPs need to be updated
-    ./bin/ck8s update-ips both dry-run
+    ./bin/ck8s update-ips ${CK8S_CLUSTER} dry-run
     # if you agree with the changes apply
-    ./bin/ck8s update-ips both apply
+    ./bin/ck8s update-ips ${CK8S_CLUSTER} apply
     ```
 
 ### Apply upgrade - *disruptive*

--- a/migration/template/prepare/50-init.sh
+++ b/migration/template/prepare/50-init.sh
@@ -6,4 +6,11 @@ ROOT="$(readlink -f "${HERE}/../../../")"
 # shellcheck source=scripts/migration/lib.sh
 source "${ROOT}/scripts/migration/lib.sh"
 
-"${ROOT}/bin/ck8s" init
+case "${CK8S_CLUSTER}" in
+  both|sc|wc)
+    "${ROOT}/bin/ck8s" init "${CK8S_CLUSTER}"
+    ;;
+  *)
+    log_fatal "usage: 50-init.sh <wc|sc|both>"
+    ;;
+esac

--- a/migration/v0.34/README.md
+++ b/migration/v0.34/README.md
@@ -127,14 +127,14 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     This will take a backup into `backups/` before modifying any files.
 
     ```bash
-    ./bin/ck8s init
+    ./bin/ck8s init ${CK8S_CLUSTER}
     # or
     ./migration/v0.34/prepare/50-init.sh
 
     # check if the netpol IPs need to be updated
-    ./bin/ck8s update-ips both dry-run
+    ./bin/ck8s update-ips ${CK8S_CLUSTER} dry-run
     # if you agree with the changes apply
-    ./bin/ck8s update-ips both apply
+    ./bin/ck8s update-ips ${CK8S_CLUSTER} apply
     ```
 
 ### Apply upgrade - *disruptive*

--- a/migration/v0.34/prepare/50-init.sh
+++ b/migration/v0.34/prepare/50-init.sh
@@ -6,4 +6,11 @@ ROOT="$(readlink -f "${HERE}/../../../")"
 # shellcheck source=scripts/migration/lib.sh
 source "${ROOT}/scripts/migration/lib.sh"
 
-"${ROOT}/bin/ck8s" init
+case "${CK8S_CLUSTER}" in
+  both|sc|wc)
+    "${ROOT}/bin/ck8s" init "${CK8S_CLUSTER}"
+    ;;
+  *)
+    log_fatal "usage: 50-init.sh <wc|sc|both>"
+    ;;
+esac

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -3,8 +3,11 @@
 If you want to run Bats tests locally (instead of in the CI pipeline), execute the following from the project root directory:
 
 ```bash
+git submodule update --recursive --init # init and update bats helpers
+
 docker build -t ck8s-apps ./pipeline
-docker run --rm -it -v "$(pwd):/ck8s-apps:ro" -w /ck8s-apps ck8s-apps \
+docker run --rm -it -e CK8S_PGP_FP=529D964DE0BBD900C4A395DA09986C297F8B7757 \
+    -v "$(pwd):/ck8s-apps:ro" -w /ck8s-apps ck8s-apps \
     bash -c './pipeline/sops-pgp-setup.bash && bats ./pipeline'
 ```
 

--- a/pipeline/init-unit-tests.bash
+++ b/pipeline/init-unit-tests.bash
@@ -24,7 +24,7 @@ if [[ "${CI:-}" == "true" ]]; then
   fi
 fi
 
-"${ck8s}" init
+"${ck8s}" init both
 
 # Add additional config changes here
 config_update "common" ".issuers.letsencrypt.staging.email" "me@example.com"

--- a/pipeline/init.bats
+++ b/pipeline/init.bats
@@ -21,19 +21,19 @@ teardown() {
 }
 
 @test "ck8s init requires CK8S_CONFIG_PATH" {
-    CK8S_CONFIG_PATH="" run ck8s init
+    CK8S_CONFIG_PATH="" run ck8s init both
     assert_failure
     assert_output --partial "Missing CK8S_CONFIG_PATH"
 }
 
 @test "ck8s init requires CK8S_ENVIRONMENT_NAME" {
-    CK8S_ENVIRONMENT_NAME="" run ck8s init
+    CK8S_ENVIRONMENT_NAME="" run ck8s init both
     assert_failure
     assert_output --partial "Missing CK8S_ENVIRONMENT_NAME"
 }
 
 @test "ck8s init requires CK8S_FLAVOR" {
-    CK8S_FLAVOR="" run ck8s init
+    CK8S_FLAVOR="" run ck8s init both
     assert_failure
     assert_output --partial "Missing CK8S_FLAVOR"
 }
@@ -41,33 +41,33 @@ teardown() {
 @test "ck8s init requires valid CK8S_PGP_FP or valid CK8S_PGP_UID" {
     unset CK8S_PGP_FP
 
-    run ck8s init
+    run ck8s init both
     assert_failure
     assert_output --partial "CK8S_PGP_FP and CK8S_PGP_UID can't both be unset"
 
-    CK8S_PGP_FP="123" run ck8s init
+    CK8S_PGP_FP="123" run ck8s init both
     assert_failure
     assert_output --partial "Fingerprint does not exist in gpg keyring"
 
-    CK8S_PGP_UID="asd" run ck8s init
+    CK8S_PGP_UID="asd" run ck8s init both
     assert_failure
     assert_output --partial "Unable to get fingerprint from gpg keyring using UID"
 }
 
 @test "ck8s init requires CK8S_CLOUD_PROVIDER" {
-    CK8S_CLOUD_PROVIDER="" run ck8s init
+    CK8S_CLOUD_PROVIDER="" run ck8s init both
     assert_failure
     assert_output --partial "Missing CK8S_CLOUD_PROVIDER"
 }
 
 @test "ck8s init checks supported cloud providers" {
-    CK8S_CLOUD_PROVIDER=foo run ck8s init
+    CK8S_CLOUD_PROVIDER=foo run ck8s init both
     assert_failure
     assert_output --partial "Unsupported cloud provider: foo"
 }
 
 @test "ck8s init checks supported flavors" {
-    CK8S_CLOUD_PROVIDER=aws CK8S_FLAVOR=foo run ck8s init
+    CK8S_CLOUD_PROVIDER=aws CK8S_FLAVOR=foo run ck8s init both
     assert_failure
     assert_output --partial "Unsupported flavor: foo"
 }
@@ -84,12 +84,12 @@ teardown() {
             local config_1="${CK8S_CONFIG_PATH}/1"
             local config_2="${CK8S_CONFIG_PATH}/2"
 
-            CK8S_CONFIG_PATH="${config_1}" run ck8s init
+            CK8S_CONFIG_PATH="${config_1}" run ck8s init both
             assert_success
 
             cp -R "${config_1}/." "${config_2}/"
 
-            CK8S_CONFIG_PATH="${config_2}" run ck8s init
+            CK8S_CONFIG_PATH="${config_2}" run ck8s init both
             assert_success
 
             run diff "${config_1}/defaults/common-config.yaml" "${config_2}/defaults/common-config.yaml"

--- a/scripts/migration/lib.sh
+++ b/scripts/migration/lib.sh
@@ -18,6 +18,7 @@ SC_CONFIG_FILES=(
   "defaults/sc-config.yaml"
   "common-config.yaml"
   "sc-config.yaml"
+  "secrets.yaml"
 )
 
 declare -a WC_CONFIG_FILES
@@ -26,6 +27,7 @@ WC_CONFIG_FILES=(
   "defaults/wc-config.yaml"
   "common-config.yaml"
   "wc-config.yaml"
+  "secrets.yaml"
 )
 
 # --- logging functions ---
@@ -87,7 +89,7 @@ config_version() {
   VERSION["${prefix}-config-patch"]="${version}"
 }
 
-# Usage: config_validation <secrets|sc|wc>
+# Usage: config_validate <secrets|sc|wc>
 config_validate() {
   local defaults
   local setmes


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice
The `ck8s init` command now requires a cluster argument which can be either of `<wc|sc|both>`.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Allow for running the `init` command per cluster. This also fixes issue with running the `fix-psp-violations` command which got introduced with [this PR](https://github.com/elastisys/compliantkubernetes-apps/pull/1778).

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1777 

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
