### PR TITLE
Add a gatekeeper constraint that warns application developers when they deploy with less then 3 replicas

### DIFF
--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -879,6 +879,12 @@ opa:
   rejectLoadBalancerService:
     enabled: set-me
     enforcement: deny
+
+  ## Enable rule that warns about minimum replica number
+  minimumDeploymentReplicas:
+    enabled: true
+    enforcement: warn
+
 trivy:
   enabled: true
   # comma separated list of namespaces (or glob patterns) to be excluded from scanning

--- a/helmfile.d/charts/gatekeeper/constraints/templates/deployment-minimum-replicas/constraint.yaml
+++ b/helmfile.d/charts/gatekeeper/constraints/templates/deployment-minimum-replicas/constraint.yaml
@@ -6,11 +6,11 @@ spec:
   enforcementAction: warn
   match:
     kinds:
-    - apiGroups:
-      - apps
-      kinds:
-      - Deployment
-      - StatefulSet
+      - apiGroups:
+          - apps
+        kinds:
+          - Deployment
+          - StatefulSet
     excludedNamespaces:
       - alertmanager
       - calico-apiserver
@@ -30,4 +30,4 @@ spec:
       - tiger-operator
       - velero
     parameters:
-        - min_replicas: 2
+      - min_replicas: 2

--- a/helmfile.d/charts/gatekeeper/constraints/templates/deployment-minimum-replicas/constraint.yaml
+++ b/helmfile.d/charts/gatekeeper/constraints/templates/deployment-minimum-replicas/constraint.yaml
@@ -1,0 +1,33 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sMinimumReplicas
+metadata:
+  name: elastisys-warn-minimum-replicas
+spec:
+  enforcementAction: warn
+  match:
+    kinds:
+    - apiGroups:
+      - apps
+      kinds:
+      - Deployment
+      - StatefulSet
+    excludedNamespaces:
+      - alertmanager
+      - calico-apiserver
+      - calico-system
+      - cert-manager
+      - falco
+      - fluentd
+      - fluentd-system
+      - gatekeeper-system
+      - gpu-operator
+      - hnc-system
+      - ingress-nginx
+      - kube-note-lease
+      - kube-public
+      - kube-system
+      - monitoring
+      - tiger-operator
+      - velero
+    parameters:
+        - min_replicas: 2

--- a/helmfile.d/charts/gatekeeper/constraints/templates/deployment-minimum-replicas/constraint.yaml
+++ b/helmfile.d/charts/gatekeeper/constraints/templates/deployment-minimum-replicas/constraint.yaml
@@ -27,7 +27,8 @@ spec:
       - kube-public
       - kube-system
       - monitoring
-      - tiger-operator
+      - tigera-operator
       - velero
-    parameters:
-      - min_replicas: 2
+  parameters:
+    min_replicas: 2
+    label: ignoreMinimumReplicas

--- a/helmfile.d/charts/gatekeeper/constraints/values.yaml
+++ b/helmfile.d/charts/gatekeeper/constraints/values.yaml
@@ -16,6 +16,9 @@ allowUserCRDs:
 rejectLoadBalancerService:
     enable: true
     enforcementAction: dryrun
+minimumDeploymentReplicas:
+    enable: true
+    enforcementAction: warn
 
 imageRegistryURL: registry.example.com
 

--- a/helmfile.d/charts/gatekeeper/templates/policies/deployment-minimum-replicas.rego
+++ b/helmfile.d/charts/gatekeeper/templates/policies/deployment-minimum-replicas.rego
@@ -10,7 +10,7 @@ violation[{"msg": msg}] {
     metadata := input.review.object.metadata
     not input_replica_limit(spec)
     not check_label(metadata)
-    msg := sprintf("The provided number of replicas is low for %v: %v. Elastisys Compliant Kubernetes recommends a minimum of 2 replicas.", [object_kind, object_name])
+    msg := sprintf("The provided number of replicas is too low for %v: %v. Elastisys Compliant Kubernetes recommends a minimum of 2 replicas.", [object_kind, object_name])
 }
 
 input_replica_limit(spec) {

--- a/helmfile.d/charts/gatekeeper/templates/policies/deployment-minimum-replicas.rego
+++ b/helmfile.d/charts/gatekeeper/templates/policies/deployment-minimum-replicas.rego
@@ -1,0 +1,20 @@
+package k8sminimumreplicas
+
+        object_name = input.review.object.metadata.name
+        object_kind = input.review.kind.kind
+
+        violation[{"msg": msg}] {
+            spec := input.review.object.spec
+            not input_replica_limit(spec)
+            msg := sprintf("The provided number of replicas is low for %v: %v. Elastisys Compliant Kubernetes recommends a minimum of 2 replicas.", [object_kind, object_name])
+        }
+
+        input_replica_limit(spec) {
+            provided := spec.replicas
+            min_replicas := input.parameters.min_replicas[_]
+            value_superior_min_replicas(min_replicas, provided)
+        }
+
+        value_superior_min_replicas(min_replicas, value) {
+            min_replicas > value
+        }

--- a/helmfile.d/charts/gatekeeper/templates/templates/deployment-minimum-replicas/template.yaml
+++ b/helmfile.d/charts/gatekeeper/templates/templates/deployment-minimum-replicas/template.yaml
@@ -15,6 +15,9 @@ spec:
               min_replicas:
                 description: The minimum number of replicas allowed, inclusive.
                 type: integer
+              label:
+                description: If this label is set the constraint is ignored.
+                type: string
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |

--- a/helmfile.d/charts/gatekeeper/templates/templates/deployment-minimum-replicas/template.yaml
+++ b/helmfile.d/charts/gatekeeper/templates/templates/deployment-minimum-replicas/template.yaml
@@ -1,0 +1,21 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8sminimumreplicas
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sMinimumReplicas
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+            type: object
+            properties:
+              min_replicas:
+                description: The minimum number of replicas allowed, inclusive.
+                type: integer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ .Files.Get "policies/deployment-minimum-replicas.rego"  | indent 8 }}

--- a/helmfile.d/charts/gatekeeper/templates/templates/deployment-minimum-replicas/template.yaml
+++ b/helmfile.d/charts/gatekeeper/templates/templates/deployment-minimum-replicas/template.yaml
@@ -16,7 +16,7 @@ spec:
                 description: The minimum number of replicas allowed, inclusive.
                 type: integer
               label:
-                description: If this label is set the constraint is ignored.
+                description: This label allows to suppress the warning of the constraint if the number of replicas is lower than the required minimum.
                 type: string
   targets:
     - target: admission.k8s.gatekeeper.sh

--- a/helmfile.d/charts/gatekeeper/templates/values.yaml
+++ b/helmfile.d/charts/gatekeeper/templates/values.yaml
@@ -30,3 +30,6 @@ securityContext:
 
 userCRDs:
   enabled: false
+
+minimumDeploymentReplicas:
+  enabled: false

--- a/helmfile.d/values/gatekeeper/constraints.yaml.gotmpl
+++ b/helmfile.d/values/gatekeeper/constraints.yaml.gotmpl
@@ -17,6 +17,9 @@ rejectLoadBalancerService:
 allowUserCRDs:
     enable: {{ .Values.gatekeeper.allowUserCRDs.enabled }}
     enforcementAction: {{ .Values.gatekeeper.allowUserCRDs.enforcement }}
+minimumDeploymentReplicas:
+    enable: {{ .Values.opa.minimumDeploymentReplicas.enabled }}
+    enforcementAction: {{ .Values.opa.minimumDeploymentReplicas.enforcement }}
 {{- end }}
 
 imageRegistryURL: {{- toYaml .Values.opa.imageRegistry.URL | nindent 2}}

--- a/helmfile.d/values/gatekeeper/templates.yaml.gotmpl
+++ b/helmfile.d/values/gatekeeper/templates.yaml.gotmpl
@@ -21,6 +21,9 @@ waitFor:
   - k8srejectloadbalancerservice
   - k8srequirenetworkpolicy
   - k8sresourcerequests
+{{- if and (eq .Environment.Name "workload_cluster") }}
+  - k8sminimumreplicas
+{{- end }}
 {{- if and (eq .Environment.Name "workload_cluster") (eq .Values.gatekeeper.allowUserCRDs.enabled true) }}
   - k8susercrds
 {{- end }}
@@ -28,4 +31,6 @@ waitFor:
 {{- if eq .Environment.Name "workload_cluster" }}
 userCRDs:
     enabled: {{ .Values.gatekeeper.allowUserCRDs.enabled }}
+minimumDeploymentReplicas:
+    enabled: {{ .Values.opa.minimumDeploymentReplicas.enabled }}
 {{- end }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
This PR adds a warning when a deployment has less than 2 replicas

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes https://github.com/elastisys/compliantkubernetes-apps/issues/2034

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
- Config checks:
  - [ ] The schema was updated
