### PR TITLE
Fix yajsv version flag for install-requirements

### DIFF
--- a/roles/get-requirements.yaml
+++ b/roles/get-requirements.yaml
@@ -43,6 +43,7 @@
         version: "{{ yajsv_version }}"
         url: https://github.com/neilpa/yajsv/releases/download/v{{ yajsv_version }}/yajsv.linux.amd64
         dest: "{{ install_path }}/yajsv"
+        version_flag: "-v"
 
   connection: local
   become: yes

--- a/roles/get-url.yaml
+++ b/roles/get-url.yaml
@@ -4,7 +4,7 @@
   register: command_exists
 
 - name: Check {{ item.dest }}
-  command: "{{ item.command }} --version"
+  command: "{{ item.command }} {{ item.version_flag | d('--version') }}"
   register: current_command_version
   ignore_errors: yes
   when: command_exists.stat.exists


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

When running `bin/ck8s install-requirements` I got the following error message:

```
TASK [Check /usr/local/bin/yajsv] *******************************************************************************************************************************************************************************************************
fatal: [127.0.0.1]: FAILED! => changed=true 
  cmd:
  - yajsv
  - --version
  delta: '0:00:00.002940'
  end: '2024-04-18 10:26:06.807610'
  msg: non-zero return code
  rc: 2
  start: '2024-04-18 10:26:06.804670'
  stderr: |-
    flag provided but not defined: -version
    Usage: yajsv -s schema.(json|yml) [options] document.(json|yml) ...
...
  
    Options:
  
...
      -v    print version and exit
```

As the error message states `yajsv` does not support `--version` flag, but instead `-v` is supported. This PR fixes so that it is possible to specify a `version_flag` for the `get-url.yaml` playbook when checking version, and if not specified it will default to the previous behavior and use `--version`.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
- Config checks:
  - [ ] The schema was updated
