### PR TITLE
Let ck8s kubeconfig show its own usage on missing arguments

### DIFF
--- a/bin/ck8s
+++ b/bin/ck8s
@@ -31,7 +31,7 @@ usage() {
     #       that direct Helmfile access is not necessary.
     echo "  ops helmfile <wc|sc>                                                      run helmfile as cluster admin" 1>&2
     echo "  s3cmd [cmd]                                                               run s3cmd" 1>&2
-    echo "  kubeconfig                                                                generate user kubeconfig, stored at CK8S_CONFIG_PATH/user"
+    echo "  kubeconfig <user|dev|admin>                                               generate user kubeconfig, stored at CK8S_CONFIG_PATH/user"
     echo "  completion bash                                                           output shell completion code for bash" 1>&2
     echo "  install-requirements                                                      installs or updates required tools to run compliantkubernetes-apps" 1>&2
     echo "  validate <wc|sc>                                                          validates config files" 1>&2
@@ -138,7 +138,6 @@ case "${1}" in
         sops_exec_file "${secrets[s3cfg_file]}" 's3cmd --config="{}" '"${*}"
     ;;
     kubeconfig)
-        [[ "${2}" =~ ^(user|dev|admin)$ ]] || usage
         shift
         "${here}/kubeconfig.bash" "${@}"
         ;;

--- a/bin/kubeconfig.bash
+++ b/bin/kubeconfig.bash
@@ -11,6 +11,8 @@ usage() {
     exit 1
 }
 
+[ -z "${1:-}" ] && usage
+
 get_user_server() {
     (
         with_kubeconfig "${kubeconfig}" \
@@ -85,7 +87,7 @@ case "${1}" in
         user_kubeconfig=${CK8S_CONFIG_PATH}/user/secret/kubeconfig.yaml
     ;;
     dev)
-        serviceAccount="${2}"
+        serviceAccount="${2:-}"
         if [ -z "${serviceAccount}" ]; then
           echo "Error: Service account name is needed" >&2
           usage
@@ -116,7 +118,7 @@ case "${1}" in
         exit
     ;;
     admin)
-        case "${2}" in
+        case "${2:-}" in
             sc)
                 config_load sc
                 cluster_config="${config[config_file_sc]}"


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [ ] personal data beyond what is necessary for interacting with this pull request
> - [ ] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

When running `ck8s kubeconfig` it showed the usage / command list for `ck8s` itself instead of usage information for the `ck8s kubeconfig` commmand.


#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
