### PR TITLE
Use objectStorage.s3.forcePathStyle in Velero values

### DIFF
--- a/helmfile.d/values/velero-sc.yaml.gotmpl
+++ b/helmfile.d/values/velero-sc.yaml.gotmpl
@@ -43,7 +43,7 @@ configuration:
       provider: aws
       config:
         region: {{ .Values.objectStorage.s3.region }}
-        s3ForcePathStyle: "true"
+        s3ForcePathStyle: {{ .Values.objectStorage.s3.forcePathStyle }}
         s3Url: {{ .Values.objectStorage.s3.regionEndpoint }}
       {{- else if eq .Values.objectStorage.type "gcs" }}
       provider: gcp

--- a/helmfile.d/values/velero-wc.yaml.gotmpl
+++ b/helmfile.d/values/velero-wc.yaml.gotmpl
@@ -43,7 +43,7 @@ configuration:
       provider: aws
       config:
         region: {{ .Values.objectStorage.s3.region }}
-        s3ForcePathStyle: "true"
+        s3ForcePathStyle: {{ .Values.objectStorage.s3.forcePathStyle }}
         s3Url: {{ .Values.objectStorage.s3.regionEndpoint }}
       {{- else if eq .Values.objectStorage.type "gcs" }}
       provider: gcp


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice
Velero now adheres to the S3 option `s3ForcePathStyle` in the configuration. Previously it was always set to `true`.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Follow up from: https://github.com/elastisys/compliantkubernetes-apps/pull/1946#discussion_r1453165845

#### Additional information to reviewers

Added a platform admin notice to inform of the change since it's not obvious to me that this won't make the Velero backups and/or restores behave differently if the configuration is set to `false`.

If either of you know that this actually should be left hardcoded to true please let me know. If so let's add a comment explaining it.

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - scripts: changes to other scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [ ] The change is transparent
  - [x] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
