### PR TITLE
Added kured alert for when nodes have required reboot for 30 days

### DIFF
--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kured.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kured.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.defaultRules.create .Values.defaultRules.rules.kured }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-alerts.fullname" .) "kured" | trunc 63 | trimSuffix "-" }}
+  labels:
+    app: {{ template "prometheus-alerts.name" . }}
+{{ include "prometheus-alerts.labels" . | indent 4 }}
+{{- if .Values.defaultRules.alertLabels }}
+{{ toYaml .Values.defaultRules.alertLabels | indent 4 }}
+{{- end }}
+{{- if .Values.defaultRules.annotations }}
+  annotations:
+{{ toYaml .Values.defaultRules.annotations | indent 4 }}
+{{- end }}
+spec:
+  groups:
+  - name: kured
+    rules:
+    - alert: 'Kured Failed Node Reboot'
+      expr: |
+        min_over_time((sum(kured_reboot_required) by (node))[30d:1m]) > 0
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        description: "Kured has failed with required reboot of node {{`{{ $labels.node }}`}} over 30 days."
+{{- end }}

--- a/helmfile.d/charts/prometheus-alerts/values.yaml
+++ b/helmfile.d/charts/prometheus-alerts/values.yaml
@@ -120,6 +120,7 @@ defaultRules:
     clusterApi: false
     harbor: true
     openstack: false
+    kured: false
 
   appNamespacesTarget: ".*"
 

--- a/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
@@ -36,6 +36,7 @@ defaultRules:
     clusterApi: {{ .Values.clusterApi.enabled }}
     webhooks: {{ .Values.prometheus.webhookAlerts.enabled }}
     openstack: {{ .Values | get "openstackMonitoring.enabled" false }}
+    kured: {{ and .Values.kured.enabled .Values.kured.metrics.enabled }}
 
   {{- if and .Values.thanos.enabled .Values.thanos.ruler.enabled }}
   thanos:

--- a/helmfile.d/values/prometheus-user-alerts-wc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-user-alerts-wc.yaml.gotmpl
@@ -24,6 +24,7 @@ defaultRules:
     networkpolicies: {{ .Values.networkPolicies.enableAlerting }}
     harbor: false
     webhooks: {{ .Values.prometheus.webhookAlerts.enabled }}
+    kured: {{ and .Values.kured.enabled .Values.kured.metrics.enabled }}
 
 capacityManagementAlertsPersistentVolumeEnabled: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.enabled }}
 capacityManagementAlertsPersistentVolumeLimit: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.limit }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Added an alert for Kured for when a node has required a reboot for 30 days

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2062 

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
- Config checks:
  - [ ] The schema was updated
