### PR TITLE
Fix ingress test

### DIFF
--- a/pipeline/test/services/service-cluster/testIngress.sh
+++ b/pipeline/test/services/service-cluster/testIngress.sh
@@ -42,16 +42,15 @@ function check_sc_ingress_health() {
     has_proxy_protocol=$(kubectl get configmap -n ingress-nginx ingress-nginx-controller -oyaml | yq4 '.data.use-proxy-protocol')
 
     diff=$((desired_replicas - ready_replicas))
-    if [[ $desired_replicas -eq $ready_replicas ]]; then
+    if "${has_proxy_protocol}"; then
+        no_error=false
+        debug_msg+="[ERROR] unable to test ingress with proxy protocol\n"
+    elif [[ $desired_replicas -eq $ready_replicas ]]; then
         read -r -a pods <<<"$(kubectl get pods -n ingress-nginx -ojson | jq -r '.items[].metadata.name' | tr '\n' ' ')"
         for pod in "${pods[@]}"; do
             if [[ "$pod" =~ ingress-nginx-controller* ]]; then
-                extra_flags=""
-                if "${has_proxy_protocol}"; then
-                  extra_flags="--haproxy-protocol"
-                fi
                 # shellcheck disable=SC2086
-                res=$(kubectl -n ingress-nginx exec -it "$pod" -- curl --retry 3 ${extra_flags} -w "%{http_code}" -o /dev/null -sk https://localhost/healthz)
+                res=$(kubectl -n ingress-nginx exec -it "$pod" -- wget --spider -S --tries=4 --no-check-certificate https://localhost/healthz 2>&1 | grep "HTTP/" | awk '{print $2}')
                 if [[ "$res" != "200" ]]; then
                     no_error=false
                     debug_msg+="[ERROR] The following nginx pod $pod is not healthy\n"


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

curl does no longer exist in the ingress-nginx container which we relied on when testing the ingress health. This replaces it with a test using wget.

Unfortunately wget does not seem to support sending PROXY protocol headers so it will fail for clusters which uses it.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
