### PR TITLE
Config Structural Validation Schema Part 2: Security and Policy

### DIFF
--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -136,7 +136,7 @@ falco:
     ebpf:
       # -- Path where the eBPF probe is located. It comes handy when the probe have been installed in the nodes using tools other than the init
       # container deployed with the chart.
-      path:
+      #path: ""
       # -- Needed to enable eBPF JIT at runtime for performance reasons.
       # Can be skipped if eBPF JIT is enabled from outside the container
       hostNetwork: false
@@ -925,7 +925,7 @@ trivy:
   # ref: https://github.com/aquasecurity/trivy-operator/tree/main/deploy/helm#values
   scanner:
     resources: {}
-    timeout: ""
+    timeout: 5m0s
     offlineScanEnabled: false
     dbRegistry: ""
     dbRepository: ""

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -1363,6 +1363,655 @@ properties:
         items:
           type: string
     type: object
+  clusterAdmin:
+    additionalProperties: false
+    properties:
+      groups:
+        items:
+          type: string
+        type: array
+      users:
+        items:
+          type: string
+        type: array
+    type: object
+  dex:
+    additionalProperties: false
+    dependentRequred:
+      enableStaticLogin:
+        - staticPassword
+    properties:
+      additionalKubeloginRedirects:
+        items:
+          examples:
+            - http://localhost:8080/redirect
+          format: uri
+          type: string
+        type: array
+      affinity:
+        $ref: '#/$defs/io.k8s.api.core.v1.Affinity'
+      enableStaticLogin:
+        default: true
+        description: enable a static password login
+        type: boolean
+      expiry:
+        additionalProperties: false
+        properties:
+          deviceRequests:
+            $ref: '#/$defs/timeRange'
+            default: 5m
+          idToken:
+            $ref: '#/$defs/timeRange'
+            default: 24h
+          refreshTokens:
+            additionalProperties: false
+            properties:
+              absoluteLifetime:
+                $ref: '#/$defs/timeRange'
+                default: 3960h
+              reuseInterval:
+                $ref: '#/$defs/timeRange'
+                default: 3s
+              validIfNotUsedFor:
+                $ref: '#/$defs/timeRange'
+                default: 2160h
+            type: object
+          signingKeys:
+            default: 6h
+            type: string
+        type: object
+      google:
+        additionalProperties: false
+        if:
+          properties:
+            groupSupport:
+              const: true
+        properties:
+          SASecretName:
+            type: string
+          groupSupport:
+            default: false
+            type: boolean
+        then:
+          required:
+            - SASecretName
+        type: object
+      nodeSelector:
+        $ref: '#/$defs/kubernetesNodeSelector'
+      replicaCount:
+        default: 2
+        type: number
+      resources:
+        $ref: '#/$defs/kubernetesResourceRequirements'
+      serviceMonitor:
+        additionalProperties: false
+        properties:
+          enabled:
+            default: true
+            type: boolean
+        type: object
+      staticPassword:
+        default: $2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W
+        description: bcrypt hash of a password
+        type: string
+      subdomain:
+        default: dex
+        type: string
+      tolerations:
+        $ref: '#/$defs/kubernetesTolerations'
+      topologySpreadConstraints:
+        $ref: '#/$defs/kubernetesTopologySpreadConstraints'
+    type: object
+  externalTrafficPolicy:
+    additionalProperties: false
+    properties:
+      local:
+        default: false
+        type: boolean
+      whitelistRange:
+        additionalProperties:
+          default: 0.0.0.0/0
+          type:
+            - string
+            - boolean
+        description: |-
+          CIDR IP ranges that enable various
+          `nginx.ingress.kubernetes.io/whitelist-source-range` annotations or a
+          boolean `false` to explicitly opt-out of the annotation.
+        title: IP range allow-lists
+        type: object
+    type: object
+  falco:
+    additionalProperties: false
+    description: |
+      Falco alerting configuration.
+
+      Available rule files and addons can be found at: <https://falcosecurity.github.io/falcoctl/index.yaml>
+    properties:
+      affinity:
+        $ref: '#/$defs/io.k8s.api.core.v1.Affinity'
+      alerts:
+        additionalProperties: false
+        description: Falco alerts will come from prometheus metrics
+        properties:
+          enabled:
+            default: false
+            type: boolean
+          hostPort:
+            default: http://alertmanager-operated.monitoring:9093
+            format: uri
+            type: string
+          priority:
+            default: notice
+            type: string
+          type:
+            default: alertmanager
+            enum:
+              - alertmanager
+              - slack
+            type: string
+        type: object
+      artifact:
+        additionalProperties: false
+        properties:
+          install:
+            additionalProperties: false
+            description: set to false in an air-gapped environment, unless artifacts are self-hosted
+            properties:
+              enabled:
+                type: boolean
+            type: object
+        type: object
+      customIndexes:
+        type: array
+      customRules:
+        additionalProperties:
+          format: yaml
+          type: string
+        type: object
+      driver:
+        properties:
+          kind:
+            default: kmod
+            type: string
+            enum:
+              - kmod
+              - ebpf
+              - modern-bpf
+        type: object
+        if:
+          properties:
+            kind:
+              const: kmod
+        then:
+          properties:
+            module:
+              additionalProperties: false
+              description: override the URL used for downloading driver modules, e.g. to use a self hosted file server in an air-gapped environment
+              properties:
+                repoURL:
+                  oneOf:
+                    - contst: ""
+                    - format: uri
+                  type: string
+              type: object
+        else:
+          properties:
+            kind:
+              type: string
+              enum:
+                - ebpf
+                - modern-bpf
+            ebpf:
+              additionalProperties: false
+              properties:
+                hostNetwork:
+                  description: Needed to enable eBPF JIT at runtime for performance reasons. Can be skipped if eBPF JIT is enabled from outside the container
+                  default: false
+                  type: boolean
+                path:
+                  description: Path where the eBPF probe is located. It comes in handy when the probe have been installed in the nodes using tools other than the init container deployed with the chart.
+                  type:
+                    - string
+                    - "null"
+                  $comment: Phase out the null default from the default config eventually
+              type: object
+      enabled:
+        default: true
+        type: boolean
+      falcoExporter:
+        additionalProperties: false
+        properties:
+          affinity:
+            $ref: '#/$defs/io.k8s.api.core.v1.Affinity'
+          nodeSelector:
+            $ref: '#/$defs/kubernetesNodeSelector'
+          resources:
+            $ref: '#/$defs/kubernetesResourceRequirements'
+          tolerations:
+            $ref: '#/$defs/kubernetesTolerations'
+        type: object
+      falcoSidekick:
+        additionalProperties: false
+        properties:
+          affinity:
+            $ref: '#/$defs/io.k8s.api.core.v1.Affinity'
+          nodeSelector:
+            $ref: '#/$defs/kubernetesNodeSelector'
+          resources:
+            $ref: '#/$defs/kubernetesResourceRequirements'
+          tolerations:
+            $ref: '#/$defs/kubernetesTolerations'
+        type: object
+      nodeSelector:
+        $ref: '#/$defs/kubernetesNodeSelector'
+      resources:
+        $ref: '#/$defs/kubernetesResourceRequirements'
+      rulesFiles:
+        additionalProperties: false
+        properties:
+          default:
+            additionalProperties: false
+            properties:
+              enabled:
+                default: true
+                type: boolean
+              version:
+                default: 2.0.0
+                type: string
+            type: object
+          incubating:
+            additionalProperties: false
+            properties:
+              enabled:
+                default: false
+                type: boolean
+              version:
+                default: 2.0.0
+                type: string
+            type: object
+          sandbox:
+            additionalProperties: false
+            properties:
+              enabled:
+                default: false
+                type: boolean
+              version:
+                default: 2.0.0
+                type: string
+            type: object
+        type: object
+      tolerations:
+        $ref: '#/$defs/kubernetesTolerations'
+      tty:
+        default: true
+        type: boolean
+    type: object
+  gatekeeper:
+    title: Open Policy Agent Gatekeeper configuration
+    type: object
+    properties:
+      allowUserCRDs:
+        properties:
+          enabled:
+            type: boolean
+          enforcement:
+            type: string
+          adminConfUser:
+            description: |-
+              The name of the user specified in /etc/kubernetes/admin.conf kubeconfig file of the control plane nodes
+              Necessary if Kubespray is used for managing the k8s cluster.
+            type: string
+          extraCRDs:
+            type: array
+            items:
+              type: object
+              properties:
+                names:
+                  type: array
+                  items:
+                    type: string
+                group:
+                  type: string
+          extraServiceAccounts:
+            type: array
+            items:
+              type: object
+              properties:
+                namespace:
+                  type: string
+                name:
+                  type: string
+              additionalProperties: false
+      enabled:
+        type: boolean
+    additionalProperties: false
+  kured:
+    additionalProperties: false
+    properties:
+      affinity:
+        $ref: '#/$defs/io.k8s.api.core.v1.Affinity'
+      configuration:
+        $comment: Would it be possible to extract schema from somewhere else in the future?
+        description: |-
+          Passed through as-is to Kured chart
+          See <helmfile.d/upstream/kubereboot/kured/README.md#Configuration>
+        properties: {}
+        type: object
+      drainTimeout: true
+      dsAnnotations:
+        type: object
+      enabled:
+        default: false
+        type: boolean
+      endTime: true
+      extraArgs:
+        type: object
+      extraEnvVars:
+        type: object
+      metrics:
+        additionalProperties: false
+        properties:
+          enabled:
+            default: true
+            type: boolean
+          interval:
+            default: 60s
+            type: string
+          labels:
+            type: object
+        type: object
+      nodeSelector:
+        $ref: '#/$defs/kubernetesNodeSelector'
+      notification:
+        additionalProperties: false
+        properties:
+          slack:
+            additionalProperties: false
+            properties:
+              channel:
+                default: ""
+                type: string
+              enabled:
+                default: false
+                type: boolean
+            type: object
+        type: object
+      period: true
+      rebootDays: true
+      resources:
+        $ref: '#/$defs/kubernetesResourceRequirements'
+      startTime: true
+      timeZone: true
+      tolerations:
+        $ref: '#/$defs/kubernetesTolerations'
+    type: object
+  opa:
+    additionalProperties: false
+    properties:
+      audit:
+        additionalProperties: false
+        properties:
+          affinity:
+            $ref: '#/$defs/io.k8s.api.core.v1.Affinity'
+          nodeSelector:
+            $ref: '#/$defs/kubernetesNodeSelector'
+          resources:
+            $ref: '#/$defs/kubernetesResourceRequirements'
+          tolerations:
+            $ref: '#/$defs/kubernetesTolerations'
+          topologySpreadConstraints:
+            $ref: '#/$defs/kubernetesTopologySpreadConstraints'
+          writeToRAMDisk:
+            default: false
+            type: boolean
+        type: object
+      auditChunkSize:
+        default: 500
+        type: number
+      auditFromCache:
+        default: false
+        type: boolean
+      auditIntervalSeconds:
+        default: 600
+        type: number
+      constraintViolationsLimit:
+        default: 20
+        type: number
+      controllerManager:
+        $ref: '#/$defs/component'
+      disallowedTags:
+        additionalProperties: false
+        properties:
+          enabled:
+            default: true
+            type: boolean
+          enforcement:
+            default: deny
+            type: string
+          tags:
+            items:
+              default: latest
+              type: string
+            type: array
+        type: object
+      imageRegistry:
+        additionalProperties: false
+        properties:
+          URL:
+            items:
+              examples:
+                - harbor.example.com
+                - quay.io/jetstack/cert-manager-acmesolver
+              type: string
+            type: array
+          enabled:
+            default: true
+            type: boolean
+          enforcement:
+            default: warn
+            type: string
+        type: object
+      mutatingWebhookTimeoutSeconds:
+        default: 5
+        type: number
+      mutations:
+        additionalProperties: false
+        properties:
+          enabled:
+            default: true
+            type: boolean
+          jobTTL:
+            additionalProperties: false
+            properties:
+              enabled:
+                default: true
+                type: boolean
+              ttlSeconds:
+                default: 604800
+                type: number
+            type: object
+          ndots:
+            additionalProperties: false
+            properties:
+              enabled:
+                default: false
+                type: boolean
+              labelSelector:
+                additionalProperties: false
+                properties:
+                  matchLabels: {}
+                type: object
+              ndotAmount:
+                default: 3
+                type: integer
+            type: object
+        type: object
+      networkPolicies:
+        additionalProperties: false
+        properties:
+          enabled:
+            default: true
+            type: boolean
+          enforcement:
+            default: warn
+            type: string
+        type: object
+      rejectLoadBalancerService:
+        additionalProperties: false
+        description: Prevent the creation of load balancer services when unsupported
+        properties:
+          enabled:
+            type: boolean
+          enforcement:
+            default: deny
+            enum:
+              - dryrun
+              - warn
+              - deny
+            type: string
+        type: object
+      resourceRequests:
+        additionalProperties: false
+        properties:
+          enabled:
+            default: true
+            type: boolean
+          enforcement:
+            default: deny
+            enum:
+              - dryrun
+              - warn
+              - deny
+            type: string
+        type: object
+      validatingWebhookTimeoutSeconds:
+        default: 5
+        type: number
+      minimumDeploymentReplicas:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: true
+          enforcemenct:
+            type: string
+            default: warn
+            enum:
+              - dryrun
+              - warn
+              - deny
+    type: object
+  trivy:
+    additionalProperties: false
+    patternProperties:
+      \w+Enabled$:
+        $comment: |-
+          This definition applies to any key that ends with 'Enabled', which are all
+          booleans. In the future it may be desirable to replace this with individual
+          entries under `properties` in order to provide documentation for each
+          scanner.
+        description: Enable or disable various security scanners
+        type: boolean
+    properties:
+      affinity:
+        $ref: '#/$defs/io.k8s.api.core.v1.Affinity'
+      enabled:
+        default: true
+        type: boolean
+      excludeNamespaces:
+        description: comma separated list of namespaces (or glob patterns) to be excluded from scanning
+        type: string
+      resources:
+        $ref: '#/$defs/kubernetesResourceRequirements'
+      scanJobs:
+        additionalProperties: false
+        properties:
+          concurrentLimit:
+            default: 1
+            type: number
+          retryDelay:
+            default: 1m
+            type: string
+          timeout:
+            default: 5m
+            type: string
+        type: object
+      scanner:
+        additionalProperties: false
+        description: |
+          configurations for an offline / air-gapped environment
+          ref: <https://github.com/aquasecurity/trivy-operator/tree/main/deploy/helm#values>
+        properties:
+          additionalProperties: false
+          dbRegistry:
+            type: string
+          dbRepository:
+            type: string
+          dbRepositoryInsecure:
+            type: boolean
+          imagePullSecret:
+            additionalProperties: false
+            description: |
+              if authorization is required for pulling from registry, create a pull
+              secret in the monitoring namespace and configure the secret name
+            properties:
+              name:
+                type: string
+            type: object
+          javaDbRegistry:
+            type: string
+          javaDbRepository:
+            type: string
+          offlineScanEnabled:
+            type: boolean
+          registry:
+            examples:
+              - docker.io: registry.example.org:5000
+                gcr.io: registry.example.org:5000
+                ghcr.io: registry.example.org:5000
+                index.docker.io: registry.example.org:5000
+                quay.io: registry.example.org:5000
+                registry.k8s.io: registry.example.org:5000
+            properties:
+              mirror:
+                additionalProperties:
+                  description: a docker registry
+                  examples:
+                    - registry.example.org:5000
+                  type: string
+                type: object
+            type: object
+          resources:
+            $ref: '#/$defs/kubernetesResourceRequirements'
+          timeout:
+            $ref: '#/$defs/goDuration'
+        type: object
+      serviceMonitor:
+        additionalProperties: false
+        properties:
+          enabled:
+            default: true
+            type: boolean
+          interval:
+            $ref: '#/$defs/timeRange'
+        type: object
+      tolerations:
+        $ref: '#/$defs/kubernetesTolerations'
+      vulnerabilityScanner:
+        additionalProperties: false
+        properties:
+          scanOnlyCurrentRevisions:
+            default: true
+            type: boolean
+          scannerReportTTL:
+            $ref: '#/$defs/timeRange'
+            default: 720h
+        type: object
+    required:
+      - enabled
+    title: Trivy security scanner
+    type: object
 additionalProperties:
   type: object
   properties: {}

--- a/tests/common/lib/env.bash
+++ b/tests/common/lib/env.bash
@@ -91,7 +91,7 @@ env.init() {
     yq_set 'sc' '.networkPolicies.opensearch.plugins.ips' '["0.0.0.0/0"]'
   fi
 
-  yq_set 'wc' '.opa.imageRegistry.URL' '"harbor.ck8s.example.com"'
+  yq_set 'wc' '.opa.imageRegistry.URL' '["harbor.ck8s.example.com"]'
 
   yq_set 'wc' '.user.adminUsers' '["user@example.com"]'
   yq_set 'wc' '.user.adminGroups' '["group@example.com"]'

--- a/tests/unit/bin/update-ips/resources/maximal-run-full-diff.out
+++ b/tests/unit/bin/update-ips/resources/maximal-run-full-diff.out
@@ -180,7 +180,7 @@
 [32m+        - 127.0.3.111/32[0m
  opa:
    imageRegistry:
-     URL: harbor.ck8s.example.com
+     URL:
 [[33mck8s[0m] Diff found for .networkPolicies.global.wcNodes.ips in wc-config.yaml (diff shows actions needed to be up to date)
 [1m--- sc-config.yaml[0m
 [1m+++ expected[0m


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This adds structural validation for the following top-level config sections:

- clusterAdmin
- dex
- externalTrafficPolicy
- falco
- gatekeeper
- kured
- opa
- trivy

For more context including the required scripts and see #1862
Part of issue #1427

#### Information to reviewers

`ck8s validate` should now perform validation of the above sections.

While the CI is failing:
Please help determine whether it is the schema that is lacking or whether it detected a config mistake.

Suggestions and improvements very welcome!

[Also see the **README** for brief information about the schema format](https://github.com/elastisys/compliantkubernetes-apps/blob/main/config/schemas/README.md)

**Obs:** The `$defs` are really added in #2063 but the commit is included here too for CI.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [x] The change updates the config *and* the schema
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests

