### PR TITLE
Added alert for failing webhooks

### DIFF
--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -378,6 +378,8 @@ prometheus:
   tolerations: []
   affinity: {}
   nodeSelector: {}
+  webhookAlerts:
+    enabled: false
   ## Predictive alert if the resource usage will hit the set percentage in 3 days
   capacityManagementAlerts:
     enabled: true

--- a/helmfile.d/charts/prometheus-alerts/files/webhooks.yaml
+++ b/helmfile.d/charts/prometheus-alerts/files/webhooks.yaml
@@ -1,0 +1,10 @@
+- name: webhook-failures
+  rules:
+  - alert: WebhookFailing
+    annotations:
+      description: Webhooks have been failing during the last 10m
+      summary: Webhooks requests are failing
+    expr: rate(apiserver_admission_webhook_rejection_count{error_type!="no_error"}[5m]) > 0
+    for: 10m
+    labels:
+      severity: warning

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/webhooks.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/webhooks.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.defaultRules.create .Values.defaultRules.rules.webhooks }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-alerts.fullname" .) "webhooks" | trunc 63 | trimSuffix "-" }}
+  labels:
+    app: {{ template "prometheus-alerts.name" . }}
+    {{- include "prometheus-alerts.labels" . | nindent 4 }}
+    {{- with .Values.defaultRules.alertLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.defaultRules.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  groups:
+    {{- .Files.Get "files/webhooks.yaml" | nindent 4 }}
+{{- end }}

--- a/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -51,7 +51,7 @@ kubeApiServer:
     metricRelabelings:
       - action: keep
         sourceLabels: [__name__]
-        regex: '(process_cpu_seconds_total|process_resident_memory_bytes|go_goroutines|workqueue_queue_duration_seconds_bucket|workqueue_adds_total|workqueue_depth|apiserver_request_total|apiserver_request_count|apiserver_request_latencies_bucket|apiserver_client_certificate_expiration_seconds_count|apiserver_request_duration_seconds_sum|apiserver_request_duration_seconds_count|APIServiceRegistrationController_depth)'
+        regex: '(process_cpu_seconds_total|process_resident_memory_bytes|go_goroutines|workqueue_queue_duration_seconds_bucket|workqueue_adds_total|workqueue_depth|apiserver_request_total|apiserver_request_count|apiserver_request_latencies_bucket|apiserver_client_certificate_expiration_seconds_count|apiserver_request_duration_seconds_sum|apiserver_request_duration_seconds_count|APIServiceRegistrationController_depth|apiserver_admission_webhook_rejection_count)'
 
 kubeEtcd:
   service:

--- a/helmfile.d/values/kube-prometheus-stack-wc.yaml.gotmpl
+++ b/helmfile.d/values/kube-prometheus-stack-wc.yaml.gotmpl
@@ -82,7 +82,7 @@ kubeApiServer:
     metricRelabelings:
       - action: keep
         sourceLabels: [__name__]
-        regex: '(process_cpu_seconds_total|process_resident_memory_bytes|go_goroutines|workqueue_queue_duration_seconds_bucket|workqueue_adds_total|workqueue_depth|apiserver_request_total|apiserver_request_count|apiserver_request_latencies_bucket|apiserver_client_certificate_expiration_seconds_count|apiserver_request_duration_seconds_sum|apiserver_request_duration_seconds_count|APIServiceRegistrationController_depth)'
+        regex: '(process_cpu_seconds_total|process_resident_memory_bytes|go_goroutines|workqueue_queue_duration_seconds_bucket|workqueue_adds_total|workqueue_depth|apiserver_request_total|apiserver_request_count|apiserver_request_latencies_bucket|apiserver_client_certificate_expiration_seconds_count|apiserver_request_duration_seconds_sum|apiserver_request_duration_seconds_count|APIServiceRegistrationController_depth|apiserver_admission_webhook_rejection_count)'
 
 kubeEtcd:
   service:

--- a/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
@@ -34,6 +34,7 @@ defaultRules:
     dailyChecks: true
     networkpolicies: {{ .Values.networkPolicies.enableAlerting }}
     clusterApi: {{ .Values.clusterApi.enabled }}
+    webhooks: {{ .Values.prometheus.webhookAlerts.enabled }}
 
   {{- if and .Values.thanos.enabled .Values.thanos.ruler.enabled }}
   thanos:

--- a/helmfile.d/values/prometheus-user-alerts-wc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-user-alerts-wc.yaml.gotmpl
@@ -23,6 +23,7 @@ defaultRules:
     capacityManagementAlerts: {{ .Values.prometheus.capacityManagementAlerts.enabled }}
     networkpolicies: {{ .Values.networkPolicies.enableAlerting }}
     harbor: false
+    webhooks: {{ .Values.prometheus.webhookAlerts.enabled }}
 
 capacityManagementAlertsPersistentVolumeEnabled: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.enabled }}
 capacityManagementAlertsPersistentVolumeLimit: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.limit }}


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Added an alert for failing webhooks

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1870 

#### Additional information to reviewers
Not sure if we would want to have it enabled by default, as of now I have disabled it by default.

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
