### PR TITLE
Improve clean scripts by removing gatekeeper webhook

### DIFF
--- a/scripts/clean-sc.sh
+++ b/scripts/clean-sc.sh
@@ -13,6 +13,19 @@ fi
 
 here="$(dirname "$(readlink -f "$0")")"
 
+GATE_VALWEBHOOK=$(
+    "${here}/.././bin/ck8s" ops \
+        kubectl sc get \
+        validatingwebhookconfigurations \
+        -l gatekeeper.sh/system=yes \
+        -oname
+    )
+
+if [ -n "${GATE_VALWEBHOOK}" ]; then
+    # Destroy gatekeeper validatingwebhook which could potentially prevent other resources from being deleted
+    "${here}/.././bin/ck8s" ops kubectl sc delete "${GATE_VALWEBHOOK}"
+fi
+
 # Destroy all helm releases
 "${here}/.././bin/ck8s" ops helmfile sc -l app!=cert-manager destroy
 

--- a/scripts/clean-wc.sh
+++ b/scripts/clean-wc.sh
@@ -14,6 +14,19 @@ fi
 
 here="$(dirname "$(readlink -f "$0")")"
 
+GATE_VALWEBHOOK=$(
+    "${here}/.././bin/ck8s" ops \
+        kubectl wc get \
+        validatingwebhookconfigurations \
+        -l gatekeeper.sh/system=yes \
+        -oname
+    )
+
+if [ -n "${GATE_VALWEBHOOK}" ]; then
+    # Destroy gatekeeper validatingwebhook which could potentially prevent other resources from being deleted
+    "${here}/.././bin/ck8s" ops kubectl wc delete "${GATE_VALWEBHOOK}"
+fi
+
 # Destroy user subnamespaces before their parent namespaces,
 # this might fail if there are multiple levels.
 "${here}/.././bin/ck8s" ops kubectl wc delete subns -A --all


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

I have encountered cases where the clean scripts gets stuck deleting resources caused by timeouts when calling the gatekeeper service via the validating webhook after gatekeeper pods have been removed (mainly an issue during reruns, e.g. if something went wrong while deleting gatekeeper namespace, there have been cases where the webhook persisted). This PR adds removal of the gatekeeper validatingwebhook before deleting anything else as to avoid these types of issues.

```console
Error from server (InternalError): Internal error occurred: failed calling webhook "validation.gatekeeper.sh": failed to call webhook: Post "https://gatekeeper-webhook-service.gatekeeper-system.svc:443/v1/admit?timeout=10s": service "gatekeeper-webhook-service" not found
```

- Fixes #1879 

#### Additional information to reviewers

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - scripts: changes to other scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
