### PR TITLE
apps: Upgrade prometheus blackbox exporter to chart v8.13.0

### DIFF
--- a/helmfile.d/upstream/index.yaml
+++ b/helmfile.d/upstream/index.yaml
@@ -66,7 +66,7 @@ charts:
   projectcalico/tigera-operator: v3.26.4
 
   prometheus-community/kube-prometheus-stack: 56.6.2
-  prometheus-community/prometheus-blackbox-exporter: 8.2.0
+  prometheus-community/prometheus-blackbox-exporter: 8.13.0
   prometheus-community/prometheus-elasticsearch-exporter: 5.1.1
 
   vmware-tanzu/velero: 4.1.5

--- a/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/Chart.yaml
+++ b/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/Chart.yaml
@@ -20,4 +20,4 @@ sources:
 - https://github.com/prometheus/blackbox_exporter
 - https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-blackbox-exporter
 type: application
-version: 8.2.0
+version: 8.13.0

--- a/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/ci/config-reloader-values.yaml
+++ b/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/ci/config-reloader-values.yaml
@@ -1,0 +1,2 @@
+configReloader:
+  enabled: true

--- a/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/_helpers.tpl
+++ b/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/_helpers.tpl
@@ -101,3 +101,205 @@ The image to use
 {{- .Values.image.repository -}}:{{- .Values.image.tag | default .Chart.AppVersion -}}
 {{- with .Values.image.digest -}}@{{ .}}{{- end -}}
 {{- end -}}
+
+{{/*
+The image to use
+*/}}
+{{- define "prometheus-blackbox-exporter.config-reloader.image" -}}
+{{- with (.Values.global.imageRegistry | default .Values.configReloader.image.registry) -}}{{ . }}/{{- end }}
+{{- .Values.configReloader.image.repository -}}:{{- .Values.configReloader.image.tag -}}
+{{- with .Values.configReloader.image.digest -}}@{{ .}}{{- end -}}
+{{- end -}}
+
+{{/*
+Define pod spec to be reused by highlevel resources (deployment, daemonset)
+*/}}
+{{- define "prometheus-blackbox-exporter.podSpec" -}}
+automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+serviceAccountName: {{ template "prometheus-blackbox-exporter.serviceAccountName" . }}
+{{- with .Values.topologySpreadConstraints }}
+topologySpreadConstraints:
+{{ toYaml . }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.tolerations }}
+tolerations:
+{{ toYaml . }}
+{{- end }}
+{{- if .Values.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+- name: {{ . }}
+{{- end }}
+{{- end }}
+{{- if .Values.hostAliases }}
+hostAliases:
+{{- range .Values.hostAliases }}
+- ip: {{ .ip }}
+  hostnames:
+  {{- range .hostNames }}
+  - {{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}
+restartPolicy: {{ .Values.restartPolicy }}
+{{- with .Values.priorityClassName }}
+priorityClassName: "{{ . }}"
+{{- end }}
+{{- with .Values.podSecurityContext }}
+securityContext:
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{- with .Values.extraInitContainers }}
+initContainers:
+{{- if kindIs "string" . }}
+  {{- tpl . $ | nindent 2 }}
+{{- else }}
+  {{-  toYaml . | nindent 2 }}
+{{- end -}}
+{{- end }}
+
+containers:
+{{ with .Values.extraContainers }}
+{{- if kindIs "string" . }}
+  {{- tpl . $ }}
+{{- else }}
+  {{-  toYaml . }}
+{{- end -}}
+{{- end }}
+
+{{- if .Values.configReloader.enabled }}
+- name: config-reloader
+  image: {{ include "prometheus-blackbox-exporter.config-reloader.image" . }}
+  imagePullPolicy: {{ .Values.configReloader.image.pullPolicy }}
+  args:
+    - --config-file={{ .Values.configPath | default "/config/blackbox.yaml" }}
+    - --watch-interval={{ .Values.configReloader.config.watchInterval }}
+    - --reload-url=http://127.0.0.1:{{ .Values.containerPort }}/-/reload
+    - --listen-address=:{{ .Values.configReloader.containerPort }}
+    - --log-format={{ .Values.configReloader.config.logFormat }}
+    - --log-level={{ .Values.configReloader.config.logLevel }}
+  {{- with .Values.resources }}
+  resources:
+{{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: reloader-web
+      containerPort: {{ .Values.configReloader.containerPort }}
+      protocol: TCP
+  livenessProbe:
+    {{- toYaml .Values.configReloader.livenessProbe | nindent 4 }}
+  readinessProbe:
+    {{- toYaml .Values.configReloader.readinessProbe | nindent 4 }}
+  volumeMounts:
+    - mountPath: /config
+      name: config
+  {{- with .Values.configReloader.securityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+- name: blackbox-exporter
+  image: {{ include "prometheus-blackbox-exporter.image" . }}
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
+  {{- with .Values.securityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  env:
+  {{- range $key, $value := .Values.extraEnv }}
+  - name: {{ $key }}
+    value: {{ $value | quote }}
+  {{- end }}
+  {{- if .Values.extraEnvFromSecret }}
+  envFrom:
+  {{- range .Values.extraEnvFromSecret }}
+    - secretRef:
+        name: {{ . }}
+  {{- end }}
+  {{- end }}
+  args:
+  {{- if .Values.config }}
+  {{- if .Values.configPath }}
+  - "--config.file={{ .Values.configPath }}"
+  {{- else }}
+  - "--config.file=/config/blackbox.yaml"
+  {{- end }}
+  {{- else }}
+  - "--config.file=/etc/blackbox_exporter/config.yml"
+  {{- end }}
+  {{- with .Values.extraArgs }}
+{{ tpl (toYaml .) $ | indent 2 }}
+  {{- end }}
+  {{- with .Values.resources }}
+  resources:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  ports:
+  - containerPort: {{ .Values.containerPort }}
+    name: http
+  livenessProbe:
+  {{- toYaml .Values.livenessProbe | trim | nindent 4 }}
+  readinessProbe:
+  {{- toYaml .Values.readinessProbe | trim | nindent 4 }}
+  volumeMounts:
+  - mountPath: /config
+    name: config
+  {{- range .Values.extraConfigmapMounts }}
+  - name: {{ .name }}
+    mountPath: {{ .mountPath }}
+    subPath: {{ .subPath | default "" }}
+    readOnly: {{ .readOnly }}
+  {{- end }}
+  {{- range .Values.extraSecretMounts }}
+  - name: {{ .name }}
+    mountPath: {{ .mountPath }}
+    subPath: {{ .subPath }}
+    readOnly: {{ .readOnly }}
+  {{- end }}
+  {{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 2 }}
+  {{- end }}
+  {{- if .Values.dnsPolicy }}
+dnsPolicy: {{ .Values.dnsPolicy | toString }}
+{{- end }}
+hostNetwork: {{ .Values.hostNetwork }}
+{{- with .Values.dnsConfig }}
+dnsConfig:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+volumes:
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes }}
+{{- end }}
+- name: config
+{{- if .Values.secretConfig }}
+  secret:
+    secretName: {{ template "prometheus-blackbox-exporter.fullname" . }}
+{{- else if .Values.configExistingSecretName }}
+  secret:
+    secretName: {{ .Values.configExistingSecretName }}
+{{- else }}
+  configMap:
+    name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+{{- end }}
+{{- range .Values.extraConfigmapMounts }}
+- name: {{ .name }}
+  configMap:
+    name: {{ .configMap }}
+    defaultMode: {{ .defaultMode }}
+{{- end }}
+{{- range .Values.extraSecretMounts }}
+- name: {{ .name }}
+  secret:
+    secretName: {{ .secretName }}
+    defaultMode: {{ .defaultMode }}
+{{- end }}
+{{- end -}}

--- a/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/configmap.yaml
+++ b/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/configmap.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
     {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
+  {{- if and .Values.secretConfig .Values.secretAnnotations }}
+  annotations:
+    {{- toYaml .Values.secretAnnotations | nindent 4 }}
+  {{- end }}
 {{ if .Values.secretConfig -}} stringData: {{- else -}} data: {{- end }}
   blackbox.yaml: |
 {{ toYaml .Values.config | indent 4 }}

--- a/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/daemonset.yaml
+++ b/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/daemonset.yaml
@@ -13,134 +13,19 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "prometheus-blackbox-exporter.labels" . | nindent 8 }}
+        {{- include "prometheus-blackbox-exporter.selectorLabels" . | nindent 8 }}
         {{- if .Values.pod.labels }}
 {{ toYaml .Values.pod.labels | indent 8 }}
         {{- end }}
+      {{- if or (not .Values.configReloader.enabled) .Values.podAnnotations }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if not .Values.configReloader.enabled }}
+        checksum/config: {{ toYaml .Values.config | sha256sum }}
+        {{- end }}
         {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
         {{- end }}
+      {{- end }}
     spec:
-      serviceAccountName: {{ template "prometheus-blackbox-exporter.serviceAccountName" . }}
-    {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
-    {{- if .Values.affinity }}
-      affinity:
-{{ toYaml .Values.affinity | indent 8 }}
-    {{- end }}
-    {{- if .Values.tolerations }}
-      tolerations:
-{{ toYaml .Values.tolerations | indent 6 }}
-    {{- end }}
-    {{- if .Values.image.pullSecrets }}
-      imagePullSecrets:
-      {{- range .Values.image.pullSecrets }}
-        - name: {{ . }}
-      {{- end }}
-    {{- end }}
-      {{- if .Values.hostAliases }}
-      hostAliases:
-        {{- range .Values.hostAliases }}
-        - ip: {{ .ip }}
-          hostnames:
-          {{- range .hostNames }}
-          - {{ . }}
-          {{- end }}
-        {{- end }}
-      {{- end }}
-      restartPolicy: {{ .Values.restartPolicy }}
-
-      {{- if .Values.priorityClassName }}
-      priorityClassName: "{{ .Values.priorityClassName }}"
-      {{- end }}
-      {{- if .Values.extraInitContainers }}
-      initContainers:
-{{ toYaml .Values.extraInitContainers | indent 8 }}
-      {{- end }}
-      containers:
-        - name: blackbox-exporter
-          image: {{ include "prometheus-blackbox-exporter.image" . }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.securityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          env:
-          {{- range $key, $value := .Values.extraEnv }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-          {{- end }}
-          args:
-{{- if (or .Values.config .Values.configExistingSecretName) }}
-   {{- if .Values.configPath }}
-            - "--config.file={{ .Values.configPath }}"
-   {{- else }}
-            - "--config.file=/config/blackbox.yaml"
-   {{- end }}
-{{- else }}
-            - "--config.file=/etc/blackbox_exporter/config.yml"
-{{- end }}
-        {{- if .Values.extraArgs }}
-{{ toYaml .Values.extraArgs | indent 12 }}
-        {{- end }}
-          resources:
-{{ toYaml .Values.resources | indent 12 }}
-          ports:
-            - containerPort: {{ .Values.service.port }}
-              name: http
-          livenessProbe:
-            {{- toYaml .Values.livenessProbe | trim | nindent 12 }}
-          readinessProbe:
-            {{- toYaml .Values.readinessProbe | trim | nindent 12 }}
-          volumeMounts:
-            - mountPath: /config
-              name: config
-          {{- range .Values.extraConfigmapMounts }}
-            - name: {{ .name }}
-              mountPath: {{ .mountPath }}
-              subPath: {{ .subPath | default "" }}
-              readOnly: {{ .readOnly }}
-          {{- end }}
-          {{- range .Values.extraSecretMounts }}
-            - name: {{ .name }}
-              mountPath: {{ .mountPath }}
-              subPath: {{ .subPath }}
-              readOnly: {{ .readOnly }}
-          {{- end }}
-{{- if .Values.dnsPolicy }}
-      dnsPolicy: {{ .Values.dnsPolicy | toString }}
-{{- end }}
-      hostNetwork: {{ .Values.hostNetwork }}
-{{- if .Values.dnsConfig }}
-      dnsConfig:
-        {{- toYaml .Values.dnsConfig | nindent 8 }}
-{{- end }}
-      volumes:
-        - name: config
-{{- if .Values.secretConfig }}
-          secret:
-            secretName: {{ template "prometheus-blackbox-exporter.fullname" . }}
-{{- else if .Values.configExistingSecretName }}
-          secret:
-            secretName: {{ .Values.configExistingSecretName }}
-{{- else }}
-          configMap:
-            name: {{ template "prometheus-blackbox-exporter.fullname" . }}
-{{- end }}
-      {{- range .Values.extraConfigmapMounts }}
-        - name: {{ .name }}
-          configMap:
-            name: {{ .configMap }}
-            defaultMode: {{ .defaultMode }}
-      {{- end }}
-      {{- range .Values.extraSecretMounts }}
-        - name: {{ .name }}
-          secret:
-            secretName: {{ .secretName }}
-            defaultMode: {{ .defaultMode }}
-      {{- end }}
+    {{- include "prometheus-blackbox-exporter.podSpec" . | nindent 6 }}
 {{- end }}

--- a/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ template "prometheus-blackbox-exporter.namespace" . }}
   labels:
     {{- include "prometheus-blackbox-exporter.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
@@ -16,150 +20,19 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "prometheus-blackbox-exporter.labels" . | nindent 8 }}
+        {{- include "prometheus-blackbox-exporter.selectorLabels" . | nindent 8 }}
         {{- if .Values.pod.labels }}
 {{ toYaml .Values.pod.labels | indent 8 }}
         {{- end }}
+      {{- if or (not .Values.configReloader.enabled) .Values.podAnnotations }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if not .Values.configReloader.enabled }}
+        checksum/config: {{ toYaml .Values.config | sha256sum }}
+        {{- end }}
         {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
         {{- end }}
+      {{- end }}
     spec:
-      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
-      serviceAccountName: {{ template "prometheus-blackbox-exporter.serviceAccountName" . }}
-    {{- with .Values.topologySpreadConstraints }}
-      topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- if .Values.image.pullSecrets }}
-      imagePullSecrets:
-      {{- range .Values.image.pullSecrets }}
-        - name: {{ . }}
-      {{- end }}
-    {{- end }}
-      {{- if .Values.hostAliases }}
-      hostAliases:
-        {{- range .Values.hostAliases }}
-        - ip: {{ .ip }}
-          hostnames:
-          {{- range .hostNames }}
-          - {{ . }}
-          {{- end }}
-        {{- end }}
-      {{- end }}
-      restartPolicy: {{ .Values.restartPolicy }}
-
-      {{- if .Values.priorityClassName }}
-      priorityClassName: "{{ .Values.priorityClassName }}"
-      {{- end }}
-      securityContext:
-{{ toYaml .Values.podSecurityContext | indent 8 }}
-      {{- if .Values.extraInitContainers }}
-      initContainers:
-{{ toYaml .Values.extraInitContainers | indent 8 }}
-      {{- end }}
-      containers:
-        {{- if .Values.extraContainers }}
-{{ toYaml .Values.extraContainers | indent 8 }}
-        {{- end }}
-        - name: blackbox-exporter
-          image: {{ include "prometheus-blackbox-exporter.image" . }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.securityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          env:
-          {{- range $key, $value := .Values.extraEnv }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-          {{- end }}
-          args:
-{{- if .Values.config }}
-   {{- if .Values.configPath }}
-            - "--config.file={{ .Values.configPath }}"
-   {{- else }}
-            - "--config.file=/config/blackbox.yaml"
-   {{- end }}
-{{- else }}
-            - "--config.file=/etc/blackbox_exporter/config.yml"
-{{- end }}
-        {{- if .Values.extraArgs }}
-{{ toYaml .Values.extraArgs | indent 12 }}
-        {{- end }}
-          resources:
-{{ toYaml .Values.resources | indent 12 }}
-          ports:
-            - containerPort: {{ .Values.containerPort }}
-              name: http
-          livenessProbe:
-            {{- toYaml .Values.livenessProbe | trim | nindent 12 }}
-          readinessProbe:
-            {{- toYaml .Values.readinessProbe | trim | nindent 12 }}
-          volumeMounts:
-            - mountPath: /config
-              name: config
-          {{- range .Values.extraConfigmapMounts }}
-            - name: {{ .name }}
-              mountPath: {{ .mountPath }}
-              subPath: {{ .subPath | default "" }}
-              readOnly: {{ .readOnly }}
-          {{- end }}
-          {{- range .Values.extraSecretMounts }}
-            - name: {{ .name }}
-              mountPath: {{ .mountPath }}
-              subPath: {{ .subPath }}
-              readOnly: {{ .readOnly }}
-          {{- end }}
-          {{- if .Values.extraVolumeMounts }}
-{{ toYaml .Values.extraVolumeMounts | indent 12 }}
-          {{- end }}
-{{- if .Values.dnsPolicy }}
-      dnsPolicy: {{ .Values.dnsPolicy | toString }}
-{{- end }}
-      hostNetwork: {{ .Values.hostNetwork }}
-{{- if .Values.dnsConfig }}
-      dnsConfig:
-        {{- toYaml .Values.dnsConfig | nindent 8 }}
-{{- end }}
-      volumes:
-    {{- if .Values.extraVolumes }}
-{{ toYaml .Values.extraVolumes | indent 8 }}
-    {{- end }}
-        - name: config
-{{- if .Values.secretConfig }}
-          secret:
-            secretName: {{ template "prometheus-blackbox-exporter.fullname" . }}
-{{- else if .Values.configExistingSecretName }}
-          secret:
-            secretName: {{ .Values.configExistingSecretName }}
-{{- else }}
-          configMap:
-            name: {{ template "prometheus-blackbox-exporter.fullname" . }}
-{{- end }}
-      {{- range .Values.extraConfigmapMounts }}
-        - name: {{ .name }}
-          configMap:
-            name: {{ .configMap }}
-            defaultMode: {{ .defaultMode }}
-      {{- end }}
-      {{- range .Values.extraSecretMounts }}
-        - name: {{ .name }}
-          secret:
-            secretName: {{ .secretName }}
-            defaultMode: {{ .defaultMode }}
-      {{- end }}
+    {{- include "prometheus-blackbox-exporter.podSpec" . | nindent 6 }}
 {{- end }}

--- a/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/podmonitoring.yaml
+++ b/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/podmonitoring.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.podMonitoring.enabled }}
+{{- range .Values.podMonitoring.targets }}
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: {{ template "prometheus-blackbox-exporter.fullname" $ }}-{{ .name }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" $ }}
+  labels:
+    {{- include "prometheus-blackbox-exporter.labels" $ | nindent 4 }}
+    {{- if or $.Values.podMonitoring.defaults.labels .labels }}
+    {{- toYaml (.labels | default $.Values.podMonitoring.defaults.labels) | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - port: http
+    scheme: {{ $.Values.podMonitoring.scheme }}
+    {{- if $.Values.podMonitoring.tlsConfig }}
+    tls: {{ toYaml $.Values.podMonitoring.tlsConfig | nindent 6 }}
+    {{- end }}
+    path: {{ $.Values.podMonitoring.path }}
+    interval: {{ .interval | default $.Values.podMonitoring.defaults.interval }}
+    timeout: {{ .scrapeTimeout | default $.Values.podMonitoring.defaults.scrapeTimeout }}
+    params:
+      module:
+      - {{ .module | default $.Values.podMonitoring.defaults.module }}
+      target:
+      - {{ .url }}
+      {{- if .hostname }}
+      hostname:
+      - {{ .hostname }}
+      {{- end }}
+    metricRelabeling:
+      - action: replace
+        targetLabel: target
+        replacement: {{ .url }}
+      - action: replace
+        targetLabel: name
+        replacement: {{ .name }}
+        {{- range $targetLabel, $replacement := .additionalMetricsRelabels | default $.Values.podMonitoring.defaults.additionalMetricsRelabels }}
+      - action: replace
+        targetLabel: {{ $targetLabel | quote }}
+        replacement: {{ $replacement | quote }}
+        {{- end }}
+  selector:
+    matchLabels:
+      {{- include "prometheus-blackbox-exporter.selectorLabels" $ | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/selfpodmonitoring.yaml
+++ b/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/selfpodmonitoring.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.podMonitoring.selfMonitor.enabled }}
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: {{ template "prometheus-blackbox-exporter.fullname" $ }}
+  namespace: {{ template "prometheus-blackbox-exporter.namespace" $ }}
+  labels:
+    {{- include "prometheus-blackbox-exporter.labels" $ | nindent 4 }}
+    {{- if .Values.podMonitoring.selfMonitor.labels  }}
+    {{- toYaml (.Values.podMonitoring.selfMonitor.labels) | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - port: http
+    scheme: {{ $.Values.podMonitoring.scheme }}
+    path: {{ .Values.podMonitoring.selfMonitor.path }}
+    interval: {{ .Values.podMonitoring.selfMonitor.interval }}
+    timeout: {{ .Values.podMonitoring.selfMonitor.scrapeTimeout }}
+
+{{- if .Values.podMonitoring.selfMonitor.additionalMetricsRelabels }}
+    metricRelabeling:
+      {{- range $targetLabel, $replacement := .Values.podMonitoring.selfMonitor.additionalMetricsRelabels | default $.Values.podMonitoring.defaults.additionalMetricsRelabels }}
+      - action: replace
+        targetLabel: {{ $targetLabel | quote }}
+        replacement: {{ $replacement | quote }}
+      {{- end }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "prometheus-blackbox-exporter.selectorLabels" $ | nindent 6 }}
+{{- end }}

--- a/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/selfservicemonitor.yaml
+++ b/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/selfservicemonitor.yaml
@@ -16,11 +16,23 @@ spec:
     interval: {{ .Values.serviceMonitor.selfMonitor.interval }}
     scrapeTimeout: {{ .Values.serviceMonitor.selfMonitor.scrapeTimeout }}
     scheme: http
-
-{{- if .Values.serviceMonitor.selfMonitor.additionalRelabeling }}
+    {{- with .Values.serviceMonitor.selfMonitor.port }}
+    port: {{ . }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.selfMonitor.additionalRelabeling }}
     relabelings:
-{{ toYaml .Values.serviceMonitor.selfMonitor.additionalRelabeling | indent 6 }}
-{{- end }}
+      {{- toYaml .Values.serviceMonitor.selfMonitor.additionalRelabeling | nindent 6 }}
+    {{- end }}
+  {{- if .Values.configReloader.enabled }}
+  - path: {{ .Values.configReloader.serviceMonitor.selfMonitor.path }}
+    interval: {{ .Values.configReloader.serviceMonitor.selfMonitor.interval }}
+    scrapeTimeout: {{ .Values.configReloader.serviceMonitor.selfMonitor.scrapeTimeout }}
+    scheme: http
+    {{- if .Values.configReloader.serviceMonitor.selfMonitor.additionalRelabeling }}
+    relabelings:
+      {{- toYaml .Values.configReloader.serviceMonitor.selfMonitor.additionalRelabeling | indent 6 }}
+    {{- end }}
+  {{- end }}
   jobLabel: "{{ .Release.Name }}"
   selector:
     matchLabels:
@@ -28,4 +40,5 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ template "prometheus-blackbox-exporter.namespace" $ }}
+
 {{- end }}

--- a/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/service.yaml
+++ b/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/service.yaml
@@ -13,12 +13,22 @@ metadata:
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
 spec:
+{{- if .Values.service.ipDualStack.enabled }}
+  ipFamilies: {{ toYaml .Values.service.ipDualStack.ipFamilies | nindent 4 }}
+  ipFamilyPolicy: {{ .Values.service.ipDualStack.ipFamilyPolicy }}
+{{- end }}
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
       name: http
+    {{ if .Values.configReloader.enabled }}
+    - port: {{ .Values.configReloader.service.port }}
+      targetPort: reloader-web
+      protocol: TCP
+      name: reloader-web
+    {{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}

--- a/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/servicemonitor.yaml
+++ b/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/templates/servicemonitor.yaml
@@ -37,12 +37,15 @@ spec:
       - sourceLabels: [instance]
         targetLabel: instance
         replacement: {{ .url }}
+        action: replace
       - sourceLabels: [target]
         targetLabel: target
         replacement: {{ .name }}
+        action: replace
         {{- range $targetLabel, $replacement := .additionalMetricsRelabels | default $.Values.serviceMonitor.defaults.additionalMetricsRelabels }}
       - targetLabel: {{ $targetLabel | quote }}
         replacement: {{ $replacement | quote }}
+        action: replace
         {{- end }}
 {{- if concat (.additionalRelabeling | default list) $.Values.serviceMonitor.defaults.additionalRelabeling }}
     relabelings:

--- a/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/values.yaml
+++ b/helmfile.d/upstream/prometheus-community/prometheus-blackbox-exporter/values.yaml
@@ -31,6 +31,12 @@ automountServiceAccountToken: false
 ##   NO_PROXY: "localhost,127.0.0.1"
 extraEnv: {}
 
+## Additional blackbox-exporter container environment variables for secret
+## extraEnvFromSecret:
+##   - secretOne
+##   - secretTwo
+extraEnvFromSecret: ""
+
 extraVolumes: []
   # - name: secret-blackbox-oauth-htpasswd
   #   secret:
@@ -46,9 +52,12 @@ extraVolumeMounts:
   #   mountPath: /etc/ssl/certs/ca-certificates.crt
 
 ## Additional InitContainers to initialize the pod
-##
+## This supports either a structured array or a templatable string
 extraInitContainers: []
 
+## This supports either a structured array or a templatable string
+
+# Array mode
 extraContainers: []
   # - name: oAuth2-proxy
   #   args:
@@ -69,6 +78,16 @@ extraContainers: []
   #   volumeMounts:
   #     - mountPath: /etc/prometheus/secrets/blackbox-tls
   #       name: secret-blackbox-tls
+
+# String mode
+# extraContainers: |-
+#   - name: oAuth2-proxy
+#     args:
+#       - -https-address=:9116
+#       - -upstream=http://localhost:9115
+#       - -skip-auth-regex=^/metrics
+#       - -openshift-delegate-urls={"/":{"group":"monitoring.coreos.com","resource":"prometheuses","verb":"get"}}
+#     image: {{ .Values.global.imageRegistry }}/openshift/oauth-proxy:v1.1.0
 
 ## Enable pod security policy
 pspEnabled: true
@@ -185,6 +204,10 @@ service:
   labels: {}
   type: ClusterIP
   port: 9115
+  ipDualStack:
+    enabled: false
+    ipFamilies: ["IPv6", "IPv4"]
+    ipFamilyPolicy: "PreferDualStack"
 
 # Only changes container port. Application port can be changed with extraArgs (--web.listen-address=:9115)
 # https://github.com/prometheus/blackbox_exporter/blob/998037b5b40c1de5fee348ffdea8820509d85171/main.go#L55
@@ -223,6 +246,12 @@ ingress:
 
 podAnnotations: {}
 
+# Annotations for the Deployment
+deploymentAnnotations: {}
+
+# Annotations for the Secret
+secretAnnotations: {}
+
 # Hostaliases allow to add additional DNS entries to be injected directly into pods.
 # This will take precedence over your implemented DNS solution
 hostAliases: []
@@ -251,6 +280,8 @@ serviceMonitor:
     path: /metrics
     interval: 30s
     scrapeTimeout: 30s
+    ## Port can be defined by assigning a value for the port key below
+    ## port:
 
   ## If true, a ServiceMonitor CRD is created for a prometheus operator
   ## https://github.com/coreos/prometheus-operator for each target
@@ -292,6 +323,49 @@ prometheusRule:
   additionalLabels: {}
   namespace: ""
   rules: []
+
+podMonitoring:
+  ## If true, a PodMonitoring CR is created for google managed prometheus
+  ## https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#gmp-pod-monitoring for blackbox-exporter itself
+  ##
+  selfMonitor:
+    enabled: false
+    additionalMetricsRelabels: {}
+    labels: {}
+    path: /metrics
+    interval: 30s
+    scrapeTimeout: 30s
+
+  ## If true, a PodMonitoring CR is created for a google managed prometheus
+  ## https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#gmp-pod-monitoring for each target
+  ##
+  enabled: false
+
+  ## Default values that will be used for all PodMonitoring created by `targets`
+  ## Following PodMonitoring API specs https://github.com/GoogleCloudPlatform/prometheus-engine/blob/main/doc/api.md#scrapeendpoint
+  defaults:
+    additionalMetricsRelabels: {}
+    labels: {}
+    interval: 30s
+    scrapeTimeout: 30s
+    module: http_2xx
+  ## scheme: Protocol scheme to use to scrape.
+  scheme: http
+  ## path: HTTP path. Needs to be adjusted, if web.route-prefix is set
+  path: "/probe"
+  ## tlsConfig: TLS configuration to use when scraping the endpoint. For example if using istio mTLS.
+  ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
+  tlsConfig: {}
+
+  targets:
+#    - name: example                    # Human readable URL that will appear in Google Managed Prometheus / AlertManager
+#      url: http://example.com/healthz  # The URL that blackbox will scrape
+#      hostname: example.com            # HTTP probes can accept an additional `hostname` parameter that will set `Host` header and TLS SNI
+#      labels: {}                       # Map of labels for PodMonitoring. Overrides value set in `defaults`
+#      interval: 60s                    # Scraping interval. Overrides value set in `defaults`
+#      scrapeTimeout: 60s               # Scrape timeout. Overrides value set in `defaults`
+#      module: http_2xx                 # Module used for scraping. Overrides value set in `defaults`
+#      additionalMetricsRelabels: {}    # Map of metric labels and values to add
 
 ## Network policy for chart
 networkPolicy:
@@ -350,3 +424,50 @@ verticalPodAutoscaler:
     # Specifies whether recommended updates are applied when a Pod is started and whether recommended updates
     # are applied during the life of a Pod. Possible values are "Off", "Initial", "Recreate", and "Auto".
     updateMode: Auto
+
+configReloader:
+  enabled: false
+  containerPort: 8080
+  config:
+    logFormat: logfmt
+    logLevel: info
+    watchInterval: 1m
+  image:
+    registry: quay.io
+    repository: prometheus-operator/prometheus-config-reloader
+    tag: "v0.71.2"
+    pullPolicy: IfNotPresent
+    digest: ""
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+  resources:
+    limits:
+      memory: 50Mi
+    requests:
+      cpu: 10m
+      memory: 20Mi
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: reloader-web
+      scheme: HTTP
+  readinessProbe:
+    httpGet:
+      path: /healthz
+      port: reloader-web
+      scheme: HTTP
+  service:
+    port: 8080
+  serviceMonitor:
+    selfMonitor:
+      additionalMetricsRelabels: {}
+      additionalRelabeling: []
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 30s


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Upgrades prometheus-blackbox-exporter chart version from 8.2.0 to 8.13.0. Still same app version v0.24.0.
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1902 

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [x] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [x] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [x] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
- Config checks:
  - [ ] The schema was updated
