### PR TITLE
Apply velero crds manually during apps v0.36 upgrade

### DIFF
--- a/helmfile.d/values/velero-sc.yaml.gotmpl
+++ b/helmfile.d/values/velero-sc.yaml.gotmpl
@@ -129,6 +129,9 @@ kubectl:
     runAsGroup: 10000
     runAsUser: 10000
 
+# This job upgrades the CRDs.
+upgradeCRDs: false
+
 # Run velero-restore-helper init container with numeric UID and GID.
 configMaps:
   restore-helper-config:

--- a/helmfile.d/values/velero-wc.yaml.gotmpl
+++ b/helmfile.d/values/velero-wc.yaml.gotmpl
@@ -137,6 +137,9 @@ kubectl:
     runAsGroup: 10000
     runAsUser: 10000
 
+# This job upgrades the CRDs.
+upgradeCRDs: false
+
 # Run velero-restore-helper init container with numeric UID and GID.
 configMaps:
   restore-helper-config:

--- a/migration/v0.36/README.md
+++ b/migration/v0.36/README.md
@@ -145,6 +145,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ./migration/v0.36/apply/40-namespaces.sh execute
     ```
 
+1. Upgrade Velero
+
+    ```bash
+    ./migration/v0.36/apply/50-velero-crds-upgrade.sh execute
+    ```
+
 1. Upgrade applications:
 
     ```bash

--- a/migration/v0.36/apply/50-velero-crds-upgrade.sh
+++ b/migration/v0.36/apply/50-velero-crds-upgrade.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+run() {
+  case "${1:-}" in
+  execute)
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      log_info "  - applying the Velero CRDs on sc"
+      kubectl_do sc apply --server-side --force-conflicts -f "${ROOT}"/helmfile.d/upstream/vmware-tanzu/velero/crds
+
+      helmfile_upgrade sc app=velero
+    fi
+    if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+      log_info "  - applying the Velero CRDs on wc"
+      kubectl_do wc apply --server-side --force-conflicts -f "${ROOT}"/helmfile.d/upstream/vmware-tanzu/velero/crds
+
+      helmfile_upgrade wc app=velero
+    fi
+    ;;
+  rollback)
+    log_warn "rollback not implemented"
+    ;;
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.36/apply/80-apply.sh
+++ b/migration/v0.36/apply/80-apply.sh
@@ -10,6 +10,7 @@ source "${ROOT}/scripts/migration/lib.sh"
 declare -a skipped
 skipped=(
   "app!=gatekeeper"
+  "app!=velero"
 )
 declare -a skipped_sc
 skipped_sc=(


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [x] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
During the upgrade to apps v0.36 the kubectl container used by Velero to apply the CRDs was failing with:
```console
/tmp/sh: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /tmp/sh)
/tmp/sh: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /tmp/sh)
```
As this error seems to appear only sometimes I decided to apply the Velero CRDs using a migration script instead.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - scripts: changes to other scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [x] The change requires migration steps
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [x] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [x] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
