### PR TITLE
apps: Add modular helmfile structure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: no-commit-to-branch
       - id: check-merge-conflict
       - id: check-yaml
-        exclude: ^helmfile/upstream/|charts/.*/templates/|helmfile.yaml|^helmfile/[0-9]+-[a-z-]+.yaml|^helmfile/bases
+        exclude: ^helmfile/stacks/|^helmfile/upstream/|charts/.*/templates/|helmfile.yaml|^helmfile/[0-9]+-[a-z-]+.yaml|^helmfile/bases
         args:
           - --allow-multiple-documents
       - id: check-json

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -1,0 +1,144 @@
+---
+missingFileHandler: Error
+bases:
+  - helmfile/bases/v2environments.yaml
+  - helmfile/bases/v2upstream.yaml
+---
+bases:
+  - helmfile/stacks/calico.yaml
+  - helmfile/stacks/cert-manager.yaml
+  - helmfile/stacks/dex.yaml
+  - helmfile/stacks/falco.yaml
+  - helmfile/stacks/fluentd.yaml
+  - helmfile/stacks/gatekeeper.yaml
+  - helmfile/stacks/harbor.yaml
+  - helmfile/stacks/hnc.yaml
+  - helmfile/stacks/ingress-nginx.yaml
+  - helmfile/stacks/kured.yaml
+  - helmfile/stacks/monitoring.yaml
+  - helmfile/stacks/monitoring-grafana.yaml
+  - helmfile/stacks/monitoring-prometheus.yaml
+  - helmfile/stacks/opensearch.yaml
+  - helmfile/stacks/rbac.yaml
+  - helmfile/stacks/rclone.yaml
+  - helmfile/stacks/system.yaml
+  - helmfile/stacks/thanos.yaml
+  - helmfile/stacks/velero.yaml
+---
+releases:
+  - inherit: [ template: admin-rbac ]
+  - inherit: [ template: dev-rbac ]
+  - inherit: [ template: dev-rbac-crds ]
+
+  - inherit: [ template: networkpolicies-common ]
+  - inherit: [ template: networkpolicies-service ]
+  - inherit: [ template: networkpolicies-workload ]
+
+  - inherit: [ template: cert-manager-controller ]
+  - inherit: [ template: cert-manager-issuers ]
+
+  - inherit: [ template: gatekeeper-controller ]
+  - inherit: [ template: gatekeeper-templates ]
+  - inherit: [ template: gatekeeper-constraints ]
+  - inherit: [ template: gatekeeper-mutations ]
+  - inherit: [ template: gatekeeper-metrics ]
+
+  - inherit: [ template: default-podsecuritypolicy ]
+
+  - inherit: [ template: falco-podsecuritypolicy ]
+  - inherit: [ template: falco-main ]
+  - inherit: [ template: falco-exporter ]
+
+  - inherit: [ template: fluentd-podsecuritypolicy ]
+  - inherit: [ template: fluentd-aggregator ]
+  - inherit: [ template: fluentd-forwarder ]
+  - inherit: [ template: fluentd-user ]
+  - inherit: [ template: log-manager ]
+
+  - inherit: [ template: ingress-nginx-podsecuritypolicy ]
+  - inherit: [ template: ingress-nginx-controller ]
+
+  - inherit: [ template: monitoring-networkpolicy ]
+  - inherit: [ template: monitoring-podsecuritypolicy ]
+
+  - inherit: [ template: metrics-server ]
+
+  - inherit: [ template: kube-prometheus-stack ]
+  - inherit: [ template: kube-state-metrics-extra-resources ]
+  - inherit: [ template: prometheus-blackbox-exporter ]
+  - inherit: [ template: prometheus-sc-monitors ]
+  - inherit: [ template: prometheus-sc-rules ]
+  - inherit: [ template: prometheus-wc-monitors ]
+  - inherit: [ template: prometheus-wc-rules ]
+
+  - inherit: [ template: dev-alertmanager ]
+
+  {{- range .Values | get "clusterApi.clusters" list }}
+  - inherit: [ template: autoscaling-monitoring ]
+    name: autoscaling-monitoring-{{ . }}
+    set:
+    - name: clusterName
+      value: {{ $.Values.global.ck8sEnvironmentName }}-{{ . }}
+  {{- end }}
+
+  - inherit: [ template: openstack-monitoring ]
+
+  - inherit: [ template: trivy-operator ]
+  - inherit: [ template: s3-exporter ]
+
+  - inherit: [ template: kubeapi-metrics ]
+
+  - inherit: [ template: thanos-networkpolicy ]
+  - inherit: [ template: thanos-ingress-secret ]
+  - inherit: [ template: thanos-objstore-secret ]
+  - inherit: [ template: thanos-query ]
+  - inherit: [ template: thanos-receiver ]
+  - inherit: [ template: thanos-ruler ]
+
+  - inherit: [ template: calico-accountant ]
+  - inherit: [ template: calico-default-deny ]
+  - inherit: [ template: calico-felix-metrics ]
+
+  - inherit: [ template: hnc-networkpolicy ]
+  - inherit: [ template: hnc-resources ]
+  - inherit: [ template: hnc-controller ]
+
+  - inherit: [ template: node-local-dns ]
+
+  - inherit: [ template: rook-ceph-podsecuritypolicy ]
+
+  - inherit: [ template: kured-podsecuritypolicy ]
+  - inherit: [ template: kured-secret ]
+  - inherit: [ template: kured-main ]
+
+  - inherit: [ template: velero-podsecuritypolicy ]
+  - inherit: [ template: velero-main ]
+
+  - inherit: [ template: rclone-sync ]
+
+  - inherit: [ template: dex ]
+
+  - inherit: [ template: grafana-admin ]
+  - inherit: [ template: grafana-dev ]
+  - inherit: [ template: grafana-label-enforcer ]
+  - inherit: [ template: grafana-dashboards ]
+
+  - inherit: [ template: harbor-networkpolicy ]
+  - inherit: [ template: harbor-podsecuritypolicy ]
+  - inherit: [ template: harbor-certs ]
+  - inherit: [ template: harbor-main ]
+  - inherit: [ template: harbor-init ]
+  - inherit: [ template: harbor-backup ]
+
+  - inherit: [ template: opensearch-podsecuritypolicy ]
+  - inherit: [ template: opensearch-secrets ]
+  - inherit: [ template: opensearch-master ]
+  - inherit: [ template: opensearch-client ]
+  - inherit: [ template: opensearch-data ]
+  - inherit: [ template: opensearch-dashboards ]
+  - inherit: [ template: opensearch-securityadmin ]
+  - inherit: [ template: opensearch-configurer ]
+  - inherit: [ template: opensearch-backup ]
+  - inherit: [ template: opensearch-slm ]
+  - inherit: [ template: opensearch-curator ]
+  - inherit: [ template: opensearch-exporter ]

--- a/helmfile/bases/v2environments.yaml
+++ b/helmfile/bases/v2environments.yaml
@@ -1,0 +1,44 @@
+helmDefaults:
+  createNamespace: false
+  skipDeps: true
+  timeout: 1800
+
+environments:
+  service_cluster:
+    values:
+      - ck8sManagementCluster: { enabled: true }
+      - ck8sWorkloadCluster: { enabled: false }
+      - {{ requiredEnv "CK8S_CONFIG_PATH" }}/defaults/common-config.yaml
+      - {{ requiredEnv "CK8S_CONFIG_PATH" }}/defaults/sc-config.yaml
+      - {{ requiredEnv "CK8S_CONFIG_PATH" }}/common-config.yaml
+      - {{ requiredEnv "CK8S_CONFIG_PATH" }}/sc-config.yaml
+    secrets:
+      - {{ requiredEnv "CK8S_CONFIG_PATH" }}/secrets.yaml
+  workload_cluster:
+    values:
+      - ck8sManagementCluster: { enabled: false }
+      - ck8sWorkloadCluster: { enabled: true }
+      - {{ requiredEnv "CK8S_CONFIG_PATH" }}/defaults/common-config.yaml
+      - {{ requiredEnv "CK8S_CONFIG_PATH" }}/defaults/wc-config.yaml
+      - {{ requiredEnv "CK8S_CONFIG_PATH" }}/common-config.yaml
+      - {{ requiredEnv "CK8S_CONFIG_PATH" }}/wc-config.yaml
+    secrets:
+      - {{ requiredEnv "CK8S_CONFIG_PATH" }}/secrets.yaml
+
+templates:
+  networkpolicies:
+    chart: helmfile/charts/networkpolicy/generator
+    version: 0.1.0
+    name: networkpolicy
+    labels:
+      policy: netpol
+
+  podsecuritypolicies:
+    disableValidationOnInstall: true
+    chart: helmfile/charts/gatekeeper/podsecuritypolicies
+    version: 0.1.0
+    name: podsecuritypolicy
+    labels:
+      policy: psp
+    needs:
+      - gatekeeper-system/gatekeeper-templates # creates gatekeeper/constraints and gatekeeper/mutations

--- a/helmfile/bases/v2upstream.yaml
+++ b/helmfile/bases/v2upstream.yaml
@@ -1,0 +1,12 @@
+{{- with readFile "helmfile/upstream/index.yaml" | fromYaml | get "charts" dict }}
+templates:
+  {{- range $chart, $version := . }}
+  {{ regexSplit "/" $chart -1 | last | printf "%s-chart" }}:
+    labels:
+      upstream: {{ regexSplit "/" $chart -1 | first }}
+    chart: {{ printf "helmfile/upstream/%s" $chart }}
+    version: {{ $version }}
+  {{- end }}
+{{- else }}
+{{ fail "unable to load upstream index" }}
+{{- end }}

--- a/helmfile/stacks/calico.yaml
+++ b/helmfile/stacks/calico.yaml
@@ -1,0 +1,43 @@
+---
+templates:
+  calico:
+    {{- if .Values | get "clusterApi.enabled" false }}
+    namespace: calico-system
+    {{- else }}
+    namespace: kube-system
+    {{- end }}
+    labels:
+      app: calico
+
+  calico-accountant:
+    disableValidationOnInstall: true
+    inherit: [ template: calico ]
+    installed: {{ .Values | get "calicoAccountant.enabled" false }}
+    chart: helmfile/charts/calico-accountant
+    version: 0.1.0
+    name: calico-accountant
+    needs:
+      - monitoring/kube-prometheus-stack # creates servicemonitors
+    values:
+      - helmfile/values/calico-accountant.yaml.gotmpl
+
+  calico-default-deny:
+    inherit: [ template: calico ]
+    installed: {{ .Values | get "networkPolicies.defaultDeny" false }}
+    chart: helmfile/charts/calico-default-deny
+    version: 0.1.0
+    namespace: kube-system
+    name: calico-default-deny
+    values:
+      - helmfile/values/calico-default-deny.yaml.gotmpl
+
+  calico-felix-metrics:
+    disableValidationOnInstall: true
+    inherit: [ template: calico ]
+    installed: {{ .Values | get "calicoFelixMetrics.enabled" false }}
+    chart: helmfile/charts/calico-felix-metrics
+    version: 0.1.0
+    namespace: kube-system
+    name: calico-felix-metrics
+    needs:
+      - monitoring/kube-prometheus-stack # creates servicemonitors

--- a/helmfile/stacks/cert-manager.yaml
+++ b/helmfile/stacks/cert-manager.yaml
@@ -1,0 +1,28 @@
+---
+templates:
+  cert-manager:
+    namespace: cert-manager
+    labels:
+      app: cert-manager
+
+  cert-manager-controller:
+    inherit:
+      - template: cert-manager
+      - template: cert-manager-chart
+    name: cert-manager
+    needs:
+      - kube-system/common-np
+    values:
+      - helmfile/values/cert-manager.yaml.gotmpl
+
+  cert-manager-issuers:
+    disableValidationOnInstall: true
+    inherit:
+      - template: cert-manager
+    chart: helmfile/charts/issuers
+    version: 0.1.0
+    name: issuers
+    needs:
+      - cert-manager/cert-manager # creates issuers
+    values:
+      - helmfile/values/letsencrypt.yaml.gotmpl

--- a/helmfile/stacks/dex.yaml
+++ b/helmfile/stacks/dex.yaml
@@ -1,0 +1,16 @@
+---
+templates:
+  dex:
+    disableValidationOnInstall: true
+    inherit: [ template: dex-chart ]
+    condition: ck8sManagementCluster.enabled
+    namespace: dex
+    name: dex
+    labels:
+      app: dex
+    needs:
+      - kube-system/service-cluster-np
+      - monitoring/kube-prometheus-stack # creates servicemonitors
+    values:
+      - helmfile/values/dex.yaml.gotmpl
+    wait: true

--- a/helmfile/stacks/falco.yaml
+++ b/helmfile/stacks/falco.yaml
@@ -1,0 +1,50 @@
+---
+templates:
+  falco:
+    installed: {{ .Values | get "falco.enabled" false }}
+    namespace: falco
+    labels:
+      app: falco
+
+  falco-podsecuritypolicy:
+    inherit:
+      - template: falco
+      - template: podsecuritypolicies
+    labels:
+      psp: falco
+    values:
+      - helmfile/values/podsecuritypolicies/common/falco.yaml.gotmpl
+
+  falco-main:
+    inherit:
+      - template: falco
+      - template: falco-chart
+    name: falco
+    needs:
+      - falco/podsecuritypolicy
+      - kube-system/common-np
+      {{- if .Values | get "ck8sManagementCluster.enabled" false }}
+      - kube-system/service-cluster-np
+      {{- else if .Values | get "ck8sWorkloadCluster.enabled" false }}
+      - kube-system/workload-cluster-np
+      {{- end }}
+    values:
+      - helmfile/values/falco/falco-common.yaml.gotmpl
+      {{- if .Values | get "ck8sManagementCluster.enabled" false }}
+      - helmfile/values/falco/falco-service-cluster.yaml.gotmpl
+      {{- else if .Values | get "ck8sWorkloadCluster.enabled" false }}
+      - helmfile/values/falco/falco-workload-cluster.yaml.gotmpl
+      {{ end }}
+
+  falco-exporter:
+    disableValidationOnInstall: true
+    inherit:
+      - template: falco
+      - template: falco-exporter-chart
+    name: falco-exporter
+    needs:
+      - falco/falco
+      - falco/podsecuritypolicy
+      - monitoring/kube-prometheus-stack # creates servicemonitors
+    values:
+      - helmfile/values/falco/falco-exporter.yaml.gotmpl

--- a/helmfile/stacks/fluentd.yaml
+++ b/helmfile/stacks/fluentd.yaml
@@ -1,0 +1,94 @@
+---
+templates:
+  fluentd:
+    namespace: fluentd-system
+    labels:
+      app: fluentd
+
+  fluentd-podsecuritypolicy:
+    inherit:
+      - template: fluentd
+      - template: podsecuritypolicies
+    installed: {{ .Values | get "fluentd.enabled" false }}
+    labels:
+      psp: fluentd
+    values:
+      - helmfile/values/podsecuritypolicies/common/fluentd.yaml.gotmpl
+
+  fluentd-aggregator:
+    disableValidationOnInstall: true
+    inherit:
+      - template: fluentd
+      - template: fluentd-chart
+    {{- if .Values | get "ck8sManagementCluster.enabled" false }}
+    installed: {{ .Values | get "fluentd.enabled" false }}
+    {{- else if .Values | get "ck8sWorkloadCluster.enabled" false }}
+    installed: {{ and (.Values | get "fluentd.enabled" false) (.Values | get "fluentd.audit.enabled" false) }}
+    {{- end }}
+    name: fluentd-aggregator
+    needs:
+      - fluentd-system/podsecuritypolicy
+      - kube-system/common-np
+      - monitoring/kube-prometheus-stack # creates servicemonitors
+    values:
+      - helmfile/values/fluentd/aggregator-common.yaml.gotmpl
+      {{- if .Values | get "ck8sManagementCluster.enabled" false }}
+      - helmfile/values/fluentd/aggregator-service-cluster.yaml.gotmpl
+      {{- else if .Values | get "ck8sWorkloadCluster.enabled" false }}
+      - helmfile/values/fluentd/aggregator-workload-cluster.yaml.gotmpl
+      {{ end }}
+
+  fluentd-forwarder:
+    disableValidationOnInstall: true
+    inherit:
+      - template: fluentd
+      - template: fluentd-elasticsearch-chart
+    {{- if .Values | get "ck8sManagementCluster.enabled" false }}
+    installed: {{ .Values | get "fluentd.enabled" false }}
+    {{- else if .Values | get "ck8sWorkloadCluster.enabled" false }}
+    installed: {{ and (.Values | get "fluentd.enabled" false) (or (.Values | get "fluentd.audit.enabled" false) (.Values | get "opensearch.enabled" false)) }}
+    {{- end }}
+    name: fluentd-forwarder
+    needs:
+      - fluentd-system/podsecuritypolicy
+      - kube-system/common-np
+      - monitoring/kube-prometheus-stack # creates servicemonitors and prometheusrules
+    values:
+      - helmfile/values/fluentd/forwarder-common.yaml.gotmpl
+      {{- if .Values | get "ck8sManagementCluster.enabled" false }}
+      - helmfile/values/fluentd/forwarder-service-cluster.yaml.gotmpl
+      {{- else if .Values | get "ck8sWorkloadCluster.enabled" false }}
+      - helmfile/values/fluentd/forwarder-workload-cluster.yaml.gotmpl
+      - helmfile/values/fluentd/forwarder-workload-cluster-system.yaml.gotmpl
+      {{ end }}
+
+  fluentd-user:
+    disableValidationOnInstall: true
+    inherit:
+      - template: fluentd
+      - template: fluentd-elasticsearch-chart
+    condition: ck8sWorkloadCluster.enabled
+    installed: {{ and (.Values | get "fluentd.enabled" false) (or (.Values | get "fluentd.audit.enabled" false) (.Values | get "opensearch.enabled" false)) }}
+    namespace: fluentd
+    name: fluentd
+    needs:
+      - fluentd-system/podsecuritypolicy
+      - kube-system/workload-cluster-np
+      - monitoring/kube-prometheus-stack # creates servicemonitors and prometheusrules
+    values:
+      - helmfile/values/fluentd/forwarder-common.yaml.gotmpl
+      - helmfile/values/fluentd/forwarder-workload-cluster.yaml.gotmpl
+      - helmfile/values/fluentd/forwarder-workload-cluster-user.yaml.gotmpl
+
+  log-manager:
+    inherit: [ template: fluentd ]
+    condition: ck8sManagementCluster.enabled
+    installed: {{ .Values | get "fluentd.enabled" false }}
+    chart: helmfile/charts/log-manager
+    version: 0.1.0
+    name: log-manager
+    needs:
+      - kube-system/service-cluster-np
+      - fluentd-system/podsecuritypolicy
+    values:
+      - helmfile/values/fluentd/log-manager.yaml.gotmpl

--- a/helmfile/stacks/gatekeeper.yaml
+++ b/helmfile/stacks/gatekeeper.yaml
@@ -1,0 +1,68 @@
+---
+templates:
+  gatekeeper:
+    namespace: gatekeeper-system
+    labels:
+      app: gatekeeper
+
+  gatekeeper-controller:
+    inherit:
+      - template: gatekeeper
+      - template: gatekeeper-chart
+    name: gatekeeper
+    needs:
+      - kube-system/common-np
+    values:
+      - helmfile/values/gatekeeper/gatekeeper.yaml.gotmpl
+    wait: true
+
+  gatekeeper-templates:
+    disableValidationOnInstall: true
+    inherit:
+      - template: gatekeeper
+    chart: helmfile/charts/gatekeeper/templates
+    version: 0.1.0
+    name: gatekeeper-templates
+    needs:
+      - gatekeeper-system/gatekeeper # creates gatekeeper/templates
+    values:
+      - helmfile/values/gatekeeper/templates.yaml.gotmpl
+    wait: true
+
+  gatekeeper-mutations:
+    disableValidationOnInstall: true
+    inherit:
+      - template: gatekeeper
+    installed: {{ .Values  | get "opa.mutations.enabled" false }}
+    chart: helmfile/charts/gatekeeper/mutations
+    version: 0.1.0
+    name: gatekeeper-mutations
+    needs:
+      - gatekeeper-system/gatekeeper # creates gatekeeper/mutations
+    values:
+      - helmfile/values/gatekeeper/mutations.yaml.gotmpl
+
+  gatekeeper-constraints:
+    disableValidationOnInstall: true
+    inherit:
+      - template: gatekeeper
+    chart: helmfile/charts/gatekeeper/constraints
+    version: 0.1.0
+    name: gatekeeper-constraints
+    condition: ck8sWorkloadCluster.enabled
+    needs:
+      - gatekeeper-system/gatekeeper-templates # creates gatekeeper/constraints
+    values:
+      - helmfile/values/gatekeeper/constraints.yaml.gotmpl
+      - helmfile/values/userCRDs/userCRDs.yaml.gotmpl
+
+  gatekeeper-metrics:
+    disableValidationOnInstall: true
+    inherit:
+      - template: gatekeeper
+    chart: helmfile/charts/gatekeeper/metrics
+    version: 0.1.0
+    name: gatekeeper-metrics
+    needs:
+      - gatekeeper-system/gatekeeper
+      - monitoring/kube-prometheus-stack # creates servicemonitors

--- a/helmfile/stacks/harbor.yaml
+++ b/helmfile/stacks/harbor.yaml
@@ -1,0 +1,80 @@
+---
+templates:
+  harbor:
+    condition: ck8sManagementCluster.enabled
+    namespace: harbor
+    labels:
+      app: harbor
+
+  harbor-networkpolicy:
+    inherit:
+      - template: harbor
+      - template: networkpolicies
+    installed: {{ and (.Values | get "harbor.enabled" false) (.Values | get "networkPolicies.harbor.enabled" false) }}
+    labels:
+      netpol: harbor
+    values:
+      - helmfile/values/networkpolicies/common/common.yaml.gotmpl
+      - helmfile/values/networkpolicies/service/harbor.yaml.gotmpl
+
+  harbor-podsecuritypolicy:
+    inherit:
+      - template: harbor
+      - template: podsecuritypolicies
+    installed: {{ .Values | get "harbor.enabled" false }}
+    labels:
+      psp: harbor
+    values:
+      - helmfile/values/podsecuritypolicies/service/harbor.yaml.gotmpl
+
+  harbor-certs:
+    disableValidationOnInstall: true
+    inherit: [ template: harbor ]
+    installed: {{ .Values | get "harbor.enabled" false }}
+    chart: helmfile/charts/harbor/harbor-certs
+    version: 0.1.0
+    name: harbor-certs
+    needs:
+      - cert-manager/cert-manager # creates certificates and issuers
+    values:
+      - helmfile/values/harbor/harbor-certs.yaml.gotmpl
+
+  harbor-main:
+    inherit:
+      - template: harbor
+      - template: harbor-chart
+    installed: {{ .Values | get "harbor.enabled" false }}
+    name: harbor
+    needs:
+      - harbor/networkpolicy
+      - harbor/podsecuritypolicy
+      - harbor/harbor-certs
+    values:
+      - helmfile/values/harbor/harbor.yaml.gotmpl
+    wait: true
+
+  harbor-init:
+    inherit: [ template: harbor ]
+    installed: {{ .Values | get "harbor.enabled" false }}
+    chart: helmfile/charts/harbor/init-harbor
+    version: 0.2.0
+    name: init-harbor
+    needs:
+      - harbor/networkpolicy
+      - harbor/podsecuritypolicy
+      - harbor/harbor
+    values:
+      - helmfile/values/harbor/init-harbor.yaml.gotmpl
+
+  harbor-backup:
+    inherit: [ template: harbor ]
+    installed: {{ .Values | get "harbor.enabled" false }}
+    chart: helmfile/charts/harbor/harbor-backup
+    version: 0.1.0
+    name: harbor-backup
+    needs:
+      - harbor/networkpolicy
+      - harbor/podsecuritypolicy
+      - harbor/harbor
+    values:
+      - helmfile/values/harbor/harbor-backup.yaml.gotmpl

--- a/helmfile/stacks/hnc.yaml
+++ b/helmfile/stacks/hnc.yaml
@@ -1,0 +1,42 @@
+---
+templates:
+  hnc:
+    condition: ck8sWorkloadCluster.enabled
+    installed: {{ .Values | get "hnc.enabled" false }}
+    namespace: hnc-system
+    labels:
+      app: hnc
+
+  hnc-networkpolicy:
+    inherit:
+      - template: hnc
+      - template: networkpolicies
+    labels:
+      netpol: hnc
+    values:
+      - helmfile/values/networkpolicies/common/common.yaml.gotmpl
+      - helmfile/values/networkpolicies/workload/hnc.yaml.gotmpl
+
+  hnc-resources:
+    disableValidationOnInstall: true # creates own resources
+    inherit: [ template: hnc ]
+    chart: helmfile/charts/hnc/config-and-crds
+    version: 0.1.0
+    name: hnc-config-and-crds
+    values:
+      - helmfile/values/hnc/controller.yaml.gotmpl
+
+  hnc-controller:
+    disableValidationOnInstall: true
+    inherit: [ template: hnc ]
+    chart: helmfile/charts/hnc/controller
+    version: 0.1.0
+    name: hnc-controller
+    needs:
+      - cert-manager/cert-manager # creates certificates
+      - gatekeeper-system/gatekeeper # creates mutations
+      - hnc-system/networkpolicy
+      - kube-system/user-rbac # creates resources in its namespaces
+      - monitoring/kube-prometheus-stack # creates servicemonitors
+    values:
+      - helmfile/values/hnc/controller.yaml.gotmpl

--- a/helmfile/stacks/ingress-nginx.yaml
+++ b/helmfile/stacks/ingress-nginx.yaml
@@ -1,0 +1,33 @@
+---
+templates:
+  ingress-nginx:
+    namespace: ingress-nginx
+    labels:
+      app: ingress-nginx
+
+  ingress-nginx-podsecuritypolicy:
+    inherit:
+      - template: ingress-nginx
+      - template: podsecuritypolicies
+    labels:
+      psp: ingress-nginx
+    values:
+      - helmfile/values/podsecuritypolicies/common/ingress-nginx.yaml.gotmpl
+
+  ingress-nginx-controller:
+    disableValidationOnInstall: true
+    inherit:
+      - template: ingress-nginx
+      - template: ingress-nginx-chart
+    name: ingress-nginx
+    needs:
+      - ingress-nginx/podsecuritypolicy
+      {{- if .Values | get "ck8sManagementCluster.enabled" false }}
+      - kube-system/service-cluster-np
+      {{- else if .Values | get "ck8sWorkloadCluster.enabled" false }}
+      - kube-system/workload-cluster-np
+      {{- end }}
+      - monitoring/kube-prometheus-stack # creates servicemonitors
+    values:
+      - helmfile/values/ingress-nginx.yaml.gotmpl
+    wait: true

--- a/helmfile/stacks/kured.yaml
+++ b/helmfile/stacks/kured.yaml
@@ -1,0 +1,38 @@
+---
+templates:
+  kured:
+    namespace: kured
+    labels:
+      app: kured
+
+  kured-podsecuritypolicy:
+    inherit:
+      - template: kured
+      - template: podsecuritypolicies
+    installed: {{ .Values | get "kured.enabled" false }}
+    labels:
+      psp: kured
+    values:
+      - helmfile/values/podsecuritypolicies/common/kured.yaml.gotmpl
+
+  kured-secret:
+    inherit: [ template: kured ]
+    installed: {{ and (.Values | get "kured.enabled" false) (.Values | get "kured.notification.slack.enabled" false) }}
+    chart: helmfile/charts/kured-secret
+    version: 0.1.0
+    name: kured-secret
+    values:
+    - helmfile/values/kured.yaml.gotmpl
+
+  kured-main:
+    disableValidationOnInstall: true
+    inherit:
+      - template: kured
+      - template: kured-chart
+    installed: {{ .Values | get "kured.enabled" false }}
+    name: kured
+    needs:
+      - kube-system/common-np
+      - monitoring/kube-prometheus-stack # creates servicemonitors
+    values:
+      - helmfile/values/kured.yaml.gotmpl

--- a/helmfile/stacks/monitoring-grafana.yaml
+++ b/helmfile/stacks/monitoring-grafana.yaml
@@ -1,0 +1,58 @@
+---
+templates:
+  grafana:
+    condition: ck8sManagementCluster.enabled
+    namespace: monitoring
+    labels:
+      app: grafana
+
+  grafana-admin:
+    disableValidationOnInstall: true # creates prometheus-operator/servicemonitors
+    inherit:
+      - template: grafana
+      - template: grafana-chart
+    name: ops-grafana
+    needs:
+      - monitoring/networkpolicy
+      - monitoring/podsecuritypolicy
+      - ingress-nginx/ingress-nginx
+    values:
+      - helmfile/values/grafana/grafana-common.yaml.gotmpl
+      - helmfile/values/grafana/grafana-ops.yaml.gotmpl
+
+  grafana-dev:
+    inherit:
+      - template: grafana
+      - template: grafana-chart
+    installed: {{ .Values | get "grafana.user.enabled" false }}
+    name: user-grafana
+    needs:
+      - monitoring/networkpolicy
+      - monitoring/podsecuritypolicy
+      - ingress-nginx/ingress-nginx
+    values:
+      - helmfile/values/grafana/grafana-common.yaml.gotmpl
+      - helmfile/values/grafana/grafana-user.yaml.gotmpl
+
+  grafana-label-enforcer:
+    inherit: [ template: grafana ]
+    installed: {{ and (.Values | get "thanos.enabled" false) (.Values | get "thanos.receiver.enabled" false) }}
+    chart: helmfile/charts/grafana-label-enforcer
+    version: 0.1.0
+    name: grafana-label-enforcer
+    needs:
+      - monitoring/networkpolicy
+      - monitoring/podsecuritypolicy
+      - thanos/thanos-receiver
+    values:
+      - helmfile/values/grafana/grafana-label-enforcer.yaml.gotmpl
+
+  grafana-dashboards:
+    inherit: [ template: grafana ]
+    chart: helmfile/charts/grafana-dashboards
+    version: 0.3.0
+    name: grafana-dashboards
+    needs:
+      - monitoring/ops-grafana
+    values:
+      - helmfile/values/grafana/grafana-dashboards.yaml.gotmpl

--- a/helmfile/stacks/monitoring-prometheus.yaml
+++ b/helmfile/stacks/monitoring-prometheus.yaml
@@ -1,0 +1,111 @@
+---
+templates:
+  prometheus:
+    namespace: monitoring
+    labels:
+      app: prometheus
+
+  kube-prometheus-stack:
+    disableValidationOnInstall: true # creates own custom resources
+    inherit:
+      - template: prometheus
+      - template: kube-prometheus-stack-chart
+    name: kube-prometheus-stack
+    needs:
+      - monitoring/networkpolicy
+      - monitoring/podsecuritypolicy
+    values:
+      {{- if .Values | get "ck8sManagementCluster.enabled" false }}
+      - helmfile/values/kube-prometheus-stack-sc.yaml.gotmpl
+      {{- else if .Values | get "ck8sWorkloadCluster.enabled" false }}
+      - helmfile/values/kube-prometheus-stack-wc.yaml.gotmpl
+      {{- end }}
+    wait: true
+
+  prometheus-blackbox-exporter:
+    disableValidationOnInstall: true
+    inherit:
+      - template: prometheus
+      - template: prometheus-blackbox-exporter-chart
+    name: prometheus-blackbox-exporter
+    needs:
+      - monitoring/kube-prometheus-stack # creates prometheus-operator/servicemonitors
+    values:
+      {{- if .Values | get "ck8sManagementCluster.enabled" false }}
+      - helmfile/values/prometheus-blackbox-exporter-sc.yaml.gotmpl
+      {{- else if .Values | get "ck8sWorkloadCluster.enabled" false }}
+      - helmfile/values/prometheus-blackbox-exporter-wc.yaml.gotmpl
+      {{- end }}
+
+  prometheus-sc-monitors:
+    disableValidationOnInstall: true
+    inherit: [ template: prometheus ]
+    condition: ck8sManagementCluster.enabled
+    chart: helmfile/charts/prometheus-servicemonitor
+    version: 0.1.1
+    name: sc-servicemonitor
+    needs:
+      - monitoring/kube-prometheus-stack # creates prometheus-operator/servicemonitors
+    values:
+      - helmfile/values/sc-servicemonitor.yaml.gotmpl
+
+  prometheus-sc-rules:
+    disableValidationOnInstall: true
+    inherit: [ template: prometheus ]
+    condition: ck8sManagementCluster.enabled
+    chart: helmfile/charts/prometheus-alerts
+    version: 0.1.1
+    name: sc-alerts
+    needs:
+      - monitoring/kube-prometheus-stack # creates prometheus-operator/prometheusrules
+    values:
+      - helmfile/values/prometheus-alerts-sc.yaml.gotmpl
+
+  prometheus-wc-monitors:
+    disableValidationOnInstall: true
+    inherit: [ template: prometheus ]
+    condition: ck8sWorkloadCluster.enabled
+    chart: helmfile/charts/prometheus-servicemonitor
+    version: 0.1.1
+    name: wc-servicemonitor
+    needs:
+      - monitoring/kube-prometheus-stack # creates prometheus-operator/servicemonitors
+    values:
+      - helmfile/values/wc-servicemonitor.yaml.gotmpl
+
+  prometheus-wc-rules:
+    disableValidationOnInstall: true
+    inherit: [ template: prometheus ]
+    condition: ck8sWorkloadCluster.enabled
+    chart: helmfile/charts/prometheus-alerts
+    version: 0.1.1
+    name: ck8s-alerts
+    needs:
+      - monitoring/kube-prometheus-stack # creates prometheus-operator/prometheusrules
+    values:
+      - helmfile/values/prometheus-user-alerts-wc.yaml.gotmpl
+
+  kube-state-metrics-extra-resources:
+    inherit: [ template: prometheus ]
+    installed: {{ .Values | get "kubeStateMetrics.clusterAPIMetrics.enabled" "false" }}
+    chart: helmfile/charts/kube-state-metrics-extra-resource-metrics
+    version: 0.1.0
+    name: kube-state-metrics-extra-resource-metrics
+    values:
+      - helmfile/values/kube-state-metrics-extra-resource-metrics.yaml.gotmpl
+
+  dev-alertmanager:
+    disableValidationOnInstall: true
+    condition: ck8sWorkloadCluster.enabled
+    installed: {{ .Values | get "user.alertmanager.enabled" false }}
+    chart: helmfile/charts/user-alertmanager
+    version: 0.1.0
+    namespace: alertmanager
+    name: user-alertmanager
+    labels:
+      app: dev-alertmanager
+    needs:
+      - kube-system/user-rbac
+      - monitoring/kube-prometheus-stack # creates prometheus-operator/alertmanagers
+    values:
+      - helmfile/values/user-alertmanager.yaml.gotmpl

--- a/helmfile/stacks/monitoring.yaml
+++ b/helmfile/stacks/monitoring.yaml
@@ -1,0 +1,115 @@
+---
+templates:
+  monitoring:
+    namespace: monitoring
+    labels:
+      app: monitoring
+
+  monitoring-networkpolicy:
+    inherit:
+      - template: monitoring
+      - template: networkpolicies
+    installed: {{ .Values | get "networkPolicies.monitoring.enabled" false }}
+    labels:
+      netpol: monitoring
+    values:
+      - helmfile/values/networkpolicies/common/common.yaml.gotmpl
+      - helmfile/values/networkpolicies/common/prometheus.yaml.gotmpl
+      - helmfile/values/networkpolicies/common/trivy.yaml.gotmpl
+      {{- if .Values | get "ck8sManagementCluster.enabled" false }}
+      - helmfile/values/networkpolicies/service/alertmanager.yaml.gotmpl
+      - helmfile/values/networkpolicies/service/grafana.yaml.gotmpl
+      {{- else if .Values | get "ck8sWorkloadCluster.enabled" false }}
+      - helmfile/values/networkpolicies/workload/alertmanager.yaml.gotmpl
+      {{- end }}
+
+  monitoring-podsecuritypolicy:
+    inherit:
+      - template: monitoring
+      - template: podsecuritypolicies
+    labels:
+      psp: monitoring
+    values:
+      - helmfile/values/podsecuritypolicies/common/monitoring.yaml.gotmpl
+
+  metrics-server:
+    inherit: [ template: metrics-server-chart ]
+    installed: {{ .Values | get "metricsServer.enabled" false }}
+    namespace: kube-system
+    name: metrics-server
+    labels:
+      app: metrics-server
+    values:
+      - helmfile/values/metrics-server.yaml.gotmpl
+
+  autoscaling-monitoring:
+    disableValidationOnInstall: true
+    condition: ck8sManagementCluster.enabled
+    installed: {{ .Values | get "clusterApi.monitoring.enabled" false }}
+    chart: helmfile/charts/autoscaling-monitoring
+    version: 0.1.0
+    namespace: capi-cluster
+    labels:
+      app: autoscaling-monitoring
+    needs:
+      - monitoring/kube-prometheus-stack # creates servicemonitors
+    values:
+      - helmfile/values/autoscaling-monitoring.yaml.gotmpl
+
+  openstack-monitoring:
+    disableValidationOnInstall: true
+    condition: ck8sManagementCluster.enabled
+    installed: {{ .Values | get "openstackMonitoring.enabled" false }}
+    chart: helmfile/charts/openstack-monitoring
+    version: 0.1.0
+    namespace: kube-system
+    name: openstack-monitoring
+    labels:
+      app: openstack-monitoring
+    needs:
+      - monitoring/kube-prometheus-stack # creates servicemonitors and prometheusrules
+    values:
+      - helmfile/values/openstack-monitoring.yaml.gotmpl
+      - helmfile/values/prometheus-alerts-sc.yaml.gotmpl
+
+  trivy-operator:
+    disableValidationOnInstall: true # creates own custom resources
+    inherit:
+      - template: monitoring
+      - template: trivy-operator-chart
+    installed: {{ .Values | get "trivy.enabled" false }}
+    name: trivy-operator
+    labels:
+      app: trivy-operator
+    needs:
+      - monitoring/networkpolicy
+      - monitoring/podsecuritypolicy
+      - monitoring/kube-prometheus-stack
+    values:
+      - helmfile/values/trivy/trivy-operator.yaml.gotmpl
+
+  s3-exporter:
+    disableValidationOnInstall: true
+    inherit: [ template: monitoring ]
+    condition: ck8sManagementCluster.enabled
+    installed: {{ and (.Values | get "s3Exporter.enabled" false) (.Values | get "objectStorage.type" "" | eq "s3") }}
+    chart: helmfile/charts/s3-exporter
+    version: 0.1.0
+    name: s3-exporter
+    needs:
+      - monitoring/networkpolicy
+      - monitoring/podsecuritypolicy
+      - monitoring/kube-prometheus-stack # creates servicemonitors
+    values:
+      - helmfile/values/s3-exporter.yaml.gotmpl
+
+  kubeapi-metrics:
+    condition: ck8sWorkloadCluster.enabled
+    chart: helmfile/charts/kubeapi-metrics
+    version: 0.1.0
+    namespace: kube-system
+    name: kubeapi-metrics
+    labels:
+      app: kubeapi-metrics
+    values:
+      - helmfile/values/kubeapi-metrics.yaml.gotmpl

--- a/helmfile/stacks/opensearch.yaml
+++ b/helmfile/stacks/opensearch.yaml
@@ -1,0 +1,175 @@
+---
+templates:
+  opensearch:
+    condition: ck8sManagementCluster.enabled
+    namespace: opensearch-system
+    labels:
+      app: opensearch
+
+  opensearch-podsecuritypolicy:
+    inherit:
+      - template: opensearch
+      - template: podsecuritypolicies
+    installed: {{ .Values | get "opensearch.enabled" false }}
+    labels:
+      psp: opensearch
+    values:
+      - helmfile/values/podsecuritypolicies/service/opensearch.yaml.gotmpl
+
+  opensearch-secrets:
+    disableValidationOnInstall: true # creates cert-manager/certificates
+    inherit: [ template: opensearch ]
+    installed: {{ .Values | get "opensearch.enabled" false }}
+    chart: helmfile/charts/opensearch/secrets
+    version: 0.1.0
+    name: opensearch-secrets
+    needs:
+      - cert-manager/cert-manager
+    values:
+      - helmfile/values/opensearch/secrets.yaml.gotmpl
+
+  opensearch-master:
+    disableValidationOnInstall: true
+    inherit:
+      - template: opensearch
+      - template: opensearch-chart
+    installed: {{ .Values | get "opensearch.enabled" false }}
+    name: opensearch-master
+    needs:
+      {{- if .Values | get "opensearch.sso.enabled" false }}
+      - dex/dex
+      {{- end }}
+      - kube-system/service-cluster-np
+      - opensearch-system/opensearch-secrets
+      - opensearch-system/podsecuritypolicy
+    values:
+      - helmfile/values/opensearch/common.yaml.gotmpl
+      - helmfile/values/opensearch/master.yaml.gotmpl
+    wait: true
+
+  opensearch-client:
+    inherit:
+      - template: opensearch
+      - template: opensearch-chart
+    installed: {{ and ( .Values | get "opensearch.enabled" false) (.Values | get "opensearch.clientNode.dedicatedPods" false) }}
+    name: opensearch-client
+    needs:
+      - kube-system/service-cluster-np
+      - opensearch-system/opensearch-master
+      - opensearch-system/podsecuritypolicy
+    values:
+      - helmfile/values/opensearch/common.yaml.gotmpl
+      - helmfile/values/opensearch/client.yaml.gotmpl
+    wait: true
+
+  opensearch-data:
+    inherit:
+      - template: opensearch
+      - template: opensearch-chart
+    installed: {{ and ( .Values | get "opensearch.enabled" false) (.Values | get "opensearch.dataNode.dedicatedPods" false) }}
+    name: opensearch-data
+    needs:
+      - kube-system/service-cluster-np
+      - opensearch-system/opensearch-master
+      - opensearch-system/podsecuritypolicy
+    values:
+      - helmfile/values/opensearch/common.yaml.gotmpl
+      - helmfile/values/opensearch/data.yaml.gotmpl
+    wait: true
+
+  opensearch-dashboards:
+    inherit:
+      - template: opensearch
+      - template: opensearch-dashboards-chart
+    installed: {{ .Values | get "opensearch.enabled" false }}
+    name: opensearch-dashboards
+    needs:
+      {{- if .Values | get "opensearch.sso.enabled" false }}
+      - dex/dex
+      {{- end }}
+      - kube-system/service-cluster-np
+      - opensearch-system/opensearch-master
+      - opensearch-system/podsecuritypolicy
+    values:
+      - helmfile/values/opensearch/dashboards.yaml.gotmpl
+    wait: true
+
+  opensearch-securityadmin:
+    inherit: [ template: opensearch ]
+    installed: {{ and ( .Values | get "opensearch.enabled" false) (.Values | get "opensearch.securityadmin.enabled" false) }}
+    chart: helmfile/charts/opensearch/securityadmin
+    version: 0.1.0
+    name: opensearch-securityadmin
+    needs:
+      - opensearch-system/opensearch-master
+      {{- if .Values | get "opensearch.clientNode.dedicatedPods" false }}
+      - opensearch-system/opensearch-client
+      {{- end }}
+      {{- if .Values | get "opensearch.dataNode.dedicatedPods" false }}
+      - opensearch-system/opensearch-data
+      {{- end }}
+    values:
+      - helmfile/values/opensearch/securityadmin.yaml.gotmpl
+
+  opensearch-configurer:
+    inherit: [ template: opensearch ]
+    installed: {{ .Values | get "opensearch.enabled" false }}
+    chart: helmfile/charts/opensearch/configurer
+    version: 0.1.0
+    name: opensearch-configurer
+    needs:
+      {{- if .Values | get "opensearch.securityadmin.enabled" false }}
+      - opensearch-system/opensearch-securityadmin
+      {{- else }}
+      - opensearch-system/opensearch-master
+      {{- end }}
+      - opensearch-system/opensearch-dashboards
+    values:
+      - helmfile/values/opensearch/securityadmin.yaml.gotmpl
+      - helmfile/values/opensearch/configurer.yaml.gotmpl
+
+  opensearch-backup:
+    inherit: [ template: opensearch ]
+    installed: {{ and ( .Values | get "opensearch.enabled" false) (.Values | get "opensearch.snapshot.enabled" false) }}
+    chart: helmfile/charts/opensearch/backup
+    version: 0.1.0
+    name: opensearch-backup
+    needs:
+      - opensearch-system/opensearch-configurer
+    values:
+      - helmfile/values/opensearch/backup.yaml.gotmpl
+
+  opensearch-slm:
+    inherit: [ template: opensearch ]
+    installed: {{ and ( .Values | get "opensearch.enabled" false) (.Values | get "opensearch.snapshot.enabled" false) }}
+    chart: helmfile/charts/opensearch/slm
+    version: 0.1.0
+    name: opensearch-slm
+    needs:
+      - opensearch-system/opensearch-configurer
+    values:
+      - helmfile/values/opensearch/slm.yaml.gotmpl
+
+  opensearch-curator:
+    inherit: [ template: opensearch ]
+    installed: {{ and ( .Values | get "opensearch.enabled" false) (.Values | get "opensearch.curator.enabled" false) }}
+    chart: helmfile/charts/opensearch/curator
+    version: 0.1.0
+    name: opensearch-curator
+    needs:
+      - opensearch-system/opensearch-configurer
+    values:
+      - helmfile/values/opensearch/curator.yaml.gotmpl
+
+  opensearch-exporter:
+    disableValidationOnInstall: true # creates prometheus-operator/servicemonitors
+    inherit:
+      - template: opensearch
+      - template: prometheus-elasticsearch-exporter-chart
+    installed: {{ .Values | get "opensearch.enabled" false }}
+    name: prometheus-opensearch-exporter
+    needs:
+      - monitoring/kube-prometheus-stack
+      - opensearch-system/opensearch-configurer
+    values:
+      - helmfile/values/prometheus-opensearch-exporter.yaml.gotmpl

--- a/helmfile/stacks/rbac.yaml
+++ b/helmfile/stacks/rbac.yaml
@@ -1,0 +1,50 @@
+---
+templates:
+  rbac:
+    namespace: kube-system
+    labels:
+      policy: rbac
+
+  admin-rbac:
+    inherit: [ template: rbac ]
+    chart: helmfile/charts/cluster-admin-rbac
+    version: 0.1.0
+    name: cluster-admin-rbac
+    labels:
+      app: admin-rbac
+    values:
+      - helmfile/values/cluster-admin-rbac.yaml.gotmpl
+
+  dev-rbac:
+    disableValidationOnInstall: true
+    inherit: [ template: rbac ]
+    condition: ck8sWorkloadCluster.enabled
+    chart: helmfile/charts/user-rbac
+    version: 0.1.0
+    name: user-rbac
+    labels:
+      app: dev-rbac
+    {{- if .Values | get "hnc.enabled" false }}
+    needs:
+      - hnc-system/hnc-config-and-crds # creates hierarchyconfigurations
+    {{- end }}
+    values:
+      - helmfile/values/user-rbac.yaml.gotmpl
+
+  dev-rbac-crds:
+    inherit: [ template: rbac ]
+    condition: ck8sWorkloadCluster.enabled
+    installed: {{ .Values | get "gatekeeper.allowUserCRDs.enabled" false }}
+    chart: helmfile/charts/user-crds
+    version: 1.0.0
+    namespace: gatekeeper-system
+    name: user-crds
+    needs:
+      - kube-system/user-rbac
+    labels:
+      app: dev-rbac
+    values:
+      - values/userCRDs/common.yaml.gotmpl
+      - values/userCRDs/bitnami/sealedsecrets.yaml.gotmpl
+      - values/userCRDs/mongodbcommunity/mongodb.yaml.gotmpl
+      - values/userCRDs/flux/fluxv2.yaml.gotmpl

--- a/helmfile/stacks/rclone.yaml
+++ b/helmfile/stacks/rclone.yaml
@@ -1,0 +1,13 @@
+---
+templates:
+  rclone-sync:
+    condition: ck8sManagementCluster.enabled
+    installed: {{ .Values | get "objectStorage.sync.enabled" false }}
+    chart: helmfile/charts/rclone-sync
+    version: 0.1.0
+    namespace: rclone
+    name: rclone-sync
+    labels:
+      app: rclone-sync
+    values:
+      - helmfile/values/rclone-sync.yaml.gotmpl

--- a/helmfile/stacks/system.yaml
+++ b/helmfile/stacks/system.yaml
@@ -1,0 +1,76 @@
+---
+templates:
+  system:
+    namespace: kube-system
+
+  networkpolicies-common:
+    inherit: [ template: system ]
+    chart: helmfile/charts/networkpolicy/common
+    version: 0.2.0
+    name: common-np
+    labels:
+      policy: netpol
+      netpol: common
+    {{- if .Values | get "ck8sWorkloadCluster" false }}
+    needs:
+      - kube-system/user-rbac # creates networkpolicies for its namespaces
+    {{- end }}
+    values:
+    - helmfile/values/networkpolicy/common.yaml.gotmpl
+
+  networkpolicies-service:
+    inherit: [ template: system ]
+    condition: ck8sManagementCluster.enabled
+    chart: helmfile/charts/networkpolicy/service-cluster
+    version: 0.2.0
+    name: service-cluster-np
+    labels:
+      policy: netpol
+      netpol: service
+    values:
+      - helmfile/values/networkpolicy/service-cluster.yaml.gotmpl
+
+  networkpolicies-workload:
+    inherit: [ template: system ]
+    condition: ck8sWorkloadCluster.enabled
+    chart: helmfile/charts/networkpolicy/workload-cluster
+    version: 0.2.0
+    name: workload-cluster-np
+    labels:
+      policy: netpol
+      netpol: workload
+    values:
+      - helmfile/values/networkpolicy/workload-cluster.yaml.gotmpl
+
+  node-local-dns:
+    disableValidationOnInstall: true
+    inherit: [ template: system ]
+    chart: helmfile/charts/node-local-dns
+    version: 0.1.1
+    name: node-local-dns
+    labels:
+      app: node-local-dns
+    needs:
+      - monitoring/kube-prometheus-stack # creates prometheus-operator/servicemonitors
+    values:
+      - helmfile/values/node-local-dns.yaml.gotmpl
+
+  default-podsecuritypolicy:
+    inherit: [ template: podsecuritypolicies ]
+    condition: ck8sWorkloadCluster.enabled
+    namespace: default
+    labels:
+      app: dev-rbac
+      psp: default
+    values:
+      - helmfile/values/podsecuritypolicies/workload/default.yaml.gotmpl
+
+  rook-ceph-podsecuritypolicy:
+    inherit: [ template: podsecuritypolicies ]
+    installed: {{ .Values | get "rookCeph.gatekeeperPsp.enabled" false }}
+    namespace: rook-ceph
+    labels:
+      app: rook-ceph
+      psp: rook-ceph
+    values:
+      - helmfile/values/podsecuritypolicies/common/rook-ceph.yaml.gotmpl

--- a/helmfile/stacks/thanos.yaml
+++ b/helmfile/stacks/thanos.yaml
@@ -1,0 +1,85 @@
+---
+templates:
+  thanos:
+    condition: ck8sManagementCluster.enabled
+    namespace: thanos
+    labels:
+      app: thanos
+
+  thanos-networkpolicy:
+    inherit:
+      - template: thanos
+      - template: networkpolicies
+    installed: {{ and (.Values | get "thanos.enabled" false) (.Values | get "networkPolicies.thanos.enabled" false) }}
+    labels:
+      netpol: thanos
+    values:
+      - helmfile/values/networkpolicies/common/common.yaml.gotmpl
+      - helmfile/values/networkpolicies/service/thanos.yaml.gotmpl
+
+  thanos-ingress-secret:
+    installed: {{ .Values | get "thanos.enabled" false }}
+    chart: helmfile/charts/thanos/ingress-secret
+    version: 0.1.0
+    {{- if .Values | get "ck8sManagementCluster.enabled" false }}
+    namespace: thanos
+    labels:
+      app: thanos
+    {{- else if .Values | get "ck8sWorkloadCluster.enabled" false }}
+    namespace: monitoring
+    labels:
+      app: prometheus
+    {{- end }}
+    name: thanos-ingress-secret
+    values:
+      - helmfile/values/thanos/ingress-secret.yaml.gotmpl
+
+  thanos-objstore-secret:
+    inherit:
+      - template: thanos
+      - template: thanos-chart
+    installed: {{ .Values | get "thanos.enabled" false }}
+    name: thanos-objectstorage-secret
+    values:
+      - helmfile/values/thanos/objectstorage-secret.yaml.gotmpl
+
+  thanos-query:
+    disableValidationOnInstall: true
+    inherit:
+      - template: thanos
+      - template: thanos-chart
+    installed: {{ and (.Values | get "thanos.enabled" false) (.Values | get "thanos.query.enabled" false) }}
+    name: thanos-query
+    needs:
+      - monitoring/kube-prometheus-stack # creates servicemonitors
+      - thanos/networkpolicy
+    values:
+      - helmfile/values/thanos/query.yaml.gotmpl
+
+  thanos-receiver:
+    disableValidationOnInstall: true
+    inherit:
+      - template: thanos
+      - template: thanos-chart
+    installed: {{ and (.Values | get "thanos.enabled" false) (.Values | get "thanos.receiver.enabled" false) }}
+    name: thanos-receiver
+    needs:
+      - monitoring/kube-prometheus-stack # creates servicemonitors
+      - thanos/networkpolicy
+      - thanos/thanos-objectstorage-secret
+    values:
+      - helmfile/values/thanos/receiver.yaml.gotmpl
+
+  thanos-ruler:
+    disableValidationOnInstall: true
+    inherit: [ template: thanos ]
+    installed: {{ and (.Values | get "thanos.enabled" false) (.Values | get "thanos.ruler.enabled" false) }}
+    chart: helmfile/charts/thanos/ruler
+    version: 0.1.0
+    name: thanos-ruler
+    needs:
+      - monitoring/kube-prometheus-stack # creates thanosrulers
+      - thanos/networkpolicy
+      - thanos/thanos-objectstorage-secret
+    values:
+      - helmfile/values/thanos/ruler.yaml.gotmpl

--- a/helmfile/stacks/velero.yaml
+++ b/helmfile/stacks/velero.yaml
@@ -1,0 +1,34 @@
+---
+templates:
+  velero:
+    namespace: velero
+    labels:
+      app: velero
+
+  velero-podsecuritypolicy:
+    inherit:
+      - template: velero
+      - template: podsecuritypolicies
+    installed: {{ .Values | get "velero.enabled" false }}
+    labels:
+      psp: velero
+    values:
+      - helmfile/values/podsecuritypolicies/common/velero.yaml.gotmpl
+
+  velero-main:
+    disableValidationOnInstall: true # creates own custom resources
+    inherit:
+      - template: velero
+      - template: velero-chart
+    installed: {{ .Values | get "velero.enabled" false }}
+    name: velero
+    needs:
+      - kube-system/common-np
+      - monitoring/kube-prometheus-stack # creates servicemonitors
+      - velero/podsecuritypolicy
+    values:
+      {{ if .Values | get "ck8sManagementCluster.enabled" false }}
+      - helmfile/values/velero-sc.yaml.gotmpl
+      {{ else if .Values | get "ck8sWorkloadCluster.enabled" false }}
+      - helmfile/values/velero-wc.yaml.gotmpl
+      {{ end }}


### PR DESCRIPTION
Currently it is running in parallel with the old one which is still the one in use.

<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice

- Helmfile now divides SC and WC releases via conditions, this means that it will list all releases for both SC and WC, although only enabled releases will be operated on.
- Helmfile labels have changed, use `helmfile list` for SC or WC to see them, and note that helmfile includes `chart`, `name` and `namespace` labels automatically.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This restructures the current helmfile setup by using a unified entry point, and using templates to define stacks and applications.

Dependencies are tracked using `needs`, which allows for select parts to be installed by using labels and including these needs.

- Fixes #695

#### Additional information to reviewers

Currently is is parallel to the previous setup, so you can use the bin scripts to run the old and for the new you have to set `KUBECONFIG` correctly then run `helmfile -e service_cluster|workload_cluster <args>...` to run with the new one.

I recommend setting `--concurrency 2*cpus` to prevent helmfile from eating to much memory.

No release has been changed with this, but some concerns/ideas have been noted down as improvements.

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
