### PR TITLE
Determine default port by URL protocol in update-ips script

### DIFF
--- a/pipeline/resources/update-ips-dry-run-full-diff.out
+++ b/pipeline/resources/update-ips-dry-run-full-diff.out
@@ -51,7 +51,7 @@
 [[34mck8s[0m] Using unencrypted kubeconfig /tmp/ck8s-apps-config/.state/kube_config_sc.yaml
 [1m--- sc-config.yaml[0m
 [1m+++ expected[0m
-[36m@@ -15,3 +15,15 @@[0m
+[36m@@ -16,3 +16,15 @@[0m
  networkPolicies:
    rcloneSync:
      enabled: "true"
@@ -73,7 +73,7 @@
 [[34mck8s[0m] Using unencrypted kubeconfig /tmp/ck8s-apps-config/.state/kube_config_sc.yaml
 [1m--- sc-config.yaml[0m
 [1m+++ expected[0m
-[36m@@ -15,3 +15,15 @@[0m
+[36m@@ -16,3 +16,15 @@[0m
  networkPolicies:
    rcloneSync:
      enabled: "true"
@@ -92,7 +92,7 @@
 [[33mck8s[0m] Diff found for .networkPolicies.global.scNodes.ips in sc-config.yaml (diff shows actions needed to be up to date)
 [1m--- sc-config.yaml[0m
 [1m+++ expected[0m
-[36m@@ -15,3 +15,8 @@[0m
+[36m@@ -16,3 +16,8 @@[0m
  networkPolicies:
    rcloneSync:
      enabled: "true"
@@ -104,7 +104,7 @@
 [[33mck8s[0m] Diff found for .networkPolicies.global.objectStorageSwift.ips in sc-config.yaml (diff shows actions needed to be up to date)
 [1m--- sc-config.yaml[0m
 [1m+++ expected[0m
-[36m@@ -15,3 +15,8 @@[0m
+[36m@@ -16,3 +16,8 @@[0m
  networkPolicies:
    rcloneSync:
      enabled: "true"
@@ -158,7 +158,7 @@
 [[33mck8s[0m] Diff found for .networkPolicies.global.wcNodes.ips in wc-config.yaml (diff shows actions needed to be up to date)
 [1m--- sc-config.yaml[0m
 [1m+++ expected[0m
-[36m@@ -15,3 +15,6 @@[0m
+[36m@@ -16,3 +16,6 @@[0m
  networkPolicies:
    rcloneSync:
      enabled: "true"
@@ -168,7 +168,7 @@
 [[33mck8s[0m] Diff found for .networkPolicies.rcloneSync.destinationObjectStorageS3.ips in sc-config.yaml (diff shows actions needed to be up to date)
 [1m--- sc-config.yaml[0m
 [1m+++ expected[0m
-[36m@@ -15,3 +15,6 @@[0m
+[36m@@ -16,3 +16,6 @@[0m
  networkPolicies:
    rcloneSync:
      enabled: "true"
@@ -178,7 +178,7 @@
 [[33mck8s[0m] Diff found for .networkPolicies.rcloneSync.destinationObjectStorageS3.ports in sc-config.yaml (diff shows actions needed to be up to date)
 [1m--- sc-config.yaml[0m
 [1m+++ expected[0m
-[36m@@ -15,3 +15,7 @@[0m
+[36m@@ -16,3 +16,7 @@[0m
  networkPolicies:
    rcloneSync:
      enabled: "true"
@@ -189,7 +189,7 @@
 [[33mck8s[0m] Diff found for .networkPolicies.rcloneSync.destinationObjectStorageSwift.ips in sc-config.yaml (diff shows actions needed to be up to date)
 [1m--- sc-config.yaml[0m
 [1m+++ expected[0m
-[36m@@ -15,3 +15,7 @@[0m
+[36m@@ -16,3 +16,7 @@[0m
  networkPolicies:
    rcloneSync:
      enabled: "true"
@@ -200,7 +200,7 @@
 [[33mck8s[0m] Diff found for .networkPolicies.rcloneSync.destinationObjectStorageSwift.ports in sc-config.yaml (diff shows actions needed to be up to date)
 [1m--- sc-config.yaml[0m
 [1m+++ expected[0m
-[36m@@ -15,3 +15,6 @@[0m
+[36m@@ -16,3 +16,6 @@[0m
  networkPolicies:
    rcloneSync:
      enabled: "true"
@@ -210,7 +210,7 @@
 [[33mck8s[0m] Diff found for .networkPolicies.rcloneSync.secondaryUrl.ips in sc-config.yaml (diff shows actions needed to be up to date)
 [1m--- sc-config.yaml[0m
 [1m+++ expected[0m
-[36m@@ -15,3 +15,6 @@[0m
+[36m@@ -16,3 +16,6 @@[0m
  networkPolicies:
    rcloneSync:
      enabled: "true"

--- a/pipeline/update-ips.bats
+++ b/pipeline/update-ips.bats
@@ -412,8 +412,12 @@ _test_apply_rclone_sync_s3_add_swift() {
   _setup_rclone_sync_s3 "${1}"
 
   yq4 -i '.objectStorage.sync.swift.authUrl = "https://keystone.foo.dev-ck8s.com:5678"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
+  yq4 -i '.objectStorage.sync.swift.region = "swift-region"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
   sops --set '["objectStorage"]["sync"]["swift"]["username"] "swift-sync-username"' "${CK8S_CONFIG_PATH}/secrets.yaml"
 
+  # GET /auth/tokens
+  mock_set_output "${mock_curl}" '\n\n\n\n\n\n\n\n\n\n\n\n\n\n[{"catalog":[{"type": "object-store", "name": "swift", "endpoints": [{"interface":"public", "region": "swift-region", "url": "https://swift.foo.dev-ck8s.com"}]}]}]' 1
+  mock_set_output "${mock_curl}" "" 2 # DELETE /auth/tokens
   mock_set_output "${mock_dig}" "127.0.0.5" 5 # $os_auth_host
   mock_set_output "${mock_dig}" "127.0.0.6" 6 # $swift_host
 
@@ -482,9 +486,13 @@ _setup_rclone_sync_swift() {
   _setup_rclone
 
   yq4 -i '.objectStorage.sync.swift.authUrl = "https://keystone.foo.dev-ck8s.com:1234"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
+  yq4 -i '.objectStorage.sync.swift.region = "swift-region"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
   sops --set '["objectStorage"]["sync"]["swift"]["username"] "swift-sync-username"' "${CK8S_CONFIG_PATH}/secrets.yaml"
   yq4 -i "${1}"' = "swift"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
 
+  # GET /auth/tokens
+  mock_set_output "${mock_curl}" '\n\n\n\n\n\n\n\n\n\n\n\n\n\n[{"catalog":[{"type": "object-store", "name": "swift", "endpoints": [{"interface":"public", "region": "swift-region", "url": "https://swift.foo.dev-ck8s.com"}]}]}]' 1
+  mock_set_output "${mock_curl}" "" 2 # DELETE /auth/tokens
   mock_set_output "${mock_dig}" "127.0.0.4" 4 # $os_auth_host
   mock_set_output "${mock_dig}" "127.0.0.5" 5 # $swift_host
 }
@@ -548,10 +556,14 @@ _test_apply_rclone_sync_swift_add_s3() {
   _setup_rclone
 
   yq4 -i '.objectStorage.sync.swift.authUrl = "https://keystone.foo.dev-ck8s.com:1234"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
+  yq4 -i '.objectStorage.sync.swift.region = "swift-region"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
   sops --set '["objectStorage"]["sync"]["swift"]["username"] "swift-sync-username"' "${CK8S_CONFIG_PATH}/secrets.yaml"
   yq4 -i "${1}"' = "swift"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
   yq4 -i '.objectStorage.sync.s3.regionEndpoint = "https://s3.foo.dev-ck8s.com:5678"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
 
+  # GET /auth/tokens
+  mock_set_output "${mock_curl}" '\n\n\n\n\n\n\n\n\n\n\n\n\n\n[{"catalog":[{"type": "object-store", "name": "swift", "endpoints": [{"interface":"public", "region": "swift-region", "url": "https://swift.foo.dev-ck8s.com"}]}]}]' 1
+  mock_set_output "${mock_curl}" "" 2 # DELETE /auth/tokens
   mock_set_output "${mock_dig}" "127.0.0.5" 4 # $S3_ENDPOINT_DST
   mock_set_output "${mock_dig}" "127.0.0.4" 5 # $os_auth_host
   mock_set_output "${mock_dig}" "127.0.0.6" 6 # $swift_host
@@ -642,8 +654,12 @@ _test_apply_rclone_sync_s3_and_swift() {
 
   yq4 -i '.objectStorage.sync.s3.regionEndpoint = "https://s3.foo.dev-ck8s.com:1234"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
   yq4 -i '.objectStorage.sync.swift.authUrl = "https://keystone.foo.dev-ck8s.com:5678"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
+  yq4 -i '.objectStorage.sync.swift.region = "swift-region"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
   sops --set '["objectStorage"]["sync"]["swift"]["username"] "swift-sync-username"' "${CK8S_CONFIG_PATH}/secrets.yaml"
 
+  # GET /auth/tokens
+  mock_set_output "${mock_curl}" '\n\n\n\n\n\n\n\n\n\n\n\n\n\n[{"catalog":[{"type": "object-store", "name": "swift", "endpoints": [{"interface":"public", "region": "swift-region", "url": "https://swift.foo.dev-ck8s.com"}]}]}]' 1
+  mock_set_output "${mock_curl}" "" 2 # DELETE /auth/tokens
   mock_set_output "${mock_dig}" "127.0.0.4" 4 # $S3_ENDPOINT_DST
   mock_set_output "${mock_dig}" "127.0.0.5" 5 # $os_auth_host
   mock_set_output "${mock_dig}" "127.0.0.6" 6 # $swift_host
@@ -786,9 +802,13 @@ _setup_full() {
   yq4 -i '.networkPolicies.rcloneSync.enabled = "true"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
   yq4 -i '.objectStorage.sync.s3.regionEndpoint = "https://s3.foo.dev-ck8s.com:1234"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
   yq4 -i '.objectStorage.sync.swift.authUrl = "https://keystone.foo.dev-ck8s.com:5678"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
+  yq4 -i '.objectStorage.sync.swift.region = "swift-region"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
   sops --set '["objectStorage"]["sync"]["swift"]["username"] "swift-sync-username"' "${CK8S_CONFIG_PATH}/secrets.yaml"
   yq4 -i '.objectStorage.sync.secondaryUrl = "https://s3.foo.dev-ck8s.com:1234"' "${CK8S_CONFIG_PATH}/sc-config.yaml"
 
+  # GET /auth/tokens
+  mock_set_output "${mock_curl}" '\n\n\n\n\n\n\n\n\n\n\n\n\n\n[{"catalog":[{"type": "object-store", "name": "swift", "endpoints": [{"interface":"public", "region": "swift-region", "url": "https://swift.foo.dev-ck8s.com"}]}]}]' 3
+  mock_set_output "${mock_curl}" "" 4 # DELETE /auth/tokens
   mock_set_output "${mock_dig}" "127.1.0.6" 6 # $S3_ENDPOINT_DST
   mock_set_output "${mock_dig}" "127.1.0.7" 7 # $os_auth_host
   mock_set_output "${mock_dig}" "127.1.0.8" 8 # $swift_host


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice
update-ips now defaults to port 443 or 80 depending on the protocol of the Swift auth URL instead of 5000. Make sure to include the port if it's required.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Follow up from: https://github.com/elastisys/compliantkubernetes-apps/pull/1853#discussion_r1395829480

#### Additional information to reviewers

I had to patch the tests as well because previously they relied on `parse_url_port` not failing if the URL was empty. It worked before because the `dig` calls were mocked.

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
