### PR TITLE
config: fix k8susercrds constraint permission issues for cluster admi…

### DIFF
--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -290,6 +290,9 @@ gatekeeper:
   allowUserCRDs:
     enabled: false
     enforcement: deny
+    # The name of the user specified in /etc/kubernetes/admin.conf kubeconfig file of the control plane nodes
+    # Necessary if Kubespray is used for managing the k8s cluster.
+    adminConfUser: kubernetes-admin
     extraCRDs: []
     # Sealed secrets and MongoDB CRDs can be enabled via user.sealedsecrets/mongodb
     # - names:

--- a/helmfile/values/userCRDs/userCRDs.yaml.gotmpl
+++ b/helmfile/values/userCRDs/userCRDs.yaml.gotmpl
@@ -1,50 +1,54 @@
 userCRDs:
-    enabled: {{ .Values.gatekeeper.allowUserCRDs.enabled }}
-    admin:
-        users: {{ .Values.clusterAdmin.users }}
-        groups: {{ .Values.clusterAdmin.groups }}
-        serviceAccounts:
-        - namespace: "gatekeeper-system"
-          name: "gatekeeper-admin-upgrade-crds"
-        - namespace: "velero"
-          name: "velero-server-upgrade-crds"
-        {{- if .Values.gatekeeper.allowUserCRDs.extraServiceAccounts }}
-        {{- toYaml .Values.gatekeeper.allowUserCRDs.extraServiceAccounts | nindent 8 }}
-        {{- end }}
-    allowedCRDs:
+  enabled: {{ .Values.gatekeeper.allowUserCRDs.enabled }}
+  admin:
+    users:
+      - {{ .Values.gatekeeper.allowUserCRDs.adminConfUser }}
+      {{- with .Values.clusterAdmin.users }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    groups: {{- toYaml .Values.clusterAdmin.groups | nindent 6 }}
+    serviceAccounts:
+      - namespace: "gatekeeper-system"
+        name: "gatekeeper-admin-upgrade-crds"
+      - namespace: "velero"
+        name: "velero-server-upgrade-crds"
+      {{- if .Values.gatekeeper.allowUserCRDs.extraServiceAccounts }}
+      {{- toYaml .Values.gatekeeper.allowUserCRDs.extraServiceAccounts | nindent 6 }}
+      {{- end }}
+  allowedCRDs:
     {{- if .Values.user.sealedSecrets.enabled }}
     - names:
-        - sealedsecrets.bitnami.com
+      - sealedsecrets.bitnami.com
       group: "bitnami.com"
     {{- end }}
     {{- if .Values.user.mongodb.enabled }}
     - names:
-        - mongodbcommunity.mongodbcommunity.mongodb.com
+      - mongodbcommunity.mongodbcommunity.mongodb.com
       group: mongodbcommunity.mongodb.com
     {{- end }}
     {{- if .Values.user.fluxv2.enabled }}
     - names:
-        - helmreleases.helm.toolkit.fluxcd.io
+      - helmreleases.helm.toolkit.fluxcd.io
       group: helm.toolkit.fluxcd.io
     - names:
-        - imageupdateautomations.image.toolkit.fluxcd.io
-        - imagepolicies.image.toolkit.fluxcd.io
-        - imagerepositories.image.toolkit.fluxcd.io
+      - imageupdateautomations.image.toolkit.fluxcd.io
+      - imagepolicies.image.toolkit.fluxcd.io
+      - imagerepositories.image.toolkit.fluxcd.io
       group: image.toolkit.fluxcd.io
     - names:
-        - kustomizations.kustomize.toolkit.fluxcd.io
+      - kustomizations.kustomize.toolkit.fluxcd.io
       group: kustomize.toolkit.fluxcd.io
     - names:
-        - alerts.notification.toolkit.fluxcd.io
-        - providers.notification.toolkit.fluxcd.io
-        - receivers.notification.toolkit.fluxcd.io
+      - alerts.notification.toolkit.fluxcd.io
+      - providers.notification.toolkit.fluxcd.io
+      - receivers.notification.toolkit.fluxcd.io
       group: notification.toolkit.fluxcd.io
     - names:
-        - buckets.source.toolkit.fluxcd.io
-        - gitrepositories.source.toolkit.fluxcd.io
-        - helmcharts.source.toolkit.fluxcd.io
-        - helmrepositories.source.toolkit.fluxcd.io
-        - ocirepositories.source.toolkit.fluxcd.io
+      - buckets.source.toolkit.fluxcd.io
+      - gitrepositories.source.toolkit.fluxcd.io
+      - helmcharts.source.toolkit.fluxcd.io
+      - helmrepositories.source.toolkit.fluxcd.io
+      - ocirepositories.source.toolkit.fluxcd.io
       group: source.toolkit.fluxcd.io
     {{- end }}
     {{- if .Values.gatekeeper.allowUserCRDs.extraCRDs }}


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1860 

This also fixes a templating issue for when multiple cluster-admin users or groups are specified, as previously this would configure all list entries as one list entry in the actual constraint resource as seen below:
```diff
➜ ./bin/ck8s ops helmfile wc -l component=gatekeeper-constraints diff
[ck8s] Validating wc config
...
Comparing release=gatekeeper-constraints, chart=charts/gatekeeper/constraints
gatekeeper-system, elastisys-allowed-user-crds, K8sUserCRDs (constraints.gatekeeper.sh) has changed:
  # Source: gatekeeper-constraints/templates/user-crds/constraint.yaml
  apiVersion: constraints.gatekeeper.sh/v1beta1
  kind: K8sUserCRDs
  metadata:
    name: elastisys-allowed-user-crds
  spec:
    enforcementAction: deny
    match:
      kinds:
        - apiGroups: ["apiextensions.k8s.io"]
          kinds: ["CustomResourceDefinition"]
    parameters:
      users:
-       - user1
+       - user1 user2
      groups:
-       - group1
+       - group1 group2
...
```

#### Additional information to reviewers
Tested running kubespray task for upgrading CSI driver with `kubernetes-admin` added as allowed user in the `users` list for `K8sUserCRDs` constraint, and it worked, see screenshot below. Kubespray command:

```bash
./bin/ck8s-kubespray run-playbook wc ../upgrade-cluster.yml -b --tags=csi-driver
```

#### Screenshots
![image](https://github.com/elastisys/compliantkubernetes-apps/assets/112394389/f1767a1c-3b96-4753-8546-0838375df189)

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
