### PR TITLE
Add S3 object storage total size alert

### DIFF
--- a/config/config/sc-config.yaml
+++ b/config/config/sc-config.yaml
@@ -423,7 +423,13 @@ prometheus:
   retention:
     alertmanager: 72h
   s3BucketAlerts:
+    # alert on each individual bucket
     size:
+      enabled: false
+      percent: 80
+      sizeQuotaGB: 1000
+    # alert for the total size of all buckets combined
+    totalSize:
       enabled: false
       percent: 80
       sizeQuotaGB: 1000

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/daily-checks.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/daily-checks.yaml
@@ -29,6 +29,18 @@ spec:
       labels:
         severity: warning
 {{- end }}
+{{- if .Values.s3BucketAlerts.totalSize.enabled }}
+    - alert: S3BucketsTotalSizeOver{{.Values.s3BucketAlerts.totalSize.percent}}Percent
+      annotations:
+        message: Over {{.Values.s3BucketAlerts.totalSize.percent}} percent for the total size of all s3 buckets.
+      expr: |-
+        (
+          sum(max_over_time(s3_objects_size_sum_bytes[1h])) >= ({{ .Values.s3BucketAlerts.totalSize.sizeQuotaGB }} * (1024^3)) * ({{ .Values.s3BucketAlerts.totalSize.percent }} / 100)
+        )
+      for: 1h
+      labels:
+        severity: warning
+{{- end }}
 {{- if .Values.s3BucketAlerts.objects.enabled }}
     - alert: S3BucketObjectsOver{{.Values.s3BucketAlerts.objects.percent}}Percent
       annotations:

--- a/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
@@ -63,6 +63,10 @@ s3BucketAlerts:
     enabled: {{ .Values.prometheus.s3BucketAlerts.size.enabled }}
     percent: {{ .Values.prometheus.s3BucketAlerts.size.percent }}
     sizeQuotaGB: {{ .Values.prometheus.s3BucketAlerts.size.sizeQuotaGB }}
+  totalSize:
+    enabled: {{ .Values.prometheus.s3BucketAlerts.totalSize.enabled }}
+    percent: {{ .Values.prometheus.s3BucketAlerts.totalSize.percent }}
+    sizeQuotaGB: {{ .Values.prometheus.s3BucketAlerts.totalSize.sizeQuotaGB }}
   objects:
     enabled: {{ .Values.prometheus.s3BucketAlerts.objects.enabled }}
     percent: {{ .Values.prometheus.s3BucketAlerts.objects.percent }}

--- a/migration/v0.38/README.md
+++ b/migration/v0.38/README.md
@@ -109,10 +109,16 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     export CK8S_CLUSTER=<wc|sc|both>
     ```
 
+1. Check if environment is running on Upcloud with S3 object storage V1, and if so enable total size of all S3 buckets alert:
+
+    ```bash
+    ./migration/v0.38/prepare/30-check-upcloud-s3-version.sh
+    ```
+
 1. Update service and rclone networkpolicies:
 
     ```bash
-    ./migration/v0.37/prepare/40-service-rclone-netpol.sh
+    ./migration/v0.38/prepare/40-service-rclone-netpol.sh
     ```
 
 1. Update apps configuration:
@@ -143,7 +149,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 1. Upgrade service and rclone networkpolicies:
 
     ```bash
-    ./migration/v0.37/apply/70-service-rclone-netpol.sh execute
+    ./migration/v0.38/apply/70-service-rclone-netpol.sh execute
     ```
 
 1. Upgrade applications:

--- a/migration/v0.38/prepare/30-check-upcloud-s3-version.sh
+++ b/migration/v0.38/prepare/30-check-upcloud-s3-version.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+  cloud_provider=$(yq_dig sc .global.ck8sCloudProvider)
+  if [[ "${cloud_provider}" != "upcloud" ]]; then
+    log_info "not running on upcloud, skipping"
+    exit 0
+  fi
+
+  log_info "checking if using upcloud object storage v1 as it has a 1TB quota"
+
+  s3_region_endpoint=$(yq_dig sc .objectStorage.s3.regionEndpoint)
+  if [[ "${s3_region_endpoint}" =~ ((.+\.){2}upcloudobjects\.com) ]]; then
+    log_info "enabling total s3 size of all buckets alert"
+
+    yq_add sc .prometheus.s3BucketAlerts.totalSize.enabled true
+    yq_add sc .prometheus.s3BucketAlerts.totalSize.sizeQuotaGB 1000
+  fi
+fi


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Add additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This PR adds a new alert for whenever the total size of all S3 buckets exceeds a set quota. The alert is disabled by default and can be enabled with `s3BucketAlerts.totalSize.percent`. There is a migration script that will enable the alert for Upcloud environments that have a S3 region endpoint in the format of Upcloud's object storage v1 (i.e. `<object-storage-name>.<region>.upcloudobjects.com` instead of the newer object storage which should have endpoints in the format of `<random-generated-prefix>.upcloudobjects.com`).

- Fixes #2071 

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
- Config checks:
  - [ ] The schema was updated
