### PR TITLE
Added new diagnostics script

### DIFF
--- a/bin/ck8s
+++ b/bin/ck8s
@@ -37,6 +37,7 @@ usage() {
     echo "  flavors                                                                   lists supported configuration flavors" 1>&2
     echo "  update-ips <wc|sc|both> <apply|dry-run>                                   Automatically fetches and applies the IPs for network policies" 1>&2
     echo "  clean <wc|sc>                                                             Cleans the cluster of apps" 1>&2
+    echo "  diagnostics <wc|sc>                                                       Runs diagnostics of apps" 1>&2
     exit 1
 }
 
@@ -157,6 +158,11 @@ case "${1}" in
         ;;
     clean)
         "${here}/clean.bash" "${2}"
+        ;;
+    diagnostics)
+        [[ "${2}" =~ ^(wc|sc)$ ]] || usage
+        shift
+        "${here}/diagnostics.bash" "${@}"
         ;;
     *) usage ;;
 esac

--- a/bin/diagnostics.bash
+++ b/bin/diagnostics.bash
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+here="$(dirname "$(readlink -f "$0")")"
+# shellcheck source=bin/common.bash
+source "${here}/common.bash"
+
+cluster="${1}"
+
+file="${CK8S_CONFIG_PATH}/diagnostics-${cluster}-$(date +%y%m%d%H%M%S).log"
+touch "${file}"
+
+if [ -z "${CK8S_PGP_FP:-}" ]; then
+  fingerprints=$(yq4 '.creation_rules[].pgp' "${sops_config}")
+
+  log_warning "Notice for self-managed customers:"
+  echo -e "\tEncrypting using the fingerprints: $fingerprints." 1>&2
+  echo -e "\tIf you want to send diagnostic data to Elastisys, make sure to do:\n" 1>&2
+
+  echo -e "\tCK8S_PGP_FP=<fingerprint provided during onboarding> ./bin/ck8s diagnostics [sc|wc]\n" 1>&2
+
+  echo -e "\tIf in doubt, contact support@elastisys.com." 1>&2
+
+  log_warning_no_newline "Do you want to continue anyway? (y/N): "
+  read -r reply
+  if [[ ! "${reply}" =~ ^[yY]$ ]]; then
+      exit 1
+  fi
+fi
+
+sops_encrypt_file() {
+    if [ -z "${CK8S_PGP_FP:-}" ]; then
+        sops_encrypt "${file}"
+        return
+    fi
+
+    log_info "Encrypting ${file}"
+
+    sops --pgp "${CK8S_PGP_FP}" -e -i "${file}"
+}
+
+run_diagnostics() {
+    # -- Nodes --
+    echo "Fetching Nodes that are NotReady (<node>)"
+    nodes=$("${here}/ops.bash" kubectl "${cluster}" get nodes -o=yaml | yq4 '.items[] | select(.status.conditions[] | select(.type == "Ready" and .status != "True")) | .metadata.name' | tr '\n' ' ')
+    echo "${nodes}" | xargs "${here}/ops.bash" kubectl "${cluster}" get nodes -o wide
+    echo -e "\nDescribing Nodes"
+    echo "${nodes}" | xargs "${here}/ops.bash" kubectl "${cluster}" describe nodes
+
+
+    # -- DS and Deployments --
+    echo -e "\nFetching Deployments without desired number of ready pods (<deployment>)"
+    "${here}/ops.bash" kubectl "${cluster}" get deployments -A -o wide | grep -v -E "([0-9]+)/\1"
+
+    echo -e "\nFetching DaemonSets without desired number of ready pods (<daemonset>)"
+    "${here}/ops.bash" kubectl "${cluster}" get daemonsets -A -o wide | grep -v -E "([0-9]+)/\1"
+
+    echo -e "\nFetching StatefulSets without desired number of ready pods (<statefulset>)"
+    "${here}/ops.bash" kubectl "${cluster}" get statefulsets -A -o wide | grep -v -E "([0-9]+)/\1"
+
+    # -- Pods --
+    echo -e "\nFetching Pods that are NotReady (<pod>)"
+
+    "${here}/ops.bash" kubectl "${cluster}" get pods -A -o wide | grep -v -E "Running|Completed"
+    pods=$("${here}/ops.bash" kubectl "${cluster}" get pod -A -o=yaml | yq4 '.items[] | select(.status.conditions[] | select(.type == "Ready" and .status != "True" and .reason != "PodCompleted")) | [{"name": .metadata.name, "namespace": .metadata.namespace}]')
+    readarray pod_arr < <(echo "$pods" | yq4 e -o=j -I=0 '.[]')
+
+    for pod in "${pod_arr[@]}"; do
+        pod_name=$(echo "$pod" | jq -r '.name')
+        namespace=$(echo "$pod" | jq -r '.namespace')
+
+        echo -e "\nDescribing pod <${pod_name}>"
+        "${here}/ops.bash" kubectl "${cluster}" describe pod "${pod_name}" -n "${namespace}"
+
+        echo -e "\nGetting logs from pod: <${pod_name}>"
+        logs=$("${here}/ops.bash" kubectl "${cluster}" logs "${pod_name}" -n "${namespace}" --tail 20 || true)
+        status="$?"
+        if [ "${status}" -eq 0 ]; then
+            echo "${logs}"
+        fi
+
+        echo -e "\nGetting previous logs from pod: <${pod_name}>"
+        logs_prev=$("${here}/ops.bash" kubectl "${cluster}" logs -p "${pod_name}" -n "${namespace}" --tail 20 || true)
+        status="$?"
+        if [ "${status}" -eq 0 ]; then
+            echo "${logs_prev}"
+        fi
+    done
+
+    # -- Top --
+    echo -e "\nFetching cluster resource usage <top>"
+    "${here}/ops.bash" kubectl "${cluster}" top nodes
+    "${here}/ops.bash" kubectl "${cluster}" top pods -A
+
+    # -- Helm --
+    echo -e "\nFetching Helm releases that are not deployed (<helm>)"
+    "${here}/ops.bash" helm "${cluster}" list -A --all | grep -v deployed
+
+    # -- Cert --
+    echo -e "\nFetching cert-manager resources (<cert>)"
+    "${here}/ops.bash" kubectl "${cluster}" get clusterissuers,issuers,certificates,orders,challenges --all-namespaces -o wide
+
+    echo -e "\nDescribing failed Challenges (<challenge>)"
+    challenges=$("${here}/ops.bash" kubectl "${cluster}" get challenge -A -o=yaml | yq4 '.items[] | select(.status.state != "valid") | [{"name": .metadata.name, "namespace": .metadata.namespace}]')
+    readarray challenge_arr < <(echo "$challenges" | yq4 e -o=j -I=0 '.[]')
+    for challenge in "${challenge_arr[@]}"; do
+        challenge_name=$(echo "$challenge" | jq -r '.name')
+        namespace=$(echo "$challenge" | jq -r '.namespace')
+        "${here}/ops.bash" kubectl "${cluster}" describe challenge "${challenge_name}" -n "${namespace}"
+    done
+
+    # -- Events --
+    echo -e "\nFetching all Events (<event>)"
+    "${here}/ops.bash" kubectl "${cluster}" get events -A --sort-by=.metadata.creationTimestamp
+}
+
+log_info "Running diagnostics..."
+run_diagnostics > "${file}" 2>&1
+log_info "Diagnostics done. Saving and encrypting file ${file}"
+
+sops_encrypt_file "${file}"

--- a/tests/unit/bin/diagnostics.bats
+++ b/tests/unit/bin/diagnostics.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+# bats file_tags=general,bin:diagnostics
+
+setup_file() {
+  load "../../common/lib"
+
+  common_setup
+
+  with_kubeconfig sc
+}
+
+setup() {
+  load "../../common/lib"
+
+  common_setup
+
+  with_kubeconfig sc
+}
+
+@test "diagnostics - requires CK8S_CONFIG_PATH" {
+  CK8S_CONFIG_PATH="" run ck8s diagnostics sc
+  assert_failure
+  assert_output --partial "Missing CK8S_CONFIG_PATH"
+}
+
+@test "diagnostics - creates diagnostics file" {
+  run ck8s diagnostics sc
+  assert_success
+
+  file=$(find "${CK8S_CONFIG_PATH}"/diagnostics-*.log | sort -r | head -n 1)
+
+  assert_file_exists "${file}"
+  assert_file_contains "${file}" '"sops":'
+
+  assert_file_contains <(sops -d "${file}") "<node>"
+  assert_file_contains <(sops -d "${file}") "<deployment>"
+  assert_file_contains <(sops -d "${file}") "<daemonset>"
+  assert_file_contains <(sops -d "${file}") "<statefulset>"
+  assert_file_contains <(sops -d "${file}") "<pod>"
+  assert_file_contains <(sops -d "${file}") "<top>"
+  assert_file_contains <(sops -d "${file}") "<helm>"
+  assert_file_contains <(sops -d "${file}") "<cert>"
+  assert_file_contains <(sops -d "${file}") "<challenge>"
+  assert_file_contains <(sops -d "${file}") "<event>"
+}


### PR DESCRIPTION
<!-- Choose you PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is public repository, ensure not to disclose:**
> - [x] personal data beyond what is necessary for interacting with this pull request
> - [x] business confidential information, such as customer names

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change  <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change    <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security      <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()       <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice
Added a new diagnostics command with the primary goal of aiding in supporting self-managed customers. By default it encrypts the file with the sops config inside of `$CK8S_CONFIG_PATH` but setting `$CK8S_PGP_FP` will override this.


<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Added a new diagnostics command which fetches the following information from a cluster into a file that is then sops encrypted:
* Getting and describing Nodes that are not ready
* Getting Deployments / DaemonSets / StatefulSets that have replicas that are not ready
* Getting and describing Pods that are not ready
* Getting the 20 newest lines of logs from Pods that are not ready if possible (also  --previous logs)
* Getting resource usage of nodes and pods
* Getting helm releases that are not deployed
* Getting various cert-manager resources
* Describing challenges that are not ready
* Getting and sorting all events

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
Fixes #2005 

#### Additional information to reviewers
Getting pods with -o yaml can give information not visible with describe. Do we want this also? My tests now generates a log with almost 8000 lines, and yaml would greatly increase that even further.

#### Screenshots

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to application running in all clusters
    - apps sc: changes to applications running in the service cluster
    - apps wc: changes to applications running in the workload cluster
    - bin: changes to management binaries or scripts
    - scripts: changes to other scripts
    - config: changes to configuration
    - docs: changes to documentation
    - tests: changes to tests
    - pipeline: changes to the pipeline
    - release: release related
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packages in the `NetworkPolicy Dashboard`
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Bug checks:
  - [ ] The bug fix is covered by regression tests
