### PR TITLE
Upgrade Velero to v1.11.1

### DIFF
--- a/helmfile.d/upstream/index.yaml
+++ b/helmfile.d/upstream/index.yaml
@@ -69,5 +69,4 @@ charts:
   prometheus-community/prometheus-blackbox-exporter: 8.2.0
   prometheus-community/prometheus-elasticsearch-exporter: 5.1.1
 
-  vmware-tanzu/velero: 3.1.6
-
+  vmware-tanzu/velero: 4.1.5

--- a/helmfile.d/upstream/vmware-tanzu/velero/Chart.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.10.2
+appVersion: 1.11.1
 description: A Helm chart for velero
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
@@ -16,4 +16,4 @@ maintainers:
 name: velero
 sources:
 - https://github.com/vmware-tanzu/velero
-version: 3.1.6
+version: 4.1.5

--- a/helmfile.d/upstream/vmware-tanzu/velero/README.md
+++ b/helmfile.d/upstream/vmware-tanzu/velero/README.md
@@ -6,7 +6,7 @@ Velero has two main components: a CLI, and a server-side Kubernetes deployment.
 
 ## Installing the Velero CLI
 
-See the different options for installing the [Velero CLI](https://velero.io/docs/v1.10/basic-install/#install-the-cli).
+See the different options for installing the [Velero CLI](https://velero.io/docs/v1.11/basic-install/#install-the-cli).
 
 ## Installing the Velero server
 
@@ -16,7 +16,7 @@ Kubernetes v1.16+, because this helm chart uses CustomResourceDefinition `apiext
 
 ### Velero version
 
-This helm chart installs Velero version v1.10 https://velero.io/docs/v1.10/. See the [#Upgrading](#upgrading) section for information on how to upgrade from other versions.
+This helm chart installs Velero version v1.11 https://velero.io/docs/v1.11/. See the [#Upgrading](#upgrading) section for information on how to upgrade from other versions.
 
 ### Provider credentials
 
@@ -26,7 +26,7 @@ When installing using the Helm chart, the provider's credential information will
 
 The default configuration values for this chart are listed in values.yaml.
 
-See Velero's full [official documentation](https://velero.io/docs/v1.10/basic-install/). More specifically, find your provider in the Velero list of [supported providers](https://velero.io/docs/v1.10/supported-providers/) for specific configuration information and examples.
+See Velero's full [official documentation](https://velero.io/docs/v1.11/basic-install/). More specifically, find your provider in the Velero list of [supported providers](https://velero.io/docs/v1.11/supported-providers/) for specific configuration information and examples.
 
 #### Set up Helm
 
@@ -46,12 +46,13 @@ helm install velero vmware-tanzu/velero \
 --namespace <YOUR NAMESPACE> \
 --create-namespace \
 --set-file credentials.secretContents.cloud=<FULL PATH TO FILE> \
---set configuration.provider=<PROVIDER NAME> \
---set configuration.backupStorageLocation.name=<BACKUP STORAGE LOCATION NAME> \
---set configuration.backupStorageLocation.bucket=<BUCKET NAME> \
---set configuration.backupStorageLocation.config.region=<REGION> \
---set configuration.volumeSnapshotLocation.name=<VOLUME SNAPSHOT LOCATION NAME> \
---set configuration.volumeSnapshotLocation.config.region=<REGION> \
+--set configuration.backupStorageLocation[0].name=<BACKUP STORAGE LOCATION NAME> \
+--set configuration.backupStorageLocation[0].provider=<PROVIDER NAME> \
+--set configuration.backupStorageLocation[0].bucket=<BUCKET NAME> \
+--set configuration.backupStorageLocation[0].config.region=<REGION> \
+--set configuration.volumeSnapshotLocation[0].name=<VOLUME SNAPSHOT LOCATION NAME> \
+--set configuration.volumeSnapshotLocation[0].provider=<PROVIDER NAME> \
+--set configuration.volumeSnapshotLocation[0].config.region=<REGION> \
 --set initContainers[0].name=velero-plugin-for-<PROVIDER NAME> \
 --set initContainers[0].image=velero/velero-plugin-for-<PROVIDER NAME>:<PROVIDER PLUGIN TAG> \
 --set initContainers[0].volumeMounts[0].mountPath=/target \
@@ -72,22 +73,26 @@ helm install vmware-tanzu/velero --namespace <YOUR NAMESPACE> -f values.yaml --g
 If a value needs to be added or changed, you may do so with the `upgrade` command. An example:
 
 ```bash
-helm upgrade <RELEASE NAME> vmware-tanzu/velero --namespace <YOUR NAMESPACE> --reuse-values --set configuration.provider=<NEW PROVIDER>
+helm upgrade <RELEASE NAME> vmware-tanzu/velero --namespace <YOUR NAMESPACE> --reuse-values --set configuration.backupStorageLocation[0].provider=<NEW PROVIDER>
 ```
 
 #### Using Helm 2
 
-We're no longer support Helm v2 since it's deprecated in November 2020.
+We're no longer supporting Helm v2 since it was deprecated in November 2020.
 
 ##### Upgrade the configuration
 
 If a value needs to be added or changed, you may do so with the `upgrade` command. An example:
 
 ```bash
-helm upgrade vmware-tanzu/velero <RELEASE NAME> --reuse-values --set configuration.provider=<NEW PROVIDER> 
+helm upgrade vmware-tanzu/velero <RELEASE NAME> --reuse-values --set configuration.backupStorageLocation[0].provider=<NEW PROVIDER>
 ```
 
 ## Upgrading
+
+### Upgrading to v1.11
+
+The [instructions found here](https://velero.io/docs/v1.11/upgrade-to-1.11/) will assist you in upgrading from version v1.10.x to v1.11.
 
 ### Upgrading to v1.10
 

--- a/helmfile.d/upstream/vmware-tanzu/velero/ci/test-values.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/ci/test-values.yaml
@@ -1,18 +1,31 @@
 # Set provider name and backup storage location bucket name
 configuration:
-  provider: aws
   backupStorageLocation:
-    name: primary
-    bucket: velero
+  - name: backups-primary
+    bucket: velero-backups
     default: true
+    provider: aws
+    credential:
+      name: test-credential
+      key: test-key
     config:
-      region: us-west-1
-      profile: test
-  volumeSnapshotLocation:
+      region: us-east-1
+      profile: us-east-1-profile
+  - name: backups-secondary
+    bucket: velero-backups
     provider: aws
     config:
-      bucket: velero
       region: us-west-1
+      profile: us-west-1-profile
+  volumeSnapshotLocation:
+  - name: ebs-us-east-1
+    provider: aws
+    config:
+      region: us-east-1
+  - name: portworx-cloud
+    provider: portworx
+    config:
+      type: cloud
 
 schedules:
   mybackup:

--- a/helmfile.d/upstream/vmware-tanzu/velero/crds/backups.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/crds/backups.yaml
@@ -56,6 +56,24 @@ spec:
                   Use DefaultVolumesToFsBackup instead."
                 nullable: true
                 type: boolean
+              excludedClusterScopedResources:
+                description: ExcludedClusterScopedResources is a slice of cluster-scoped
+                  resource type names to exclude from the backup. If set to "*", all
+                  cluster-scoped resource types are excluded. The default value is
+                  empty.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              excludedNamespaceScopedResources:
+                description: ExcludedNamespaceScopedResources is a slice of namespace-scoped
+                  resource type names to exclude from the backup. If set to "*", all
+                  namespace-scoped resource types are excluded. The default value
+                  is empty.
+                items:
+                  type: string
+                nullable: true
+                type: array
               excludedNamespaces:
                 description: ExcludedNamespaces contains a list of namespaces that
                   are not included in the backup.
@@ -261,6 +279,23 @@ spec:
                   resources should be included for consideration in the backup.
                 nullable: true
                 type: boolean
+              includedClusterScopedResources:
+                description: IncludedClusterScopedResources is a slice of cluster-scoped
+                  resource type names to include in the backup. If set to "*", all
+                  cluster-scoped resource types are included. The default value is
+                  empty, which means only related cluster-scoped resources are included.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              includedNamespaceScopedResources:
+                description: IncludedNamespaceScopedResources is a slice of namespace-scoped
+                  resource type names to include in the backup. The default value
+                  is "*".
+                items:
+                  type: string
+                nullable: true
+                type: array
               includedNamespaces:
                 description: IncludedNamespaces is a slice of namespace names to include
                   objects from. If empty, all namespaces are included.
@@ -275,6 +310,11 @@ spec:
                   type: string
                 nullable: true
                 type: array
+              itemOperationTimeout:
+                description: ItemOperationTimeout specifies the time used to wait
+                  for asynchronous BackupItemAction operations The default value is
+                  1 hour.
+                type: string
               labelSelector:
                 description: LabelSelector is a metav1.LabelSelector to filter with
                   when adding individual objects to the backup. If empty or nil, all
@@ -388,14 +428,35 @@ spec:
                 additionalProperties:
                   type: string
                 description: OrderedResources specifies the backup order of resources
-                  of specific Kind. The map key is the Kind name and value is a list
-                  of resource names separated by commas. Each resource name has format
-                  "namespace/resourcename".  For cluster resources, simply use "resourcename".
+                  of specific Kind. The map key is the resource name and value is
+                  a list of object names separated by commas. Each resource name has
+                  format "namespace/objectname".  For cluster resources, simply use
+                  "objectname".
                 nullable: true
                 type: object
+              resourcePolicy:
+                description: ResourcePolicy specifies the referenced resource policies
+                  that backup should follow
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in
+                      the core API group. For any other third-party types, APIGroup
+                      is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
               snapshotVolumes:
-                description: SnapshotVolumes specifies whether to take cloud snapshots
-                  of any PV's referenced in the set of objects included in the Backup.
+                description: SnapshotVolumes specifies whether to take snapshots of
+                  any PV's referenced in the set of objects included in the Backup.
                 nullable: true
                 type: boolean
               storageLocation:
@@ -416,6 +477,20 @@ spec:
           status:
             description: BackupStatus captures the current status of a Velero backup.
             properties:
+              backupItemOperationsAttempted:
+                description: BackupItemOperationsAttempted is the total number of
+                  attempted async BackupItemAction operations for this backup.
+                type: integer
+              backupItemOperationsCompleted:
+                description: BackupItemOperationsCompleted is the total number of
+                  successfully completed async BackupItemAction operations for this
+                  backup.
+                type: integer
+              backupItemOperationsFailed:
+                description: BackupItemOperationsFailed is the total number of async
+                  BackupItemAction operations for this backup which ended with an
+                  error.
+                type: integer
               completionTimestamp:
                 description: CompletionTimestamp records the time a backup was completed.
                   Completion time is recorded even on failed backups. Completion time
@@ -456,6 +531,10 @@ spec:
                 - New
                 - FailedValidation
                 - InProgress
+                - WaitingForPluginOperations
+                - WaitingForPluginOperationsPartiallyFailed
+                - Finalizing
+                - FinalizingPartiallyFailed
                 - Completed
                 - PartiallyFailed
                 - Failed

--- a/helmfile.d/upstream/vmware-tanzu/velero/crds/downloadrequests.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/crds/downloadrequests.yaml
@@ -48,10 +48,13 @@ spec:
                     - BackupLog
                     - BackupContents
                     - BackupVolumeSnapshots
-                    - BackupItemSnapshots
+                    - BackupItemOperations
                     - BackupResourceList
+                    - BackupResults
                     - RestoreLog
                     - RestoreResults
+                    - RestoreResourceList
+                    - RestoreItemOperations
                     - CSIBackupVolumeSnapshots
                     - CSIBackupVolumeSnapshotContents
                     type: string

--- a/helmfile.d/upstream/vmware-tanzu/velero/crds/restores.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/crds/restores.yaml
@@ -58,7 +58,7 @@ spec:
                 nullable: true
                 type: array
               existingResourcePolicy:
-                description: ExistingResourcePolicy specifies the restore behaviour
+                description: ExistingResourcePolicy specifies the restore behavior
                   for the kubernetes resource to be restored
                 nullable: true
                 type: string
@@ -240,6 +240,10 @@ spec:
                   type: string
                 nullable: true
                 type: array
+              itemOperationTimeout:
+                description: ItemOperationTimeout specifies the time used to wait
+                  for RestoreItemAction operations The default value is 1 hour.
+                type: string
               labelSelector:
                 description: LabelSelector is a metav1.LabelSelector to filter with
                   when restoring individual objects from the backup. If empty or nil,
@@ -357,7 +361,7 @@ spec:
                 type: boolean
               restorePVs:
                 description: RestorePVs specifies whether to restore all included
-                  PVs from snapshot (via the cloudprovider).
+                  PVs from snapshot
                 nullable: true
                 type: boolean
               restoreStatus:
@@ -414,6 +418,8 @@ spec:
                 - New
                 - FailedValidation
                 - InProgress
+                - WaitingForPluginOperations
+                - WaitingForPluginOperationsPartiallyFailed
                 - Completed
                 - PartiallyFailed
                 - Failed
@@ -434,6 +440,20 @@ spec:
                       due to plugins that return additional related items to restore
                     type: integer
                 type: object
+              restoreItemOperationsAttempted:
+                description: RestoreItemOperationsAttempted is the total number of
+                  attempted async RestoreItemAction operations for this restore.
+                type: integer
+              restoreItemOperationsCompleted:
+                description: RestoreItemOperationsCompleted is the total number of
+                  successfully completed async RestoreItemAction operations for this
+                  restore.
+                type: integer
+              restoreItemOperationsFailed:
+                description: RestoreItemOperationsFailed is the total number of async
+                  RestoreItemAction operations for this restore which ended with an
+                  error.
+                type: integer
               startTimestamp:
                 description: StartTimestamp records the time the restore operation
                   was started. The server's time is used for StartTimestamps

--- a/helmfile.d/upstream/vmware-tanzu/velero/crds/schedules.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/crds/schedules.yaml
@@ -86,6 +86,24 @@ spec:
                       entirely in future. Use DefaultVolumesToFsBackup instead."
                     nullable: true
                     type: boolean
+                  excludedClusterScopedResources:
+                    description: ExcludedClusterScopedResources is a slice of cluster-scoped
+                      resource type names to exclude from the backup. If set to "*",
+                      all cluster-scoped resource types are excluded. The default
+                      value is empty.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  excludedNamespaceScopedResources:
+                    description: ExcludedNamespaceScopedResources is a slice of namespace-scoped
+                      resource type names to exclude from the backup. If set to "*",
+                      all namespace-scoped resource types are excluded. The default
+                      value is empty.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
                   excludedNamespaces:
                     description: ExcludedNamespaces contains a list of namespaces
                       that are not included in the backup.
@@ -296,6 +314,24 @@ spec:
                       resources should be included for consideration in the backup.
                     nullable: true
                     type: boolean
+                  includedClusterScopedResources:
+                    description: IncludedClusterScopedResources is a slice of cluster-scoped
+                      resource type names to include in the backup. If set to "*",
+                      all cluster-scoped resource types are included. The default
+                      value is empty, which means only related cluster-scoped resources
+                      are included.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  includedNamespaceScopedResources:
+                    description: IncludedNamespaceScopedResources is a slice of namespace-scoped
+                      resource type names to include in the backup. The default value
+                      is "*".
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
                   includedNamespaces:
                     description: IncludedNamespaces is a slice of namespace names
                       to include objects from. If empty, all namespaces are included.
@@ -310,6 +346,11 @@ spec:
                       type: string
                     nullable: true
                     type: array
+                  itemOperationTimeout:
+                    description: ItemOperationTimeout specifies the time used to wait
+                      for asynchronous BackupItemAction operations The default value
+                      is 1 hour.
+                    type: string
                   labelSelector:
                     description: LabelSelector is a metav1.LabelSelector to filter
                       with when adding individual objects to the backup. If empty
@@ -423,14 +464,34 @@ spec:
                     additionalProperties:
                       type: string
                     description: OrderedResources specifies the backup order of resources
-                      of specific Kind. The map key is the Kind name and value is
-                      a list of resource names separated by commas. Each resource
-                      name has format "namespace/resourcename".  For cluster resources,
-                      simply use "resourcename".
+                      of specific Kind. The map key is the resource name and value
+                      is a list of object names separated by commas. Each resource
+                      name has format "namespace/objectname".  For cluster resources,
+                      simply use "objectname".
                     nullable: true
                     type: object
+                  resourcePolicy:
+                    description: ResourcePolicy specifies the referenced resource
+                      policies that backup should follow
+                    properties:
+                      apiGroup:
+                        description: APIGroup is the group for the resource being
+                          referenced. If APIGroup is not specified, the specified
+                          Kind must be in the core API group. For any other third-party
+                          types, APIGroup is required.
+                        type: string
+                      kind:
+                        description: Kind is the type of resource being referenced
+                        type: string
+                      name:
+                        description: Name is the name of resource being referenced
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
                   snapshotVolumes:
-                    description: SnapshotVolumes specifies whether to take cloud snapshots
+                    description: SnapshotVolumes specifies whether to take snapshots
                       of any PV's referenced in the set of objects included in the
                       Backup.
                     nullable: true

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/NOTES.txt
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/NOTES.txt
@@ -26,6 +26,18 @@ More info on the official site: https://velero.io/docs
 {{- $breaking_title = print $breaking_title "\n######             the `helm template` command.                             #####" }}
 {{- $breaking_title = print $breaking_title "\n#################################################################################" }}
 
+{{- if typeIs "map[string]interface {}" .Values.configuration.backupStorageLocation }}
+{{- $breaking = print $breaking "\n\nERROR: Please make .configuration.backupStorageLocation from map to slice" }}
+{{- end }}
+
+{{- if typeIs "map[string]interface {}" .Values.configuration.volumeSnapshotLocation }}
+{{- $breaking = print $breaking "\n\nERROR: Please make .configuration.volumeSnapshotLocation from map to slice" }}
+{{- end }}
+
+{{- if hasKey .Values.configuration "provider" }}
+{{- $breaking = print $breaking "\n\nREMOVED: .configuration.provider has been removed, instead each backupStorageLocation and volumeSnapshotLocation has a provider configured" }}
+{{- end }}
+
 {{- if hasKey .Values "resticTimeout" }}
 {{- $breaking = print $breaking "\n\nREMOVED: resticTimeout has been removed, and it is named fsBackupTimeout" }}
 {{- end }}

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/_helpers.tpl
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/_helpers.tpl
@@ -76,42 +76,6 @@ Create the node-Agent priority class name.
 {{- end -}}
 
 {{/*
-Create the backup storage location name
-*/}}
-{{- define "velero.backupStorageLocation.name" -}}
-{{- with .Values.configuration.backupStorageLocation -}}
-{{ default "default" .name }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create the backup storage location provider
-*/}}
-{{- define "velero.backupStorageLocation.provider" -}}
-{{- with .Values.configuration -}}
-{{ default .provider .backupStorageLocation.provider }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create the volume snapshot location name
-*/}}
-{{- define "velero.volumeSnapshotLocation.name" -}}
-{{- with .Values.configuration.volumeSnapshotLocation -}}
-{{ default "default" .name }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create the volume snapshot location provider
-*/}}
-{{- define "velero.volumeSnapshotLocation.provider" -}}
-{{- with .Values.configuration -}}
-{{ default .provider .volumeSnapshotLocation.provider }}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Kubernetes version
 Built-in object .Capabilities.KubeVersion.Minor can provide non-number output
 For examples:

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/backupstoragelocation.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/backupstoragelocation.yaml
@@ -1,24 +1,39 @@
 {{- if .Values.backupsEnabled }}
+
+{{- if typeIs "[]interface {}" .Values.configuration.backupStorageLocation }}
+{{- range .Values.configuration.backupStorageLocation }}
+---
 apiVersion: velero.io/v1
 kind: BackupStorageLocation
 metadata:
-  name: {{ include "velero.backupStorageLocation.name" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ .name | default "default" }}
+  namespace: {{ $.Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    app.kubernetes.io/name: {{ include "velero.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "velero.chart" . }}
+    app.kubernetes.io/name: {{ include "velero.name" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" $ }}
 spec:
-  provider: {{ include "velero.backupStorageLocation.provider" . }}
-  {{- with .Values.configuration.backupStorageLocation.default }}
+  {{- if not (empty .credential) }}
+  credential:
+    {{- with .credential.name }}
+    name: {{ . }}
+    {{- end }}
+    {{- with .credential.key }}
+    key: {{ . }}
+    {{- end }}
+  {{- end }}
+  provider: {{ .provider }}
+  accessMode: {{ .accessMode | default "ReadWrite" }}
+  {{- with .default }}
   default: {{ . }}
   {{- end }}
-  accessMode: {{ .Values.configuration.backupStorageLocation.accessMode }}
-{{- with .Values.configuration.backupStorageLocation }}
+  {{- with .validationFrequency }}
+  validationFrequency: {{ . }}
+  {{- end }}
   objectStorage:
     bucket: {{ .bucket | quote }}
     {{- with .prefix }}
@@ -31,6 +46,7 @@ spec:
   config:
 {{- range $key, $value := . }}
 {{- $key | nindent 4 }}: {{ $value | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/deployment.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/deployment.yaml
@@ -1,5 +1,3 @@
-{{- if .Values.configuration.provider -}}
-{{- $provider := .Values.configuration.provider -}}
 {{/* 'securityContext' got renamed to 'podSecurityContext', merge both dicts into one for backward compatibility */}}
 {{- $podSecurityContext := merge (.Values.podSecurityContext | default dict) (.Values.securityContext | default dict) -}}
 apiVersion: apps/v1
@@ -156,6 +154,14 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.metrics.enabled }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
           {{- with .Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
@@ -192,19 +198,14 @@ spec:
             - name: LD_LIBRARY_PATH
               value: /plugins
           {{- if .Values.credentials.useSecret }}
-            {{- if eq $provider "aws" }}
             - name: AWS_SHARED_CREDENTIALS_FILE
               value: /credentials/cloud
-            {{- else if eq $provider "gcp"}}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /credentials/cloud
-            {{- else if eq $provider "azure" }}
             - name: AZURE_CREDENTIALS_FILE
               value: /credentials/cloud
-            {{- else if eq $provider "alibabacloud" }}
             - name: ALIBABA_CLOUD_CREDENTIALS_FILE
               value: /credentials/cloud
-            {{- end }}
           {{- end }}
           {{- with .Values.configuration.extraEnvVars }}
           {{- range $key, $value := . }}
@@ -270,4 +271,3 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-{{- end -}}

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/node-agent-daemonset.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/node-agent-daemonset.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.deployNodeAgent }}
-{{- $provider := .Values.configuration.provider -}}
 {{/* 'nodeAgent.securityContext' got renamed to 'nodeAgent.containerSecurityContext', merge both dicts into one for backward compatibility */}}
 {{- $containerSecurityContext := merge (.Values.nodeAgent.containerSecurityContext | default dict) (.Values.nodeAgent.securityContext | default dict) -}}
 apiVersion: apps/v1
@@ -132,19 +131,14 @@ spec:
             - name: VELERO_SCRATCH_DIR
               value: /scratch
           {{- if .Values.credentials.useSecret }}
-            {{- if eq $provider "aws" }}
             - name: AWS_SHARED_CREDENTIALS_FILE
               value: /credentials/cloud
-            {{- else if eq $provider "gcp" }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /credentials/cloud
-            {{- else if eq $provider "azure" }}
             - name: AZURE_CREDENTIALS_FILE
               value: /credentials/cloud
-            {{- else if eq $provider "alibabacloud" }}
             - name: ALIBABA_CLOUD_CREDENTIALS_FILE
               value: /credentials/cloud
-            {{- end }}
           {{- end }}
           {{- with .Values.configuration.extraEnvVars }}
           {{- range $key, $value := . }}

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/prometheusrule.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/prometheusrule.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enabled .Values.metrics.prometheusRule.enabled }}
+{{- if and (and .Values.metrics.enabled .Values.metrics.prometheusRule.enabled) (or (not .Values.metrics.prometheusRule.autodetect) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) (.Values.metrics.prometheusRule.spec) }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/volumesnapshotlocation.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/volumesnapshotlocation.yaml
@@ -1,23 +1,29 @@
 {{- if .Values.snapshotsEnabled }}
+
+{{- if typeIs "[]interface {}" .Values.configuration.volumeSnapshotLocation }}
+{{- range .Values.configuration.volumeSnapshotLocation }}
+---
 apiVersion: velero.io/v1
 kind: VolumeSnapshotLocation
 metadata:
-  name: {{ include "velero.volumeSnapshotLocation.name" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ .name | default "default" }}
+  namespace: {{ $.Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
-    app.kubernetes.io/name: {{ include "velero.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "velero.chart" . }}
+    app.kubernetes.io/name: {{ include "velero.name" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    helm.sh/chart: {{ include "velero.chart" $ }}
 spec:
-  provider: {{ include "velero.volumeSnapshotLocation.provider" . }}
-{{- with .Values.configuration.volumeSnapshotLocation.config }}
+  provider: {{ .provider }}
+{{- with .config }}
   config:
 {{- range $key, $value := . }}
 {{- $key | nindent 4 }}: {{ $value | quote }}
 {{- end }}
 {{- end -}}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/helmfile.d/upstream/vmware-tanzu/velero/values.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/values.yaml
@@ -6,7 +6,7 @@
 # enabling node-agent). Required.
 image:
   repository: velero/velero
-  tag: v1.10.2
+  tag: v1.11.1
   # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
   # If used, it will take precedence over the image.tag.
   # digest:
@@ -53,13 +53,13 @@ dnsPolicy: ClusterFirst
 # If the value is a string then it is evaluated as a template.
 initContainers:
   # - name: velero-plugin-for-csi
-  #   image: velero/velero-plugin-for-csi:v0.4.2
+  #   image: velero/velero-plugin-for-csi:v0.5.0
   #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target
   #       name: plugins
   # - name: velero-plugin-for-aws
-  #   image: velero/velero-plugin-for-aws:v1.6.1
+  #   image: velero/velero-plugin-for-aws:v1.7.0
   #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target
@@ -88,6 +88,30 @@ priorityClassName: ""
 
 # The number of seconds to allow for graceful termination of the pod. Optional.
 terminationGracePeriodSeconds: 3600
+
+# Liveness probe of the pod
+livenessProbe:
+  httpGet:
+    path: /metrics
+    port: http-monitoring
+    scheme: HTTP
+  initialDelaySeconds: 10
+  periodSeconds: 30
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 5
+
+# Readiness probe of the pod
+readinessProbe:
+  httpGet:
+    path: /metrics
+    port: http-monitoring
+    scheme: HTTP
+  initialDelaySeconds: 10
+  periodSeconds: 30
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 5
 
 # Tolerations to use for the Velero deployment. Optional.
 tolerations: []
@@ -174,6 +198,7 @@ metrics:
     # tlsConfig: {}
 
   prometheusRule:
+    autodetect: true
     enabled: false
     # Additional labels to add to deployed PrometheusRule
     additionalLabels: {}
@@ -233,17 +258,13 @@ cleanUpCRDs: false
 ## and additional server settings.
 ##
 configuration:
-  # Cloud provider being used (e.g. aws, azure, gcp).
-  provider:
-
-  # Parameters for the `default` BackupStorageLocation. See
-  # https://velero.io/docs/v1.6/api-types/backupstoragelocation/
+  # Parameters for the BackupStorageLocation(s). Configure multiple by adding other element(s) to the backupStorageLocation slice.
+  # See https://velero.io/docs/v1.6/api-types/backupstoragelocation/
   backupStorageLocation:
     # name is the name of the backup storage location where backups should be stored. If a name is not provided,
     # a backup storage location will be created with the name "default". Optional.
-    name:
-    # provider is the name for the backup storage location provider. If omitted
-    # `configuration.provider` will be used instead.
+  - name:
+    # provider is the name for the backup storage location provider.
     provider:
     # bucket is the name of the bucket to store backups in. Required.
     bucket:
@@ -253,9 +274,16 @@ configuration:
     prefix:
     # default indicates this location is the default backup storage location. Optional.
     default:
+    # validationFrequency defines how frequently Velero should validate the object storage. Optional.
+    validationFrequency:
     # accessMode determines if velero can write to this backup storage location. Optional.
     # default to ReadWrite, ReadOnly is used during migrations and restores.
     accessMode: ReadWrite
+    credential:
+      # name of the secret used by this backupStorageLocation.
+      name:
+      # name of key that contains the secret data to be used.
+      key:
     # Additional provider-specific configuration. See link above
     # for details of required/optional fields for your provider.
     config: {}
@@ -275,13 +303,12 @@ configuration:
     #  flag. For Velero client Command like velero backup describe, velero backup logs needs to add the flag --insecure-skip-tls-verify
     #  insecureSkipTLSVerify:
 
-  # Parameters for the `default` VolumeSnapshotLocation. See
-  # https://velero.io/docs/v1.6/api-types/volumesnapshotlocation/
+  # Parameters for the VolumeSnapshotLocation(s). Configure multiple by adding other element(s) to the volumeSnapshotLocation slice.
+  # See https://velero.io/docs/v1.6/api-types/volumesnapshotlocation/
   volumeSnapshotLocation:
     # name is the name of the volume snapshot location where snapshots are being taken. Required.
-    name:
-    # provider is the name for the volume snapshot provider. If omitted
-    # `configuration.provider` will be used instead.
+  - name:
+    # provider is the name for the volume snapshot provider.
     provider:
     # Additional provider-specific configuration. See link above
     # for details of required/optional fields for your provider.
@@ -499,6 +526,7 @@ nodeAgent:
 #     useOwnerReferencesInBackup: false
 #     template:
 #       ttl: "240h"
+#       storageLocation: default
 #       includedNamespaces:
 #       - foo
 schedules: {}
@@ -506,12 +534,26 @@ schedules: {}
 # Velero ConfigMaps.
 # Eg:
 # configMaps:
+    # See: https://velero.io/docs/v1.11/file-system-backup/
 #   fs-restore-action-config:
 #     labels:
 #       velero.io/plugin-config: ""
 #       velero.io/pod-volume-restore: RestoreItemAction
 #     data:
 #       image: velero/velero-restore-helper:v1.10.2
+#       cpuRequest: 200m
+#       memRequest: 128Mi
+#       cpuLimit: 200m
+#       memLimit: 128Mi
+#       secCtx: |
+#         capabilities:
+#           drop:
+#           - ALL
+#           add: []
+#         allowPrivilegeEscalation: false
+#         readOnlyRootFilesystem: true
+#         runAsUser: 1001
+#         runAsGroup: 999
 configMaps: {}
 
 ##

--- a/helmfile.d/values/velero-sc.yaml.gotmpl
+++ b/helmfile.d/values/velero-sc.yaml.gotmpl
@@ -33,52 +33,33 @@ initContainers:
   {{- end }}
 
 configuration:
-  # Cloud provider being used (e.g. aws, azure, gcp).
-  {{- if eq .Values.objectStorage.type "s3" }}
-  provider: aws
-  {{- else if eq .Values.objectStorage.type "gcs" }}
-  provider: gcp
-  {{- end }}
-
   defaultVolumesToFsBackup: true
 
-  # https://velero.io/docs/v1.0.0/api-types/backupstoragelocation/
+  # https://velero.io/docs/v1.11/api-types/backupstoragelocation/
   backupStorageLocation:
-    {{- if eq .Values.objectStorage.type "s3" }}
-    # Cloud provider where backups should be stored. Usually should
-    # match `configuration.provider`. Required.
-    name: default
-    # Bucket to store backups in. Required.
-    bucket: {{ .Values.objectStorage.buckets.velero }}
-    # Prefix within bucket under which to store backups. Optional.
-    prefix: service-cluster
-    # Additional provider-specific configuration. See link above
-    # for details of required/optional fields for your provider.
-    config:
-      region: {{ .Values.objectStorage.s3.region }}
-      s3ForcePathStyle: "true"
-      s3Url: {{ .Values.objectStorage.s3.regionEndpoint }}
-    {{- else if eq .Values.objectStorage.type "gcs" }}
-    # Cloud provider where backups should be stored. Usually should
-    # match `configuration.provider`. Required.
-    name: default
-    # Bucket to store backups in. Required.
-    bucket: {{ .Values.objectStorage.buckets.velero }}
-    # Prefix within bucket under which to store backups. Optional.
-    prefix: service-cluster
-    # Additional provider-specific configuration. See link above
-    # for details of required/optional fields for your provider.
-    {{- end }}
-
-  # Parameters for the `default` VolumeSnapshotLocation. See
-  # https://velero.io/docs/v1.0.0/api-types/volumesnapshotlocation/
-  volumeSnapshotLocation:
-    config:
+    - bucket: {{ .Values.objectStorage.buckets.velero }}
+      prefix: service-cluster
       {{- if eq .Values.objectStorage.type "s3" }}
-      region: {{ .Values.objectStorage.s3.region }}
+      provider: aws
+      config:
+        region: {{ .Values.objectStorage.s3.region }}
+        s3ForcePathStyle: "true"
+        s3Url: {{ .Values.objectStorage.s3.regionEndpoint }}
       {{- else if eq .Values.objectStorage.type "gcs" }}
-      project: {{ .Values.objectStorage.gcs.project }}
+      provider: gcp
       {{- end }}
+
+  # https://velero.io/docs/v1.11/api-types/volumesnapshotlocation/
+  volumeSnapshotLocation:
+    {{- if eq .Values.objectStorage.type "s3" }}
+    - provider: aws
+      config:
+        region: {{ .Values.objectStorage.s3.region }}
+    {{- else if eq .Values.objectStorage.type "gcs" }}
+    - provider: gcp
+      config:
+        project: {{ .Values.objectStorage.gcs.project }}
+    {{- end }}
 
 credentials:
   # Create secret with credentials

--- a/helmfile.d/values/velero-wc.yaml.gotmpl
+++ b/helmfile.d/values/velero-wc.yaml.gotmpl
@@ -33,52 +33,33 @@ initContainers:
   {{- end }}
 
 configuration:
-  # Cloud provider being used (e.g. aws, azure, gcp).
-  {{- if eq .Values.objectStorage.type "s3" }}
-  provider: aws
-  {{- else if eq .Values.objectStorage.type "gcs" }}
-  provider: gcp
-  {{- end }}
-
   defaultVolumesToFsBackup: true
 
-  # https://velero.io/docs/v1.0.0/api-types/backupstoragelocation/
+  # https://velero.io/docs/v1.11/api-types/backupstoragelocation/
   backupStorageLocation:
-    {{- if eq .Values.objectStorage.type "s3" }}
-    # Cloud provider where backups should be stored. Usually should
-    # match `configuration.provider`. Required.
-    name: default
-    # Bucket to store backups in. Required.
-    bucket: {{ .Values.objectStorage.buckets.velero }}
-    # Prefix within bucket under which to store backups. Optional.
-    prefix: {{ .Values.velero.storagePrefix }}
-    # Additional provider-specific configuration. See link above
-    # for details of required/optional fields for your provider.
-    config:
-      region: {{ .Values.objectStorage.s3.region }}
-      s3ForcePathStyle: "true"
-      s3Url: {{ .Values.objectStorage.s3.regionEndpoint }}
-    {{- else if eq .Values.objectStorage.type "gcs" }}
-    # Cloud provider where backups should be stored. Usually should
-    # match `configuration.provider`. Required.
-    name: default
-    # Bucket to store backups in. Required.
-    bucket: {{ .Values.objectStorage.buckets.velero }}
-    # Prefix within bucket under which to store backups. Optional.
-    prefix: {{ .Values.velero.storagePrefix }}
-    # Additional provider-specific configuration. See link above
-    # for details of required/optional fields for your provider.
-    {{- end }}
-
-  # Parameters for the `default` VolumeSnapshotLocation. See
-  # https://velero.io/docs/v1.0.0/api-types/volumesnapshotlocation/
-  volumeSnapshotLocation:
-    config:
+    - bucket: {{ .Values.objectStorage.buckets.velero }}
+      prefix: {{ .Values.velero.storagePrefix }}
       {{- if eq .Values.objectStorage.type "s3" }}
-      region: {{ .Values.objectStorage.s3.region }}
+      provider: aws
+      config:
+        region: {{ .Values.objectStorage.s3.region }}
+        s3ForcePathStyle: "true"
+        s3Url: {{ .Values.objectStorage.s3.regionEndpoint }}
       {{- else if eq .Values.objectStorage.type "gcs" }}
-      project: {{ .Values.objectStorage.gcs.project }}
+      provider: gcp
       {{- end }}
+
+  # https://velero.io/docs/v1.11/api-types/volumesnapshotlocation/
+  volumeSnapshotLocation:
+    {{- if eq .Values.objectStorage.type "s3" }}
+    - provider: aws
+      config:
+        region: {{ .Values.objectStorage.s3.region }}
+    {{- else if eq .Values.objectStorage.type "gcs" }}
+    - provider: gcp
+      config:
+        project: {{ .Values.objectStorage.gcs.project }}
+    {{- end }}
 
 credentials:
   # Create secret with credentials


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice
Only perform the upgrade if no Velero backup or restore operation is active.
Upgrade the Velero client to v1.11.1 on your host machine.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1665 

#### Additional information to reviewers

Tested on a local (kind) cluster.
* Deployed 1.10.2
* Created a backup from daily schedule
* Upgraded to 1.11.1
* Restored the backup
* Created a new backup from daily schedule
* Restored from the new backup
* Deployed Prometheus
* Checked target and a few metrics

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [ ] The change is transparent
  - [x] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [x] The metrics are still exposed ~and present in Grafana after the change~
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
