### PR TITLE
Added networkpolicy for wc ingress probe

### DIFF
--- a/helmfile.d/stacks/ingress-nginx.yaml
+++ b/helmfile.d/stacks/ingress-nginx.yaml
@@ -45,6 +45,19 @@ templates:
       - values/ingress-nginx.yaml.gotmpl
     wait: true
 
+  ingress-nginx-networkpolicy:
+    condition: ck8sWorkloadCluster.enabled
+    inherit:
+      - template: networkpolicies
+    installed: {{ .Values | get "wcProbeIngress.enabled" false }}
+    labels:
+      netpol: ingress-nginx-probe
+    needs:
+      - kube-system/admin-namespaces
+    values:
+      - values/networkpolicies/common/common.yaml.gotmpl
+      - values/networkpolicies/workload/ingress-nginx-probe.yaml.gotmpl
+
   ingress-nginx-probe-ingress:
     name: ingress-nginx-probe-ingresss
     condition: ck8sWorkloadCluster.enabled

--- a/helmfile.d/state.yaml
+++ b/helmfile.d/state.yaml
@@ -69,6 +69,7 @@ releases:
   - inherit: [ template: ingress-nginx-podsecuritypolicy ]
   - inherit: [ template: ingress-nginx-controller ]
   - inherit: [ template: ingress-nginx-probe-ingress ]
+  - inherit: [ template: ingress-nginx-networkpolicy ]
 
   - inherit: [ template: monitoring-networkpolicy ]
   - inherit: [ template: monitoring-podsecuritypolicy ]

--- a/helmfile.d/values/networkpolicies/workload/ingress-nginx-probe.yaml.gotmpl
+++ b/helmfile.d/values/networkpolicies/workload/ingress-nginx-probe.yaml.gotmpl
@@ -1,0 +1,9 @@
+policies:
+  ingress-nginx:
+    cert-manager-http01-solver:
+      podSelectorLabels:
+        acme.cert-manager.io/http01-solver: "true"
+      ingress:
+        - rule: ingress-rule-ingress
+          ports:
+            - tcp: 8089


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
The netpol for the http01-solver was missing, so I added that

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->

#### Additional information to reviewers
I ma not super familiar with the new helm setup, so please comment if I missed anything.

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - scripts: changes to other scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Network Policy checks:
  - [x] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [x] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [x] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [x] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
