### PR TITLE
tests: Add releases unit tests

### DIFF
--- a/helmfile.d/stacks/ingress-nginx.yaml
+++ b/helmfile.d/stacks/ingress-nginx.yaml
@@ -68,5 +68,7 @@ templates:
     chart: charts/ingress-nginx-probe-ingress
     installed: {{ .Values | get "wcProbeIngress.enabled" false }}
     version: 0.1.0
+    needs:
+      - ingress-nginx/networkpolicy
     values:
       - values/ingress-nginx-probe-ingress.yaml.gotmpl

--- a/tests/common/lib/env.bash
+++ b/tests/common/lib/env.bash
@@ -106,19 +106,16 @@ env.teardown() {
   rm -rf "${CK8S_CONFIG_PATH}"
 }
 
-env.cache_create() {
+# Create a private copy of the current config path
+env.private() {
   if [[ -z "${CK8S_CONFIG_PATH:-}" ]]; then
     fail "CK8S_CONFIG_PATH is unset!"
   fi
 
-  cp -r "${CK8S_CONFIG_PATH}" "${CK8S_CONFIG_PATH}-cache"
-}
+  local target
+  target="$(mktemp --directory)"
 
-env.cache_delete() {
-  rm -rf "${CK8S_CONFIG_PATH}" "${CK8S_CONFIG_PATH}-cache"
-}
+  cp -Tr "${CK8S_CONFIG_PATH}" "${target}"
 
-env.cache_restore() {
-  rm -rf "${CK8S_CONFIG_PATH}"
-  cp -r "${CK8S_CONFIG_PATH}-cache" "${CK8S_CONFIG_PATH}"
+  export CK8S_CONFIG_PATH="${target}"
 }

--- a/tests/unit/bin/init/template.bats.gotmpl
+++ b/tests/unit/bin/init/template.bats.gotmpl
@@ -8,9 +8,6 @@
 # bats file_tags=static,bin:init,{{ .provider }}
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -19,7 +16,6 @@ setup_file() {
   env.setup
 
   env.init {{ .flavor }} {{ .provider }}
-  env.cache_create
 }
 
 setup() {
@@ -28,11 +24,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-aws-air-gapped.gen.bats
+++ b/tests/unit/bin/init/test-aws-air-gapped.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,aws
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init air-gapped aws
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-aws-dev.gen.bats
+++ b/tests/unit/bin/init/test-aws-dev.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,aws
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init dev aws
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-aws-prod.gen.bats
+++ b/tests/unit/bin/init/test-aws-prod.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,aws
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init prod aws
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-baremetal-air-gapped.gen.bats
+++ b/tests/unit/bin/init/test-baremetal-air-gapped.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,baremetal
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init air-gapped baremetal
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-baremetal-dev.gen.bats
+++ b/tests/unit/bin/init/test-baremetal-dev.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,baremetal
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init dev baremetal
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-baremetal-prod.gen.bats
+++ b/tests/unit/bin/init/test-baremetal-prod.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,baremetal
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init prod baremetal
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-citycloud-air-gapped.gen.bats
+++ b/tests/unit/bin/init/test-citycloud-air-gapped.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,citycloud
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init air-gapped citycloud
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-citycloud-dev.gen.bats
+++ b/tests/unit/bin/init/test-citycloud-dev.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,citycloud
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init dev citycloud
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-citycloud-prod.gen.bats
+++ b/tests/unit/bin/init/test-citycloud-prod.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,citycloud
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init prod citycloud
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-elastx-air-gapped.gen.bats
+++ b/tests/unit/bin/init/test-elastx-air-gapped.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,elastx
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init air-gapped elastx
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-elastx-dev.gen.bats
+++ b/tests/unit/bin/init/test-elastx-dev.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,elastx
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init dev elastx
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-elastx-prod.gen.bats
+++ b/tests/unit/bin/init/test-elastx-prod.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,elastx
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init prod elastx
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-exoscale-air-gapped.gen.bats
+++ b/tests/unit/bin/init/test-exoscale-air-gapped.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,exoscale
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init air-gapped exoscale
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-exoscale-dev.gen.bats
+++ b/tests/unit/bin/init/test-exoscale-dev.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,exoscale
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init dev exoscale
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-exoscale-prod.gen.bats
+++ b/tests/unit/bin/init/test-exoscale-prod.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,exoscale
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init prod exoscale
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-safespring-air-gapped.gen.bats
+++ b/tests/unit/bin/init/test-safespring-air-gapped.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,safespring
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init air-gapped safespring
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-safespring-dev.gen.bats
+++ b/tests/unit/bin/init/test-safespring-dev.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,safespring
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init dev safespring
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-safespring-prod.gen.bats
+++ b/tests/unit/bin/init/test-safespring-prod.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,safespring
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init prod safespring
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-upcloud-air-gapped.gen.bats
+++ b/tests/unit/bin/init/test-upcloud-air-gapped.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,upcloud
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init air-gapped upcloud
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-upcloud-dev.gen.bats
+++ b/tests/unit/bin/init/test-upcloud-dev.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,upcloud
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init dev upcloud
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/init/test-upcloud-prod.gen.bats
+++ b/tests/unit/bin/init/test-upcloud-prod.gen.bats
@@ -5,9 +5,6 @@
 # bats file_tags=static,bin:init,upcloud
 
 setup_file() {
-  # Not supported right now, might be able to leverage env.cache with some adaptions
-  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
-
   load "../../../common/lib"
   load "../../../common/lib/env"
   load "../../../common/lib/gpg"
@@ -16,7 +13,6 @@ setup_file() {
   env.setup
 
   env.init prod upcloud
-  env.cache_create
 }
 
 setup() {
@@ -25,11 +21,14 @@ setup() {
   load "script"
 
   common_setup
-  env.cache_restore
+  env.private
+}
+
+teardown() {
+  env.teardown
 }
 
 teardown_file() {
-  env.cache_delete
   env.teardown
   gpg.teardown
 }

--- a/tests/unit/bin/update-ips/main.bats
+++ b/tests/unit/bin/update-ips/main.bats
@@ -18,13 +18,9 @@ setup_file() {
 
   yq_set common .objectStorage.type '"s3"'
   yq_set common .objectStorage.s3.regionEndpoint '"https://s3.foo.dev-ck8s.com:1234"'
-
-  env.cache_create
 }
 
 teardown_file() {
-  env.cache_delete
-
   env.teardown
   gpg.teardown
 }
@@ -36,12 +32,17 @@ setup() {
 
   common_setup
 
-  env.cache_restore
+  env.private
+
   update_ips.setup_mocks
 
   export mock_curl
   export mock_dig
   export mock_kubectl
+}
+
+teardown() {
+  env.teardown
 }
 
 _apply_normalise() {

--- a/tests/unit/bin/update-ips/rclone.bats
+++ b/tests/unit/bin/update-ips/rclone.bats
@@ -30,13 +30,9 @@ setup_file() {
   yq_set sc .objectStorage.sync.syncDefaultBuckets 'false'
 
   yq_set sc .networkPolicies.rclone.enabled 'true'
-
-  env.cache_create
 }
 
 teardown_file() {
-  env.cache_delete
-
   env.teardown
   gpg.teardown
 }
@@ -48,13 +44,17 @@ setup() {
 
   common_setup
 
-  env.cache_restore
+  env.private
 
   update_ips.setup_mocks
 
   export mock_curl
   export mock_dig
   export mock_kubectl
+}
+
+teardown() {
+  env.teardown
 }
 
 # ---- setup -----------------------------------------------------------------------------------------------------------

--- a/tests/unit/bin/update-ips/swift.bats
+++ b/tests/unit/bin/update-ips/swift.bats
@@ -24,13 +24,9 @@ setup_file() {
   yq_set sc .objectStorage.swift.domainName '"swift-domain"'
   yq_set sc .objectStorage.swift.projectDomainName '"swift-project-domain"'
   yq_set sc .objectStorage.swift.projectName '"swift-project"'
-
-  env.cache_create
 }
 
 teardown_file() {
-  env.cache_delete
-
   env.teardown
   gpg.teardown
 }
@@ -42,13 +38,17 @@ setup() {
 
   common_setup
 
-  env.cache_restore
+  env.private
 
   update_ips.setup_mocks
 
   export mock_curl
   export mock_dig
   export mock_kubectl
+}
+
+teardown() {
+  env.teardown
 }
 
 _test_requires_auth_endpoint() {

--- a/tests/unit/releases/script.bash
+++ b/tests/unit/releases/script.bash
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+
+# returns the releases filtered on { condition: true, installed: true } for the given cluster <sc|wc>
+# additionally sets { selector: "namespace=<release-namespace>,name=<release-name>" } for subsequent filtering
+# additionally sets { needs: [ "namespace=<needs-namespace>,name=<needs-name>" ] } for subsequent filtering
+# caches the results
+helmfile_build_releases() {
+  local releases expression
+  releases="${CK8S_CONFIG_PATH}/pre-build/${1}.yaml"
+
+
+  if ! [[ -f "${releases}" ]]; then
+    mkdir -p "$(dirname "${releases}")"
+
+    # with the merged config as $values, select releases with condition and installed not false,
+    # set selector with format "namespace=%,name=%", set needs with format "namespace=%,name=%", collect to array
+    # shellcheck disable=SC2016
+    expression='.renderedvalues as $values | [
+      .releases[] |
+      select(
+        eval("$values." + .condition) != false and .installed != false
+      ) |
+      .selector = "namespace=" + .namespace + ",name=" + .name |
+      with(.needs[];
+        . = "namespace=" + sub("/", ",name=")
+      )
+    ]'
+
+    local target
+    target="$(mktemp)"
+
+    case "${1:-}" in
+    sc)
+      helmfile -e service_cluster -f "${ROOT}/helmfile.d" -q build | yq4 -oj -I0 "${expression}" > "${target}"
+      ;;
+    wc)
+      helmfile -e workload_cluster -f "${ROOT}/helmfile.d" -q build | yq4 -oj -I0 "${expression}" > "${target}"
+      ;;
+    *)
+      echo "error: usage: helmfile_build_releases <sc|wc>"
+      exit 1
+      ;;
+    esac
+
+    mv "${target}" "${releases}"
+  fi
+
+  cat "${releases}"
+}
+
+# returns the resolved transitive needs for the given cluster <sc|wc> and selector "namespace=<namespace>,name=<name>"
+helmfile_build_needs() {
+  local releases incoming outgoing
+
+  releases="$(helmfile_build_releases "${1}")"
+
+  incoming=""
+  outgoing="${2}"
+
+  # until the data does not change between iterations
+  while [[ "${incoming}" != "${outgoing}" ]]; do
+    # save outgoing selectors for next iteration
+    incoming="${outgoing}"
+    # from releases. select anything matching the incoming selectors,
+    # generate a list from releases with its selector and needs,
+    # take unique selectors and join them with a space
+    outgoing="$(yq4 "[
+      .[] | select(
+        .selector | match(\"${incoming// /|}\")
+      ) | .needs + [.selector] | .[]
+    ] | sort | unique | join(\" \") " <<< "${releases}")"
+  done
+
+  echo "${outgoing// /$'\n'}"
+}
+
+# creates a cache with templated releases
+helmfile_template_releases() {
+  local target_template
+  target_template="${CK8S_CONFIG_PATH}/pre-template/${1}/namespace={{ .Release.Namespace }},name={{ .Release.Name }}"
+
+  case "${1:-}" in
+  sc)
+    # template matching release and add namespace of release if missing
+    helmfile -e service_cluster -f "${ROOT}/helmfile.d" -q template --include-crds --output-dir-template "${target_template}"
+    ;;
+  wc)
+    # template matching release and add namespace of release if missing
+    helmfile -e workload_cluster -f "${ROOT}/helmfile.d" -q template --include-crds --output-dir-template "${target_template}"
+    ;;
+  *)
+    echo "error: usage: helmfile_template_release <sc|wc> <selector>"
+    exit 1
+    ;;
+  esac
+}
+
+# returns the templated release for the given cluster <sc|wc> and selector "namespace=<namespace>,name=<name>" from cache
+helmfile_template_release() {
+  local release
+  release="${CK8S_CONFIG_PATH}/pre-template/${1}/${2}"
+
+  if [[ -d "${release}" ]]; then
+    # get namespace from selector
+    local namespace="${2}"
+    namespace="${namespace##namespace=}"
+    namespace="${namespace%%,name=*}"
+
+    local -a files
+    readarray -t files <<< "$(find "${release}" -type f -name '*.yaml')"
+
+    for file in "${files[@]}"; do
+      yq4 ".metadata.namespace = (.metadata.namespace // \"${namespace}\")" "${file}"
+    done
+
+  else
+    echo "error: missing release ${1}/${2}" >&2
+    exit 1
+  fi
+}
+
+# returns the templated release and transitive needs for the given cluster <sc|wc> and selector "namespace=<namespace>,name=<name>"
+# caches the results
+helmfile_template_release_needs() {
+  local -a selectors
+  readarray -t selectors <<< "$(helmfile_build_needs "${1}" "${2}")"
+
+  local selector
+  for selector in "${selectors[@]}"; do
+    helmfile_template_release "${1}" "${selector}"
+  done
+}
+
+# renders templates in two passes for each release, with and without transitive needs
+# arguments: <sc|wc> <yq-expression-for-used-resources> <yq-expression-for-created-resources>
+# - the <yq-expression-for-used-resources> should create unique identifiers for resources that the release depends on based on the rendered templates **without** transitive needs
+# - the <yq-expression-for-created-resources> should create unique identifiers for resources that the releases provides based on the rendered templates **with** transitive needs
+releases_have_through_needs() {
+  local cluster used_expression created_expression
+
+  cluster="${1}"
+  used_expression="${2}"
+  created_expression="${3}"
+
+  local -a selectors
+  readarray -t selectors <<< "$(helmfile_build_releases "${cluster}" | yq4 -r -oj -I0 '.[] | "namespace=" + .namespace + ",name=" + .name')"
+
+  local fail=false
+
+  local selector
+  for selector in "${selectors[@]}"; do
+    local used_resources
+    used_resources="$(helmfile_template_release "${cluster}" "${selector}" | yq4 -N "select(. != null) | [${used_expression}] | .[]" | sort -u)"
+
+    local created_resources
+    created_resources="$(helmfile_template_release_needs "${cluster}" "${selector}" | yq4 -N "select(. != null) | [${created_expression}] | .[]" | sort -u)"
+
+    local uniques
+    # print used resources once and created resources twice, then filter on totally unique identifiers
+    uniques="$(tr ' ' '\n' <<< "${used_resources} ${created_resources} ${created_resources}" | sort | uniq -u | tr '\n' ' ')"
+
+    # if we have a totally unique identifier then we have an issue
+    if [[ -n "${uniques%% }" ]]; then
+      echo "error: release {${selector}} requires [${uniques%% }] which seems to be missing from its needs!"
+      fail=true
+    fi
+  done
+
+  if [[ "${fail}" == "true" ]]; then
+    exit 1
+  fi
+}
+
+release_with_custom_resources_have_validation_on_install_disabled() {
+  local -a selectors
+  readarray -t selectors <<< "$(helmfile_build_releases "${1}" | yq4 -r -oj -I0 '.[] | select(.disableValidationOnInstall != true) | "namespace=" + .namespace + ",name=" + .name')"
+
+  local fail=false
+
+  local selector
+  for selector in "${selectors[@]}"; do
+    local custom_resources
+    custom_resources="$(helmfile_template_release "${1}" "${selector}" | yq4 -r -oj -I0 'select(.apiVersion | test("^(.+\.k8s\.io/|apps/|batch/|policy/|)v1.*") | not) | .apiVersion + "/" + .kind' | sort -u)"
+
+    if [[ -n "${custom_resources}" ]]; then
+      echo "error: release {${selector//=/:}} creates custom resources [${custom_resources//$'\n'/,}] and must have { disableValidationOnInstall: true }!"
+      fail=true
+    fi
+  done
+
+  if [[ "${fail}" == "true" ]]; then
+    exit 1
+  fi
+}

--- a/tests/unit/releases/template.bats.gotmpl
+++ b/tests/unit/releases/template.bats.gotmpl
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+
+{{- define "template" -}}
+#!/usr/bin/env bats
+
+# Generated from {{ tmpl.Path }}
+
+# bats file_tags=static,{{ .provider }}
+
+setup_file() {
+  load "../../common/lib"
+  load "../../common/lib/env"
+  load "../../common/lib/gpg"
+  load "script"
+
+  gpg.setup
+  env.setup
+
+  env.init prod {{ .provider }}
+
+  helmfile_template_releases sc
+  helmfile_template_releases wc
+}
+
+setup() {
+  load "../../common/lib"
+  load "script"
+
+  common_setup
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "releases have constraint templates through needs - {{ .provider }} - service cluster" {
+  # used filter: a constraint's kind...
+  # created filter: should exist in a constraint's templates spec
+  releases_have_through_needs sc \
+    'select(.apiVersion == "constraints.gatekeeper.sh/v1beta1") | .kind | "ConstraintTemplate/" + .' \
+    'select(.kind == "ConstraintTemplate") | .spec.crd.spec.names.kind | "ConstraintTemplate/" + .'
+}
+
+@test "releases have constraint templates through needs - {{ .provider }} - workload cluster" {
+  # used filter: a constraint's kind...
+  # created filter: should exist in a constraint's templates spec
+  releases_have_through_needs wc \
+    'select(.apiVersion == "constraints.gatekeeper.sh/v1beta1") | .kind | "ConstraintTemplate/" + .' \
+    'select(.kind == "ConstraintTemplate") | .spec.crd.spec.names.kind | "ConstraintTemplate/" + .'
+}
+
+@test "releases have custom resource definitions through needs - {{ .provider }} - service cluster" {
+  # used filter: a custom resource's kind...
+  # created filter: should exist in a custom resource definition's templates spec
+  releases_have_through_needs sc \
+    'select(.apiVersion | test("^(.+\.k8s\.io/|apps/|batch/|policy/|constraints.gatekeeper.sh/|)v1.*") | not) | .kind | "CustomResourceDefinition/" + .' \
+    'select(.kind == "CustomResourceDefinition") | .spec.names.kind | "CustomResourceDefinition/" + .'
+}
+
+@test "releases have custom resource definitions through needs - {{ .provider }} - workload cluster" {
+  # used filter: a custom resource's kind...
+  # created filter: should exist in a custom resource definition's templates spec
+  releases_have_through_needs wc \
+    'select(.apiVersion | test("^(.+\.k8s\.io/|apps/|batch/|policy/|constraints.gatekeeper.sh/|)v1.*") | not) | .kind | "CustomResourceDefinition/" + .' \
+    'select(.kind == "CustomResourceDefinition") | .spec.names.kind | "CustomResourceDefinition/" + .'
+}
+
+@test "releases have namespaces through needs - {{ .provider }} - service cluster" {
+  # used filter: a resource's namespace (except certain defaults)...
+  # created filter: should exist
+  releases_have_through_needs sc \
+    '.metadata.namespace | select(. != "default" and . != "kube-system" and . != "rook-ceph") | "Namespace/" + .' \
+    'select(.kind == "Namespace") | .metadata.name | "Namespace/" + .'
+}
+
+@test "releases have namespaces through needs - {{ .provider }} - workload cluster" {
+  # used filter: a resource's namespace (except certain defaults)...
+  # created filter: should exist
+  releases_have_through_needs wc \
+    '.metadata.namespace | select(. != "default" and . != "kube-system" and . != "rook-ceph") | "Namespace/" + .' \
+    'select(.kind == "Namespace") | .metadata.name | "Namespace/" + .'
+}
+
+@test "releases with custom resources have validation on install disabled - {{ .provider }} - service cluster" {
+  release_with_custom_resources_have_validation_on_install_disabled sc
+}
+
+@test "releases with custom resources have validation on install disabled - {{ .provider }} - workload cluster" {
+  release_with_custom_resources_have_validation_on_install_disabled wc
+}
+{{ end }}
+
+# These tests are generated into these files:
+{{- range $provider := coll.Slice "aws" "baremetal" "citycloud" "elastx" "exoscale" "safespring" "upcloud" }}
+{{- $file := tmpl.Path | path.Dir }}
+{{- $file = printf "test-%s.gen.bats" $provider | path.Join $file }}
+# - {{ $file }}
+{{- coll.Dict "provider" $provider | tmpl.Exec "template" | file.Write $file }}
+{{- end }}

--- a/tests/unit/releases/template.gen.bats
+++ b/tests/unit/releases/template.gen.bats
@@ -1,0 +1,10 @@
+#!/usr/bin/env bats
+
+# These tests are generated into these files:
+# - tests/unit/releases/test-aws.gen.bats
+# - tests/unit/releases/test-baremetal.gen.bats
+# - tests/unit/releases/test-citycloud.gen.bats
+# - tests/unit/releases/test-elastx.gen.bats
+# - tests/unit/releases/test-exoscale.gen.bats
+# - tests/unit/releases/test-safespring.gen.bats
+# - tests/unit/releases/test-upcloud.gen.bats

--- a/tests/unit/releases/test-aws.gen.bats
+++ b/tests/unit/releases/test-aws.gen.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/releases/template.bats.gotmpl
+
+# bats file_tags=static,aws
+
+setup_file() {
+  load "../../common/lib"
+  load "../../common/lib/env"
+  load "../../common/lib/gpg"
+  load "script"
+
+  gpg.setup
+  env.setup
+
+  env.init prod aws
+
+  helmfile_template_releases sc
+  helmfile_template_releases wc
+}
+
+setup() {
+  load "../../common/lib"
+  load "script"
+
+  common_setup
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "releases have constraint templates through needs - aws - service cluster" {
+  # used filter: a constraint's kind...
+  # created filter: should exist in a constraint's templates spec
+  releases_have_through_needs sc \
+    'select(.apiVersion == "constraints.gatekeeper.sh/v1beta1") | .kind | "ConstraintTemplate/" + .' \
+    'select(.kind == "ConstraintTemplate") | .spec.crd.spec.names.kind | "ConstraintTemplate/" + .'
+}
+
+@test "releases have constraint templates through needs - aws - workload cluster" {
+  # used filter: a constraint's kind...
+  # created filter: should exist in a constraint's templates spec
+  releases_have_through_needs wc \
+    'select(.apiVersion == "constraints.gatekeeper.sh/v1beta1") | .kind | "ConstraintTemplate/" + .' \
+    'select(.kind == "ConstraintTemplate") | .spec.crd.spec.names.kind | "ConstraintTemplate/" + .'
+}
+
+@test "releases have custom resource definitions through needs - aws - service cluster" {
+  # used filter: a custom resource's kind...
+  # created filter: should exist in a custom resource definition's templates spec
+  releases_have_through_needs sc \
+    'select(.apiVersion | test("^(.+\.k8s\.io/|apps/|batch/|policy/|constraints.gatekeeper.sh/|)v1.*") | not) | .kind | "CustomResourceDefinition/" + .' \
+    'select(.kind == "CustomResourceDefinition") | .spec.names.kind | "CustomResourceDefinition/" + .'
+}
+
+@test "releases have custom resource definitions through needs - aws - workload cluster" {
+  # used filter: a custom resource's kind...
+  # created filter: should exist in a custom resource definition's templates spec
+  releases_have_through_needs wc \
+    'select(.apiVersion | test("^(.+\.k8s\.io/|apps/|batch/|policy/|constraints.gatekeeper.sh/|)v1.*") | not) | .kind | "CustomResourceDefinition/" + .' \
+    'select(.kind == "CustomResourceDefinition") | .spec.names.kind | "CustomResourceDefinition/" + .'
+}
+
+@test "releases have namespaces through needs - aws - service cluster" {
+  # used filter: a resource's namespace (except certain defaults)...
+  # created filter: should exist
+  releases_have_through_needs sc \
+    '.metadata.namespace | select(. != "default" and . != "kube-system" and . != "rook-ceph") | "Namespace/" + .' \
+    'select(.kind == "Namespace") | .metadata.name | "Namespace/" + .'
+}
+
+@test "releases have namespaces through needs - aws - workload cluster" {
+  # used filter: a resource's namespace (except certain defaults)...
+  # created filter: should exist
+  releases_have_through_needs wc \
+    '.metadata.namespace | select(. != "default" and . != "kube-system" and . != "rook-ceph") | "Namespace/" + .' \
+    'select(.kind == "Namespace") | .metadata.name | "Namespace/" + .'
+}
+
+@test "releases with custom resources have validation on install disabled - aws - service cluster" {
+  release_with_custom_resources_have_validation_on_install_disabled sc
+}
+
+@test "releases with custom resources have validation on install disabled - aws - workload cluster" {
+  release_with_custom_resources_have_validation_on_install_disabled wc
+}

--- a/tests/unit/releases/test-baremetal.gen.bats
+++ b/tests/unit/releases/test-baremetal.gen.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/releases/template.bats.gotmpl
+
+# bats file_tags=static,baremetal
+
+setup_file() {
+  load "../../common/lib"
+  load "../../common/lib/env"
+  load "../../common/lib/gpg"
+  load "script"
+
+  gpg.setup
+  env.setup
+
+  env.init prod baremetal
+
+  helmfile_template_releases sc
+  helmfile_template_releases wc
+}
+
+setup() {
+  load "../../common/lib"
+  load "script"
+
+  common_setup
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "releases have constraint templates through needs - baremetal - service cluster" {
+  # used filter: a constraint's kind...
+  # created filter: should exist in a constraint's templates spec
+  releases_have_through_needs sc \
+    'select(.apiVersion == "constraints.gatekeeper.sh/v1beta1") | .kind | "ConstraintTemplate/" + .' \
+    'select(.kind == "ConstraintTemplate") | .spec.crd.spec.names.kind | "ConstraintTemplate/" + .'
+}
+
+@test "releases have constraint templates through needs - baremetal - workload cluster" {
+  # used filter: a constraint's kind...
+  # created filter: should exist in a constraint's templates spec
+  releases_have_through_needs wc \
+    'select(.apiVersion == "constraints.gatekeeper.sh/v1beta1") | .kind | "ConstraintTemplate/" + .' \
+    'select(.kind == "ConstraintTemplate") | .spec.crd.spec.names.kind | "ConstraintTemplate/" + .'
+}
+
+@test "releases have custom resource definitions through needs - baremetal - service cluster" {
+  # used filter: a custom resource's kind...
+  # created filter: should exist in a custom resource definition's templates spec
+  releases_have_through_needs sc \
+    'select(.apiVersion | test("^(.+\.k8s\.io/|apps/|batch/|policy/|constraints.gatekeeper.sh/|)v1.*") | not) | .kind | "CustomResourceDefinition/" + .' \
+    'select(.kind == "CustomResourceDefinition") | .spec.names.kind | "CustomResourceDefinition/" + .'
+}
+
+@test "releases have custom resource definitions through needs - baremetal - workload cluster" {
+  # used filter: a custom resource's kind...
+  # created filter: should exist in a custom resource definition's templates spec
+  releases_have_through_needs wc \
+    'select(.apiVersion | test("^(.+\.k8s\.io/|apps/|batch/|policy/|constraints.gatekeeper.sh/|)v1.*") | not) | .kind | "CustomResourceDefinition/" + .' \
+    'select(.kind == "CustomResourceDefinition") | .spec.names.kind | "CustomResourceDefinition/" + .'
+}
+
+@test "releases have namespaces through needs - baremetal - service cluster" {
+  # used filter: a resource's namespace (except certain defaults)...
+  # created filter: should exist
+  releases_have_through_needs sc \
+    '.metadata.namespace | select(. != "default" and . != "kube-system" and . != "rook-ceph") | "Namespace/" + .' \
+    'select(.kind == "Namespace") | .metadata.name | "Namespace/" + .'
+}
+
+@test "releases have namespaces through needs - baremetal - workload cluster" {
+  # used filter: a resource's namespace (except certain defaults)...
+  # created filter: should exist
+  releases_have_through_needs wc \
+    '.metadata.namespace | select(. != "default" and . != "kube-system" and . != "rook-ceph") | "Namespace/" + .' \
+    'select(.kind == "Namespace") | .metadata.name | "Namespace/" + .'
+}
+
+@test "releases with custom resources have validation on install disabled - baremetal - service cluster" {
+  release_with_custom_resources_have_validation_on_install_disabled sc
+}
+
+@test "releases with custom resources have validation on install disabled - baremetal - workload cluster" {
+  release_with_custom_resources_have_validation_on_install_disabled wc
+}

--- a/tests/unit/releases/test-citycloud.gen.bats
+++ b/tests/unit/releases/test-citycloud.gen.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/releases/template.bats.gotmpl
+
+# bats file_tags=static,citycloud
+
+setup_file() {
+  load "../../common/lib"
+  load "../../common/lib/env"
+  load "../../common/lib/gpg"
+  load "script"
+
+  gpg.setup
+  env.setup
+
+  env.init prod citycloud
+
+  helmfile_template_releases sc
+  helmfile_template_releases wc
+}
+
+setup() {
+  load "../../common/lib"
+  load "script"
+
+  common_setup
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "releases have constraint templates through needs - citycloud - service cluster" {
+  # used filter: a constraint's kind...
+  # created filter: should exist in a constraint's templates spec
+  releases_have_through_needs sc \
+    'select(.apiVersion == "constraints.gatekeeper.sh/v1beta1") | .kind | "ConstraintTemplate/" + .' \
+    'select(.kind == "ConstraintTemplate") | .spec.crd.spec.names.kind | "ConstraintTemplate/" + .'
+}
+
+@test "releases have constraint templates through needs - citycloud - workload cluster" {
+  # used filter: a constraint's kind...
+  # created filter: should exist in a constraint's templates spec
+  releases_have_through_needs wc \
+    'select(.apiVersion == "constraints.gatekeeper.sh/v1beta1") | .kind | "ConstraintTemplate/" + .' \
+    'select(.kind == "ConstraintTemplate") | .spec.crd.spec.names.kind | "ConstraintTemplate/" + .'
+}
+
+@test "releases have custom resource definitions through needs - citycloud - service cluster" {
+  # used filter: a custom resource's kind...
+  # created filter: should exist in a custom resource definition's templates spec
+  releases_have_through_needs sc \
+    'select(.apiVersion | test("^(.+\.k8s\.io/|apps/|batch/|policy/|constraints.gatekeeper.sh/|)v1.*") | not) | .kind | "CustomResourceDefinition/" + .' \
+    'select(.kind == "CustomResourceDefinition") | .spec.names.kind | "CustomResourceDefinition/" + .'
+}
+
+@test "releases have custom resource definitions through needs - citycloud - workload cluster" {
+  # used filter: a custom resource's kind...
+  # created filter: should exist in a custom resource definition's templates spec
+  releases_have_through_needs wc \
+    'select(.apiVersion | test("^(.+\.k8s\.io/|apps/|batch/|policy/|constraints.gatekeeper.sh/|)v1.*") | not) | .kind | "CustomResourceDefinition/" + .' \
+    'select(.kind == "CustomResourceDefinition") | .spec.names.kind | "CustomResourceDefinition/" + .'
+}
+
+@test "releases have namespaces through needs - citycloud - service cluster" {
+  # used filter: a resource's namespace (except certain defaults)...
+  # created filter: should exist
+  releases_have_through_needs sc \
+    '.metadata.namespace | select(. != "default" and . != "kube-system" and . != "rook-ceph") | "Namespace/" + .' \
+    'select(.kind == "Namespace") | .metadata.name | "Namespace/" + .'
+}
+
+@test "releases have namespaces through needs - citycloud - workload cluster" {
+  # used filter: a resource's namespace (except certain defaults)...
+  # created filter: should exist
+  releases_have_through_needs wc \
+    '.metadata.namespace | select(. != "default" and . != "kube-system" and . != "rook-ceph") | "Namespace/" + .' \
+    'select(.kind == "Namespace") | .metadata.name | "Namespace/" + .'
+}
+
+@test "releases with custom resources have validation on install disabled - citycloud - service cluster" {
+  release_with_custom_resources_have_validation_on_install_disabled sc
+}
+
+@test "releases with custom resources have validation on install disabled - citycloud - workload cluster" {
+  release_with_custom_resources_have_validation_on_install_disabled wc
+}

--- a/tests/unit/releases/test-elastx.gen.bats
+++ b/tests/unit/releases/test-elastx.gen.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/releases/template.bats.gotmpl
+
+# bats file_tags=static,elastx
+
+setup_file() {
+  load "../../common/lib"
+  load "../../common/lib/env"
+  load "../../common/lib/gpg"
+  load "script"
+
+  gpg.setup
+  env.setup
+
+  env.init prod elastx
+
+  helmfile_template_releases sc
+  helmfile_template_releases wc
+}
+
+setup() {
+  load "../../common/lib"
+  load "script"
+
+  common_setup
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "releases have constraint templates through needs - elastx - service cluster" {
+  # used filter: a constraint's kind...
+  # created filter: should exist in a constraint's templates spec
+  releases_have_through_needs sc \
+    'select(.apiVersion == "constraints.gatekeeper.sh/v1beta1") | .kind | "ConstraintTemplate/" + .' \
+    'select(.kind == "ConstraintTemplate") | .spec.crd.spec.names.kind | "ConstraintTemplate/" + .'
+}
+
+@test "releases have constraint templates through needs - elastx - workload cluster" {
+  # used filter: a constraint's kind...
+  # created filter: should exist in a constraint's templates spec
+  releases_have_through_needs wc \
+    'select(.apiVersion == "constraints.gatekeeper.sh/v1beta1") | .kind | "ConstraintTemplate/" + .' \
+    'select(.kind == "ConstraintTemplate") | .spec.crd.spec.names.kind | "ConstraintTemplate/" + .'
+}
+
+@test "releases have custom resource definitions through needs - elastx - service cluster" {
+  # used filter: a custom resource's kind...
+  # created filter: should exist in a custom resource definition's templates spec
+  releases_have_through_needs sc \
+    'select(.apiVersion | test("^(.+\.k8s\.io/|apps/|batch/|policy/|constraints.gatekeeper.sh/|)v1.*") | not) | .kind | "CustomResourceDefinition/" + .' \
+    'select(.kind == "CustomResourceDefinition") | .spec.names.kind | "CustomResourceDefinition/" + .'
+}
+
+@test "releases have custom resource definitions through needs - elastx - workload cluster" {
+  # used filter: a custom resource's kind...
+  # created filter: should exist in a custom resource definition's templates spec
+  releases_have_through_needs wc \
+    'select(.apiVersion | test("^(.+\.k8s\.io/|apps/|batch/|policy/|constraints.gatekeeper.sh/|)v1.*") | not) | .kind | "CustomResourceDefinition/" + .' \
+    'select(.kind == "CustomResourceDefinition") | .spec.names.kind | "CustomResourceDefinition/" + .'
+}
+
+@test "releases have namespaces through needs - elastx - service cluster" {
+  # used filter: a resource's namespace (except certain defaults)...
+  # created filter: should exist
+  releases_have_through_needs sc \
+    '.metadata.namespace | select(. != "default" and . != "kube-system" and . != "rook-ceph") | "Namespace/" + .' \
+    'select(.kind == "Namespace") | .metadata.name | "Namespace/" + .'
+}
+
+@test "releases have namespaces through needs - elastx - workload cluster" {
+  # used filter: a resource's namespace (except certain defaults)...
+  # created filter: should exist
+  releases_have_through_needs wc \
+    '.metadata.namespace | select(. != "default" and . != "kube-system" and . != "rook-ceph") | "Namespace/" + .' \
+    'select(.kind == "Namespace") | .metadata.name | "Namespace/" + .'
+}
+
+@test "releases with custom resources have validation on install disabled - elastx - service cluster" {
+  release_with_custom_resources_have_validation_on_install_disabled sc
+}
+
+@test "releases with custom resources have validation on install disabled - elastx - workload cluster" {
+  release_with_custom_resources_have_validation_on_install_disabled wc
+}

--- a/tests/unit/releases/test-exoscale.gen.bats
+++ b/tests/unit/releases/test-exoscale.gen.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/releases/template.bats.gotmpl
+
+# bats file_tags=static,exoscale
+
+setup_file() {
+  load "../../common/lib"
+  load "../../common/lib/env"
+  load "../../common/lib/gpg"
+  load "script"
+
+  gpg.setup
+  env.setup
+
+  env.init prod exoscale
+
+  helmfile_template_releases sc
+  helmfile_template_releases wc
+}
+
+setup() {
+  load "../../common/lib"
+  load "script"
+
+  common_setup
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "releases have constraint templates through needs - exoscale - service cluster" {
+  # used filter: a constraint's kind...
+  # created filter: should exist in a constraint's templates spec
+  releases_have_through_needs sc \
+    'select(.apiVersion == "constraints.gatekeeper.sh/v1beta1") | .kind | "ConstraintTemplate/" + .' \
+    'select(.kind == "ConstraintTemplate") | .spec.crd.spec.names.kind | "ConstraintTemplate/" + .'
+}
+
+@test "releases have constraint templates through needs - exoscale - workload cluster" {
+  # used filter: a constraint's kind...
+  # created filter: should exist in a constraint's templates spec
+  releases_have_through_needs wc \
+    'select(.apiVersion == "constraints.gatekeeper.sh/v1beta1") | .kind | "ConstraintTemplate/" + .' \
+    'select(.kind == "ConstraintTemplate") | .spec.crd.spec.names.kind | "ConstraintTemplate/" + .'
+}
+
+@test "releases have custom resource definitions through needs - exoscale - service cluster" {
+  # used filter: a custom resource's kind...
+  # created filter: should exist in a custom resource definition's templates spec
+  releases_have_through_needs sc \
+    'select(.apiVersion | test("^(.+\.k8s\.io/|apps/|batch/|policy/|constraints.gatekeeper.sh/|)v1.*") | not) | .kind | "CustomResourceDefinition/" + .' \
+    'select(.kind == "CustomResourceDefinition") | .spec.names.kind | "CustomResourceDefinition/" + .'
+}
+
+@test "releases have custom resource definitions through needs - exoscale - workload cluster" {
+  # used filter: a custom resource's kind...
+  # created filter: should exist in a custom resource definition's templates spec
+  releases_have_through_needs wc \
+    'select(.apiVersion | test("^(.+\.k8s\.io/|apps/|batch/|policy/|constraints.gatekeeper.sh/|)v1.*") | not) | .kind | "CustomResourceDefinition/" + .' \
+    'select(.kind == "CustomResourceDefinition") | .spec.names.kind | "CustomResourceDefinition/" + .'
+}
+
+@test "releases have namespaces through needs - exoscale - service cluster" {
+  # used filter: a resource's namespace (except certain defaults)...
+  # created filter: should exist
+  releases_have_through_needs sc \
+    '.metadata.namespace | select(. != "default" and . != "kube-system" and . != "rook-ceph") | "Namespace/" + .' \
+    'select(.kind == "Namespace") | .metadata.name | "Namespace/" + .'
+}
+
+@test "releases have namespaces through needs - exoscale - workload cluster" {
+  # used filter: a resource's namespace (except certain defaults)...
+  # created filter: should exist
+  releases_have_through_needs wc \
+    '.metadata.namespace | select(. != "default" and . != "kube-system" and . != "rook-ceph") | "Namespace/" + .' \
+    'select(.kind == "Namespace") | .metadata.name | "Namespace/" + .'
+}
+
+@test "releases with custom resources have validation on install disabled - exoscale - service cluster" {
+  release_with_custom_resources_have_validation_on_install_disabled sc
+}
+
+@test "releases with custom resources have validation on install disabled - exoscale - workload cluster" {
+  release_with_custom_resources_have_validation_on_install_disabled wc
+}

--- a/tests/unit/releases/test-safespring.gen.bats
+++ b/tests/unit/releases/test-safespring.gen.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/releases/template.bats.gotmpl
+
+# bats file_tags=static,safespring
+
+setup_file() {
+  load "../../common/lib"
+  load "../../common/lib/env"
+  load "../../common/lib/gpg"
+  load "script"
+
+  gpg.setup
+  env.setup
+
+  env.init prod safespring
+
+  helmfile_template_releases sc
+  helmfile_template_releases wc
+}
+
+setup() {
+  load "../../common/lib"
+  load "script"
+
+  common_setup
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "releases have constraint templates through needs - safespring - service cluster" {
+  # used filter: a constraint's kind...
+  # created filter: should exist in a constraint's templates spec
+  releases_have_through_needs sc \
+    'select(.apiVersion == "constraints.gatekeeper.sh/v1beta1") | .kind | "ConstraintTemplate/" + .' \
+    'select(.kind == "ConstraintTemplate") | .spec.crd.spec.names.kind | "ConstraintTemplate/" + .'
+}
+
+@test "releases have constraint templates through needs - safespring - workload cluster" {
+  # used filter: a constraint's kind...
+  # created filter: should exist in a constraint's templates spec
+  releases_have_through_needs wc \
+    'select(.apiVersion == "constraints.gatekeeper.sh/v1beta1") | .kind | "ConstraintTemplate/" + .' \
+    'select(.kind == "ConstraintTemplate") | .spec.crd.spec.names.kind | "ConstraintTemplate/" + .'
+}
+
+@test "releases have custom resource definitions through needs - safespring - service cluster" {
+  # used filter: a custom resource's kind...
+  # created filter: should exist in a custom resource definition's templates spec
+  releases_have_through_needs sc \
+    'select(.apiVersion | test("^(.+\.k8s\.io/|apps/|batch/|policy/|constraints.gatekeeper.sh/|)v1.*") | not) | .kind | "CustomResourceDefinition/" + .' \
+    'select(.kind == "CustomResourceDefinition") | .spec.names.kind | "CustomResourceDefinition/" + .'
+}
+
+@test "releases have custom resource definitions through needs - safespring - workload cluster" {
+  # used filter: a custom resource's kind...
+  # created filter: should exist in a custom resource definition's templates spec
+  releases_have_through_needs wc \
+    'select(.apiVersion | test("^(.+\.k8s\.io/|apps/|batch/|policy/|constraints.gatekeeper.sh/|)v1.*") | not) | .kind | "CustomResourceDefinition/" + .' \
+    'select(.kind == "CustomResourceDefinition") | .spec.names.kind | "CustomResourceDefinition/" + .'
+}
+
+@test "releases have namespaces through needs - safespring - service cluster" {
+  # used filter: a resource's namespace (except certain defaults)...
+  # created filter: should exist
+  releases_have_through_needs sc \
+    '.metadata.namespace | select(. != "default" and . != "kube-system" and . != "rook-ceph") | "Namespace/" + .' \
+    'select(.kind == "Namespace") | .metadata.name | "Namespace/" + .'
+}
+
+@test "releases have namespaces through needs - safespring - workload cluster" {
+  # used filter: a resource's namespace (except certain defaults)...
+  # created filter: should exist
+  releases_have_through_needs wc \
+    '.metadata.namespace | select(. != "default" and . != "kube-system" and . != "rook-ceph") | "Namespace/" + .' \
+    'select(.kind == "Namespace") | .metadata.name | "Namespace/" + .'
+}
+
+@test "releases with custom resources have validation on install disabled - safespring - service cluster" {
+  release_with_custom_resources_have_validation_on_install_disabled sc
+}
+
+@test "releases with custom resources have validation on install disabled - safespring - workload cluster" {
+  release_with_custom_resources_have_validation_on_install_disabled wc
+}

--- a/tests/unit/releases/test-upcloud.gen.bats
+++ b/tests/unit/releases/test-upcloud.gen.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/releases/template.bats.gotmpl
+
+# bats file_tags=static,upcloud
+
+setup_file() {
+  load "../../common/lib"
+  load "../../common/lib/env"
+  load "../../common/lib/gpg"
+  load "script"
+
+  gpg.setup
+  env.setup
+
+  env.init prod upcloud
+
+  helmfile_template_releases sc
+  helmfile_template_releases wc
+}
+
+setup() {
+  load "../../common/lib"
+  load "script"
+
+  common_setup
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "releases have constraint templates through needs - upcloud - service cluster" {
+  # used filter: a constraint's kind...
+  # created filter: should exist in a constraint's templates spec
+  releases_have_through_needs sc \
+    'select(.apiVersion == "constraints.gatekeeper.sh/v1beta1") | .kind | "ConstraintTemplate/" + .' \
+    'select(.kind == "ConstraintTemplate") | .spec.crd.spec.names.kind | "ConstraintTemplate/" + .'
+}
+
+@test "releases have constraint templates through needs - upcloud - workload cluster" {
+  # used filter: a constraint's kind...
+  # created filter: should exist in a constraint's templates spec
+  releases_have_through_needs wc \
+    'select(.apiVersion == "constraints.gatekeeper.sh/v1beta1") | .kind | "ConstraintTemplate/" + .' \
+    'select(.kind == "ConstraintTemplate") | .spec.crd.spec.names.kind | "ConstraintTemplate/" + .'
+}
+
+@test "releases have custom resource definitions through needs - upcloud - service cluster" {
+  # used filter: a custom resource's kind...
+  # created filter: should exist in a custom resource definition's templates spec
+  releases_have_through_needs sc \
+    'select(.apiVersion | test("^(.+\.k8s\.io/|apps/|batch/|policy/|constraints.gatekeeper.sh/|)v1.*") | not) | .kind | "CustomResourceDefinition/" + .' \
+    'select(.kind == "CustomResourceDefinition") | .spec.names.kind | "CustomResourceDefinition/" + .'
+}
+
+@test "releases have custom resource definitions through needs - upcloud - workload cluster" {
+  # used filter: a custom resource's kind...
+  # created filter: should exist in a custom resource definition's templates spec
+  releases_have_through_needs wc \
+    'select(.apiVersion | test("^(.+\.k8s\.io/|apps/|batch/|policy/|constraints.gatekeeper.sh/|)v1.*") | not) | .kind | "CustomResourceDefinition/" + .' \
+    'select(.kind == "CustomResourceDefinition") | .spec.names.kind | "CustomResourceDefinition/" + .'
+}
+
+@test "releases have namespaces through needs - upcloud - service cluster" {
+  # used filter: a resource's namespace (except certain defaults)...
+  # created filter: should exist
+  releases_have_through_needs sc \
+    '.metadata.namespace | select(. != "default" and . != "kube-system" and . != "rook-ceph") | "Namespace/" + .' \
+    'select(.kind == "Namespace") | .metadata.name | "Namespace/" + .'
+}
+
+@test "releases have namespaces through needs - upcloud - workload cluster" {
+  # used filter: a resource's namespace (except certain defaults)...
+  # created filter: should exist
+  releases_have_through_needs wc \
+    '.metadata.namespace | select(. != "default" and . != "kube-system" and . != "rook-ceph") | "Namespace/" + .' \
+    'select(.kind == "Namespace") | .metadata.name | "Namespace/" + .'
+}
+
+@test "releases with custom resources have validation on install disabled - upcloud - service cluster" {
+  release_with_custom_resources_have_validation_on_install_disabled sc
+}
+
+@test "releases with custom resources have validation on install disabled - upcloud - workload cluster" {
+  release_with_custom_resources_have_validation_on_install_disabled wc
+}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This adds test coverage to the needs set on releases, and this should catch errors such as [these](https://github.com/elastisys/compliantkubernetes-apps/pull/2074)

#### Information to reviewers

This takes _**ages**_ to run since it has to render every release that it can, though I've tried to optimise it so that it only ever have to render every release once and then pull it from cache.

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
- Config checks:
  - [ ] The schema was updated
