### PR TITLE
Add templating for air-gapped environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,16 @@ Assuming you already have everything needed to install the apps, this is what yo
 
     ```bash
     export CK8S_ENVIRONMENT_NAME=my-ck8s-cluster
-    export CK8S_FLAVOR=[dev|prod] # defaults to dev
+    export CK8S_FLAVOR=[dev|prod|air-gapped] # defaults to dev
 
     #
     # If 'none', no infra provider tailored configuration will be performed!
     #
     export CK8S_CLOUD_PROVIDER=[exoscale|safespring|citycloud|elastx|aws|baremetal|none]
     ```
+
+    > [!NOTE]
+    > The `air-gapped` flavor has a lot of the same settings as the `prod` flavor but with some additional variables that you need to configure yourself (these are set to `set-me`).
 
 1. Then set the path to where the ck8s configuration should be stored and the PGP fingerprint of the key(s) to use for encryption:
 

--- a/bin/common.bash
+++ b/bin/common.bash
@@ -22,6 +22,7 @@ ck8s_cloud_providers=(
 ck8s_flavors=(
     "dev"
     "prod"
+    "air-gapped"
 )
 
 CK8S_AUTO_APPROVE=${CK8S_AUTO_APPROVE:-"false"}

--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -118,6 +118,11 @@ falco:
       enabled: false
       version: 2.0.0
 
+  artifact:
+    install:
+      # set to false in an air-gapped environment, unless artifacts are self-hosted
+      enabled: true
+
   # Setting tty to "true" will immediately display Falco logs by flushing them as they are emitted
   tty: true
 
@@ -133,6 +138,14 @@ falco:
       # -- Needed to enable eBPF JIT at runtime for performance reasons.
       # Can be skipped if eBPF JIT is enabled from outside the container
       hostNetwork: false
+
+    module:
+      # override the URL used for downloading driver modules, e.g. to use a self hosted file server in an air-gapped environment
+      repoURL: ""
+
+  # use custom indexes for falcoctl downloads
+  # ref: https://github.com/falcosecurity/charts/blob/falco-3.8.3/charts/falco/values.yaml#L390-L395
+  customIndexes: []
 
   ## additional falco rules
   ## ref: https://falco.org/docs/rules/
@@ -853,6 +866,29 @@ trivy:
     interval: 5m
   tolerations: []
   affinity: {}
+
+  # configurations for an offline / air-gapped environment
+  # ref: https://github.com/aquasecurity/trivy-operator/tree/main/deploy/helm#values
+  scanner:
+    offlineScanEnabled: false
+    dbRegistry: ""
+    dbRepository: ""
+    dbRepositoryInsecure: false
+    javaDbRegistry: ""
+    javaDbRepository: ""
+    # if authorization is required for pulling from registry, create a pull
+    # secret in the monitoring namespace and configure the secret name
+    imagePullSecret:
+      name: ""
+    registry:
+      mirror: {}
+        # "docker.io": registry.example.org:5000
+        # "gcr.io": registry.example.org:5000
+        # "ghcr.io": registry.example.org:5000
+        # "index.docker.io": registry.example.org:5000
+        # "quay.io": registry.example.org:5000
+        # "registry.k8s.io": registry.example.org:5000
+
 kured:
   enabled: false
   # See options at https://github.com/weaveworks/kured/blob/1.9.1/charts/kured/values.yaml#L24

--- a/config/config/flavors/air-gapped/common-config.yaml
+++ b/config/config/flavors/air-gapped/common-config.yaml
@@ -1,0 +1,32 @@
+global:
+  issuer: set-me
+
+prometheus:
+  storage:
+    size: 15Gi
+  retention:
+    size: 12GiB
+
+falco:
+  artifact:
+    install:
+      enabled: false
+
+trivy:
+  scanner:
+    offlineScanEnabled: true
+    dbRegistry: set-me
+    dbRepository: set-me
+    dbRepositoryInsecure: false # set to true if the private registry is not configured with HTTPS
+    javaDbRegistry: set-me
+    javaDbRepository: set-me
+
+    # add registries that should be mirrored to private registry
+    registry:
+      mirror:
+        "docker.io": set-me
+        "gcr.io": set-me
+        "ghcr.io": set-me
+        "index.docker.io": set-me
+        "quay.io": set-me
+        "registry.k8s.io": set-me

--- a/config/config/flavors/air-gapped/sc-config.yaml
+++ b/config/config/flavors/air-gapped/sc-config.yaml
@@ -1,0 +1,77 @@
+dex:
+  enableStaticLogin: false
+
+alerts:
+  alertTo: set-me
+  customReceivers:
+  - set-me
+
+prometheus:
+  retention:
+    age: 7d
+
+opensearch:
+  sso:
+    enabled: true
+  plugins:
+    installExternalObjectStoragePlugin: false
+    additionalPlugins:
+    - set-me
+  masterNode:
+    javaOpts: -Xms1024m -Xmx1024m
+    resources:
+      requests:
+        memory: 2Gi
+        cpu: 100m
+      limits:
+        memory: 3Gi
+  dataNode:
+    storageSize: 130Gi
+    javaOpts: -Xms2048m -Xmx2048m
+    resources:
+      requests:
+        memory: 4Gi
+      limits:
+        memory: 5Gi
+  clientNode:
+    javaOpts: -Xms1024m -Xmx1024m
+    resources:
+      requests:
+        memory: 2Gi
+      limits:
+        memory: 2.5Gi
+  ism:
+    rolloverSizeGB: 5
+    rolloverAgeDays: 1
+  curator:
+    retention:
+      - pattern: other-*
+        sizeGB: 5
+        ageDays: 10
+      - pattern: kubeaudit-*
+        sizeGB: 50
+        ageDays: 30
+      - pattern: kubernetes-*
+        sizeGB: 50
+        ageDays: 30
+      - pattern: authlog-*
+        sizeGB: 5
+        ageDays: 30
+      - pattern: security-auditlog-*
+        sizeGB: 1
+        ageDays: 14
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+  snapshot:
+    min: 300 # 12 / day * 30 days = 360, subtract some to account for failures
+    max: 500
+    ageSeconds: 2592000 # 30 days
+    backupSchedule: 30 */2 * * * # 30 min past every 2nd hour to avoid collision with retention
+
+harbor:
+  database:
+    internal:
+      persistentVolumeClaim:
+        size: 5Gi

--- a/config/config/flavors/air-gapped/wc-config.yaml
+++ b/config/config/flavors/air-gapped/wc-config.yaml
@@ -1,0 +1,5 @@
+user:
+  namespaces:
+    - set-me
+    - production
+    - staging

--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -718,6 +718,15 @@ opensearch:
   defaultTemplates: true
   additionalTemplates: {}
 
+  plugins:
+    # in an air-gapped environment where the nodes are not connected to the Internet, set
+    # following variable to false to prevent downloading external object storage plugin
+    installExternalObjectStoragePlugin: true
+
+    # in an air-gapped environment this can be used to install plugins from known sources
+    additionalPlugins: []
+    # - server.local:8080/repository-s3-2.8.0.zip
+
   # Index state management
   ism:
     rolloverSizeGB: 1
@@ -1034,6 +1043,8 @@ alerts:
     #   {{ end }}
   opsGenie:
     apiUrl: https://api.eu.opsgenie.com
+  # Configure custom alert receivers
+  customReceivers: []
 
 externalTrafficPolicy:
   # Whitelisting requires externalTrafficPolicy.local to be true

--- a/helmfile.d/values/falco/falco-common.yaml.gotmpl
+++ b/helmfile.d/values/falco/falco-common.yaml.gotmpl
@@ -24,6 +24,7 @@ falco:
     {{end}}
     - /etc/falco/falco_rules.local.yaml
     - /etc/falco/rules.d
+
 tty: {{ .Values.falco.tty }}
 
 {{- if eq .Values.falco.driver.kind "module" }}
@@ -52,6 +53,11 @@ driver:
         runAsUser: 0
         privileged: true
         allowPrivilegeEscalation: true
+      {{- with .Values.falco.driver.module.repoURL }}
+      env:
+      - name: DRIVERS_REPO
+        value: {{ . }}
+      {{- end }}
 
 resources: {{- toYaml .Values.falco.resources | nindent 2  }}
 nodeSelector: {{- toYaml .Values.falco.nodeSelector | nindent 2  }}
@@ -61,7 +67,7 @@ tolerations: {{- toYaml .Values.falco.tolerations | nindent 2  }}
 falcoctl:
   artifact:
     install:
-      enabled: true
+      enabled: {{ .Values.falco.artifact.install.enabled }}
     follow:
       enabled: false
   config:
@@ -77,6 +83,10 @@ falcoctl:
           {{- if eq .Values.falco.rulesFiles.sandbox.enabled true }}
           - falco-sandbox-rules:{{.Values.falco.rulesFiles.sandbox.version}}
           {{end}}
+    {{- with .Values.falco.customIndexes }}
+    indexes:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 customRules:
   {{- if .Values.falco.customRules }}
     {{ toYaml .Values.falco.customRules | nindent 2}}

--- a/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -151,6 +151,9 @@ alertmanager:
           source: {{ .Values.grafana.user.subdomain }}.{{ .Values.global.opsDomain }}
           priority: {{`'{{ if eq .GroupLabels.severity "critical"}}P1{{else if eq .GroupLabels.severity "warning"}}P2{{else if eq .GroupLabels.severity "medium"}}P3{{else if eq .GroupLabels.severity "low"}}P4{{else}}P5{{end}}'`}}
       {{ end }}
+    {{- with .Values.alerts.customReceivers }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 
   alertmanagerSpec:
     replicas: {{ .Values.prometheus.alertmanagerSpec.replicas }}

--- a/helmfile.d/values/opensearch/common.yaml.gotmpl
+++ b/helmfile.d/values/opensearch/common.yaml.gotmpl
@@ -166,9 +166,14 @@ keystore:
 plugins:
   enabled: true
   installList:
+    {{- if .Values.opensearch.plugins.installExternalObjectStoragePlugin }}
     {{- if (eq .Values.objectStorage.type "s3") }}
     - repository-s3
     {{- else if (eq .Values.objectStorage.type "gcs") }}
     - repository-gcs
+    {{- end }}
+    {{- end }}
+    {{- with .Values.opensearch.plugins.additionalPlugins }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 {{- end}}

--- a/helmfile.d/values/prometheus-blackbox-exporter-sc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-blackbox-exporter-sc.yaml.gotmpl
@@ -4,6 +4,10 @@ pspEnabled: false
 
 config:
   modules:
+    http_2xx:
+      http:
+        tls_config:
+          insecure_skip_verify: {{ not .Values.global.verifyTls }}
     http_400:
       prober: http
       timeout: 5s

--- a/helmfile.d/values/prometheus-blackbox-exporter-wc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-blackbox-exporter-wc.yaml.gotmpl
@@ -4,6 +4,10 @@ pspEnabled: false
 
 config:
   modules:
+    http_2xx:
+      http:
+        tls_config:
+          insecure_skip_verify: {{ not .Values.global.verifyTls }}
     http_400:
       prober: http
       timeout: 5s

--- a/helmfile.d/values/trivy/trivy-operator.yaml.gotmpl
+++ b/helmfile.d/values/trivy/trivy-operator.yaml.gotmpl
@@ -9,6 +9,30 @@ targetNamespaces: ""
 # mode, i.e. when the targetNamespaces values is a blank string.
 excludeNamespaces: {{ .Values.trivy.excludeNamespaces }}
 
+trivy:
+  offlineScan: {{ .Values.trivy.scanner.offlineScanEnabled }}
+
+  {{- with .Values.trivy.scanner.dbRegistry }}
+  dbRegistry: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.trivy.scanner.dbRepository }}
+  dbRepository: {{ . | quote }}
+  {{- end }}
+  dbRepositoryInsecure: {{ .Values.trivy.scanner.dbRepositoryInsecure }}
+
+  {{- with .Values.trivy.scanner.javaDbRegistry }}
+  javaDbRegistry: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.trivy.scanner.javaDbRepository }}
+  javaDbRepository: {{ . | quote }}
+  {{- end }}
+
+  {{- with .Values.trivy.scanner.registry }}
+  registry:
+    mirror:
+      {{ toYaml .mirror | nindent 6 }}
+  {{- end }}
+
 operator:
 
   replicas: 1
@@ -38,6 +62,10 @@ operator:
   scanJobsRetryDelay: {{ .Values.trivy.scanJobs.retryDelay }}
   # scanJobTimeout the length of time to wait before giving up on a scan job
   scanJobTimeout: {{ .Values.trivy.scanJobs.timeout }}
+
+  {{- with .Values.trivy.scanner.imagePullSecret.name }}
+  privateRegistryScanSecretsNames: {"monitoring": {{ . }}}
+  {{- end }}
 
 tolerations: {{- toYaml .Values.trivy.tolerations | nindent 2 }}
 

--- a/tests/unit/bin/init.bats.yaml
+++ b/tests/unit/bin/init.bats.yaml
@@ -101,8 +101,10 @@ tests:
         tests:
           - target: dev
           - target: prod
+          - target: air-gapped
 
       - function: test_init_idempotent # cloud flavor
         tests:
           - target: dev
           - target: prod
+          - target: air-gapped

--- a/tests/unit/validate.bats.yaml
+++ b/tests/unit/validate.bats.yaml
@@ -57,8 +57,10 @@ tests:
         tests:
           - target: dev
           - target: prod
+          - target: air-gapped
 
       - function: validate_template # cloud flavor
         tests:
           - target: dev
           - target: prod
+          - target: air-gapped


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [ ] personal data beyond what is necessary for interacting with this pull request
> - [ ] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice

There is now an additional `CK8S_FLAVOR` called `air-gapped` with similar settings to `prod` but with some additional configuration to avoid any outgoing traffic to the Internet.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
This PR introduces additional templating to be able to configure CK8s in an air-gapped environment. Most of the config options provides ways of overriding services that normally downloads plugins from the Internet to instead pull from a URL of a server or registry available inside the air-gapped environment.

Also added so that `http_2xx` blackbox monitors work even when `global.verifyTls=false`.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - scripts: changes to other scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
