### PR TITLE
Lookup Swift endpoint for RClone sync in update-ips script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: end-of-file-fixer
         exclude: ^helmfile/upstream/
       - id: trailing-whitespace
-        exclude: ^helmfile/upstream/
+        exclude: ^helmfile/upstream/|^pipeline/resources/
 
   - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
     rev: 2.7.1

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -24,10 +24,10 @@ RUN wget --progress=dot:giga "https://github.com/yannh/kubeconform/releases/down
 
 # sops
 # NOTE: This needs to be installed before the helm-secrets plugin.
-ENV SOPS_VERSION="3.7.3"
-RUN wget --progress=dot:giga "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux" && \
-    install -Tm 755 "sops-v${SOPS_VERSION}.linux" /usr/local/bin/sops && \
-    rm "sops-v${SOPS_VERSION}.linux"
+ENV SOPS_VERSION="3.8.1"
+RUN wget --progress=dot:giga "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" && \
+    install -Tm 755 "sops-v${SOPS_VERSION}.linux.amd64" /usr/local/bin/sops && \
+    rm "sops-v${SOPS_VERSION}.linux.amd64"
 
 # Helm
 ENV HELM_VERSION "v3.8.0"

--- a/pipeline/resources/get-swift-url.out
+++ b/pipeline/resources/get-swift-url.out
@@ -1,0 +1,21 @@
+-i -s -H Content-Type: application/json -d 
+        {
+          "auth": {
+            "identity": {
+              "methods": ["password"],
+              "password": {
+                "user": {
+                  "name": "swift-username",
+                  "domain": { "name": "swift-domain" },
+                  "password": "swift-password"
+                }
+              }
+            },
+            "scope": {
+              "project": {
+                "name": "swift-project",
+                "domain": { "name": "swift-project-domain" }
+              }
+            }
+          }
+        } https://keystone.foo.dev-ck8s.com:5678/auth/tokens

--- a/pipeline/resources/update-ips-dry-run-full-diff.out
+++ b/pipeline/resources/update-ips-dry-run-full-diff.out
@@ -178,22 +178,24 @@
 [[33mck8s[0m] Diff found for .networkPolicies.rcloneSync.destinationObjectStorageS3.ports in sc-config.yaml (diff shows actions needed to be up to date)
 [1m--- sc-config.yaml[0m
 [1m+++ expected[0m
-[36m@@ -15,3 +15,6 @@[0m
+[36m@@ -15,3 +15,7 @@[0m
  networkPolicies:
    rcloneSync:
      enabled: "true"
 [32m+    destinationObjectStorageSwift:[0m
 [32m+      ips:[0m
 [32m+        - 127.1.0.7/32[0m
+[32m+        - 127.1.0.8/32[0m
 [[33mck8s[0m] Diff found for .networkPolicies.rcloneSync.destinationObjectStorageSwift.ips in sc-config.yaml (diff shows actions needed to be up to date)
 [1m--- sc-config.yaml[0m
 [1m+++ expected[0m
-[36m@@ -15,3 +15,6 @@[0m
+[36m@@ -15,3 +15,7 @@[0m
  networkPolicies:
    rcloneSync:
      enabled: "true"
 [32m+    destinationObjectStorageSwift:[0m
 [32m+      ports:[0m
+[32m+        - 443[0m
 [32m+        - 5678[0m
 [[33mck8s[0m] Diff found for .networkPolicies.rcloneSync.destinationObjectStorageSwift.ports in sc-config.yaml (diff shows actions needed to be up to date)
 [1m--- sc-config.yaml[0m
@@ -204,7 +206,7 @@
      enabled: "true"
 [32m+    secondaryUrl:[0m
 [32m+      ips:[0m
-[32m+        - 127.1.0.8/32[0m
+[32m+        - 127.1.0.9/32[0m
 [[33mck8s[0m] Diff found for .networkPolicies.rcloneSync.secondaryUrl.ips in sc-config.yaml (diff shows actions needed to be up to date)
 [1m--- sc-config.yaml[0m
 [1m+++ expected[0m

--- a/pipeline/update-ips.bats
+++ b/pipeline/update-ips.bats
@@ -427,7 +427,7 @@ _test_apply_rclone_sync_s3_add_swift() {
 
   assert_equal "$(mock_get_call_num "${mock_dig}")" 6
   assert_equal "$(mock_get_call_num "${mock_kubectl}")" 12
-  assert_equal "$(mock_get_call_num "${mock_curl}")" 1
+  assert_equal "$(mock_get_call_num "${mock_curl}")" 2
 }
 
 @test "rclone sync - s3 and add swift - buckets destination type" {
@@ -499,7 +499,7 @@ _test_apply_rclone_sync_swift() {
 
   assert_equal "$(mock_get_call_num "${mock_dig}")" 5
   assert_equal "$(mock_get_call_num "${mock_kubectl}")" 12
-  assert_equal "$(mock_get_call_num "${mock_curl}")" 1
+  assert_equal "$(mock_get_call_num "${mock_curl}")" 2
 }
 
 @test "rclone sync - swift - buckets destination type" {
@@ -529,7 +529,7 @@ _test_apply_rclone_sync_swift_remove_s3() {
 
   assert_equal "$(mock_get_call_num "${mock_dig}")" 5
   assert_equal "$(mock_get_call_num "${mock_kubectl}")" 12
-  assert_equal "$(mock_get_call_num "${mock_curl}")" 1
+  assert_equal "$(mock_get_call_num "${mock_curl}")" 2
 }
 
 @test "rclone sync - swift and remove s3 - buckets destination type" {
@@ -566,7 +566,7 @@ _test_apply_rclone_sync_swift_add_s3() {
 
   assert_equal "$(mock_get_call_num "${mock_dig}")" 6
   assert_equal "$(mock_get_call_num "${mock_kubectl}")" 12
-  assert_equal "$(mock_get_call_num "${mock_curl}")" 1
+  assert_equal "$(mock_get_call_num "${mock_curl}")" 2
 }
 
 @test "rclone sync - swift and add s3 - buckets destination type" {
@@ -660,7 +660,7 @@ _test_apply_rclone_sync_s3_and_swift() {
 
   assert_equal "$(mock_get_call_num "${mock_dig}")" 6
   assert_equal "$(mock_get_call_num "${mock_kubectl}")" 12
-  assert_equal "$(mock_get_call_num "${mock_curl}")" 1
+  assert_equal "$(mock_get_call_num "${mock_curl}")" 2
 }
 
 @test "rclone sync - s3 and swift - s3" {


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice
(OpenStack only) You should see a new Network Policy for `.networkPolicies.rcloneSync.destinationObjectStorageSwift` after running `update-ips` if Swift and Keystone have separate IPs and/or ports.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Before this only the auth/Keystone endpoint would be allow-listed when updating the network policy configuration for RClone sync using Swift.

This might not have been an issue as long as the main object storage also was Swift since .networkPolicies.global.objectStorageSwift would have also been set (which performed the Swift endpoint lookup).

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Part of https://github.com/elastisys/compliantkubernetes-apps/issues/1750

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
