### PR TITLE
apps: Steps to restore from encrypted and object lock enabled off-site s3 bucket

### DIFF
--- a/scripts/restore-sync/README.md
+++ b/scripts/restore-sync/README.md
@@ -35,12 +35,26 @@ The destination bucket will be created automatically if it does not exists alrea
 With `<encrypted-bucket>` being the name of the encrypted bucket to restore, `<restored-bucket>` being the bucket to restore to, and `<prefix>` being the destination S3 service (`default` or `backup`):
 
 ```bash
-SOURCE="encrypt-<encrypted-bucket>:" DESTINATION="<prefix>:<restored-bucket>" envsubst < ./scripts/restore-sync-encrypt/template.job.yaml | ./bin/ck8s ops kubectl sc apply -f -
+SOURCE="encrypt-<encrypted-bucket>:" DESTINATION="<prefix>:<restored-bucket>" envsubst < ./scripts/restore-sync/template.job.yaml | ./bin/ck8s ops kubectl sc apply -f -
 ```
 
 > Important here that the value set for `SOURCE` is prefixed with `encrypt-` and ends with `:`!
 >
 > Make sure that the two buckets have separate names when restoring into the off-site S3 service!
+
+### Encrypted and Object lock enabled
+
+With `<encrypted-bucket>` being the name of the encrypted and object locked bucket to restore, `<restored-bucket>` being the bucket to restore to, and `<prefix>` being the destination S3 service (`default` or `backup`):
+
+```bash
+SOURCE="encrypt-<encrypted-bucket>,version_at="<version-timestamp>":" DESTINATION="<prefix>:<restored-bucket>" envsubst < ./scripts/restore-sync/template.job.yaml | ./bin/ck8s ops kubectl sc apply -f -
+```
+
+> Important here that the value set for `SOURCE` is prefixed with `encrypt-` and ends with `:`!
+>
+> Make sure that the two buckets have separate names when restoring into the off-site S3 service!
+>
+> You can find the `version-timestamp` using `aws --endpoint https://<s3-endpoint-url> s3api list-object-versions --bucket <encrypted-bucket>`
 
 ### Unencrypted
 


### PR DESCRIPTION
Steps to restore from encrypted and object lock enabled off-site s3 bucket

<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [x] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
