### PR TITLE
Ability to customize both Alertmanagers images

### DIFF
--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -424,6 +424,10 @@ prometheus:
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: DoNotSchedule
+    #image:
+    # registry: registry.example.com
+    # repository: prometheus/alertmanager
+    # tag: vX.Y.Z
   diskAlerts:
     perf: true
 

--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -54,6 +54,7 @@ user:
     tolerations: []
     affinity: {}
     topologySpreadConstraints: []
+    # image: quay.io/prometheus/alertmanager:vX.Y.Z
 
   # Installs required cluster resources needed to install sealedSecrets
   # Requires that gatekeeper.allowUserCRDs.enabled is enabled.

--- a/helmfile.d/charts/user-alertmanager/templates/alertmanager.yaml
+++ b/helmfile.d/charts/user-alertmanager/templates/alertmanager.yaml
@@ -25,3 +25,6 @@ spec:
   topologySpreadConstraints:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.image }}
+  image: {{ .Values.image | quote }}
+  {{- end }}

--- a/helmfile.d/charts/user-alertmanager/values.yaml
+++ b/helmfile.d/charts/user-alertmanager/values.yaml
@@ -15,3 +15,4 @@ resources:
 tolerations: []
 affinity: {}
 topologySpreadConstraints: []
+# image: quay.io/prometheus/alertmanager:vX.Y.Z

--- a/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -162,6 +162,9 @@ alertmanager:
     resources: {{- toYaml .Values.prometheus.alertmanagerSpec.resources | nindent 6 }}
     storage: {{- toYaml .Values.prometheus.alertmanagerSpec.storage | nindent 6 }}
     topologySpreadConstraints: {{- toYaml .Values.prometheus.alertmanagerSpec.topologySpreadConstraints | nindent 4 }}
+{{- if .Values | get "prometheus.alertmanagerSpec.image" nil }}
+    image: {{- toYaml .Values.prometheus.alertmanagerSpec.image | nindent 6 }}
+{{- end }}
 
 kubeControllerManager:
   enabled: false

--- a/helmfile.d/values/user-alertmanager.yaml.gotmpl
+++ b/helmfile.d/values/user-alertmanager.yaml.gotmpl
@@ -13,3 +13,4 @@ resources: {{- toYaml .Values.user.alertmanager.resources | nindent 2  }}
 tolerations: {{- toYaml .Values.user.alertmanager.tolerations | nindent 2 }}
 affinity: {{- toYaml .Values.user.alertmanager.affinity | nindent 2 }}
 topologySpreadConstraints: {{- toYaml .Values.user.alertmanager.topologySpreadConstraints | nindent 2 }}
+image: {{ .Values | get "user.alertmanager.image" "" | quote }}


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->


### Platform Administrator notice
The image used for alertmanager can now be customized by setting `.prometheus.alertmanagerSpec.image = {registry: "...", repository: "...", tag: "..."}` for sc, or `.user.alertmanager.image = "registry/repository:tag"` for wc.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This allows overriding the image(s) used for alertmanager in both kube-stack-sc and user-alertmanager by passing through config trough helm and helmfile.

- Fixes #1927

#### Additional information to reviewers

Note that the config for sc and wc unfortunately take different formats, one using a map of parts (registry, repo, tag etc) and the other takes a plain string.
This is because the respective charts takes values in these formats.
Question is whether this is fine for now, as they may be unified once #1871 is done?

#### Screenshots

#### Testing

Primarily tested by observing that configured images make it through `helmfile template`, i.e.
- `helmfile -e service_cluster template -l app=prometheus | grep 'image: .*alertmanager'`
- `helmfile -e workload_cluster template -l app=dev-alertmanager | grep 'image: .*alertmanager'`

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - scripts: changes to other scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
