### PR TITLE
apps sc: OpenSearch Dashboards use internal communication to dex

### DIFF
--- a/helmfile/charts/networkpolicy/service-cluster/templates/dex/allow-dex.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/dex/allow-dex.yaml
@@ -45,6 +45,12 @@ spec:
           namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: opensearch-system
+        - podSelector:
+            matchLabels:
+              app: opensearch-dashboards
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: opensearch-system
       ports:
         - port: 5556
     - from:

--- a/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/dashboard.yaml
+++ b/helmfile/charts/networkpolicy/service-cluster/templates/opensearch/dashboard.yaml
@@ -34,6 +34,15 @@ spec:
         - port: 5601
   egress:
     - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: dex
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: dex
+      ports:
+        - port: 5556
+    - to:
         - podSelector:
             matchLabels:
               app.kubernetes.io/component: opensearch-master
@@ -44,33 +53,4 @@ spec:
           protocol: UDP
         - port: 53
           protocol: TCP
-    - to:
-      {{- if and .Values.global.externalLoadBalancer .Values.global.scIngress.ips }}
-        {{- range $ip := .Values.global.scIngress.ips }}
-        - ipBlock:
-            cidr: {{ $ip }}
-        {{- end }}
-      {{- else if and .Values.global.ingressUsingHostNetwork .Values.global.scNodes.ips }}
-        {{- range $ip := .Values.global.scNodes.ips }}
-        - ipBlock:
-            cidr: {{ $ip }}
-        {{- end }}
-      {{- else }}
-        {{- if .Values.global.scIngress.ips }}
-        {{- range $ip := .Values.global.scIngress.ips }}
-        - ipBlock:
-            cidr: {{ $ip }}
-        {{- end }}
-        {{- end }}
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: ingress-nginx
-          podSelector:
-            matchLabels:
-              app.kubernetes.io/component: controller
-              app.kubernetes.io/instance: ingress-nginx
-      {{- end }}
-      ports:
-        - protocol: TCP
-          port: 443
 {{ end }}

--- a/helmfile/values/opensearch/dashboards.yaml.gotmpl
+++ b/helmfile/values/opensearch/dashboards.yaml.gotmpl
@@ -21,7 +21,7 @@ config:
         type: "openid"
       openid:
         scope: {{ .Values.opensearch.sso.scope }}
-        connect_url: https://{{ .Values.dex.subdomain }}.{{ .Values.global.baseDomain }}/.well-known/openid-configuration
+        connect_url: http://dex.dex.svc.cluster.local:5556/.well-known/openid-configuration
         client_id: "opensearch"
         client_secret: {{ .Values.opensearch.clientSecret }}
         base_redirect_url: https://{{ .Values.opensearch.dashboards.subdomain }}.{{ .Values.global.baseDomain }}


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [x] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Use inter-cluster communication between OpenSearch Dashboards and dex.

With this in place apps doesn't need correct DNS records during deployment.

#### Additional information to reviewers

:pray: Please test on a full dev cluster, my kind cluster still lacks ingress :sweat_smile: 

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
