### PR TITLE
Rework capacity management alerts and add dashboard

### DIFF
--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -400,7 +400,14 @@ prometheus:
     persistentVolume:
       enabled: true
       limit: 75
+    predictUsage: false
     usagelimit: 95
+    nodeGroupCpuLimit24h: 75
+    nodeGroupMemoryLimit24h: 75
+    nodeGroupCpuLimit1h: 95
+    nodeGroupMemoryLimit1h: 85
+    nodeCpuLimit1h: 95
+    nodeMemoryLimit1h: 85
     ## for each cpu and memory add the node pattern for which you want to create an alert
     requestlimit:
       cpu:

--- a/helmfile.d/charts/grafana-dashboards/dashboards/capacity-management-dashboard.json
+++ b/helmfile.d/charts/grafana-dashboards/dashboards/capacity-management-dashboard.json
@@ -1,0 +1,1197 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 40,
+      "title": "Summary",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 51,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(sum by (instance)(rate(node_cpu_seconds_total{mode!='idle',cluster=~'$cluster'}[1h])) / on (instance) instance:node_num_cpu:sum * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group=~\"$NodeGroup\"}, \"instance\", \"$1\", \"node\", \"(.*)\") > 0.95)",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes with average CPU usage over 1h above threshold",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 82,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(sum by (instance)(rate(node_cpu_seconds_total{mode!='idle',cluster=~'$cluster'}[24h])) / on (instance) instance:node_num_cpu:sum * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group=~\"$NodeGroup\"}, \"instance\", \"$1\", \"node\", \"(.*)\") > 0.75)",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes with average CPU usage over 24h above threshold",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 113,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(avg_over_time(instance:node_memory_utilisation:ratio{cluster=~'$cluster'}[1h]) * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group=~\"$NodeGroup\"}, \"instance\", \"$1\", \"node\", \"(.*)\") > 0.85)",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes with average Memory usage over 1h above threshold",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 144,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(avg_over_time(instance:node_memory_utilisation:ratio{cluster=~'$cluster'}[24h]) * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group=~\"$NodeGroup\"}, \"instance\", \"$1\", \"node\", \"(.*)\") > 0.75)",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes with average Memory usage over 24h above threshold",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 8,
+      "panels": [],
+      "repeat": "NodeGroup",
+      "repeatDirection": "h",
+      "title": "CPU Usage - $NodeGroup",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode!='idle',cluster='$cluster'}[1h])) / on (instance) instance:node_num_cpu:sum * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group=~\"$NodeGroup\"}, \"instance\", \"$1\", \"node\", \"(.*)\")",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average CPU usage per Node over 1 hour",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg((sum by (instance)(rate(node_cpu_seconds_total{mode!='idle',cluster='$cluster'}[1h])) / on (instance) instance:node_num_cpu:sum) * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group=~\"$NodeGroup\"}, \"instance\", \"$1\", \"node\", \"(.*)\"))",
+          "legendFormat": "$NodeGroup",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average CPU usage per Node Group over 1 hour",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(sum by (instance)(rate(node_cpu_seconds_total{mode!='idle',cluster='$cluster'}[$__rate_interval])) / on (instance) instance:node_num_cpu:sum) * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group=~\"$NodeGroup\"}, \"instance\", \"$1\", \"node\", \"(.*)\")",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU usage per Node",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 75
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg((sum by (instance)(rate(node_cpu_seconds_total{mode!='idle',cluster='$cluster'}[24h])) / on (instance) instance:node_num_cpu:sum) * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group=~\"$NodeGroup\"}, \"instance\", \"$1\", \"node\", \"(.*)\"))",
+          "legendFormat": "$NodeGroup",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average CPU usage per Node Group over 24 hours",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 73
+      },
+      "id": 6,
+      "panels": [],
+      "repeat": "NodeGroup",
+      "repeatDirection": "h",
+      "title": "Memory Usage - $NodeGroup",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 74
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time(instance:node_memory_utilisation:ratio{cluster=~\"$cluster\"}[1h]) * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group=~\"$NodeGroup\"}, \"instance\", \"$1\", \"node\", \"(.*)\")",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average Memory usage per Node over 1 hour",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 74
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(avg_over_time(instance:node_memory_utilisation:ratio{cluster=~\"$cluster\"}[1h]) * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group=~\"$NodeGroup\"}, \"instance\", \"$1\", \"node\", \"(.*)\"))",
+          "hide": false,
+          "legendFormat": "$NodeGroup",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Average Memory usage per Node Group over 1 hour",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 82
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "instance:node_memory_utilisation:ratio{cluster=~\"$cluster\"} * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group=~\"$NodeGroup\"}, \"instance\", \"$1\", \"node\", \"(.*)\")",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory usage per Node",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 75
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 82
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "avg(avg_over_time(instance:node_memory_utilisation:ratio{cluster=~\"$cluster\"}[24h]) * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group=~\"$NodeGroup\"}, \"instance\", \"$1\", \"node\", \"(.*)\"))",
+          "hide": false,
+          "legendFormat": "$NodeGroup",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Average Memory usage per Node Group over 24 hours",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "datasource": "${datasource}",
+        "definition": "label_values(node_cpu_seconds_total, cluster)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(node_cpu_seconds_total, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(kube_node_labels{cluster=~\"$cluster\"},label_elastisys_io_node_group)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": true,
+        "name": "NodeGroup",
+        "options": [],
+        "query": {
+          "query": "label_values(kube_node_labels{cluster=~\"$cluster\"},label_elastisys_io_node_group)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Capacity Management Dashboard",
+  "uid": "c8aab7f3-697d-4a23-86b4-d8f7f9067947",
+  "version": 5,
+  "weekStart": ""
+}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/cluster-capacity-management-alerts.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/cluster-capacity-management-alerts.yaml
@@ -42,6 +42,7 @@ spec:
       labels:
         severity: warning
     {{- end }}
+    {{- if .Values.capacityManagementAlertsPredictUsage}}
     - alert: Memory{{.Values.capacityManagementAlertsUsageLimit}}PercentInThreeDays
       annotations:
         message: Memory usage in Cluster {{`{{ $labels.cluster }}`}} Instance {{`{{ $labels.instance }}`}} is predicted to go over {{.Values.capacityManagementAlertsUsageLimit}}% within the next 3 days at current use rate.
@@ -49,10 +50,46 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: CPU{{.Values.capacityManagementAlertsUsageLimit}}PercentOnAverage
+    {{- end }}
+    - alert: NodeGroupCPU{{.Values.capacityManagementAlertsNodeGroupCpuLimit24h}}PercentOver24h
       annotations:
-        message: CPU usage has been over {{.Values.capacityManagementAlertsUsageLimit}}% on average over the span of 24h in a Instance {{`{{ $labels.instance }}`}} of a Cluster {{`{{ $labels.cluster }}`}}.
-      expr: 1 - (avg by (instance, cluster) (rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[24h]))) >= {{ .Values.capacityManagementAlertsUsageLimit }}/100
+        message: CPU usage has been over {{.Values.capacityManagementAlertsNodeGroupCpuLimit24h}}% on average over the span of 24h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} on Cluster {{`{{ $labels.cluster }}`}}.
+      expr: avg by (label_elastisys_io_node_group,cluster) (sum by (instance) (rate(node_cpu_seconds_total{mode!='idle',cluster=~".*"}[24h])) / on (instance) instance:node_num_cpu:sum * on (instance) group_left (label_elastisys_io_node_group,cluster) label_replace(kube_node_labels{label_elastisys_io_node_group!=""}, "instance", "$1", "node", "(.*)")) > {{.Values.capacityManagementAlertsNodeGroupCpuLimit24h}}/100
+      for: 5m
+      labels:
+        severity: warning
+    - alert: NodeGroupCPU{{.Values.capacityManagementAlertsNodeGroupCpuLimit1h}}PercentOver1h
+      annotations:
+        message: CPU usage has been over {{.Values.capacityManagementAlertsNodeGroupCpuLimit1h}}% on average over the span of 1h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} on Cluster {{`{{ $labels.cluster }}`}}.
+      expr: avg by (label_elastisys_io_node_group,cluster) (sum by (instance) (rate(node_cpu_seconds_total{mode!='idle',cluster=~".*"}[1h])) / on (instance) instance:node_num_cpu:sum * on (instance) group_left (label_elastisys_io_node_group,cluster) label_replace(kube_node_labels{label_elastisys_io_node_group!=""}, "instance", "$1", "node", "(.*)")) > {{.Values.capacityManagementAlertsNodeGroupCpuLimit1h}}/100
+      for: 5m
+      labels:
+        severity: warning
+    - alert: NodeGroupMemory{{.Values.capacityManagementAlertsNodeGroupMemoryLimit24h}}PercentOver24h
+      annotations:
+        message: Memory usage has been over {{.Values.capacityManagementAlertsNodeGroupMemoryLimit24h}}% on average over the span of 24h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} on Cluster {{`{{ $labels.cluster }}`}}.
+      expr: avg by (label_elastisys_io_node_group,cluster) ((avg_over_time (instance:node_memory_utilisation:ratio{cluster=~".*"}[24h])) * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group!=""}, "instance", "$1", "node", "(.*)")) > {{.Values.capacityManagementAlertsNodeGroupMemoryLimit24h}}/100
+      for: 5m
+      labels:
+        severity: warning
+    - alert: NodeGroupMemory{{.Values.capacityManagementAlertsNodeGroupMemoryLimit1h}}PercentOver1h
+      annotations:
+        message: Memory usage has been over {{.Values.capacityManagementAlertsNodeGroupMemoryLimit1h}}% on average over the span of 1h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} on Cluster {{`{{ $labels.cluster }}`}}.
+      expr: avg by (label_elastisys_io_node_group,cluster) ((avg_over_time (instance:node_memory_utilisation:ratio{cluster=~".*"}[1h])) * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group!=""}, "instance", "$1", "node", "(.*)")) > {{.Values.capacityManagementAlertsNodeGroupMemoryLimit1h}}/100
+      for: 5m
+      labels:
+        severity: warning
+    - alert: NodeCPU{{.Values.capacityManagementAlertsNodeCpuLimit1h}}PercentOver1h
+      annotations:
+        message: CPU usage has been over {{.Values.capacityManagementAlertsNodeCpuLimit1h}}% on average over the span of 1h for the node {{`{{ $labels.instance }}`}} on Cluster {{`{{ $labels.cluster }}`}}.
+      expr: sum by (instance) (rate(node_cpu_seconds_total{mode!='idle',cluster=~".*"}[1h])) / on (instance) instance:node_num_cpu:sum * on (instance) group_left (label_elastisys_io_node_group,cluster) label_replace(kube_node_labels{label_elastisys_io_node_group!=""}, "instance", "$1", "node", "(.*)") > {{.Values.capacityManagementAlertsNodeCpuLimit1h}}/100
+      for: 5m
+      labels:
+        severity: warning
+    - alert: NodeMemory{{.Values.capacityManagementAlertsNodeMemoryLimit1h}}PercentOver1h
+      annotations:
+        message: Memory usage has been over {{.Values.capacityManagementAlertsNodeMemoryLimit1h}}% on average over the span of 1h for the Node {{`{{ $labels.instance }}`}} on Cluster {{`{{ $labels.cluster }}`}}.
+      expr: avg_over_time (instance:node_memory_utilisation:ratio{cluster=~".*"}[1h]) * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group!=""}, "instance", "$1", "node", "(.*)") > {{.Values.capacityManagementAlertsNodeMemoryLimit1h}}/100
       for: 5m
       labels:
         severity: warning

--- a/helmfile.d/charts/prometheus-alerts/templates/records/node-exporter.rules.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/records/node-exporter.rules.yaml
@@ -18,7 +18,7 @@ spec:
   - name: node-exporter.rules
     rules:
     - expr: |-
-        count without (cpu, mode) (
+        count without (cpu, mode, pod) (
           node_cpu_seconds_total{job="node-exporter",mode="idle"}
         )
       record: instance:node_num_cpu:sum
@@ -35,22 +35,24 @@ spec:
         )
       record: instance:node_load1_per_cpu:ratio
     - expr: |-
-        1 - (
-          (
-            node_memory_MemAvailable_bytes{job="node-exporter"}
-            or
+        sum by (instance) (
+          1 - (
             (
-              node_memory_Buffers_bytes{job="node-exporter"}
-              +
-              node_memory_Cached_bytes{job="node-exporter"}
-              +
-              node_memory_MemFree_bytes{job="node-exporter"}
-              +
-              node_memory_Slab_bytes{job="node-exporter"}
+              node_memory_MemAvailable_bytes{job="node-exporter"}
+              or
+              (
+                node_memory_Buffers_bytes{job="node-exporter"}
+                +
+                node_memory_Cached_bytes{job="node-exporter"}
+                +
+                node_memory_MemFree_bytes{job="node-exporter"}
+                +
+                node_memory_Slab_bytes{job="node-exporter"}
+              )
             )
+          /
+            node_memory_MemTotal_bytes{job="node-exporter"}
           )
-        /
-          node_memory_MemTotal_bytes{job="node-exporter"}
         )
       record: instance:node_memory_utilisation:ratio
     - expr: rate(node_vmstat_pgmajfault{job="node-exporter"}[5m])

--- a/helmfile.d/charts/prometheus-alerts/values.yaml
+++ b/helmfile.d/charts/prometheus-alerts/values.yaml
@@ -127,6 +127,14 @@ defaultRules:
     # alertLabels:
     #   key: value
 
+capacityManagementAlertsPredictUsage: false
+capacityManagementAlertsNodeGroupCpuLimit24h: 75
+capacityManagementAlertsNodeGroupMemoryLimit24h: 75
+capacityManagementAlertsNodeGroupCpuLimit1h: 95
+capacityManagementAlertsNodeGroupMemoryLimit1h: 85
+capacityManagementAlertsNodeCpuLimit1h: 95
+capacityManagementAlertsNodeMemoryLimit1h: 85
+
 buckets:
   harbor: set-me
   velero: set-me

--- a/helmfile.d/values/grafana/grafana-dashboards.yaml.gotmpl
+++ b/helmfile.d/values/grafana/grafana-dashboards.yaml.gotmpl
@@ -27,7 +27,7 @@ disabledDashboards:
   {{- if not .Values.clusterApi.monitoring.enabled }}
   - cluster-api-dashboard
   - cluster-api-autoscaling-dashboard
-  {{- end }}}
+  {{- end }}
   - vulnerability-dashboard
   - thanos-sidecar-dashboard
   - thanos-bucket-replicate-dashboard

--- a/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -45,7 +45,8 @@ kube-state-metrics:
   extraArgs:
     - "--custom-resource-state-config-file=/etc/config/clusterapi-metrics.yaml"
   {{- end }}
-
+  metricLabelsAllowlist:
+  - nodes=[topology.kubernetes.io/zone,elastisys.io/node-group]
 kubeApiServer:
   serviceMonitor:
     metricRelabelings:

--- a/helmfile.d/values/kube-prometheus-stack-wc.yaml.gotmpl
+++ b/helmfile.d/values/kube-prometheus-stack-wc.yaml.gotmpl
@@ -65,7 +65,7 @@ kube-state-metrics:
   {{- end }}
 
   metricLabelsAllowlist:
-  - nodes=[topology.kubernetes.io/zone]
+  - nodes=[topology.kubernetes.io/zone,elastisys.io/node-group]
 
 prometheus-node-exporter:
   resources: {{- toYaml .Values.prometheusNodeExporter.resources | nindent 4 }}

--- a/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
@@ -45,8 +45,16 @@ defaultRules:
 capacityManagementAlertsPersistentVolumeEnabled: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.enabled }}
 capacityManagementAlertsPersistentVolumeLimit: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.limit }}
 capacityManagementAlertsDiskLimit: {{ .Values.prometheus.capacityManagementAlerts.disklimit }}
+capacityManagementAlertsPredictUsage: {{ .Values.prometheus.capacityManagementAlerts.predictUsage }}
 capacityManagementAlertsUsageLimit: {{ .Values.prometheus.capacityManagementAlerts.usagelimit }}
 capacityManagementAlertsRequestLimit: {{ toYaml .Values.prometheus.capacityManagementAlerts.requestlimit | nindent 2 }}
+capacityManagementAlertsNodeGroupCpuLimit24h: {{ .Values.prometheus.capacityManagementAlerts.nodeGroupCpuLimit24h }}
+capacityManagementAlertsNodeGroupMemoryLimit24h: {{ .Values.prometheus.capacityManagementAlerts.nodeGroupMemoryLimit24h }}
+capacityManagementAlertsNodeGroupCpuLimit1h: {{ .Values.prometheus.capacityManagementAlerts.nodeGroupCpuLimit1h }}
+capacityManagementAlertsNodeGroupMemoryLimit1h: {{ .Values.prometheus.capacityManagementAlerts.nodeGroupMemoryLimit1h }}
+capacityManagementAlertsNodeCpuLimit1h: {{ .Values.prometheus.capacityManagementAlerts.nodeCpuLimit1h }}
+capacityManagementAlertsNodeMemoryLimit1h: {{ .Values.prometheus.capacityManagementAlerts.nodeMemoryLimit1h }}
+
 
 s3BucketAlerts:
   size:

--- a/helmfile.d/values/prometheus-user-alerts-wc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-user-alerts-wc.yaml.gotmpl
@@ -28,6 +28,13 @@ defaultRules:
 capacityManagementAlertsPersistentVolumeEnabled: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.enabled }}
 capacityManagementAlertsPersistentVolumeLimit: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.limit }}
 capacityManagementAlertsDiskLimit: {{ .Values.prometheus.capacityManagementAlerts.disklimit }}
+capacityManagementAlertsPredictUsage: {{ .Values.prometheus.capacityManagementAlerts.predictUsage }}
 capacityManagementAlertsUsageLimit: {{ .Values.prometheus.capacityManagementAlerts.usagelimit }}
 capacityManagementAlertsRequestLimit:
 {{ toYaml .Values.prometheus.capacityManagementAlerts.requestlimit | indent 2 }}
+capacityManagementAlertsNodeGroupCpuLimit24h: {{ .Values.prometheus.capacityManagementAlerts.nodeGroupCpuLimit24h }}
+capacityManagementAlertsNodeGroupMemoryLimit24h: {{ .Values.prometheus.capacityManagementAlerts.nodeGroupMemoryLimit24h }}
+capacityManagementAlertsNodeGroupCpuLimit1h: {{ .Values.prometheus.capacityManagementAlerts.nodeGroupCpuLimit1h }}
+capacityManagementAlertsNodeGroupMemoryLimit1h: {{ .Values.prometheus.capacityManagementAlerts.nodeGroupMemoryLimit1h }}
+capacityManagementAlertsNodeCpuLimit1h: {{ .Values.prometheus.capacityManagementAlerts.nodeCpuLimit1h }}
+capacityManagementAlertsNodeMemoryLimit1h: {{ .Values.prometheus.capacityManagementAlerts.nodeMemoryLimit1h }}


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice
Capacity management has been reworked with new alerts and a Grafana dashboard. In order for these to work, nodes must be labeled with `elastisys.io/node-group=<node-group>`.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Adds capacity management alerts and a dashboard, based on our previous investigation regarding this.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1864 

#### Additional information to reviewers

- The alerts and dashboard will only account for nodes that have been labeled with `elastisys.io/node-group`.
  - This is checked per cluster, so you can use the same label, e.g. for control planes, in both clusters if you want.
- When migrating you will see duplicate entries for each node in the "Average per node over 1h"-panels of the dashboard due to the metric changes. This will go away after 2 hours.
  - I have not found any other negative side-effects caused by this.

#### Screenshots

Alert
![Screenshot from 2024-02-05 14-40-32](https://github.com/elastisys/compliantkubernetes-apps/assets/60571221/afef0bb5-db07-4b71-a63f-550ad39994c1)

Dashboard
![Screenshot from 2024-02-05 14-42-09](https://github.com/elastisys/compliantkubernetes-apps/assets/60571221/fefd6678-f266-4635-b3f1-8fb1e5f9cad9)

Node Exporter dashboard for reference
![Screenshot from 2024-02-05 14-41-47](https://github.com/elastisys/compliantkubernetes-apps/assets/60571221/12f5ecae-8011-42c3-a37e-4225aa89dd2e)

Latest revision:

![Screenshot from 2024-02-13 10-49-20](https://github.com/elastisys/compliantkubernetes-apps/assets/60571221/1fcd53cd-8f83-46a1-b97d-fe6809c40000)


#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - scripts: changes to other scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
