### PR TITLE
Tweak disk usage alerts

### DIFF
--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -401,20 +401,9 @@ prometheus:
     storage:
       predictLinear:
         - hours: 24
-          freeSpacePercentage: 30
+          freeSpacePercentage: 5
           severity: warning
-          for: 1h
-          pattern:
-            include:
-              node: ".*"
-              disk: ".*"
-            exclude:
-              node: ""
-              disk: ""
-        - hours: 4
-          freeSpacePercentage: 15
-          severity: critical
-          for: 1h
+          for: 2h
           pattern:
             include:
               node: ".*"
@@ -423,7 +412,7 @@ prometheus:
               node: ""
               disk: ""
       space:
-        - freeSpacePercentage: 5
+        - freeSpacePercentage: 20
           severity: warning
           for: 30m
           pattern:
@@ -433,7 +422,7 @@ prometheus:
             exclude:
               node: ""
               disk: ""
-        - freeSpacePercentage: 3
+        - freeSpacePercentage: 10
           severity: critical
           for: 30m
           pattern:
@@ -448,17 +437,6 @@ prometheus:
         - hours: 24
           freeSpacePercentage: 40
           severity: warning
-          for: 1h
-          pattern:
-            include:
-              node: ".*"
-              disk: ".*"
-            exclude:
-              node: ""
-              disk: ""
-        - hours: 4
-          freeSpacePercentage: 20
-          severity: critical
           for: 1h
           pattern:
             include:


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [ ] personal data beyond what is necessary for interacting with this pull request
> - [ ] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->


### Platform Administrator notice

Alerts for low remaining free space has changed. There is no longer a **critical** level alert for when free disk space is predicted to run out, but a `warning` level alert remains. Other disk low free disk space alerts have been tweaked.


<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

- Tweaks thresholds for low free space on disks in the hopes of being less noisy.
- See commit messages for rationales for each change.
- Notably removes the **critical** level alerts for a predicted future running out of space condition on the theory that the promql `predict_linear()` function does not produce good results when faced with sudden changes.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1836

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
