### PR TITLE
Upgrade cert-manager to v1.12.8

### DIFF
--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -733,6 +733,10 @@ certmanager:
     tolerations: {}
     affinity: {}
 
+    ## Extra args for cainjector, docs for available args: https://cert-manager.io/docs/cli/cainjector/
+    extraArgs: []
+    #- --enable-certificates-data-source=true
+
 ## Configuration for metric-server
 metricsServer:
   enabled: true

--- a/helmfile.d/charts/issuers/templates/letsencrypt-prod.yaml
+++ b/helmfile.d/charts/issuers/templates/letsencrypt-prod.yaml
@@ -19,6 +19,6 @@ spec:
     - selector: {}
       http01:
         ingress:
-          class: nginx
+          ingressClassName: nginx
     {{- end }}
 {{- end }}

--- a/helmfile.d/charts/issuers/templates/letsencrypt-staging.yaml
+++ b/helmfile.d/charts/issuers/templates/letsencrypt-staging.yaml
@@ -19,6 +19,6 @@ spec:
     - selector: {}
       http01:
         ingress:
-          class: nginx
+          ingressClassName: nginx
     {{- end }}
 {{- end }}

--- a/helmfile.d/upstream/index.yaml
+++ b/helmfile.d/upstream/index.yaml
@@ -47,7 +47,7 @@ charts:
 
   grafana/grafana: 7.3.0
 
-  jetstack/cert-manager: v1.11.0
+  jetstack/cert-manager: v1.12.8
 
   kokuwa/fluentd-elasticsearch: 13.10.0
 

--- a/helmfile.d/upstream/jetstack/cert-manager/Chart.yaml
+++ b/helmfile.d/upstream/jetstack/cert-manager/Chart.yaml
@@ -4,7 +4,7 @@ annotations:
     fingerprint: 1020CF3C033D4F35BAE1C19E1226061C665DF13E
     url: https://cert-manager.io/public-keys/cert-manager-keyring-2021-09-20-1020CF3C033D4F35BAE1C19E1226061C665DF13E.gpg
 apiVersion: v1
-appVersion: v1.11.0
+appVersion: v1.12.8
 description: A Helm chart for cert-manager
 home: https://github.com/cert-manager/cert-manager
 icon: https://raw.githubusercontent.com/cert-manager/cert-manager/d53c0b9270f8cd90d908460d69502694e1838f5f/logo/logo-small.png
@@ -13,7 +13,7 @@ keywords:
 - kube-lego
 - letsencrypt
 - tls
-kubeVersion: '>= 1.21.0-0'
+kubeVersion: '>= 1.22.0-0'
 maintainers:
 - email: cert-manager-maintainers@googlegroups.com
   name: cert-manager-maintainers
@@ -21,4 +21,4 @@ maintainers:
 name: cert-manager
 sources:
 - https://github.com/cert-manager/cert-manager
-version: v1.11.0
+version: v1.12.8

--- a/helmfile.d/upstream/jetstack/cert-manager/README.md
+++ b/helmfile.d/upstream/jetstack/cert-manager/README.md
@@ -19,7 +19,7 @@ Before installing the chart, you must first install the cert-manager CustomResou
 This is performed in a separate step to allow you to easily uninstall and reinstall cert-manager without deleting your installed custom resources.
 
 ```bash
-$ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.crds.yaml
+$ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.8/cert-manager.crds.yaml
 ```
 
 To install the chart with the release name `my-release`:
@@ -29,7 +29,7 @@ To install the chart with the release name `my-release`:
 $ helm repo add jetstack https://charts.jetstack.io
 
 ## Install the cert-manager helm chart
-$ helm install my-release --namespace cert-manager --version v1.11.0 jetstack/cert-manager
+$ helm install my-release --namespace cert-manager --version v1.12.8 jetstack/cert-manager
 ```
 
 In order to begin issuing certificates, you will need to set up a ClusterIssuer
@@ -65,7 +65,7 @@ If you want to completely uninstall cert-manager from your cluster, you will als
 delete the previously installed CustomResourceDefinition resources:
 
 ```console
-$ kubectl delete -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.crds.yaml
+$ kubectl delete -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.8/cert-manager.crds.yaml
 ```
 
 ## Configuration
@@ -86,7 +86,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `global.leaderElection.retryPeriod` | The duration the clients should wait between attempting acquisition and renewal of a leadership |  |
 | `installCRDs` | If true, CRD resources will be installed as part of the Helm chart. If enabled, when uninstalling CRD resources will be deleted causing all installed custom resources to be DELETED | `false` |
 | `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
-| `image.tag` | Image tag | `v1.11.0` |
+| `image.tag` | Image tag | `v1.12.8` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `clusterResourceNamespace` | Override the namespace used to store DNS provider credentials etc. for ClusterIssuer resources | Same namespace as cert-manager pod |
@@ -106,6 +106,13 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `affinity` | Node affinity for pod assignment | `{}` |
 | `tolerations` | Node tolerations for pod assignment | `[]` |
 | `topologySpreadConstraints` | Topology spread constraints for pod assignment | `[]` |
+| `livenessProbe.enabled` | Enable or disable the liveness probe for the controller container in the controller Pod. See https://cert-manager.io/docs/installation/best-practice/ to learn about when you might want to enable this livenss probe. | `false` |
+| `livenessProbe.initialDelaySeconds` | The liveness probe initial delay (in seconds) | `10` |
+| `livenessProbe.periodSeconds` | The liveness probe period (in seconds) | `10` |
+| `livenessProbe.timeoutSeconds` | The liveness probe timeout (in seconds) | `10` |
+| `livenessProbe.periodSeconds` | The liveness probe period (in seconds) | `10` |
+| `livenessProbe.successThreshold` | The liveness probe success threshold | `1` |
+| `livenessProbe.failureThreshold` | The liveness probe failure threshold | `8` |
 | `ingressShim.defaultIssuerName` | Optional default issuer to use for ingress resources |  |
 | `ingressShim.defaultIssuerKind` | Optional default issuer kind to use for ingress resources |  |
 | `ingressShim.defaultIssuerGroup` | Optional default issuer group to use for ingress resources |  |
@@ -121,6 +128,9 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `prometheus.servicemonitor.honorLabels` | Enable label honoring for metrics scraped by Prometheus (see [Prometheus scrape config docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) for details). By setting `honorLabels` to `true`, Prometheus will prefer label contents given by cert-manager on conflicts. Can be used to remove the "exported_namespace" label for example.  | `false` |
 | `podAnnotations` | Annotations to add to the cert-manager pod | `{}` |
 | `deploymentAnnotations` | Annotations to add to the cert-manager deployment | `{}` |
+| `podDisruptionBudget.enabled` | Adds a PodDisruptionBudget for the cert-manager deployment | `false` |
+| `podDisruptionBudget.minAvailable` | Configures the minimum available pods for voluntary disruptions. Cannot used if `maxUnavailable` is set. | `1` |
+| `podDisruptionBudget.maxUnavailable` | Configures the maximum unavailable pods for voluntary disruptions. Cannot used if `minAvailable` is set. |  |
 | `podDnsPolicy` | Optional cert-manager pod [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods-dns-policy) |  |
 | `podDnsConfig` | Optional cert-manager pod [DNS configurations](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods-dns-config) |  |
 | `podLabels` | Labels to add to the cert-manager pod | `{}` |
@@ -129,12 +139,18 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `http_proxy` | Value of the `HTTP_PROXY` environment variable in the cert-manager pod | |
 | `https_proxy` | Value of the `HTTPS_PROXY` environment variable in the cert-manager pod | |
 | `no_proxy` | Value of the `NO_PROXY` environment variable in the cert-manager pod | |
+| `dns01RecursiveNameservers` | Comma separated string with host and port of the recursive nameservers cert-manager should query | `` |
+| `dns01RecursiveNameserversOnly` | Forces cert-manager to only use the recursive nameservers for verification.  | `false` |
+| `enableCertificateOwnerRef` | When this flag is enabled, secrets will be automatically removed when the certificate resource is deleted | `false` |
 | `webhook.replicaCount` | Number of cert-manager webhook replicas | `1` |
 | `webhook.timeoutSeconds` | Seconds the API server should wait the webhook to respond before treating the call as a failure. | `10` |
 | `webhook.podAnnotations` | Annotations to add to the webhook pods | `{}` |
 | `webhook.podLabels` | Labels to add to the cert-manager webhook pod | `{}` |
 | `webhook.serviceLabels` | Labels to add to the cert-manager webhook service | `{}` |
 | `webhook.deploymentAnnotations` | Annotations to add to the webhook deployment | `{}` |
+| `webhook.podDisruptionBudget.enabled` | Adds a PodDisruptionBudget for the cert-manager deployment | `false` |
+| `webhook.podDisruptionBudget.minAvailable` | Configures the minimum available pods for voluntary disruptions. Cannot used if `maxUnavailable` is set. | `1` |
+| `webhook.podDisruptionBudget.maxUnavailable` | Configures the maximum unavailable pods for voluntary disruptions. Cannot used if `minAvailable` is set. |  |
 | `webhook.mutatingWebhookConfigurationAnnotations` | Annotations to add to the mutating webhook configuration | `{}` |
 | `webhook.validatingWebhookConfigurationAnnotations` | Annotations to add to the validating webhook configuration | `{}` |
 | `webhook.serviceAnnotations` | Annotations to add to the webhook service | `{}` |
@@ -153,7 +169,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.tolerations` | Node tolerations for webhook pod assignment | `[]` |
 | `webhook.topologySpreadConstraints` | Topology spread constraints for webhook pod assignment | `[]` |
 | `webhook.image.repository` | Webhook image repository | `quay.io/jetstack/cert-manager-webhook` |
-| `webhook.image.tag` | Webhook image tag | `v1.11.0` |
+| `webhook.image.tag` | Webhook image tag | `v1.12.8` |
 | `webhook.image.pullPolicy` | Webhook image pull policy | `IfNotPresent` |
 | `webhook.securePort` | The port that the webhook should listen on for requests. | `10250` |
 | `webhook.securityContext` | Security context for webhook pod assignment | refer to [Default Security Contexts](#default-security-contexts) |
@@ -177,6 +193,9 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `cainjector.podAnnotations` | Annotations to add to the cainjector pods | `{}` |
 | `cainjector.podLabels` | Labels to add to the cert-manager cainjector pod | `{}` |
 | `cainjector.deploymentAnnotations` | Annotations to add to the cainjector deployment | `{}` |
+| `cainjector.podDisruptionBudget.enabled` | Adds a PodDisruptionBudget for the cert-manager deployment | `false` |
+| `cainjector.podDisruptionBudget.minAvailable` | Configures the minimum available pods for voluntary disruptions. Cannot used if `maxUnavailable` is set. | `1` |
+| `cainjector.podDisruptionBudget.maxUnavailable` | Configures the maximum unavailable pods for voluntary disruptions. Cannot used if `minAvailable` is set. |  |
 | `cainjector.extraArgs` | Optional flags for cert-manager cainjector component | `[]` |
 | `cainjector.serviceAccount.create` | If `true`, create a new service account for the cainjector component | `true` |
 | `cainjector.serviceAccount.name` | Service account for the cainjector component to be used. If not set and `cainjector.serviceAccount.create` is `true`, a name is generated using the fullname template |  |
@@ -188,12 +207,12 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `cainjector.tolerations` | Node tolerations for cainjector pod assignment | `[]` |
 | `cainjector.topologySpreadConstraints` | Topology spread constraints for cainjector pod assignment | `[]` |
 | `cainjector.image.repository` | cainjector image repository | `quay.io/jetstack/cert-manager-cainjector` |
-| `cainjector.image.tag` | cainjector image tag | `v1.11.0` |
+| `cainjector.image.tag` | cainjector image tag | `v1.12.8` |
 | `cainjector.image.pullPolicy` | cainjector image pull policy | `IfNotPresent` |
 | `cainjector.securityContext` | Security context for cainjector pod assignment | refer to [Default Security Contexts](#default-security-contexts) |
 | `cainjector.containerSecurityContext` | Security context to be set on cainjector component container | refer to [Default Security Contexts](#default-security-contexts) |
 | `acmesolver.image.repository` | acmesolver image repository | `quay.io/jetstack/cert-manager-acmesolver` |
-| `acmesolver.image.tag` | acmesolver image tag | `v1.11.0` |
+| `acmesolver.image.tag` | acmesolver image tag | `v1.12.8` |
 | `acmesolver.image.pullPolicy` | acmesolver image pull policy | `IfNotPresent` |
 | `startupapicheck.enabled` | Toggles whether the startupapicheck Job should be installed | `true` |
 | `startupapicheck.securityContext` | Security context for startupapicheck pod assignment | refer to [Default Security Contexts](#default-security-contexts) |
@@ -209,7 +228,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `startupapicheck.tolerations` | Node tolerations for startupapicheck pod assignment | `[]` |
 | `startupapicheck.podLabels` | Optional additional labels to add to the startupapicheck Pods | `{}` |
 | `startupapicheck.image.repository` | startupapicheck image repository | `quay.io/jetstack/cert-manager-ctl` |
-| `startupapicheck.image.tag` | startupapicheck image tag | `v1.11.0` |
+| `startupapicheck.image.tag` | startupapicheck image tag | `v1.12.8` |
 | `startupapicheck.image.pullPolicy` | startupapicheck image pull policy | `IfNotPresent` |
 | `startupapicheck.serviceAccount.create` | If `true`, create a new service account for the startupapicheck component | `true` |
 | `startupapicheck.serviceAccount.name` | Service account for the startupapicheck component to be used. If not set and `startupapicheck.serviceAccount.create` is `true`, a name is generated using the fullname template |  |

--- a/helmfile.d/upstream/jetstack/cert-manager/templates/cainjector-deployment.yaml
+++ b/helmfile.d/upstream/jetstack/cert-manager/templates/cainjector-deployment.yaml
@@ -90,6 +90,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.cainjector.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.cainjector.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -104,6 +108,10 @@ spec:
       {{- end }}
       {{- with  .Values.cainjector.topologySpreadConstraints }}
       topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cainjector.volumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/helmfile.d/upstream/jetstack/cert-manager/templates/cainjector-poddisruptionbudget.yaml
+++ b/helmfile.d/upstream/jetstack/cert-manager/templates/cainjector-poddisruptionbudget.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.cainjector.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cainjector.fullname" . }}
+  namespace: {{ include "cert-manager.namespace" . }}
+  labels:
+    app: {{ include "cainjector.name" . }}
+    app.kubernetes.io/name: {{ include "cainjector.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "cainjector"
+    {{- include "labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "cainjector.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: "cainjector"
+
+  {{- with .Values.cainjector.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.cainjector.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+{{- end }}

--- a/helmfile.d/upstream/jetstack/cert-manager/templates/cainjector-rbac.yaml
+++ b/helmfile.d/upstream/jetstack/cert-manager/templates/cainjector-rbac.yaml
@@ -22,13 +22,13 @@ rules:
     verbs: ["get", "create", "update", "patch"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["apiregistration.k8s.io"]
     resources: ["apiservices"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helmfile.d/upstream/jetstack/cert-manager/templates/crds.yaml
+++ b/helmfile.d/upstream/jetstack/cert-manager/templates/crds.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
     # Generated labels {{- include "labels" . | nindent 4 }}
 spec:
   group: cert-manager.io
@@ -484,7 +484,10 @@ spec:
                                 type: object
                                 properties:
                                   class:
-                                    description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                                    description: This field configures the annotation `kubernetes.io/ingress.class` when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of `class`, `name` or `ingressClassName` may be specified.
+                                    type: string
+                                  ingressClassName:
+                                    description: This field configures the field `ingressClassName` on the created Ingress resources used to solve ACME challenges that use this challenge solver. This is the recommended way of configuring the ingress class. Only one of `class`, `name` or `ingressClassName` may be specified.
                                     type: string
                                   ingressTemplate:
                                     description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.
@@ -505,7 +508,7 @@ spec:
                                             additionalProperties:
                                               type: string
                                   name:
-                                    description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                                    description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources. Only one of `class`, `name` or `ingressClassName` may be specified.
                                     type: string
                                   podTemplate:
                                     description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.
@@ -526,7 +529,7 @@ spec:
                                             additionalProperties:
                                               type: string
                                       spec:
-                                        description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                        description: PodSpec defines overrides for the HTTP01 challenge solver pod. Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields. All other fields will be ignored.
                                         type: object
                                         properties:
                                           affinity:
@@ -1001,6 +1004,17 @@ spec:
                                                         topologyKey:
                                                           description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                           type: string
+                                          imagePullSecrets:
+                                            description: If specified, the pod's imagePullSecrets
+                                            type: array
+                                            items:
+                                              description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                              type: object
+                                              properties:
+                                                name:
+                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  type: string
+                                              x-kubernetes-map-type: atomic
                                           nodeSelector:
                                             description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                                             type: object
@@ -1128,7 +1142,6 @@ spec:
                           type: object
                           required:
                             - role
-                            - secretRef
                           properties:
                             mountPath:
                               description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
@@ -1147,6 +1160,15 @@ spec:
                                   type: string
                                 name:
                                   description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            serviceAccountRef:
+                              description: A reference to a service account that will be used to request a bound token (also known as "projected token"). Compared to using "secretRef", using this field means that you don't rely on statically bound tokens. To use this field, you must configure an RBAC rule to let cert-manager request a token.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                name:
+                                  description: Name of the ServiceAccount used to request a token.
                                   type: string
                         tokenSecretRef:
                           description: TokenSecretRef authenticates with Vault by presenting a token.
@@ -1246,6 +1268,9 @@ spec:
                   description: ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.
                   type: object
                   properties:
+                    lastPrivateKeyHash:
+                      description: LastPrivateKeyHash is a hash of the private key associated with the latest registered ACME account, in order to track changes made to registered account associated with the Issuer
+                      type: string
                     lastRegisteredEmail:
                       description: LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer
                       type: string
@@ -1738,7 +1763,10 @@ spec:
                           type: object
                           properties:
                             class:
-                              description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                              description: This field configures the annotation `kubernetes.io/ingress.class` when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of `class`, `name` or `ingressClassName` may be specified.
+                              type: string
+                            ingressClassName:
+                              description: This field configures the field `ingressClassName` on the created Ingress resources used to solve ACME challenges that use this challenge solver. This is the recommended way of configuring the ingress class. Only one of `class`, `name` or `ingressClassName` may be specified.
                               type: string
                             ingressTemplate:
                               description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.
@@ -1759,7 +1787,7 @@ spec:
                                       additionalProperties:
                                         type: string
                             name:
-                              description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                              description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources. Only one of `class`, `name` or `ingressClassName` may be specified.
                               type: string
                             podTemplate:
                               description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.
@@ -1780,7 +1808,7 @@ spec:
                                       additionalProperties:
                                         type: string
                                 spec:
-                                  description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                  description: PodSpec defines overrides for the HTTP01 challenge solver pod. Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields. All other fields will be ignored.
                                   type: object
                                   properties:
                                     affinity:
@@ -2255,6 +2283,17 @@ spec:
                                                   topologyKey:
                                                     description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                     type: string
+                                    imagePullSecrets:
+                                      description: If specified, the pod's imagePullSecrets
+                                      type: array
+                                      items:
+                                        description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                        type: object
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                        x-kubernetes-map-type: atomic
                                     nodeSelector:
                                       description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                                       type: object
@@ -2559,7 +2598,7 @@ metadata:
   labels:
     app: '{{ template "cert-manager.name" . }}'
     app.kubernetes.io/name: '{{ template "cert-manager.name" . }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
     # Generated labels {{- include "labels" . | nindent 4 }}
 spec:
   group: cert-manager.io
@@ -3037,7 +3076,10 @@ spec:
                                 type: object
                                 properties:
                                   class:
-                                    description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                                    description: This field configures the annotation `kubernetes.io/ingress.class` when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of `class`, `name` or `ingressClassName` may be specified.
+                                    type: string
+                                  ingressClassName:
+                                    description: This field configures the field `ingressClassName` on the created Ingress resources used to solve ACME challenges that use this challenge solver. This is the recommended way of configuring the ingress class. Only one of `class`, `name` or `ingressClassName` may be specified.
                                     type: string
                                   ingressTemplate:
                                     description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.
@@ -3058,7 +3100,7 @@ spec:
                                             additionalProperties:
                                               type: string
                                   name:
-                                    description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                                    description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources. Only one of `class`, `name` or `ingressClassName` may be specified.
                                     type: string
                                   podTemplate:
                                     description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.
@@ -3079,7 +3121,7 @@ spec:
                                             additionalProperties:
                                               type: string
                                       spec:
-                                        description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                        description: PodSpec defines overrides for the HTTP01 challenge solver pod. Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields. All other fields will be ignored.
                                         type: object
                                         properties:
                                           affinity:
@@ -3554,6 +3596,17 @@ spec:
                                                         topologyKey:
                                                           description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                           type: string
+                                          imagePullSecrets:
+                                            description: If specified, the pod's imagePullSecrets
+                                            type: array
+                                            items:
+                                              description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                              type: object
+                                              properties:
+                                                name:
+                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  type: string
+                                              x-kubernetes-map-type: atomic
                                           nodeSelector:
                                             description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                                             type: object
@@ -3681,7 +3734,6 @@ spec:
                           type: object
                           required:
                             - role
-                            - secretRef
                           properties:
                             mountPath:
                               description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
@@ -3700,6 +3752,15 @@ spec:
                                   type: string
                                 name:
                                   description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            serviceAccountRef:
+                              description: A reference to a service account that will be used to request a bound token (also known as "projected token"). Compared to using "secretRef", using this field means that you don't rely on statically bound tokens. To use this field, you must configure an RBAC rule to let cert-manager request a token.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                name:
+                                  description: Name of the ServiceAccount used to request a token.
                                   type: string
                         tokenSecretRef:
                           description: TokenSecretRef authenticates with Vault by presenting a token.
@@ -3799,6 +3860,9 @@ spec:
                   description: ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.
                   type: object
                   properties:
+                    lastPrivateKeyHash:
+                      description: LastPrivateKeyHash is a hash of the private key associated with the latest registered ACME account, in order to track changes made to registered account associated with the Issuer
+                      type: string
                     lastRegisteredEmail:
                       description: LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer
                       type: string
@@ -3981,7 +4045,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
+                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. If the issuer provided a CA certificate, a file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore.
@@ -4003,7 +4067,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
+                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. If the issuer provided a CA certificate, a file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the PKCS12 keystore.
@@ -4192,7 +4256,7 @@ spec:
                   description: The number of continuous failed issuance attempts up till now. This field gets removed (if set) on a successful issuance and gets set to 1 if unset and an issuance has failed. If an issuance has failed, the delay till the next issuance will be calculated using formula time.Hour * 2 ^ (failedIssuanceAttempts - 1).
                   type: integer
                 lastFailureTime:
-                  description: LastFailureTime is the time as recorded by the Certificate controller of the most recent failure to complete a CertificateRequest for this Certificate resource. If set, cert-manager will not re-request another Certificate until 1 hour has elapsed from this time.
+                  description: LastFailureTime is set only if the lastest issuance for this Certificate failed and contains the time of the failure. If an issuance has failed, the delay till the next issuance will be calculated using formula time.Hour * 2 ^ (failedIssuanceAttempts - 1). If the latest issuance has succeeded this field will be unset.
                   type: string
                   format: date-time
                 nextPrivateKeySecretName:

--- a/helmfile.d/upstream/jetstack/cert-manager/templates/deployment.yaml
+++ b/helmfile.d/upstream/jetstack/cert-manager/templates/deployment.yaml
@@ -113,9 +113,21 @@ spec:
           {{- if .Values.maxConcurrentChallenges }}
           - --max-concurrent-challenges={{ .Values.maxConcurrentChallenges }}
           {{- end }}
+          {{- if .Values.enableCertificateOwnerRef }}
+          - --enable-certificate-owner-ref=true
+          {{- end }}
+          {{- if .Values.dns01RecursiveNameserversOnly }}
+          - --dns01-recursive-nameservers-only=true
+          {{- end }}
+          {{- with .Values.dns01RecursiveNameservers }}
+          - --dns01-recursive-nameservers={{ . }}
+          {{- end }}
           ports:
           - containerPort: 9402
             name: http-metrics
+            protocol: TCP
+          - containerPort: 9403
+            name: http-healthz
             protocol: TCP
           {{- with .Values.containerSecurityContext }}
           securityContext:
@@ -148,6 +160,24 @@ spec:
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          {{- with .Values.livenessProbe }}
+          {{- if .enabled }}
+          # LivenessProbe settings are based on those used for the Kubernetes
+          # controller-manager. See:
+          # https://github.com/kubernetes/kubernetes/blob/806b30170c61a38fedd54cc9ede4cd6275a1ad3b/cmd/kubeadm/app/util/staticpod/utils.go#L241-L245
+          livenessProbe:
+            httpGet:
+              port: http-healthz
+              path: /livez
+              scheme: HTTP
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+            successThreshold: {{ .successThreshold }}
+            failureThreshold: {{ .failureThreshold }}
+          {{- end }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helmfile.d/upstream/jetstack/cert-manager/templates/poddisruptionbudget.yaml
+++ b/helmfile.d/upstream/jetstack/cert-manager/templates/poddisruptionbudget.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cert-manager.fullname" . }}
+  namespace: {{ include "cert-manager.namespace" . }}
+  labels:
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "controller"
+    {{- include "labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "cert-manager.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: "controller"
+
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+{{- end }}

--- a/helmfile.d/upstream/jetstack/cert-manager/templates/rbac.yaml
+++ b/helmfile.d/upstream/jetstack/cert-manager/templates/rbac.yaml
@@ -70,7 +70,6 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
-
 ---
 
 # ClusterIssuer controller role

--- a/helmfile.d/upstream/jetstack/cert-manager/templates/startupapicheck-job.yaml
+++ b/helmfile.d/upstream/jetstack/cert-manager/templates/startupapicheck-job.yaml
@@ -34,6 +34,9 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ template "startupapicheck.serviceAccountName" . }}
+      {{- if hasKey .Values.startupapicheck "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.startupapicheck.automountServiceAccountToken }}
+      {{- end }}
       {{- with .Values.global.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
@@ -62,6 +65,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.startupapicheck.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.startupapicheck.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -72,6 +79,10 @@ spec:
       {{- end }}
       {{- with .Values.startupapicheck.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.startupapicheck.volumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/helmfile.d/upstream/jetstack/cert-manager/templates/webhook-deployment.yaml
+++ b/helmfile.d/upstream/jetstack/cert-manager/templates/webhook-deployment.yaml
@@ -146,10 +146,15 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.webhook.config }}
+          {{- if or .Values.webhook.config .Values.webhook.volumeMounts }}
           volumeMounts:
+            {{- if .Values.webhook.config }}
             - name: config
               mountPath: /var/cert-manager/config
+            {{- end }}
+            {{- if .Values.webhook.volumeMounts }}
+            {{- toYaml .Values.webhook.volumeMounts | nindent 12 }}
+            {{- end }}
           {{- end }}
       {{- with .Values.webhook.nodeSelector }}
       nodeSelector:
@@ -167,9 +172,14 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.webhook.config }}
+      {{- if or .Values.webhook.config .Values.webhook.volumes }}
       volumes:
+        {{- if .Values.webhook.config }}
         - name: config
           configMap:
             name: {{ include "webhook.fullname" . }}
+        {{- end }}
+        {{- if .Values.webhook.volumes }}
+        {{- toYaml .Values.webhook.volumes | nindent 8 }}
+        {{- end }}
       {{- end }}

--- a/helmfile.d/upstream/jetstack/cert-manager/templates/webhook-poddisruptionbudget.yaml
+++ b/helmfile.d/upstream/jetstack/cert-manager/templates/webhook-poddisruptionbudget.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.webhook.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "webhook.fullname" . }}
+  namespace: {{ include "cert-manager.namespace" . }}
+  labels:
+    app: {{ include "webhook.name" . }}
+    app.kubernetes.io/name: {{ include "webhook.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "webhook"
+    {{- include "labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "webhook.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: "webhook"
+
+  {{- with .Values.webhook.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.webhook.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+{{- end }}

--- a/helmfile.d/upstream/jetstack/cert-manager/templates/webhook-psp-clusterrole.yaml
+++ b/helmfile.d/upstream/jetstack/cert-manager/templates/webhook-psp-clusterrole.yaml
@@ -15,4 +15,4 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "webhook.fullname" . }}
-{{- end }} 
+{{- end }}

--- a/helmfile.d/upstream/jetstack/cert-manager/values.yaml
+++ b/helmfile.d/upstream/jetstack/cert-manager/values.yaml
@@ -60,8 +60,20 @@ strategy: {}
   #   maxSurge: 0
   #   maxUnavailable: 1
 
-# Comma separated list of feature gates that should be enabled on the
-# controller pod & webhook pod.
+podDisruptionBudget:
+  enabled: false
+
+  minAvailable: 1
+  # maxUnavailable: 1
+
+  # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
+  # or a percentage value (e.g. 25%)
+
+# Comma separated list of feature gates that should be enabled on the controller
+# Note: do not use this field to pass feature gate values into webhook
+# component as this behaviour relies on a bug that will be fixed in cert-manager 1.13
+# https://github.com/cert-manager/cert-manager/pull/6093
+# Use webhook.extraArgs to pass --feature-gates flag directly instead.
 featureGates: ""
 
 # The maximum number of challenges that can be scheduled as 'processing' at once
@@ -107,11 +119,22 @@ serviceAccount:
 # Automounting API credentials for a particular pod
 # automountServiceAccountToken: true
 
+# When this flag is enabled, secrets will be automatically removed when the certificate resource is deleted
+enableCertificateOwnerRef: false
+
+# Setting Nameservers for DNS01 Self Check
+# See: https://cert-manager.io/docs/configuration/acme/dns01/#setting-nameservers-for-dns01-self-check
+
+# Comma separated string with host and port of the recursive nameservers cert-manager should query
+dns01RecursiveNameservers: ""
+
+# Forces cert-manager to only use the recursive nameservers for verification.
+# Enabling this option could cause the DNS01 self check to take longer due to caching performed by the recursive nameservers
+dns01RecursiveNameserversOnly: false
+
 # Additional command line flags to pass to cert-manager controller binary.
 # To see all available flags run docker run quay.io/jetstack/cert-manager-controller:<version> --help
 extraArgs: []
-  # When this flag is enabled, secrets will be automatically removed when the certificate resource is deleted
-  # - --enable-certificate-owner-ref=true
   # Use this flag to enable or disable arbitrary controllers, for example, disable the CertificiateRequests approver
   # - --controllers=*,-certificaterequests-approver
 
@@ -197,7 +220,7 @@ prometheus:
 # https_proxy: "https://proxy:8080"
 # no_proxy: 127.0.0.1,localhost
 
-# expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
+# A Kubernetes Affinty, if required; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core
 # for example:
 #   affinity:
 #     nodeAffinity:
@@ -210,7 +233,7 @@ prometheus:
 #            - master
 affinity: {}
 
-# expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
+# A list of Kubernetes Tolerations, if required; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core
 # for example:
 #   tolerations:
 #   - key: foo.bar.com/role
@@ -219,7 +242,7 @@ affinity: {}
 #     effect: NoSchedule
 tolerations: []
 
-# expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#topologyspreadconstraint-v1-core
+# A list of Kubernetes TopologySpreadConstraints, if required; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core
 # for example:
 #   topologySpreadConstraints:
 #   - maxSkew: 2
@@ -230,6 +253,22 @@ tolerations: []
 #         app.kubernetes.io/instance: cert-manager
 #         app.kubernetes.io/component: controller
 topologySpreadConstraints: []
+
+# LivenessProbe settings for the controller container of the controller Pod.
+#
+# Disabled by default, because the controller has a leader election mechanism
+# which should cause it to exit if it is unable to renew its leader election
+# record.
+# LivenessProbe durations and thresholds are based on those used for the Kubernetes
+# controller-manager. See:
+# https://github.com/kubernetes/kubernetes/blob/806b30170c61a38fedd54cc9ede4cd6275a1ad3b/cmd/kubeadm/app/util/staticpod/utils.go#L241-L245
+livenessProbe:
+  enabled: false
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 15
+  successThreshold: 1
+  failureThreshold: 8
 
 webhook:
   replicaCount: 1
@@ -264,6 +303,15 @@ webhook:
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
+
+  podDisruptionBudget:
+    enabled: false
+
+    minAvailable: 1
+    # maxUnavailable: 1
+
+    # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
+    # or a percentage value (e.g. 25%)
 
   # Container Security Context to be set on the webhook component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -409,9 +457,16 @@ webhook:
         protocol: TCP
       - port: 53
         protocol: UDP
+      # On OpenShift and OKD, the Kubernetes API server listens on
+      # port 6443.
+      - port: 6443
+        protocol: TCP
       to:
       - ipBlock:
           cidr: 0.0.0.0/0
+
+  volumes: []
+  volumeMounts: []
 
 cainjector:
   enabled: true
@@ -429,6 +484,15 @@ cainjector:
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
+
+  podDisruptionBudget:
+    enabled: false
+
+    minAvailable: 1
+    # maxUnavailable: 1
+
+    # minAvailable and maxUnavailable can either be set to an integer (e.g. 1)
+    # or a percentage value (e.g. 25%)
 
   # Container Security Context to be set on the cainjector component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -500,6 +564,9 @@ cainjector:
 
   # Automounting API credentials for a particular pod
   # automountServiceAccountToken: true
+
+  volumes: []
+  volumeMounts: []
 
 acmesolver:
   image:
@@ -598,6 +665,9 @@ startupapicheck:
       helm.sh/hook-weight: "-5"
       helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 
+  # Automounting API credentials for a particular pod
+  # automountServiceAccountToken: true
+
   serviceAccount:
     # Specifies whether a service account should be created
     create: true
@@ -617,3 +687,6 @@ startupapicheck:
 
     # Optional additional labels to add to the startupapicheck's ServiceAccount
     # labels: {}
+
+  volumes: []
+  volumeMounts: []

--- a/helmfile.d/values/cert-manager.yaml.gotmpl
+++ b/helmfile.d/values/cert-manager.yaml.gotmpl
@@ -15,5 +15,6 @@ cainjector:
   nodeSelector: {{- toYaml .Values.certmanager.cainjector.nodeSelector | nindent 4 }}
   affinity:     {{- toYaml .Values.certmanager.cainjector.affinity | nindent 4 }}
   tolerations:  {{- toYaml .Values.certmanager.cainjector.tolerations | nindent 4 }}
+  extraArgs:    {{- toYaml .Values.certmanager.cainjector.extraArgs | nindent 4 }}
 
 installCRDs: true

--- a/migration/v0.37/README.md
+++ b/migration/v0.37/README.md
@@ -1,0 +1,168 @@
+# Upgrade to v0.37.x
+
+> [!WARNING]
+> Upgrade only supported from v0.36.x.
+
+<!--
+Notice to developers on writing migration steps:
+
+- Migration steps:
+  - are written per minor version and placed in a subdirectory of the migration directory with the name `vX.Y/`,
+  - are written to be idempotent and usable no matter which patch version you are upgrading from and to,
+  - are documented in this document to be able to run them manually,
+  - are divided into prepare and apply steps:
+    - Prepare steps:
+      - are placed in the `prepare/` directory,
+      - may **only** modify the configuration of the environment,
+      - may **not** modify the state of the environment,
+      - steps are run in order of their names use two digit prefixes.
+    - Apply steps:
+      - are placed in the `apply/` directory,
+      - may **only** modify the state of the environment,
+      - may **not** modify the configuration of the environment,
+      - are run in order of their names use two digit prefixes,
+      - are run with the argument `execute` on upgrade and should return 1 on failure and 2 on successful internal rollback,
+      - are rerun with the argument `rollback` on execute failure and should return 1 on failure.
+
+For prepare the init step is given.
+For apply the bootstrap and the apply steps are given, it is expected that releases upgraded in custom steps are excluded from the apply step.
+
+Upgrades of components that are dependent on each other should be done within the same snippet to easily manage the upgrade to a working state and to be able to rollback to a working state.
+
+Steps should use the `scripts/migration/lib.sh` which will provide helper functions, see the file for available helper functions.
+This script expects the `ROOT` environment variable to be set pointing to the root of the repository.
+As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
+-->
+
+## Prerequisites
+
+- [ ] Read through the changelog to check if there are any changes you need to be aware of. Read through the release notes, Platform Administrator notices, Application Developer notices, and Security notice.
+- [ ] Notify the users (if any) before the upgrade starts;
+- [ ] Check if there are any pending changes to the environment;
+- [ ] Check the state of the environment, pods, nodes and backup jobs:
+
+    ```bash
+    ./bin/ck8s test sc|wc
+    ./bin/ck8s ops kubectl sc|wc get pods -A -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-false:status.containerStatuses[*].ready,REASON:status.containerStatuses[*].state.terminated.reason | grep false | grep -v Completed
+    ./bin/ck8s ops kubectl sc|wc get nodes
+    ./bin/ck8s ops kubectl sc|wc get jobs -A
+    ./bin/ck8s ops helm sc|wc list -A --all
+    velero get backup
+    ```
+
+- [ ] Silence the notifications for the alerts. e.g you can use [alertmanager silences](https://prometheus.io/docs/alerting/latest/alertmanager/#silences);
+
+## Automatic method
+
+1. Pull the latest changes and switch to the correct branch:
+
+    ```bash
+    git pull
+    git switch -d v0.37.x
+    ```
+
+1. Prepare upgrade - *non-disruptive*
+
+    > *Done before maintenance window.*
+
+    ```bash
+    ./bin/ck8s upgrade both v0.37 prepare
+
+    # check if the netpol IPs need to be updated
+    ./bin/ck8s update-ips both dry-run
+    # if you agree with the changes apply
+    ./bin/ck8s update-ips both apply
+    ```
+
+    > [!NOTE]
+    > It is possible to upgrade `wc` and `sc` clusters separately by replacing `both` when running the `upgrade` command, e.g. the following will only upgrade the workload cluster:
+    > ```bash
+    > ./bin/ck8s upgrade wc v0.37 prepare
+    > ./bin/ck8s upgrade wc v0.37 apply
+    > ```
+
+1. Apply upgrade - *disruptive*
+
+    > *Done during maintenance window.*
+
+    ```bash
+    ./bin/ck8s upgrade both v0.37 apply
+    ```
+
+## Manual method
+
+### Prepare upgrade - *non-disruptive*
+
+> *Done before maintenance window.*
+
+1. Pull the latest changes and switch to the correct branch:
+
+    ```bash
+    git pull
+    git switch -d v0.37.x
+    ```
+
+1. Set whether or not upgrade should be prepared for `both` clusters or for one of `sc` or `wc`:
+
+    ```bash
+    export CK8S_CLUSTER=<wc|sc|both>
+    ```
+
+1. Update apps configuration:
+
+    This will take a backup into `backups/` before modifying any files.
+
+    ```bash
+    ./bin/ck8s init wc
+    # or
+    ./migration/v0.37/prepare/50-init.sh
+
+    # check if the netpol IPs need to be updated
+    ./bin/ck8s update-ips wc dry-run
+    # if you agree with the changes apply
+    ./bin/ck8s update-ips wc apply
+    ```
+
+1. Move issuer ingress class keys:
+
+    ```bash
+    ./migration/v0.37/prepare/60-move-issuer-ingress-class.sh
+    ```
+
+### Apply upgrade - *disruptive*
+
+> *Done during maintenance window.*
+
+1. Set whether or not upgrade should be applied for `both` clusters or for one of `sc` or `wc`:
+
+    ```bash
+    export CK8S_CLUSTER=<wc|sc|both>
+    ```
+
+1. Upgrade applications:
+
+    ```bash
+    ./bin/ck8s apply {sc|wc}
+    # or
+    ./migration/v0.37/apply/80-apply.sh execute
+    ```
+
+## Postrequisite:
+
+- [ ] Check the state of the environment, pods and nodes:
+
+    ```bash
+    ./bin/ck8s test sc|wc
+    ./bin/ck8s ops kubectl sc|wc get pods -A -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-false:status.containerStatuses[*].ready,REASON:status.containerStatuses[*].state.terminated.reason | grep false | grep -v Completed
+    ./bin/ck8s ops kubectl sc|wc get nodes
+    ./bin/ck8s ops helm sc|wc list -A --all
+    ```
+
+- [ ] Enable the notifications for the alerts;
+- [ ] Notify the users (if any) when the upgrade is complete;
+
+> [!NOTE]
+> Additionally it is good to check:
+> - if any alerts generated by the upgrade didn't close;
+> - if you can login to Grafana, Opensearch or Harbor;
+> - you can see fresh metrics and logs.

--- a/migration/v0.37/apply/00-template.sh
+++ b/migration/v0.37/apply/00-template.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+# functions currently available in the library:
+#   - logging:
+#     - log_info(_no_newline) <message>
+#     - log_warn(_no_newline) <message>
+#     - log_error(_no_newline) <message>
+#     - log_fatal <message> # this will call "exit 1"
+#
+#   - kubectl
+#     # Use kubectl with kubeconfig set
+#     - kubectl_do <sc|wc> <kubectl args...>
+#     # Perform kubectl delete, will not cause errors if the resource is missing
+#     - kubectl_delete <sc|wc> <resource> <namespace> <name>
+#
+#   - helm
+#     # Use helm with kubeconfig set
+#     - helm_do <sc|wc> <helm args...>
+#     # Checks if a release is installed
+#     - helm_installed <sc|wc> <namespace> <release>
+#     # Uninstalls a release if it is installed
+#     - helm_uninstall <sc|wc> <namespace> <release>
+#
+#   - helmfile
+#     # Use helmfile with kubeconfig set
+#     - helmfile_do <sc|wc> <helmfile args...>
+#     # For selector args all will be prefixed with "-l"
+#     # List releases matching the selector
+#     - helmfile_list <sc|wc> <selectors...>
+#     # Apply releases matching the selector
+#     - helmfile_apply <sc|wc> <selectors...>
+#     # Check for changes on releases matching the selector
+#     - helmfile_change <sc|wc> <selectors...>
+#     # Destroy releases matching the selector
+#     - helmfile_destroy <sc|wc> <selectors...>
+#     # Replaces the releases matching the selector, performing destroy and apply on each release individually
+#     - helmfile_replace <sc|wc> <selectors...>
+#     # Upgrades the releases matching the selector, performing automatic rollback on failure set "CK8S_ROLLBACK=false" to disable
+#     - helmfile_upgrade <sc|wc> <selectors...>
+
+run() {
+  case "${1:-}" in
+  execute)
+    # Note: 00-template.sh will be skipped by the upgrade command
+    log_info "no operation: this is a template"
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      log_info "operation on service cluster"
+    fi
+    if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+      log_info "operation on workload cluster"
+    fi
+    ;;
+  rollback)
+    log_warn "rollback not implemented"
+
+    # if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+    #   log_info "rollback operation on service cluster"
+    # fi
+    # if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+    #   log_info "rollback operation on workload cluster"
+    # fi
+    ;;
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.37/apply/80-apply.sh
+++ b/migration/v0.37/apply/80-apply.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+# Add selector filters if covered by other snippets.
+# Example: "app!=something"
+declare -a skipped
+skipped=(
+)
+declare -a skipped_sc
+skipped_sc=(
+)
+declare -a skipped_wc
+skipped_wc=(
+)
+
+run() {
+  case "${1:-}" in
+  execute)
+    local -a filters
+    local selector
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      filters=("${skipped[@]}" "${skipped_sc[@]}")
+      selector="${filters[*]:-"app!=null"}"
+      helmfile_upgrade sc "${selector// /,}"
+    fi
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+      filters=("${skipped[@]}" "${skipped_wc[@]}")
+      selector="${filters[*]:-"app!=null"}"
+      helmfile_upgrade wc "${selector// /,}"
+    fi
+    ;;
+
+  rollback)
+    log_warn "rollback not implemented"
+
+    # if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+    #   log_info "rollback operation on service cluster"
+    # fi
+    # if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+    #   log_info "rollback operation on workload cluster"
+    # fi
+    ;;
+
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.37/prepare/00-template.sh
+++ b/migration/v0.37/prepare/00-template.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+# functions currently available in the library:
+#   - logging:
+#     - log_info(_no_newline) <message>
+#     - log_warn(_no_newline) <message>
+#     - log_error(_no_newline) <message>
+#     - log_fatal <message> # this will call "exit 1"
+#
+#  - yq:
+#     - yq_null <common|sc|wc> <target>
+#     - yq_copy <common|sc|wc> <source> <destination>
+#     - yq_move <common|sc|wc> <source> <destination>
+#     - yq_remove <common|sc|wc> <target>
+#     - yq_add <common|sc|wc> <target> <destination> <value>
+
+# Note: 00-template.sh will be skipped by the upgrade command
+log_info "no operation: this is a template"
+
+if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+  log_info "operation on service cluster"
+fi
+if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+  log_info "operation on workload cluster"
+fi

--- a/migration/v0.37/prepare/50-init.sh
+++ b/migration/v0.37/prepare/50-init.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+case "${CK8S_CLUSTER}" in
+  both|sc|wc)
+    "${ROOT}/bin/ck8s" init "${CK8S_CLUSTER}"
+    ;;
+  *)
+    log_fatal "usage: 50-init.sh <wc|sc|both>"
+    ;;
+esac

--- a/migration/v0.37/prepare/60-move-issuer-ingress-class.sh
+++ b/migration/v0.37/prepare/60-move-issuer-ingress-class.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+log_info "Moving issuer ingress class keys"
+log_info "- Operating on common-config"
+
+if ! yq_null common .issuers.letsencrypt.prod.solvers; then
+  log_info "- move: .issuers.letsencrypt.prod.solvers[].http01.ingress.class to: .issuers.letsencrypt.prod.solvers[].http01.ingress.ingressClassName"
+  yq4 -i "with(.issuers.letsencrypt.prod.solvers[].http01.ingress | select(has(\"class\")); .ingressClassName = .class | del(.class))" "${CK8S_CONFIG_PATH}/common-config.yaml"
+fi
+
+if ! yq_null common .issuers.letsencrypt.staging.solvers; then
+  log_info "- move: .issuers.letsencrypt.staging.solvers[].http01.ingress.class to: .issuers.letsencrypt.staging.solvers[].http01.ingress.ingressClassName"
+  yq4 -i "with(.issuers.letsencrypt.staging.solvers[].http01.ingress | select(has(\"class\")); .ingressClassName = .class | del(.class))" "${CK8S_CONFIG_PATH}/common-config.yaml"
+fi
+
+if ! yq_null common .issuers.extraIssuers; then
+  log_info "- move: .issuers.extraIssuers[].spec.acme.solvers[].http01.ingress.class to: .issuers.extraIssuers[].spec.acme.solvers[].http01.ingress.ingressClassName"
+  yq4 -i "with(.issuers.extraIssuers[].spec.acme.solvers[].http01.ingress | select(has(\"class\")); .ingressClassName = .class | del(.class))" "${CK8S_CONFIG_PATH}/common-config.yaml"
+fi
+
+if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+  log_info "- Operating on sc-config"
+
+  if ! yq_null sc .issuers.letsencrypt.prod.solvers; then
+    log_info "- move: .issuers.letsencrypt.prod.solvers[].http01.ingress.class to: .issuers.letsencrypt.prod.solvers[].http01.ingress.ingressClassName"
+    yq4 -i "with(.issuers.letsencrypt.prod.solvers[].http01.ingress | select(has(\"class\")); .ingressClassName = .class | del(.class))" "${CK8S_CONFIG_PATH}/sc-config.yaml"
+  fi
+
+  if ! yq_null sc .issuers.letsencrypt.staging.solvers; then
+    log_info "- move: .issuers.letsencrypt.staging.solvers[].http01.ingress.class to: .issuers.letsencrypt.staging.solvers[].http01.ingress.ingressClassName"
+    yq4 -i "with(.issuers.letsencrypt.staging.solvers[].http01.ingress | select(has(\"class\")); .ingressClassName = .class | del(.class))" "${CK8S_CONFIG_PATH}/sc-config.yaml"
+  fi
+
+  if ! yq_null sc .issuers.extraIssuers; then
+    log_info "- move: .issuers.extraIssuers[].spec.acme.solvers[].http01.ingress.class to: .issuers.extraIssuers[].spec.acme.solvers[].http01.ingress.ingressClassName"
+    yq4 -i "with(.issuers.extraIssuers[].spec.acme.solvers[].http01.ingress | select(has(\"class\")); .ingressClassName = .class | del(.class))" "${CK8S_CONFIG_PATH}/sc-config.yaml"
+  fi
+
+fi
+
+if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+  log_info "- Operating on wc-config"
+
+  if ! yq_null wc .issuers.letsencrypt.prod.solvers; then
+    log_info "- move: .issuers.letsencrypt.prod.solvers[].http01.ingress.class to: .issuers.letsencrypt.prod.solvers[].http01.ingress.ingressClassName"
+    yq4 -i "with(.issuers.letsencrypt.prod.solvers[].http01.ingress | select(has(\"class\")); .ingressClassName = .class | del(.class))" "${CK8S_CONFIG_PATH}/wc-config.yaml"
+  fi
+
+  if ! yq_null wc .issuers.letsencrypt.staging.solvers; then
+    log_info "- move: .issuers.letsencrypt.staging.solvers[].http01.ingress.class to: .issuers.letsencrypt.staging.solvers[].http01.ingress.ingressClassName"
+    yq4 -i "with(.issuers.letsencrypt.staging.solvers[].http01.ingress | select(has(\"class\")); .ingressClassName = .class | del(.class))" "${CK8S_CONFIG_PATH}/wc-config.yaml"
+  fi
+
+  if ! yq_null wc .issuers.extraIssuers; then
+    log_info "- move: .issuers.extraIssuers[].spec.acme.solvers[].http01.ingress.class to: .issuers.extraIssuers[].spec.acme.solvers[].http01.ingress.ingressClassName"
+    yq4 -i "with(.issuers.extraIssuers[].spec.acme.solvers[].http01.ingress | select(has(\"class\")); .ingressClassName = .class | del(.class))" "${CK8S_CONFIG_PATH}/wc-config.yaml"
+  fi
+
+fi


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [x] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

### Application Developer notice
Cert-manager Issuers and ClusterIssuers have been updated to use the [recommended](https://cert-manager.io/docs/configuration/acme/http01/#ingressclassname) `ingressClassName` field over the `class` field. We recommend that Application Developers use the `ingressClassName` field as well.

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Upgrades `cert-manager` from `v1.11.0` to `v1.12.8`

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1910 

#### Additional information to reviewers
- Upgraded the chart
- Added migration script to move `class` to `ingressClassName` for issuers per recommendation from [upstream](https://cert-manager.io/docs/releases/release-notes/release-notes-1.12/#support-for-ingressclassname-in-the-http-01-solver)
- Exposed `extraArgs` for `cainjector` for if we ever would like to try things like `--enable-certificates-data-source=true` (original [PR](https://github.com/cert-manager/cert-manager/pull/5746) and [renaming](https://github.com/cert-manager/cert-manager/pull/5766) for context) for certain environments.
- Tested deploying the [user-demo](https://elastisys.io/compliantkubernetes/user-guide/deploy/#deploy-user-demo) - Have not run into any issues with Certificate creation.

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - scripts: changes to other scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [x] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Network Policy checks:
  - [x] Any changed pod is covered by Network Policies
  - [x] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [x] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
