### PR TITLE
Trivy-operator added the option to exclude namespaces and to disable scans

### DIFF
--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -822,13 +822,13 @@ trivy:
   enabled: true
   # comma separated list of namespaces (or glob patterns) to be excluded from scanning
   excludeNamespaces: ""
+  clusterComplianceEnabled: true
+  configAuditScannerEnabled: true
+  exposedSecretScannerEnabled: true
+  infraAssessmentScannerEnabled: true
+  rbacAssessmentScannerEnabled: true
   vulnerabilityScannerEnabled: true
   sbomGenerationEnabled: false
-  configAuditScannerEnabled: true
-  rbacAssessmentScannerEnabled: true
-  infraAssessmentScannerEnabled: true
-  clusterComplianceEnabled: true
-  exposedSecretScannerEnabled: true
   # All durations must be specified in seconds, minutes or hours
   # Example 40s / 30m / 20h
   vulnerabilityScanner:

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -820,6 +820,15 @@ opa:
 
 trivy:
   enabled: true
+  # comma separated list of namespaces (or glob patterns) to be excluded from scanning
+  excludeNamespaces: ""
+  vulnerabilityScannerEnabled: true
+  sbomGenerationEnabled: false
+  configAuditScannerEnabled: true
+  rbacAssessmentScannerEnabled: true
+  infraAssessmentScannerEnabled: true
+  clusterComplianceEnabled: true
+  exposedSecretScannerEnabled: true
   # All durations must be specified in seconds, minutes or hours
   # Example 40s / 30m / 20h
   vulnerabilityScanner:
@@ -839,6 +848,7 @@ trivy:
   serviceMonitor:
   # enabled determines whether a serviceMonitor should be deployed
     enabled: true
+    interval: 5m
   tolerations: []
   affinity: {}
 kured:

--- a/helmfile.d/values/trivy/trivy-operator.yaml.gotmpl
+++ b/helmfile.d/values/trivy/trivy-operator.yaml.gotmpl
@@ -4,16 +4,31 @@
 # to a blank string to let it operate in all namespaces.
 targetNamespaces: ""
 
+# excludeNamespaces is a comma separated list of namespaces (or glob patterns)
+# to be excluded from scanning. Only applicable in the all namespaces install
+# mode, i.e. when the targetNamespaces values is a blank string.
+excludeNamespaces: {{ .Values.trivy.excludeNamespaces }}
+
 operator:
 
   replicas: 1
 
   # configAuditScannerEnabled the flag to enable configuration audit scanner
-  configAuditScannerEnabled: true
+  configAuditScannerEnabled: {{ .Values.trivy.configAuditScannerEnabled }}
   # vulnerabilityScannerEnabled the flag to enable vulnerability scanner
-  vulnerabilityScannerEnabled: true
+  vulnerabilityScannerEnabled: {{ .Values.trivy.vulnerabilityScannerEnabled }}
+  # the flag to enable sbom generation
+  sbomGenerationEnabled: {{ .Values.trivy.sbomGenerationEnabled }}
+  # rbacAssessmentScannerEnabled the flag to enable rbac assessment scanner
+  rbacAssessmentScannerEnabled: {{ .Values.trivy.rbacAssessmentScannerEnabled }}
+  # infraAssessmentScannerEnabled the flag to enable infra assessment scanner
+  infraAssessmentScannerEnabled: {{ .Values.trivy.infraAssessmentScannerEnabled }}
+  # clusterComplianceEnabled the flag to enable cluster compliance scanner
+  clusterComplianceEnabled: {{ .Values.trivy.clusterComplianceEnabled }}
   # vulnerabilityScannerReportTTL the flag to set how long a vulnerability report should exist. "" means that the vulnerabilityScannerReportTTL feature is disabled
   scannerReportTTL: {{ .Values.trivy.vulnerabilityScanner.scannerReportTTL }}
+  # exposedSecretScannerEnabled the flag to enable exposed secret scanner
+  exposedSecretScannerEnabled: {{ .Values.trivy.exposedSecretScannerEnabled }}
   # vulnerabilityScannerScanOnlyCurrentRevisions the flag to only create vulnerability scans on the current revision of a deployment.
   vulnerabilityScannerScanOnlyCurrentRevisions: {{ .Values.trivy.vulnerabilityScanner.scanOnlyCurrentRevisions }}
   configAuditScannerScanOnlyCurrentRevisions: false
@@ -33,3 +48,4 @@ resources: {{- toYaml .Values.trivy.resources | nindent 2 }}
 serviceMonitor:
   # enabled determines whether a serviceMonitor should be deployed
   enabled: {{ .Values.trivy.serviceMonitor.enabled }}
+  interval: {{ .Values.trivy.serviceMonitor.interval }}


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
To have more control over the trivy-operator configuration we added the option to exclude namespaces and also disable reports from the overwrite configs. Also, the scrapeInterval was increased to 5m.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [x] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [x] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [x] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [x] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
