### PR TITLE
bin: set helmfile concurrency to avoid out of memory issues

### DIFF
--- a/bin/apps.bash
+++ b/bin/apps.bash
@@ -24,7 +24,7 @@ apps_run_sc() {
     log_info "Applying applications in service cluster"
     (
         with_kubeconfig "${config[kube_config_sc]}" \
-            "${scripts_path}/deploy-sc.sh" "${1:-""}"
+            "${scripts_path}/deploy-sc.sh" "${@}"
     )
 }
 
@@ -32,7 +32,7 @@ apps_run_wc() {
     log_info "Applying applications in workload cluster"
     (
         with_kubeconfig "${config[kube_config_wc]}" \
-            "${scripts_path}/deploy-wc.sh" "${1:-""}"
+            "${scripts_path}/deploy-wc.sh" "${@}"
     )
 }
 
@@ -71,8 +71,7 @@ apps_sc() {
     # but feels good enough until we figure out something smarter.
     #
     #[ "$1" != "--skip-template-validate" ] && template_validate_sc
-
-    apps_run_sc "${2:-""}"
+    apps_run_sc "${2:-""}" "$3"
 
     log_info "Applications applied successfully!"
 }
@@ -82,7 +81,7 @@ apps_wc() {
     # See rationale above
     #[ "$1" != "--skip-template-validate" ] && template_validate_wc
 
-    apps_run_wc "${2:-""}"
+    apps_run_wc "${2:-""}" "$3"
 
     log_info "Applications applied successfully!"
 }
@@ -103,7 +102,7 @@ if [[ $1 == "wc" ]]; then
         fi
     fi
     config_load "$1"
-    apps_wc "$2" "$3"
+    apps_wc "$2" "$3" "$4"
 elif [[ $1 == "sc" ]]; then
     if ! "${here}/update-ips.bash" "sc" "dry-run"; then
         log_warning "Diff in sc config for network policy IPs, run 'ck8s update-ips sc apply' to fix this issue."
@@ -117,7 +116,7 @@ elif [[ $1 == "sc" ]]; then
         fi
     fi
     config_load "$1"
-    apps_sc "$2" "$3"
+    apps_sc "$2" "$3" "$4"
 else
     echo "ERROR:  [$1] is an invalid argument:"
     echo "usage:   ck8s apps <wc|sc>. "

--- a/bin/ck8s
+++ b/bin/ck8s
@@ -10,35 +10,35 @@ source "${here}/common.bash"
 
 usage() {
     echo "COMMANDS:" 1>&2
-    echo "  init <wc|sc|both> [--generate-new-secrets]        initialize the config path" 1>&2
-    echo "  bootstrap <wc|sc>                                 bootstrap the cluster" 1>&2
-    echo "  apps <wc|sc> [--sync] [--skip-template-validate]  deploy the applications" 1>&2
-    echo "  apply <wc|sc> [--sync] [--skip-template-validate] bootstrap and apps" 1>&2
-    echo "  test <wc|sc> [--logging-enabled]                  test the applications" 1>&2
-    echo "  dry-run <wc|sc> [--kubectl]                       runs helmfile diff" 1>&2
-    echo "  fix-psp-violations <wc|sc>                        Checks and restarts pods that violates Pod Security Polices, applicable for new environments" 1>&2
-    echo "  upgrade <wc|sc|both> <vX.Y> prepare               runs all prepare steps upgrading the configuration" 1>&2
-    echo "  upgrade <wc|sc|both> <vX.Y> apply                 runs all apply steps upgrading the environment" 1>&2
-    echo "  team add-pgp <fp>                                 add a new PGP key to secrets" 1>&2
-    echo "  team remove-pgp <fp>                              remove a PGP key from secrets and rotate the data encryption key" 1>&2
+    echo "  init <wc|sc|both> [--generate-new-secrets]                                initialize the config path" 1>&2
+    echo "  bootstrap <wc|sc>                                                         bootstrap the cluster" 1>&2
+    echo "  apps <wc|sc> [--sync] [--skip-template-validate] [--concurrency=<num>]    deploy the applications" 1>&2
+    echo "  apply <wc|sc> [--sync] [--skip-template-validate] [--concurrency=<num>]   bootstrap and apps" 1>&2
+    echo "  test <wc|sc> [--logging-enabled]                                          test the applications" 1>&2
+    echo "  dry-run <wc|sc> [--kubectl]                                               runs helmfile diff" 1>&2
+    echo "  fix-psp-violations <wc|sc>                                                Checks and restarts pods that violates Pod Security Polices, applicable for new environments" 1>&2
+    echo "  upgrade <wc|sc|both> <vX.Y> prepare                                       runs all prepare steps upgrading the configuration" 1>&2
+    echo "  upgrade <wc|sc|both> <vX.Y> apply                                         runs all apply steps upgrading the environment" 1>&2
+    echo "  team add-pgp <fp>                                                         add a new PGP key to secrets" 1>&2
+    echo "  team remove-pgp <fp>                                                      remove a PGP key from secrets and rotate the data encryption key" 1>&2
     # TODO: We might want to make this command less visible once we have proper
     #       support for OIDC logins.
-    echo "  ops kubectl <wc|sc>                               run kubectl as cluster admin" 1>&2
-    echo "  ops kubecolor <wc|sc>                             run kubecolor as cluster admin" 1>&2
-    echo "  ops helm <wc|sc>                                  run helm as cluster admin" 1>&2
+    echo "  ops kubectl <wc|sc>                                                       run kubectl as cluster admin" 1>&2
+    echo "  ops kubecolor <wc|sc>                                                     run kubecolor as cluster admin" 1>&2
+    echo "  ops helm <wc|sc>                                                          run helm as cluster admin" 1>&2
     # TODO: We might want to make this command less visible once we feel
     #       confident that the apply command and migrations are good enough
     #       that direct Helmfile access is not necessary.
-    echo "  ops helmfile <wc|sc>                              run helmfile as cluster admin" 1>&2
-    echo "  s3cmd [cmd]                                       run s3cmd" 1>&2
-    echo "  kubeconfig                                        generate user kubeconfig, stored at CK8S_CONFIG_PATH/user"
-    echo "  completion bash                                   output shell completion code for bash" 1>&2
-    echo "  install-requirements                              installs or updates required tools to run compliantkubernetes-apps" 1>&2
-    echo "  validate <wc|sc>                                  validates config files" 1>&2
-    echo "  providers                                         lists supported cloud providers" 1>&2
-    echo "  flavors                                           lists supported configuration flavors" 1>&2
-    echo "  update-ips <wc|sc|both> <apply|dry-run>           Automatically fetches and applies the IPs for network policies" 1>&2
-    echo "  clean <wc|sc>                                     Cleans the cluster of apps" 1>&2
+    echo "  ops helmfile <wc|sc>                                                      run helmfile as cluster admin" 1>&2
+    echo "  s3cmd [cmd]                                                               run s3cmd" 1>&2
+    echo "  kubeconfig                                                                generate user kubeconfig, stored at CK8S_CONFIG_PATH/user"
+    echo "  completion bash                                                           output shell completion code for bash" 1>&2
+    echo "  install-requirements                                                      installs or updates required tools to run compliantkubernetes-apps" 1>&2
+    echo "  validate <wc|sc>                                                          validates config files" 1>&2
+    echo "  providers                                                                 lists supported cloud providers" 1>&2
+    echo "  flavors                                                                   lists supported configuration flavors" 1>&2
+    echo "  update-ips <wc|sc|both> <apply|dry-run>                                   Automatically fetches and applies the IPs for network policies" 1>&2
+    echo "  clean <wc|sc>                                                             Cleans the cluster of apps" 1>&2
     exit 1
 }
 
@@ -46,6 +46,7 @@ SYNC=""
 SKIP=""
 KUBECTL=""
 GEN_NEW_SECRETS=""
+CONCURRENCY="--concurrency=8"
 
 for arg in "$@"; do
   case "$arg" in
@@ -53,6 +54,7 @@ for arg in "$@"; do
     "--sync") SYNC="sync" ;;
     "--kubectl") KUBECTL="kubectl" ;;
     "--generate-new-secrets") GEN_NEW_SECRETS="--generate-new-secrets" ;;
+    "--concurrency="*) CONCURRENCY="$arg" ;;
   esac
 done
 
@@ -71,13 +73,13 @@ case "${1}" in
     apps)
         [[ "${2}" =~ ^(wc|sc)$ ]] || usage
         check_tools
-        "${here}/apps.bash" "${2}" "${SKIP}" "${SYNC}"
+        "${here}/apps.bash" "${2}" "${SKIP}" "${SYNC}" "${CONCURRENCY}"
         ;;
     apply)
         [[ "${2}" =~ ^(wc|sc)$ ]] || usage
         check_tools
         "${here}/bootstrap.bash" "${2}"
-        "${here}/apps.bash" "${2}" "${SKIP}" "${SYNC}"
+        "${here}/apps.bash" "${2}" "${SKIP}" "${SYNC}" "${CONCURRENCY}"
         ;;
     test)
         [[ "${2}" =~ ^(wc|sc)$ ]] || usage

--- a/bin/common.bash
+++ b/bin/common.bash
@@ -568,7 +568,7 @@ with_kubeconfig() {
     else
         log_info "Using unencrypted kubeconfig ${kubeconfig}"
         # shellcheck disable=SC2048
-        KUBECONFIG=${kubeconfig} ${*}
+        KUBECONFIG=${kubeconfig} "$@"
     fi
 }
 

--- a/scripts/deploy-sc.sh
+++ b/scripts/deploy-sc.sh
@@ -17,17 +17,13 @@ if [[ "$alertTo" != "slack" && "$alertTo" != "null" && "$alertTo" != "opsgenie" 
     exit 1
 fi
 
-INTERACTIVE=${1:-""}
-
 echo "Installing helm charts" >&2
 cd "${SCRIPTS_PATH}/../helmfile"
-declare -a helmfile_opt_flags
-[[ -n "$INTERACTIVE" ]] && helmfile_opt_flags+=("$INTERACTIVE")
 
 if [ ${#} -eq 1 ] && [ "$1" = "sync" ]; then
-    helmfile -f . -e service_cluster sync
+    helmfile -f . -e service_cluster sync "$2"
 else
-    helmfile -f . -e service_cluster apply --suppress-diff
+    helmfile -f . -e service_cluster apply "$2" --suppress-diff
 fi
 
 echo "Deploy sc completed!" >&2

--- a/scripts/deploy-wc.sh
+++ b/scripts/deploy-wc.sh
@@ -11,11 +11,6 @@ config_load wc --skip-validation
 : "${config[config_file_wc]:?Missing config}"
 : "${secrets[secrets_file]:?Missing secrets}"
 
-# Arg for Helmfile to be interactive so that one can decide on which releases
-# to update if changes are found.
-# USE: --interactive, default is not interactive.
-INTERACTIVE=${1:-""}
-
 # Add example resources.
 # We use `create` here instead of `apply` to avoid overwriting any changes the
 # user may have done.
@@ -46,13 +41,11 @@ fi
 
 echo "Installing helm charts" >&2
 cd "${SCRIPTS_PATH}/../helmfile"
-declare -a helmfile_opt_flags
-[[ -n "$INTERACTIVE" ]] && helmfile_opt_flags+=("$INTERACTIVE")
 
 if [ ${#} -eq 1 ] && [ "$1" = "sync" ]; then
-    helmfile -f . -e workload_cluster sync
+    helmfile -f . -e workload_cluster sync "$2"
 else
-    helmfile -f . -e workload_cluster apply --suppress-diff
+    helmfile -f . -e workload_cluster apply "$2" --suppress-diff
 fi
 
 echo "Deploy wc completed!" >&2


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->


### Platform Administrator notice
The commands `apps` and `apply` now sets helmfile concurrency to 8 by default to avoid memory issues

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Sets helmfile concurrency to avoid oom issues with diff.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1880 

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
