### PR TITLE
apps: Add ability to set IP families for the ingress-nginx service

### DIFF
--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -569,6 +569,16 @@ ingressNginx:
       ## ref: https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#restrict-access-for-loadbalancer-service
       loadBalancerSourceRanges: []
 
+      # -- Represents the dual-stack-ness requested or required by this Service. Possible values are
+      # SingleStack (default), PreferDualStack or RequireDualStack. When utilizing an internal loadbalancer service (ie MetalLB),
+      # set this field to "RequireDualStack" if you want both IPv4 and IPv6 connectivity.
+      # The ipFamilies and clusterIPs fields depend on the value of this field.
+      ## Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+      ipFamilyPolicy: ""
+      # -- List of IP families (e.g. IPv4, IPv6) assigned to the service. Default is IPv4 only. When utilizing an internal loadbalancer service (ie MetalLB),
+      # IPv6 would also need to be included in order for the ingress service to allocate an address in that family.
+      ipFamilies: []
+
       ## type: NodePort
       nodePorts:
         http: "30080"

--- a/helmfile.d/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile.d/values/ingress-nginx.yaml.gotmpl
@@ -109,6 +109,12 @@ controller:
     {{ else }}
     enabled: false
     {{ end }}
+    {{ if .Values.ingressNginx.controller.service.ipFamilyPolicy }}
+    ipFamilyPolicy: {{ .Values.ingressNginx.controller.service.ipFamilyPolicy }}
+    {{ end }}
+    {{ if .Values.ingressNginx.controller.service.ipFamilies }}
+    ipFamilies: {{- toYaml .Values.ingressNginx.controller.service.ipFamilies | nindent 6 }}
+    {{ end }}
     {{ if eq .Values.ingressNginx.controller.service.type "NodePort" }}
     nodePorts: {{- toYaml .Values.ingressNginx.controller.service.nodePorts | nindent 6 }}
     {{ end }}


### PR DESCRIPTION
> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

By default, from ingress-nginx' helmcharts, the ingress controller will configure itself with IPv4 only, and with external
load balancers it is still possible to expose workloads on IPv6 as well. However, when exposing an internal load balancer service (ie MetalLB), it's not possible for the ingress-nginx to request addresses from other IP families (ie IPv6). These changes allow a platform administrator to configure the ingress controller with dualstack - the ingress-nginx service will request both an IPv4 and an IPv6 address. It will also be possible to configure an IPv6 only ingress service.

If not configured, the upstream values will continue to be used, and no change in default behavior is expected. No action for existing or new cluster needs to be taken.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->

#### Additional information to reviewers

The comments section in the generated default config file may be overly verbose.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - scripts: changes to other scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
