### PR TITLE
Upgrade trivy-operator v0.20.1

### DIFF
--- a/config/config/common-config.yaml
+++ b/config/config/common-config.yaml
@@ -916,6 +916,8 @@ trivy:
   # configurations for an offline / air-gapped environment
   # ref: https://github.com/aquasecurity/trivy-operator/tree/main/deploy/helm#values
   scanner:
+    resources: {}
+    timeout: ""
     offlineScanEnabled: false
     dbRegistry: ""
     dbRepository: ""

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/Chart.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.18.1
+appVersion: 0.20.1
 description: Keeps security report resources updated
 keywords:
 - aquasecurity
@@ -9,4 +9,4 @@ name: trivy-operator
 sources:
 - https://github.com/aquasecurity/trivy-operator
 type: application
-version: 0.20.1
+version: 0.22.1

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/Chart.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.17.1
+appVersion: 0.18.1
 description: Keeps security report resources updated
 keywords:
 - aquasecurity
@@ -9,4 +9,4 @@ name: trivy-operator
 sources:
 - https://github.com/aquasecurity/trivy-operator
 type: application
-version: 0.19.1
+version: 0.20.1

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/README.md
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/README.md
@@ -1,6 +1,6 @@
 # trivy-operator
 
-![Version: 0.20.1](https://img.shields.io/badge/Version-0.20.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.18.1](https://img.shields.io/badge/AppVersion-0.18.1-informational?style=flat-square)
+![Version: 0.22.1](https://img.shields.io/badge/Version-0.22.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.20.1](https://img.shields.io/badge/AppVersion-0.20.1-informational?style=flat-square)
 
 Keeps security report resources updated
 
@@ -31,22 +31,27 @@ Keeps security report resources updated
 | nodeCollector.imagePullSecret | string | `nil` | imagePullSecret is the secret name to be used when pulling node-collector image from private registries example : reg-secret It is the user responsibility to create the secret for the private registry in `trivy-operator` namespace |
 | nodeCollector.registry | string | `"ghcr.io"` | registry of the node-collector image |
 | nodeCollector.repository | string | `"aquasecurity/node-collector"` | repository of the node-collector image |
-| nodeCollector.tag | string | `"0.1.1"` | tag version of the node-collector image |
+| nodeCollector.tag | string | `"0.1.4"` | tag version of the node-collector image |
+| nodeCollector.tolerations | list | `[]` | tolerations to be applied to the node-collector so that they can run on nodes with matching taints |
+| nodeCollector.useNodeSelector | bool | `true` | useNodeSelector determine if to use nodeSelector (by auto detecting node name) with node-collector scan job |
 | nodeCollector.volumeMounts | list | `[{"mountPath":"/var/lib/etcd","name":"var-lib-etcd","readOnly":true},{"mountPath":"/var/lib/kubelet","name":"var-lib-kubelet","readOnly":true},{"mountPath":"/var/lib/kube-scheduler","name":"var-lib-kube-scheduler","readOnly":true},{"mountPath":"/var/lib/kube-controller-manager","name":"var-lib-kube-controller-manager","readOnly":true},{"mountPath":"/etc/systemd","name":"etc-systemd","readOnly":true},{"mountPath":"/lib/systemd/","name":"lib-systemd","readOnly":true},{"mountPath":"/etc/kubernetes","name":"etc-kubernetes","readOnly":true},{"mountPath":"/etc/cni/net.d/","name":"etc-cni-netd","readOnly":true}]` | node-collector pod volume mounts definition for collecting config files information |
 | nodeCollector.volumes | list | `[{"hostPath":{"path":"/var/lib/etcd"},"name":"var-lib-etcd"},{"hostPath":{"path":"/var/lib/kubelet"},"name":"var-lib-kubelet"},{"hostPath":{"path":"/var/lib/kube-scheduler"},"name":"var-lib-kube-scheduler"},{"hostPath":{"path":"/var/lib/kube-controller-manager"},"name":"var-lib-kube-controller-manager"},{"hostPath":{"path":"/etc/systemd"},"name":"etc-systemd"},{"hostPath":{"path":"/lib/systemd"},"name":"lib-systemd"},{"hostPath":{"path":"/etc/kubernetes"},"name":"etc-kubernetes"},{"hostPath":{"path":"/etc/cni/net.d/"},"name":"etc-cni-netd"}]` | node-collector pod volumes definition for collecting config files information |
 | nodeSelector | object | `{}` | nodeSelector set the operator nodeSelector |
 | operator.accessGlobalSecretsAndServiceAccount | bool | `true` | accessGlobalSecretsAndServiceAccount The flag to enable access to global secrets/service accounts to allow `vulnerability scan job` to pull images from private registries |
+| operator.annotations | object | `{}` | additional annotations for the operator deployment |
 | operator.batchDeleteDelay | string | `"10s"` | batchDeleteDelay the duration to wait before deleting another batch of config audit reports. |
 | operator.batchDeleteLimit | int | `10` | batchDeleteLimit the maximum number of config audit reports deleted by the operator when the plugin's config has changed. |
-| operator.builtInTrivyServer | bool | `false` | builtInTrivyServer The flag enable the usage of built-in trivy server in cluster ,its also override the following trivy params with built-in values trivy.mode = ClientServer and serverURL = http://<serverServiceName>.<trivy operator namespace>:4975 |
+| operator.builtInServerRegistryInsecure | bool | `false` | builtInServerRegistryInsecure is the flag to enable insecure connection from the built-in Trivy server to the registry. |
+| operator.builtInTrivyServer | bool | `false` | builtInTrivyServer The flag enables the usage of built-in trivy server in cluster. It also overrides the following trivy params with built-in values trivy.mode = ClientServer and serverURL = http://<serverServiceName>.<trivy operator namespace>:4975 |
 | operator.cacheReportTTL | string | `"120h"` | cacheReportTTL the flag to set how long a cluster sbom report should exist. "" means that the cacheReportTTL feature is disabled |
 | operator.clusterComplianceEnabled | bool | `true` | clusterComplianceEnabled the flag to enable cluster compliance scanner |
-| operator.clusterSbomCacheEnabled | bool | `true` | the flag to enable cluster sbom cache generation |
+| operator.clusterSbomCacheEnabled | bool | `false` | the flag to enable cluster sbom cache generation |
 | operator.configAuditScannerEnabled | bool | `true` | configAuditScannerEnabled the flag to enable configuration audit scanner |
 | operator.configAuditScannerScanOnlyCurrentRevisions | bool | `true` | configAuditScannerScanOnlyCurrentRevisions the flag to only create config audit scans on the current revision of a deployment. |
 | operator.controllerCacheSyncTimeout | string | `"5m"` | controllerCacheSyncTimeout the duration to wait for controller resources cache sync (default: 5m). |
 | operator.exposedSecretScannerEnabled | bool | `true` | exposedSecretScannerEnabled the flag to enable exposed secret scanner |
 | operator.infraAssessmentScannerEnabled | bool | `true` | infraAssessmentScannerEnabled the flag to enable infra assessment scanner |
+| operator.labels | object | `{}` | additional labels for the operator deployment |
 | operator.leaderElectionId | string | `"trivyoperator-lock"` | leaderElectionId determines the name of the resource that leader election will use for holding the leader lock. |
 | operator.logDevMode | bool | `false` | logDevMode the flag to enable development mode (more human-readable output, extra stack traces and logging information, etc) |
 | operator.mergeRbacFindingWithConfigAudit | bool | `false` | mergeRbacFindingWithConfigAudit the flag to enable merging rbac finding with config-audit report |
@@ -64,14 +69,18 @@ Keeps security report resources updated
 | operator.rbacAssessmentScannerEnabled | bool | `true` | rbacAssessmentScannerEnabled the flag to enable rbac assessment scanner |
 | operator.replicas | int | `1` | replicas the number of replicas of the operator's pod |
 | operator.revisionHistoryLimit | string | `nil` | number of old history to retain to allow rollback (if not set, default Kubernetes value is set to 10) |
-| operator.sbomGenerationEnabled | bool | `true` | the flag to enable sbom generation |
+| operator.sbomGenerationEnabled | bool | `true` | the flag to enable sbom generation, required for enabling ClusterVulnerabilityReports |
 | operator.scanJobTTL | string | `""` | scanJobTTL the set automatic cleanup time after the job is completed |
 | operator.scanJobTimeout | string | `"5m"` | scanJobTimeout the length of time to wait before giving up on a scan job |
 | operator.scanJobsConcurrentLimit | int | `10` | scanJobsConcurrentLimit the maximum number of scan jobs create by the operator |
 | operator.scanJobsRetryDelay | string | `"30s"` | scanJobsRetryDelay the duration to wait before retrying a failed scan job |
 | operator.scanNodeCollectorLimit | int | `1` | scanNodeCollectorLimit the maximum number of node collector jobs create by the operator |
+| operator.scanSecretTTL | string | `""` | scanSecretTTL set an automatic cleanup for scan job secrets |
 | operator.scannerReportTTL | string | `"24h"` | scannerReportTTL the flag to set how long a report should exist. "" means that the ScannerReportTTL feature is disabled |
+| operator.serverAdditionalAnnotations | object | `{}` | serverAdditionalAnnotations the flag to set additional annotations for the trivy server pod |
 | operator.trivyServerHealthCheckCacheExpiration | string | `"10h"` | trivyServerHealthCheckCacheExpiration The flag to set the interval for trivy server health cache before it invalidate |
+| operator.valuesFromConfigMap | string | `""` | vaulesFromConfigMap name of a ConfigMap to apply OPERATOR_* environment variables. Will override Helm values. |
+| operator.valuesFromSecret | string | `""` | valuesFromSecret name of a Secret to apply OPERATOR_* environment variables. Will override Helm AND ConfigMap values. |
 | operator.vulnerabilityScannerEnabled | bool | `true` | the flag to enable vulnerability scanner |
 | operator.vulnerabilityScannerScanOnlyCurrentRevisions | bool | `true` | vulnerabilityScannerScanOnlyCurrentRevisions the flag to only create vulnerability scans on the current revision of a deployment. |
 | operator.webhookBroadcastTimeout | string | `"30s"` | webhookBroadcastTimeout the flag to set timeout for webhook requests if webhookBroadcastURL is enabled |
@@ -79,12 +88,23 @@ Keeps security report resources updated
 | operator.webhookSendDeletedReports | bool | `false` | webhookSendDeletedReports the flag to enable sending deleted reports if webhookBroadcastURL is enabled |
 | podAnnotations | object | `{}` | podAnnotations annotations added to the operator's pod |
 | podSecurityContext | object | `{}` |  |
+| policiesBundle.existingSecret | bool | `false` | existingSecret if a secret containing registry credentials that have been created outside the chart (e.g external-secrets, sops, etc...). Keys must be at least one of the following: policies.bundle.oci.user, policies.bundle.oci.password Overrides policiesBundle.registryUser, policiesBundle.registryPassword values. Note: The secret has to be named "trivy-operator". |
+| policiesBundle.registry | string | `"ghcr.io"` | registry of the policies bundle |
+| policiesBundle.registryPassword | string | `nil` | registryPassword is the password for the registry |
+| policiesBundle.registryUser | string | `nil` | registryUser is the user for the registry |
+| policiesBundle.repository | string | `"aquasecurity/trivy-checks"` | repository of the policies bundle |
+| policiesBundle.tag | int | `0` | tag version of the policies bundle |
 | priorityClassName | string | `""` | priorityClassName set the operator priorityClassName |
 | rbac.create | bool | `true` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true}` | securityContext security context |
-| service | object | `{"annotations":{},"headless":true,"metricsPort":80}` | service only expose a metrics endpoint for prometheus to scrape, trivy-operator does not have a user interface. |
+| service | object | `{"annotations":{},"headless":true,"metricsAppProtocol":"TCP","metricsPort":80,"nodePort":null,"type":"ClusterIP"}` | service only expose a metrics endpoint for prometheus to scrape, trivy-operator does not have a user interface. |
 | service.annotations | object | `{}` | annotations added to the operator's service |
+| service.headless | bool | `true` | if true, the Service doesn't allocate any IP |
+| service.metricsAppProtocol | string | `"TCP"` | appProtocol of the monitoring service |
+| service.metricsPort | int | `80` | port exposed by the Service |
+| service.nodePort | string | `nil` | the nodeport to use when service type is LoadBalancer or NodePort. If not set, Kubernetes automatically select one. |
+| service.type | string | `"ClusterIP"` | the Service type |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `""` | name specifies the name of the k8s Service Account. If not set and create is true, a name is generated using the fullname template. |
@@ -118,17 +138,18 @@ Keeps security report resources updated
 | trivy.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy is the imge pull policy used for trivy image , valid values are (Always, Never, IfNotPresent) |
 | trivy.image.registry | string | `"ghcr.io"` | registry of the Trivy image |
 | trivy.image.repository | string | `"aquasecurity/trivy"` | repository of the Trivy image |
-| trivy.image.tag | string | `"0.48.1"` | tag version of the Trivy image |
+| trivy.image.tag | string | `"0.50.2"` | tag version of the Trivy image |
 | trivy.imageScanCacheDir | string | `"/tmp/trivy/.cache"` | imageScanCacheDir the flag to set custom path for trivy image scan `cache-dir` parameter. Only applicable in image scan mode. |
 | trivy.includeDevDeps | bool | `false` | includeDevDeps include development dependencies in the report (supported: npm, yarn) (default: false) note: this flag is only applicable when trivy.command is set to filesystem |
 | trivy.insecureRegistries | object | `{}` | The registry to which insecure connections are allowed. There can be multiple registries with different keys. |
 | trivy.javaDbRegistry | string | `"ghcr.io"` | javaDbRegistry is the registry for the Java vulnerability database. |
 | trivy.javaDbRepository | string | `"aquasecurity/trivy-java-db"` |  |
+| trivy.labels | object | `{}` | labels is the extra labels to be used for trivy server statefulset |
 | trivy.mode | string | `"Standalone"` | mode is the Trivy client mode. Either Standalone or ClientServer. Depending on the active mode other settings might be applicable or required. |
 | trivy.noProxy | string | `nil` | noProxy is a comma separated list of IPs and domain names that are not subject to proxy settings. |
 | trivy.nonSslRegistries | object | `{}` | Registries without SSL. There can be multiple registries with different keys. |
 | trivy.offlineScan | bool | `false` | offlineScan is the flag to enable the offline scan functionality in Trivy This will prevent outgoing HTTP requests, e.g. to search.maven.org |
-| trivy.podLabels | string | `nil` | podLabels is the extra pod labels to be used for trivy server |
+| trivy.podLabels | object | `{}` | podLabels is the extra pod labels to be used for trivy server |
 | trivy.priorityClassName | string | `""` | priorityClassName is the name of the priority class used for trivy server |
 | trivy.registry | object | `{"mirror":{}}` | Mirrored registries. There can be multiple registries with different keys. Make sure to quote registries containing dots |
 | trivy.resources | object | `{"limits":{"cpu":"500m","memory":"500M"},"requests":{"cpu":"100m","memory":"100M"}}` | resources resource requests and limits for scan job containers |
@@ -152,6 +173,7 @@ Keeps security report resources updated
 | trivy.sslCertDir | string | `nil` | sslCertDir can be used to override the system default locations for SSL certificate files directory, example: /ssl/certs |
 | trivy.storageClassEnabled | bool | `true` | whether to use a storage class for trivy server or emptydir (one mey want to use ephemeral storage) |
 | trivy.storageClassName | string | `""` | storageClassName is the name of the storage class to be used for trivy server PVC. If empty, tries to find default storage class |
+| trivy.storageSize | string | `"5Gi"` | storageSize is the size of the trivy server PVC |
 | trivy.supportedConfigAuditKinds | string | `"Workload,Service,Role,ClusterRole,NetworkPolicy,Ingress,LimitRange,ResourceQuota"` | The Flag is the list of supported kinds separated by comma delimiter to be scanned by the config audit scanner  |
 | trivy.timeout | string | `"5m0s"` | timeout is the duration to wait for scan completion. |
 | trivy.useBuiltinRegoPolicies | string | `"true"` | The Flag to enable the usage of builtin rego policies by default  |
@@ -162,18 +184,24 @@ Keeps security report resources updated
 | trivyOperator.policiesConfig | string | `""` | policiesConfig Custom Rego Policies to be used by the config audit scanner See https://github.com/aquasecurity/trivy-operator/blob/main/docs/tutorials/writing-custom-configuration-audit-policies.md for more details. |
 | trivyOperator.reportRecordFailedChecksOnly | bool | `true` | reportRecordFailedChecksOnly flag is to record only failed checks on misconfiguration reports (config-audit and rbac assessment) |
 | trivyOperator.reportResourceLabels | string | `""` | reportResourceLabels comma-separated scanned resource labels which the user wants to include in the Prometheus metrics report. Example: `owner,app` |
+| trivyOperator.scanJobAffinity | list | `[]` | scanJobAffinity affinity to be applied to the scanner pods and node-collector |
 | trivyOperator.scanJobAnnotations | string | `""` | scanJobAnnotations comma-separated representation of the annotations which the user wants the scanner pods to be annotated with. Example: `foo=bar,env=stage` will annotate the scanner pods with the annotations `foo: bar` and `env: stage` |
 | trivyOperator.scanJobAutomountServiceAccountToken | bool | `false` | scanJobAutomountServiceAccountToken the flag to enable automount for service account token on scan job |
 | trivyOperator.scanJobCompressLogs | bool | `true` | scanJobCompressLogs control whether scanjob output should be compressed or plain |
+| trivyOperator.scanJobCustomVolumes | list | `[]` | scanJobCustomVolumes add custom volumes to the scan job |
+| trivyOperator.scanJobCustomVolumesMount | list | `[]` | scanJobCustomVolumesMount add custom volumes mount to the scan job |
 | trivyOperator.scanJobNodeSelector | object | `{}` | scanJobNodeSelector nodeSelector to be applied to the scanner pods so that they can run on nodes with matching labels |
 | trivyOperator.scanJobPodPriorityClassName | string | `""` | scanJobPodPriorityClassName Priority class name to be set on the pods created by trivy operator jobs. This accepts a string value |
 | trivyOperator.scanJobPodTemplateContainerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true}` | scanJobPodTemplateContainerSecurityContext SecurityContext the user wants the scanner and node collector containers (and their initContainers) to be amended with. |
 | trivyOperator.scanJobPodTemplateLabels | string | `""` | scanJobPodTemplateLabels comma-separated representation of the labels which the user wants the scanner pods to be labeled with. Example: `foo=bar,env=stage` will labeled the scanner pods with the labels `foo: bar` and `env: stage` |
 | trivyOperator.scanJobPodTemplatePodSecurityContext | object | `{}` | scanJobPodTemplatePodSecurityContext podSecurityContext the user wants the scanner and node collector pods to be amended with. Example:   RunAsUser: 10000   RunAsGroup: 10000   RunAsNonRoot: true |
-| trivyOperator.scanJobTolerations | list | `[]` | scanJobTolerations tolerations to be applied to the scanner pods and node-collector so that they can run on nodes with matching taints |
+| trivyOperator.scanJobTolerations | list | `[]` | scanJobTolerations tolerations to be applied to the scanner pods so that they can run on nodes with matching taints |
 | trivyOperator.skipInitContainers | bool | `false` | skipInitContainers when this flag is set to true, the initContainers will be skipped for the scanner and node collector pods |
 | trivyOperator.skipResourceByLabels | string | `""` | skipResourceByLabels comma-separated labels keys which trivy-operator will skip scanning on resources with matching labels |
 | trivyOperator.vulnerabilityReportsPlugin | string | `"Trivy"` | vulnerabilityReportsPlugin the name of the plugin that generates vulnerability reports `Trivy` |
-| volumeMounts | list | `[]` |  |
-| volumes | list | `[]` |  |
+| volumeMounts[0].mountPath | string | `"/tmp"` |  |
+| volumeMounts[0].name | string | `"cache-policies"` |  |
+| volumeMounts[0].readOnly | bool | `false` |  |
+| volumes[0].emptyDir | object | `{}` |  |
+| volumes[0].name | string | `"cache-policies"` |  |
 

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/README.md
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/README.md
@@ -1,6 +1,6 @@
 # trivy-operator
 
-![Version: 0.19.1](https://img.shields.io/badge/Version-0.19.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.1](https://img.shields.io/badge/AppVersion-0.17.1-informational?style=flat-square)
+![Version: 0.20.1](https://img.shields.io/badge/Version-0.20.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.18.1](https://img.shields.io/badge/AppVersion-0.18.1-informational?style=flat-square)
 
 Keeps security report resources updated
 
@@ -31,7 +31,7 @@ Keeps security report resources updated
 | nodeCollector.imagePullSecret | string | `nil` | imagePullSecret is the secret name to be used when pulling node-collector image from private registries example : reg-secret It is the user responsibility to create the secret for the private registry in `trivy-operator` namespace |
 | nodeCollector.registry | string | `"ghcr.io"` | registry of the node-collector image |
 | nodeCollector.repository | string | `"aquasecurity/node-collector"` | repository of the node-collector image |
-| nodeCollector.tag | string | `"0.0.9"` | tag version of the node-collector image |
+| nodeCollector.tag | string | `"0.1.1"` | tag version of the node-collector image |
 | nodeCollector.volumeMounts | list | `[{"mountPath":"/var/lib/etcd","name":"var-lib-etcd","readOnly":true},{"mountPath":"/var/lib/kubelet","name":"var-lib-kubelet","readOnly":true},{"mountPath":"/var/lib/kube-scheduler","name":"var-lib-kube-scheduler","readOnly":true},{"mountPath":"/var/lib/kube-controller-manager","name":"var-lib-kube-controller-manager","readOnly":true},{"mountPath":"/etc/systemd","name":"etc-systemd","readOnly":true},{"mountPath":"/lib/systemd/","name":"lib-systemd","readOnly":true},{"mountPath":"/etc/kubernetes","name":"etc-kubernetes","readOnly":true},{"mountPath":"/etc/cni/net.d/","name":"etc-cni-netd","readOnly":true}]` | node-collector pod volume mounts definition for collecting config files information |
 | nodeCollector.volumes | list | `[{"hostPath":{"path":"/var/lib/etcd"},"name":"var-lib-etcd"},{"hostPath":{"path":"/var/lib/kubelet"},"name":"var-lib-kubelet"},{"hostPath":{"path":"/var/lib/kube-scheduler"},"name":"var-lib-kube-scheduler"},{"hostPath":{"path":"/var/lib/kube-controller-manager"},"name":"var-lib-kube-controller-manager"},{"hostPath":{"path":"/etc/systemd"},"name":"etc-systemd"},{"hostPath":{"path":"/lib/systemd"},"name":"lib-systemd"},{"hostPath":{"path":"/etc/kubernetes"},"name":"etc-kubernetes"},{"hostPath":{"path":"/etc/cni/net.d/"},"name":"etc-cni-netd"}]` | node-collector pod volumes definition for collecting config files information |
 | nodeSelector | object | `{}` | nodeSelector set the operator nodeSelector |
@@ -41,6 +41,7 @@ Keeps security report resources updated
 | operator.builtInTrivyServer | bool | `false` | builtInTrivyServer The flag enable the usage of built-in trivy server in cluster ,its also override the following trivy params with built-in values trivy.mode = ClientServer and serverURL = http://<serverServiceName>.<trivy operator namespace>:4975 |
 | operator.cacheReportTTL | string | `"120h"` | cacheReportTTL the flag to set how long a cluster sbom report should exist. "" means that the cacheReportTTL feature is disabled |
 | operator.clusterComplianceEnabled | bool | `true` | clusterComplianceEnabled the flag to enable cluster compliance scanner |
+| operator.clusterSbomCacheEnabled | bool | `true` | the flag to enable cluster sbom cache generation |
 | operator.configAuditScannerEnabled | bool | `true` | configAuditScannerEnabled the flag to enable configuration audit scanner |
 | operator.configAuditScannerScanOnlyCurrentRevisions | bool | `true` | configAuditScannerScanOnlyCurrentRevisions the flag to only create config audit scans on the current revision of a deployment. |
 | operator.controllerCacheSyncTimeout | string | `"5m"` | controllerCacheSyncTimeout the duration to wait for controller resources cache sync (default: 5m). |
@@ -104,6 +105,8 @@ Keeps security report resources updated
 | trivy.dbRegistry | string | `"ghcr.io"` |  |
 | trivy.dbRepository | string | `"aquasecurity/trivy-db"` |  |
 | trivy.dbRepositoryInsecure | string | `"false"` | The Flag to enable insecure connection for downloading trivy-db via proxy (air-gaped env)  |
+| trivy.dbRepositoryPassword | string | `nil` | The password for dbRepository authentication  |
+| trivy.dbRepositoryUsername | string | `nil` | The username for dbRepository authentication  |
 | trivy.debug | bool | `false` | debug One of `true` or `false`. Enables debug mode. |
 | trivy.filesystemScanCacheDir | string | `"/var/trivyoperator/trivy-db"` | filesystemScanCacheDir the flag to set custom path for trivy filesystem scan `cache-dir` parameter. Only applicable in filesystem scan mode. |
 | trivy.githubToken | string | `nil` | githubToken is the GitHub access token used by Trivy to download the vulnerabilities database from GitHub. Only applicable in Standalone mode. |
@@ -115,8 +118,9 @@ Keeps security report resources updated
 | trivy.image.pullPolicy | string | `"IfNotPresent"` | pullPolicy is the imge pull policy used for trivy image , valid values are (Always, Never, IfNotPresent) |
 | trivy.image.registry | string | `"ghcr.io"` | registry of the Trivy image |
 | trivy.image.repository | string | `"aquasecurity/trivy"` | repository of the Trivy image |
-| trivy.image.tag | string | `"0.47.0"` | tag version of the Trivy image |
+| trivy.image.tag | string | `"0.48.1"` | tag version of the Trivy image |
 | trivy.imageScanCacheDir | string | `"/tmp/trivy/.cache"` | imageScanCacheDir the flag to set custom path for trivy image scan `cache-dir` parameter. Only applicable in image scan mode. |
+| trivy.includeDevDeps | bool | `false` | includeDevDeps include development dependencies in the report (supported: npm, yarn) (default: false) note: this flag is only applicable when trivy.command is set to filesystem |
 | trivy.insecureRegistries | object | `{}` | The registry to which insecure connections are allowed. There can be multiple registries with different keys. |
 | trivy.javaDbRegistry | string | `"ghcr.io"` | javaDbRegistry is the registry for the Java vulnerability database. |
 | trivy.javaDbRepository | string | `"aquasecurity/trivy-java-db"` |  |
@@ -128,6 +132,7 @@ Keeps security report resources updated
 | trivy.priorityClassName | string | `""` | priorityClassName is the name of the priority class used for trivy server |
 | trivy.registry | object | `{"mirror":{}}` | Mirrored registries. There can be multiple registries with different keys. Make sure to quote registries containing dots |
 | trivy.resources | object | `{"limits":{"cpu":"500m","memory":"500M"},"requests":{"cpu":"100m","memory":"100M"}}` | resources resource requests and limits for scan job containers |
+| trivy.sbomSources | string | `""` | sbomSources trivy will try to retrieve SBOM from the specified sources (oci,rekor) |
 | trivy.server.podSecurityContext | object | `{"fsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | podSecurityContext set trivy-server podSecurityContext |
 | trivy.server.replicas | int | `1` | the number of replicas of the trivy-server |
 | trivy.server.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}` | resources set trivy-server resource |

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_clustercompliancereports.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_clustercompliancereports.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: clustercompliancereports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -39,14 +38,19 @@ spec:
           resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -251,6 +255,7 @@ spec:
             - updateTimestamp
             type: object
         type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
     subresources:

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_clusterconfigauditreports.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_clusterconfigauditreports.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: clusterconfigauditreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -53,14 +52,19 @@ spec:
           resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -168,6 +172,7 @@ spec:
         required:
         - report
         type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
     subresources: {}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_clusterinfraassessmentreports.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_clusterinfraassessmentreports.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: clusterinfraassessmentreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -53,14 +52,19 @@ spec:
           resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -167,6 +171,7 @@ spec:
         required:
         - report
         type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
     subresources: {}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_clusterrbacassessmentreports.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_clusterrbacassessmentreports.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: clusterrbacassessmentreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -53,14 +52,19 @@ spec:
           resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -167,6 +171,7 @@ spec:
         required:
         - report
         type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
     subresources: {}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_clustersbomreports.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_clustersbomreports.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: clustersbomreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -51,14 +50,19 @@ spec:
           in container image
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -66,8 +70,9 @@ spec:
             description: Report is the actual sbom report data.
             properties:
               artifact:
-                description: Artifact represents a standalone, executable package
-                  of software that includes everything needed to run an application.
+                description: |-
+                  Artifact represents a standalone, executable package of software that includes everything needed to
+                  run an application.
                 properties:
                   digest:
                     description: Digest is a unique and immutable identifier of an
@@ -86,7 +91,7 @@ spec:
                     type: string
                 type: object
               components:
-                description: Bom isartifact bill of materials.
+                description: Bom is artifact bill of materials.
                 properties:
                   bomFormat:
                     type: string
@@ -246,16 +251,79 @@ spec:
                       timestamp:
                         type: string
                       tools:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            vendor:
-                              type: string
-                            version:
-                              type: string
-                          type: object
-                        type: array
+                        properties:
+                          components:
+                            items:
+                              properties:
+                                bom-ref:
+                                  type: string
+                                group:
+                                  type: string
+                                hashes:
+                                  items:
+                                    properties:
+                                      alg:
+                                        type: string
+                                      content:
+                                        type: string
+                                    type: object
+                                  type: array
+                                licenses:
+                                  items:
+                                    properties:
+                                      expression:
+                                        type: string
+                                      license:
+                                        properties:
+                                          id:
+                                            type: string
+                                          name:
+                                            type: string
+                                          url:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  type: array
+                                name:
+                                  type: string
+                                properties:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                                purl:
+                                  type: string
+                                supplier:
+                                  properties:
+                                    contact:
+                                      items:
+                                        properties:
+                                          email:
+                                            type: string
+                                          name:
+                                            type: string
+                                          phone:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    url:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type:
+                                  type: string
+                                version:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
                     type: object
                   serialNumber:
                     type: string

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_clustervulnerabilityreports.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_clustervulnerabilityreports.yaml
@@ -1,0 +1,284 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: clustervulnerabilityreports.aquasecurity.github.io
+spec:
+  group: aquasecurity.github.io
+  names:
+    kind: ClusterVulnerabilityReport
+    listKind: ClusterVulnerabilityReportList
+    plural: clustervulnerabilityreports
+    shortNames:
+    - clustervuln
+    singular: clustervulnerabilityreport
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: The name of image repository
+      jsonPath: .report.artifact.repository
+      name: Repository
+      type: string
+    - description: The name of image tag
+      jsonPath: .report.artifact.tag
+      name: Tag
+      type: string
+    - description: The name of the vulnerability scanner
+      jsonPath: .report.scanner.name
+      name: Scanner
+      type: string
+    - description: The age of the report
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The number of critical vulnerabilities
+      jsonPath: .report.summary.criticalCount
+      name: Critical
+      priority: 1
+      type: integer
+    - description: The number of high vulnerabilities
+      jsonPath: .report.summary.highCount
+      name: High
+      priority: 1
+      type: integer
+    - description: The number of medium vulnerabilities
+      jsonPath: .report.summary.mediumCount
+      name: Medium
+      priority: 1
+      type: integer
+    - description: The number of low vulnerabilities
+      jsonPath: .report.summary.lowCount
+      name: Low
+      priority: 1
+      type: integer
+    - description: The number of unknown vulnerabilities
+      jsonPath: .report.summary.unknownCount
+      name: Unknown
+      priority: 1
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterVulnerabilityReport summarizes vulnerabilities in application
+          dependencies and operating system packages built into container images.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          report:
+            description: Report is the actual vulnerability report data.
+            properties:
+              artifact:
+                description: Artifact represents a standalone, executable package
+                  of software that includes everything needed to run an application.
+                properties:
+                  digest:
+                    description: Digest is a unique and immutable identifier of an
+                      Artifact.
+                    type: string
+                  mimeType:
+                    description: MimeType represents a type and format of an Artifact.
+                    type: string
+                  repository:
+                    description: Repository is the name of the repository in the Artifact
+                      registry.
+                    type: string
+                  tag:
+                    description: Tag is a mutable, human-readable string used to identify
+                      an Artifact.
+                    type: string
+                type: object
+              os:
+                description: OS information of the artifact
+                properties:
+                  eosl:
+                    description: Eosl is true if OS version has reached end of service
+                      life
+                    type: boolean
+                  family:
+                    description: Operating System Family
+                    type: string
+                  name:
+                    description: Name or version of the OS
+                    type: string
+                type: object
+              registry:
+                description: Registry is the registry the Artifact was pulled from.
+                properties:
+                  server:
+                    description: Server the FQDN of registry server.
+                    type: string
+                type: object
+              scanner:
+                description: Scanner is the scanner that generated this report.
+                properties:
+                  name:
+                    description: Name the name of the scanner.
+                    type: string
+                  vendor:
+                    description: Vendor the name of the vendor providing the scanner.
+                    type: string
+                  version:
+                    description: Version the version of the scanner.
+                    type: string
+                required:
+                - name
+                - vendor
+                - version
+                type: object
+              summary:
+                description: Summary is a summary of Vulnerability counts grouped
+                  by Severity.
+                properties:
+                  criticalCount:
+                    description: CriticalCount is the number of vulnerabilities with
+                      Critical Severity.
+                    minimum: 0
+                    type: integer
+                  highCount:
+                    description: HighCount is the number of vulnerabilities with High
+                      Severity.
+                    minimum: 0
+                    type: integer
+                  lowCount:
+                    description: LowCount is the number of vulnerabilities with Low
+                      Severity.
+                    minimum: 0
+                    type: integer
+                  mediumCount:
+                    description: MediumCount is the number of vulnerabilities with
+                      Medium Severity.
+                    minimum: 0
+                    type: integer
+                  noneCount:
+                    description: NoneCount is the number of packages without any vulnerability.
+                    minimum: 0
+                    type: integer
+                  unknownCount:
+                    description: UnknownCount is the number of vulnerabilities with
+                      unknown severity.
+                    minimum: 0
+                    type: integer
+                required:
+                - criticalCount
+                - highCount
+                - lowCount
+                - mediumCount
+                - unknownCount
+                type: object
+              updateTimestamp:
+                description: UpdateTimestamp is a timestamp representing the server
+                  time in UTC when this report was updated.
+                format: date-time
+                type: string
+              vulnerabilities:
+                description: Vulnerabilities is a list of operating system (OS) or
+                  application software Vulnerability items found in the Artifact.
+                items:
+                  description: Vulnerability is the spec for a vulnerability record.
+                  properties:
+                    class:
+                      type: string
+                    cvss:
+                      additionalProperties:
+                        properties:
+                          V2Score:
+                            type: number
+                          V2Vector:
+                            type: string
+                          V3Score:
+                            type: number
+                          V3Vector:
+                            type: string
+                        type: object
+                      type: object
+                    cvsssource:
+                      type: string
+                    description:
+                      type: string
+                    fixedVersion:
+                      description: FixedVersion indicates the version of the Resource
+                        in which this vulnerability has been fixed.
+                      type: string
+                    installedVersion:
+                      description: InstalledVersion indicates the installed version
+                        of the Resource.
+                      type: string
+                    lastModifiedDate:
+                      description: LastModifiedDate indicates the last date CVE has
+                        been modified.
+                      type: string
+                    links:
+                      items:
+                        type: string
+                      type: array
+                    packagePath:
+                      type: string
+                    packageType:
+                      type: string
+                    primaryLink:
+                      type: string
+                    publishedDate:
+                      description: PublishedDate indicates the date of published CVE.
+                      type: string
+                    resource:
+                      description: Resource is a vulnerable package, application,
+                        or library.
+                      type: string
+                    score:
+                      type: number
+                    severity:
+                      description: Severity level of a vulnerability or a configuration
+                        audit check.
+                      enum:
+                      - CRITICAL
+                      - HIGH
+                      - MEDIUM
+                      - LOW
+                      - UNKNOWN
+                      type: string
+                    target:
+                      type: string
+                    title:
+                      type: string
+                    vulnerabilityID:
+                      description: VulnerabilityID the vulnerability identifier.
+                      type: string
+                  required:
+                  - fixedVersion
+                  - installedVersion
+                  - lastModifiedDate
+                  - publishedDate
+                  - resource
+                  - severity
+                  - title
+                  - vulnerabilityID
+                  type: object
+                type: array
+            required:
+            - artifact
+            - os
+            - scanner
+            - summary
+            - updateTimestamp
+            - vulnerabilities
+            type: object
+        required:
+        - report
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
+    subresources: {}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_clustervulnerabilityreports.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_clustervulnerabilityreports.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: clustervulnerabilityreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -62,18 +61,24 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterVulnerabilityReport summarizes vulnerabilities in application
-          dependencies and operating system packages built into container images.
+        description: |-
+          ClusterVulnerabilityReport summarizes vulnerabilities in application dependencies and operating system packages
+          built into container images.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -81,8 +86,9 @@ spec:
             description: Report is the actual vulnerability report data.
             properties:
               artifact:
-                description: Artifact represents a standalone, executable package
-                  of software that includes everything needed to run an application.
+                description: |-
+                  Artifact represents a standalone, executable package of software that includes everything needed to
+                  run an application.
                 properties:
                   digest:
                     description: Digest is a unique and immutable identifier of an

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_configauditreports.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_configauditreports.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: configauditreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -54,14 +53,19 @@ spec:
           resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -169,6 +173,7 @@ spec:
         required:
         - report
         type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
     subresources: {}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_exposedsecretreports.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_exposedsecretreports.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: exposedsecretreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -62,14 +61,19 @@ spec:
           built into container images.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -77,8 +81,9 @@ spec:
             description: Report is the actual exposed secret report data.
             properties:
               artifact:
-                description: Artifact represents a standalone, executable package
-                  of software that includes everything needed to run an application.
+                description: |-
+                  Artifact represents a standalone, executable package of software that includes everything needed to
+                  run an application.
                 properties:
                   digest:
                     description: Digest is a unique and immutable identifier of an
@@ -201,6 +206,7 @@ spec:
         required:
         - report
         type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
     subresources: {}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_infraassessmentreports.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_infraassessmentreports.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: infraassessmentreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -54,14 +53,19 @@ spec:
           resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_rbacassessmentreports.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_rbacassessmentreports.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: rbacassessmentreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -54,14 +53,19 @@ spec:
           resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -168,6 +172,7 @@ spec:
         required:
         - report
         type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
     subresources: {}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_sbomreports.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_sbomreports.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sbomreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -52,14 +51,19 @@ spec:
           image
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -67,8 +71,9 @@ spec:
             description: Report is the actual sbom report data.
             properties:
               artifact:
-                description: Artifact represents a standalone, executable package
-                  of software that includes everything needed to run an application.
+                description: |-
+                  Artifact represents a standalone, executable package of software that includes everything needed to
+                  run an application.
                 properties:
                   digest:
                     description: Digest is a unique and immutable identifier of an
@@ -87,7 +92,7 @@ spec:
                     type: string
                 type: object
               components:
-                description: Bom isartifact bill of materials.
+                description: Bom is artifact bill of materials.
                 properties:
                   bomFormat:
                     type: string
@@ -247,16 +252,79 @@ spec:
                       timestamp:
                         type: string
                       tools:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            vendor:
-                              type: string
-                            version:
-                              type: string
-                          type: object
-                        type: array
+                        properties:
+                          components:
+                            items:
+                              properties:
+                                bom-ref:
+                                  type: string
+                                group:
+                                  type: string
+                                hashes:
+                                  items:
+                                    properties:
+                                      alg:
+                                        type: string
+                                      content:
+                                        type: string
+                                    type: object
+                                  type: array
+                                licenses:
+                                  items:
+                                    properties:
+                                      expression:
+                                        type: string
+                                      license:
+                                        properties:
+                                          id:
+                                            type: string
+                                          name:
+                                            type: string
+                                          url:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  type: array
+                                name:
+                                  type: string
+                                properties:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                                purl:
+                                  type: string
+                                supplier:
+                                  properties:
+                                    contact:
+                                      items:
+                                        properties:
+                                          email:
+                                            type: string
+                                          name:
+                                            type: string
+                                          phone:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    url:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type:
+                                  type: string
+                                version:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
                     type: object
                   serialNumber:
                     type: string
@@ -323,6 +391,7 @@ spec:
         required:
         - report
         type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
     subresources: {}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_vulnerabilityreports.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/crds/aquasecurity.github.io_vulnerabilityreports.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: vulnerabilityreports.aquasecurity.github.io
 spec:
   group: aquasecurity.github.io
@@ -63,18 +62,24 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: VulnerabilityReport summarizes vulnerabilities in application
-          dependencies and operating system packages built into container images.
+        description: |-
+          VulnerabilityReport summarizes vulnerabilities in application dependencies and operating system packages
+          built into container images.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -82,8 +87,9 @@ spec:
             description: Report is the actual vulnerability report data.
             properties:
               artifact:
-                description: Artifact represents a standalone, executable package
-                  of software that includes everything needed to run an application.
+                description: |-
+                  Artifact represents a standalone, executable package of software that includes everything needed to
+                  run an application.
                 properties:
                   digest:
                     description: Digest is a unique and immutable identifier of an

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/generated/role.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/generated/role.yaml
@@ -199,6 +199,18 @@ rules:
 - apiGroups:
   - aquasecurity.github.io
   resources:
+  - clustervulnerabilityreports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
   - configauditreports
   verbs:
   - create

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/generated/role.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/generated/role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: trivy-operator
 rules:
 - apiGroups:

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/configmaps/operator.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/configmaps/operator.yaml
@@ -6,8 +6,20 @@ metadata:
   namespace: {{ include "trivy-operator.namespace" . }}
   labels: {{- include "trivy-operator.labels" . | nindent 4 }}
 data:
+  {{- with .Values.trivyOperator.scanJobAffinity }}
+  scanJob.affinity: {{ . | toJson | quote }}
+  {{- end }}
   {{- with .Values.trivyOperator.scanJobTolerations }}
   scanJob.tolerations: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.trivyOperator.scanJobCustomVolumesMount }}
+  scanJob.customVolumesMount: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.trivyOperator.scanJobCustomVolumes }}
+  scanJob.customVolumes: {{ . | toJson | quote }}
+  {{- end }}
+  {{- with .Values.nodeCollector.tolerations }}
+  nodeCollector.tolerations: {{ . | toJson | quote }}
   {{- end }}
   {{- with .Values.nodeCollector.volumes }}
   nodeCollector.volumes: {{ . | toJson | quote }}
@@ -71,6 +83,8 @@ data:
   trivy.serverURL: {{ printf "http://%s.%s:%s" .Values.trivy.serverServiceName (include "trivy-operator.namespace" .) "4954"  | quote }}
   {{- end }}
   node.collector.imageRef: "{{ include "global.imageRegistry" . | default .Values.nodeCollector.registry }}/{{ .Values.nodeCollector.repository }}:{{ .Values.nodeCollector.tag }}"
+  policies.bundle.oci.ref: "{{ .Values.policiesBundle.registry }}/{{ .Values.policiesBundle.repository }}:{{ .Values.policiesBundle.tag }}"
   {{- with .Values.nodeCollector.imagePullSecret }}
   node.collector.imagePullSecret: "{{ . }}"
   {{- end }}
+  node.collector.nodeSelector: {{ .Values.nodeCollector.useNodeSelector | quote }}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/configmaps/trivy-operator-config.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/configmaps/trivy-operator-config.yaml
@@ -1,0 +1,50 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: trivy-operator-config
+  namespace: {{ include "trivy-operator.namespace" . }}
+  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
+data:
+  OPERATOR_LOG_DEV_MODE: {{ .Values.operator.logDevMode | quote }}
+  OPERATOR_SCAN_JOB_TTL: {{ .Values.operator.scanJobTTL | quote }}
+  OPERATOR_SCAN_JOB_TIMEOUT: {{ .Values.operator.scanJobTimeout | quote }}
+  OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT: {{ .Values.operator.scanJobsConcurrentLimit | quote }}
+  OPERATOR_CONCURRENT_NODE_COLLECTOR_LIMIT: {{ .Values.operator.scanNodeCollectorLimit | quote }}
+  OPERATOR_SCAN_JOB_RETRY_AFTER: {{ .Values.operator.scanJobsRetryDelay | quote }}
+  OPERATOR_BATCH_DELETE_LIMIT: {{ .Values.operator.batchDeleteLimit | quote }}
+  OPERATOR_BATCH_DELETE_DELAY: {{ .Values.operator.batchDeleteDelay | quote }}
+  OPERATOR_METRICS_BIND_ADDRESS: ":8080"
+  OPERATOR_METRICS_FINDINGS_ENABLED: {{ .Values.operator.metricsFindingsEnabled | quote }}
+  OPERATOR_METRICS_VULN_ID_ENABLED: {{ .Values.operator.metricsVulnIdEnabled | quote }}
+  OPERATOR_HEALTH_PROBE_BIND_ADDRESS: ":9090"
+  OPERATOR_VULNERABILITY_SCANNER_ENABLED: {{ .Values.operator.vulnerabilityScannerEnabled | quote }}
+  OPERATOR_SBOM_GENERATION_ENABLED: {{ .Values.operator.sbomGenerationEnabled | quote }}
+  OPERATOR_CLUSTER_SBOM_CACHE_ENABLED: {{ .Values.operator.clusterSbomCacheEnabled | quote }}
+  OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS: {{ .Values.operator.vulnerabilityScannerScanOnlyCurrentRevisions | quote }}
+  OPERATOR_SCANNER_REPORT_TTL: {{ .Values.operator.scannerReportTTL | quote }}
+  OPERATOR_CACHE_REPORT_TTL: {{ .Values.operator.cacheReportTTL | quote }}
+  CONTROLLER_CACHE_SYNC_TIMEOUT: {{ .Values.operator.controllerCacheSyncTimeout | quote }}
+  OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED: {{ .Values.operator.configAuditScannerEnabled | quote }}
+  OPERATOR_RBAC_ASSESSMENT_SCANNER_ENABLED: {{ .Values.operator.rbacAssessmentScannerEnabled | quote }}
+  OPERATOR_INFRA_ASSESSMENT_SCANNER_ENABLED: {{ .Values.operator.infraAssessmentScannerEnabled | quote }}
+  OPERATOR_CONFIG_AUDIT_SCANNER_SCAN_ONLY_CURRENT_REVISIONS: {{ .Values.operator.configAuditScannerScanOnlyCurrentRevisions | quote }}
+  OPERATOR_EXPOSED_SECRET_SCANNER_ENABLED: {{ .Values.operator.exposedSecretScannerEnabled | quote }}
+  OPERATOR_METRICS_EXPOSED_SECRET_INFO_ENABLED: {{ .Values.operator.metricsExposedSecretInfo | quote }}
+  OPERATOR_METRICS_CONFIG_AUDIT_INFO_ENABLED: {{ .Values.operator.metricsConfigAuditInfo | quote }}
+  OPERATOR_METRICS_RBAC_ASSESSMENT_INFO_ENABLED: {{ .Values.operator.metricsRbacAssessmentInfo | quote }}
+  OPERATOR_METRICS_INFRA_ASSESSMENT_INFO_ENABLED: {{ .Values.operator.metricsInfraAssessmentInfo | quote }}
+  OPERATOR_METRICS_IMAGE_INFO_ENABLED: {{ .Values.operator.metricsImageInfo | quote }}
+  OPERATOR_METRICS_CLUSTER_COMPLIANCE_INFO_ENABLED: {{ .Values.operator.metricsClusterComplianceInfo | quote }}
+  OPERATOR_WEBHOOK_BROADCAST_URL: {{ .Values.operator.webhookBroadcastURL | quote }}
+  OPERATOR_WEBHOOK_BROADCAST_TIMEOUT: {{ .Values.operator.webhookBroadcastTimeout | quote }}
+  OPERATOR_SEND_DELETED_REPORTS: {{ .Values.operator.webhookSendDeletedReports | quote }}
+  OPERATOR_PRIVATE_REGISTRY_SCAN_SECRETS_NAMES: {{ .Values.operator.privateRegistryScanSecretsNames | toJson | quote }}
+  OPERATOR_ACCESS_GLOBAL_SECRETS_SERVICE_ACCOUNTS: {{ .Values.operator.accessGlobalSecretsAndServiceAccount | quote }}
+  OPERATOR_BUILT_IN_TRIVY_SERVER: {{ .Values.operator.builtInTrivyServer | quote }}
+  TRIVY_SERVER_HEALTH_CHECK_CACHE_EXPIRATION: {{ .Values.operator.trivyServerHealthCheckCacheExpiration | quote }}
+  OPERATOR_MERGE_RBAC_FINDING_WITH_CONFIG_AUDIT: {{ .Values.operator.mergeRbacFindingWithConfigAudit | quote }}
+  OPERATOR_CLUSTER_COMPLIANCE_ENABLED: {{ .Values.operator.clusterComplianceEnabled | quote }}
+{{- if gt (int .Values.operator.replicas) 1 }}
+  OPERATOR_LEADER_ELECTION_ENABLED: "true"
+  OPERATOR_LEADER_ELECTION_ID: {{ .Values.operator.leaderElectionId | quote }}
+{{- end }}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/configmaps/trivy.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/configmaps/trivy.yaml
@@ -45,11 +45,13 @@ data:
   trivy.severity: {{ .Values.trivy.severity | quote }}
   trivy.slow: {{ .Values.trivy.slow | quote }}
   trivy.skipJavaDBUpdate: {{ .Values.trivy.skipJavaDBUpdate | quote }}
+  trivy.includeDevDeps: {{ .Values.trivy.includeDevDeps | quote }}
   trivy.imageScanCacheDir: {{ .Values.trivy.imageScanCacheDir | quote }}
   trivy.filesystemScanCacheDir: {{ .Values.trivy.filesystemScanCacheDir | quote }}
   trivy.dbRepository: "{{ .Values.trivy.dbRegistry }}/{{ .Values.trivy.dbRepository }}"
   trivy.javaDbRepository: "{{ .Values.trivy.javaDbRegistry }}/{{ .Values.trivy.javaDbRepository }}"
   trivy.command: {{ .Values.trivy.command | quote }}
+  trivy.sbomSources: {{ .Values.trivy.sbomSources | quote }}
   {{- with .Values.trivy.skipFiles }}
   trivy.skipFiles: {{ . | quote }}
   {{- end }}
@@ -75,9 +77,11 @@ data:
   {{- with .Values.trivy.timeout }}
   trivy.timeout: {{ . | quote }}
   {{- end }}
-  {{- with .Values.trivy.ignoreFile }}
+  {{- if .Values.trivy.ignoreFile }}
   trivy.ignoreFile: |
-    {{- . | trim | nindent 4 }}
+  {{- range .Values.trivy.ignoreFile }}
+    {{ . | indent 4 }}
+  {{- end }}
   {{- end }}
   {{- range $k, $v := .Values.trivy }}
   {{- if hasPrefix "ignorePolicy" $k }}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/configmaps/trivy.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/configmaps/trivy.yaml
@@ -79,7 +79,7 @@ data:
   {{- end }}
   {{- if .Values.trivy.ignoreFile }}
   trivy.ignoreFile: |
-  {{- range .Values.trivy.ignoreFile }}
+{{- range .Values.trivy.ignoreFile }}
     {{ . | indent 4 }}
   {{- end }}
   {{- end }}
@@ -125,6 +125,7 @@ data:
   TRIVY_DEBUG: {{ .Values.trivy.debug | quote }}
   TRIVY_SKIP_DB_UPDATE: "false"
   TRIVY_DB_REPOSITORY: "{{ .Values.trivy.dbRegistry }}/{{ .Values.trivy.dbRepository }}"
+  TRIVY_INSECURE: "{{ .Values.operator.builtInServerRegistryInsecure }}"
   {{- end }}
 {{- end }}
 {{- end }}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/deployment.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/deployment.yaml
@@ -71,6 +71,8 @@ spec:
               value: {{ .Values.operator.vulnerabilityScannerEnabled | quote }}
             - name: OPERATOR_SBOM_GENERATION_ENABLED
               value: {{ .Values.operator.sbomGenerationEnabled | quote }}
+            - name: OPERATOR_CLUSTER_SBOM_CACHE_ENABLED
+              value: {{ .Values.operator.clusterSbomCacheEnabled | quote }}
             - name: OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS
               value: {{ .Values.operator.vulnerabilityScannerScanOnlyCurrentRevisions | quote }}
             - name: OPERATOR_SCANNER_REPORT_TTL

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/deployment.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/deployment.yaml
@@ -3,7 +3,14 @@ kind: Deployment
 metadata:
   name: {{ include "trivy-operator.fullname" . }}
   namespace: {{ include "trivy-operator.namespace" . }}
-  labels: {{- include "trivy-operator.labels" . | nindent 4 }}
+  {{- with .Values.operator.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels: 
+    {{- include "trivy-operator.labels" . | nindent 4 }}
+    {{- with .Values.operator.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.operator.replicas }}
   {{- with .Values.operator.revisionHistoryLimit }}
@@ -43,89 +50,16 @@ spec:
               value: {{ tpl .Values.targetWorkloads . | quote }}
             - name: OPERATOR_SERVICE_ACCOUNT
               value: {{ include "trivy-operator.serviceAccountName" . | quote }}
-            - name: OPERATOR_LOG_DEV_MODE
-              value: {{ .Values.operator.logDevMode | quote }}
-            - name: OPERATOR_SCAN_JOB_TTL
-              value: {{ .Values.operator.scanJobTTL | quote }}
-            - name: OPERATOR_SCAN_JOB_TIMEOUT
-              value: {{ .Values.operator.scanJobTimeout | quote }}
-            - name: OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT
-              value: {{ .Values.operator.scanJobsConcurrentLimit | quote }}
-            - name: OPERATOR_CONCURRENT_NODE_COLLECTOR_LIMIT
-              value: {{ .Values.operator.scanNodeCollectorLimit | quote }}
-            - name: OPERATOR_SCAN_JOB_RETRY_AFTER
-              value: {{ .Values.operator.scanJobsRetryDelay | quote }}
-            - name: OPERATOR_BATCH_DELETE_LIMIT
-              value: {{ .Values.operator.batchDeleteLimit | quote }}
-            - name: OPERATOR_BATCH_DELETE_DELAY
-              value: {{ .Values.operator.batchDeleteDelay | quote }}
-            - name: OPERATOR_METRICS_BIND_ADDRESS
-              value: ":8080"
-            - name: OPERATOR_METRICS_FINDINGS_ENABLED
-              value: {{ .Values.operator.metricsFindingsEnabled | quote }}
-            - name: OPERATOR_METRICS_VULN_ID_ENABLED
-              value: {{ .Values.operator.metricsVulnIdEnabled | quote }}
-            - name: OPERATOR_HEALTH_PROBE_BIND_ADDRESS
-              value: ":9090"
-            - name: OPERATOR_VULNERABILITY_SCANNER_ENABLED
-              value: {{ .Values.operator.vulnerabilityScannerEnabled | quote }}
-            - name: OPERATOR_SBOM_GENERATION_ENABLED
-              value: {{ .Values.operator.sbomGenerationEnabled | quote }}
-            - name: OPERATOR_CLUSTER_SBOM_CACHE_ENABLED
-              value: {{ .Values.operator.clusterSbomCacheEnabled | quote }}
-            - name: OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS
-              value: {{ .Values.operator.vulnerabilityScannerScanOnlyCurrentRevisions | quote }}
-            - name: OPERATOR_SCANNER_REPORT_TTL
-              value: {{ .Values.operator.scannerReportTTL | quote }}
-            - name: OPERATOR_CACHE_REPORT_TTL
-              value: {{ .Values.operator.cacheReportTTL | quote }}
-            - name: CONTROLLER_CACHE_SYNC_TIMEOUT
-              value: {{ .Values.operator.controllerCacheSyncTimeout | quote }}
-            - name: OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED
-              value: {{ .Values.operator.configAuditScannerEnabled | quote }}
-            - name: OPERATOR_RBAC_ASSESSMENT_SCANNER_ENABLED
-              value: {{ .Values.operator.rbacAssessmentScannerEnabled | quote }}
-            - name: OPERATOR_INFRA_ASSESSMENT_SCANNER_ENABLED
-              value: {{ .Values.operator.infraAssessmentScannerEnabled | quote }}
-            - name: OPERATOR_CONFIG_AUDIT_SCANNER_SCAN_ONLY_CURRENT_REVISIONS
-              value: {{ .Values.operator.configAuditScannerScanOnlyCurrentRevisions | quote }}
-            - name: OPERATOR_EXPOSED_SECRET_SCANNER_ENABLED
-              value: {{ .Values.operator.exposedSecretScannerEnabled | quote }}
-            - name: OPERATOR_METRICS_EXPOSED_SECRET_INFO_ENABLED
-              value: {{ .Values.operator.metricsExposedSecretInfo | quote }}
-            - name: OPERATOR_METRICS_CONFIG_AUDIT_INFO_ENABLED
-              value: {{ .Values.operator.metricsConfigAuditInfo | quote }}
-            - name: OPERATOR_METRICS_RBAC_ASSESSMENT_INFO_ENABLED
-              value: {{ .Values.operator.metricsRbacAssessmentInfo | quote }}
-            - name: OPERATOR_METRICS_INFRA_ASSESSMENT_INFO_ENABLED
-              value: {{ .Values.operator.metricsInfraAssessmentInfo | quote }}
-            - name: OPERATOR_METRICS_IMAGE_INFO_ENABLED
-              value: {{ .Values.operator.metricsImageInfo | quote }}  
-            - name: OPERATOR_METRICS_CLUSTER_COMPLIANCE_INFO_ENABLED
-              value: {{ .Values.operator.metricsClusterComplianceInfo | quote }}  
-            - name: OPERATOR_WEBHOOK_BROADCAST_URL
-              value: {{ .Values.operator.webhookBroadcastURL | quote }}
-            - name: OPERATOR_WEBHOOK_BROADCAST_TIMEOUT
-              value: {{ .Values.operator.webhookBroadcastTimeout | quote }}
-            - name: OPERATOR_SEND_DELETED_REPORTS
-              value: {{ .Values.operator.webhookSendDeletedReports | quote }}
-            - name: OPERATOR_PRIVATE_REGISTRY_SCAN_SECRETS_NAMES
-              value: {{ .Values.operator.privateRegistryScanSecretsNames | toJson | quote }}
-            - name: OPERATOR_ACCESS_GLOBAL_SECRETS_SERVICE_ACCOUNTS
-              value: {{ .Values.operator.accessGlobalSecretsAndServiceAccount | quote }}
-            - name: OPERATOR_BUILT_IN_TRIVY_SERVER
-              value: {{ .Values.operator.builtInTrivyServer | quote }}
-            - name: TRIVY_SERVER_HEALTH_CHECK_CACHE_EXPIRATION
-              value: {{ .Values.operator.trivyServerHealthCheckCacheExpiration | quote }}
-            - name: OPERATOR_MERGE_RBAC_FINDING_WITH_CONFIG_AUDIT
-              value: {{ .Values.operator.mergeRbacFindingWithConfigAudit | quote }}
-            - name: OPERATOR_CLUSTER_COMPLIANCE_ENABLED
-              value: {{ .Values.operator.clusterComplianceEnabled | quote }}
-            {{- if gt (int .Values.operator.replicas) 1 }}
-            - name: OPERATOR_LEADER_ELECTION_ENABLED
-              value: "true"
-            - name: OPERATOR_LEADER_ELECTION_ID
-              value: {{ .Values.operator.leaderElectionId | quote }}
+          envFrom:
+            - configMapRef:
+                name: trivy-operator-config
+            {{- if .Values.operator.valuesFromConfigMap }}
+            - configMapRef:
+                name: {{ .Values.operator.valuesFromConfigMap }}
+            {{- end }}
+            {{- if .Values.operator.valuesFromSecret }}
+            - secretRef:
+                name: {{ .Values.operator.valuesFromSecret }}
             {{- end }}
           ports:
             - name: metrics

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/monitor/service.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/monitor/service.yaml
@@ -8,12 +8,17 @@ metadata:
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{ if .Values.service.headless }}
+  {{- if and (.Values.service.headless) (eq .Values.service.type "ClusterIP") }}
   clusterIP: None
-  {{ end }}
+  {{- end }}
   ports:
     - name: metrics
       port: {{ .Values.service.metricsPort }}
       targetPort: metrics
+      {{- if not (empty .Values.service.nodePort) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
       protocol: TCP
+      appProtocol: {{ .Values.service.metricsAppProtocol }}
   selector: {{- include "trivy-operator.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.service.type }}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/rbac/clusterrole.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/rbac/clusterrole.yaml
@@ -16,5 +16,11 @@
   - serviceaccounts
   verbs:
   - get
+- apiGroups:
+    - ""
+  resources:
+    - nodes/proxy
+  verbs:
+    - get
 {{- end }}
 {{- end }}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/secrets/operator.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/secrets/operator.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.policiesBundle.existingSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -5,3 +6,11 @@ metadata:
   name: trivy-operator
   namespace: {{ include "trivy-operator.namespace" . }}
   labels: {{- include "trivy-operator.labels" . | nindent 4 }}
+data:
+  {{- with .Values.policiesBundle.registryUser }}
+  policies.bundle.oci.user: {{ . | b64enc | quote }}
+  {{- end }}
+  {{- with .Values.policiesBundle.registryPassword }}
+  policies.bundle.oci.password: {{ . | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/secrets/trivy.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/secrets/trivy.yaml
@@ -10,6 +10,12 @@ data:
   {{- with .Values.trivy.githubToken }}
   trivy.githubToken: {{ . | b64enc | quote }}
   {{- end }}
+  {{- with .Values.trivy.dbRepositoryUsername }}
+  trivy.dbRepositoryUsername: {{ . | b64enc | quote }}
+  {{- end }}
+  {{- with .Values.trivy.dbRepositoryPassword }}
+  trivy.dbRepositoryPassword: {{ . | b64enc | quote }}
+  {{- end }}
   {{- if or (eq .Values.trivy.mode "ClientServer") .Values.operator.builtInTrivyServer }}
   {{- with .Values.trivy.serverToken }}
   trivy.serverToken: {{ . | b64enc | quote }}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/specs/cis-1.23.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/specs/cis-1.23.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: 0.17.1
+    app.kubernetes.io/version: 0.18.1
     app.kubernetes.io/managed-by: kubectl
 spec:
   cron: {{ .Values.compliance.cron | quote}}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/specs/cis-1.23.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/specs/cis-1.23.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: 0.18.1
+    app.kubernetes.io/version: 0.20.1
     app.kubernetes.io/managed-by: kubectl
 spec:
   cron: {{ .Values.compliance.cron | quote}}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/specs/nsa-1.0.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/specs/nsa-1.0.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.18.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 spec:
   cron: {{ .Values.compliance.cron | quote }}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/specs/nsa-1.0.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/specs/nsa-1.0.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.17.1"
+    app.kubernetes.io/version: "0.18.1"
     app.kubernetes.io/managed-by: kubectl
 spec:
   cron: {{ .Values.compliance.cron | quote }}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/specs/pss-baseline.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/specs/pss-baseline.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: 0.18.1
+    app.kubernetes.io/version: 0.20.1
     app.kubernetes.io/managed-by: kubectl
 spec:
   cron: {{ .Values.compliance.cron | quote }}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/specs/pss-baseline.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/specs/pss-baseline.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: 0.17.1
+    app.kubernetes.io/version: 0.18.1
     app.kubernetes.io/managed-by: kubectl
 spec:
   cron: {{ .Values.compliance.cron | quote }}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/specs/pss-restricted.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/specs/pss-restricted.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: 0.18.1
+    app.kubernetes.io/version: 0.20.1
     app.kubernetes.io/managed-by: kubectl
 spec:
   cron: {{ .Values.compliance.cron | quote }}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/specs/pss-restricted.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/specs/pss-restricted.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: 0.17.1
+    app.kubernetes.io/version: 0.18.1
     app.kubernetes.io/managed-by: kubectl
 spec:
   cron: {{ .Values.compliance.cron | quote }}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/templates/trivy-server/statefulset.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/templates/trivy-server/statefulset.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-server
     app.kubernetes.io/instance: trivy-server
+    {{- with .Values.trivy.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   podManagementPolicy: "Parallel"
   serviceName: {{ .Values.trivy.serverServiceName }}
@@ -24,15 +27,18 @@ spec:
       spec:
         resources:
           requests:
-            storage: 5Gi
+            storage: {{ .Values.trivy.storageSize }}
         accessModes:
           - ReadWriteOnce
         storageClassName: {{ .Values.trivy.storageClassName }}
-  {{- end }}        
+  {{- end }}
   template:
     metadata:
       annotations:
         checksum/config: 7fcc66ace3f98462349856795765021e7bf7a0106f28439a9f6dc74257404370
+        {{- with .Values.operator.serverAdditionalAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- with .Values.trivy.podLabels }}
           {{- toYaml . | nindent 8 }}
@@ -109,6 +115,11 @@ spec:
             - mountPath: /home/scanner/.cache
               name: data
               readOnly: false
+          {{- with .Values.trivy.sslCertDir | quote }}
+            - mountPath: {{ . }}
+              name: ssl-cert-dir
+              readOnly: true
+          {{- end }}
           {{- with .Values.trivy.server.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -118,6 +129,11 @@ spec:
         {{- if not .Values.trivy.storageClassEnabled }}
         - name: data
           emptyDir: {}
+        {{- end }}
+        {{- with .Values.trivy.sslCertDir | quote }}
+        - name: ssl-cert-dir
+          hostPath:
+            path: {{ . }}
         {{- end }}
       {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/values.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/values.yaml
@@ -40,6 +40,12 @@ operator:
   # -- number of old history to retain to allow rollback (if not set, default Kubernetes value is set to 10)
   revisionHistoryLimit: ~
 
+  # -- additional annotations for the operator deployment
+  annotations: {}
+
+  # -- additional labels for the operator deployment
+  labels: {}
+
   # -- additional labels for the operator pod
   podLabels: {}
 
@@ -52,6 +58,9 @@ operator:
 
   # -- scanJobTTL the set automatic cleanup time after the job is completed
   scanJobTTL: ""
+
+  # -- scanSecretTTL set an automatic cleanup for scan job secrets
+  scanSecretTTL: ""
 
   # -- scanJobTimeout the length of time to wait before giving up on a scan job
   scanJobTimeout: 5m
@@ -67,10 +76,10 @@ operator:
 
   # -- the flag to enable vulnerability scanner
   vulnerabilityScannerEnabled: true
-  # -- the flag to enable sbom generation
+  # -- the flag to enable sbom generation, required for enabling ClusterVulnerabilityReports
   sbomGenerationEnabled: true
   # -- the flag to enable cluster sbom cache generation
-  clusterSbomCacheEnabled: true
+  clusterSbomCacheEnabled: false
   # -- scannerReportTTL the flag to set how long a report should exist. "" means that the ScannerReportTTL feature is disabled
   scannerReportTTL: "24h"
   # -- cacheReportTTL the flag to set how long a cluster sbom report should exist. "" means that the cacheReportTTL feature is disabled
@@ -93,9 +102,11 @@ operator:
   batchDeleteDelay: 10s
   # -- accessGlobalSecretsAndServiceAccount The flag to enable access to global secrets/service accounts to allow `vulnerability scan job` to pull images from private registries
   accessGlobalSecretsAndServiceAccount: true
-  # -- builtInTrivyServer The flag enable the usage of built-in trivy server in cluster ,its also override the following trivy params with built-in values
+  # -- builtInTrivyServer The flag enables the usage of built-in trivy server in cluster. It also overrides the following trivy params with built-in values
   # trivy.mode = ClientServer and serverURL = http://<serverServiceName>.<trivy operator namespace>:4975
   builtInTrivyServer: false
+  # -- builtInServerRegistryInsecure is the flag to enable insecure connection from the built-in Trivy server to the registry.
+  builtInServerRegistryInsecure: false
   # -- controllerCacheSyncTimeout the duration to wait for controller resources cache sync (default: 5m).
   controllerCacheSyncTimeout: "5m"
 
@@ -137,6 +148,9 @@ operator:
   # be aware of metrics cardinality is significantly increased with this feature enabled.
   metricsClusterComplianceInfo: false
 
+  # -- serverAdditionalAnnotations the flag to set additional annotations for the trivy server pod
+  serverAdditionalAnnotations: {}
+
   # -- webhookBroadcastURL the flag to set reports should be sent to a webhook endpoint. "" means that the webhookBroadcastURL feature is disabled
   webhookBroadcastURL: ""
 
@@ -152,6 +166,12 @@ operator:
   # -- mergeRbacFindingWithConfigAudit the flag to enable merging rbac finding with config-audit report
   mergeRbacFindingWithConfigAudit: false
 
+  # -- vaulesFromConfigMap name of a ConfigMap to apply OPERATOR_* environment variables. Will override Helm values.
+  valuesFromConfigMap: ""
+
+  # -- valuesFromSecret name of a Secret to apply OPERATOR_* environment variables. Will override Helm AND ConfigMap values.
+  valuesFromSecret: ""
+
 image:
   registry: "ghcr.io"
   repository: "aquasecurity/trivy-operator"
@@ -166,10 +186,18 @@ image:
 # -- service only expose a metrics endpoint for prometheus to scrape,
 # trivy-operator does not have a user interface.
 service:
+  # -- if true, the Service doesn't allocate any IP
   headless: true
+  # -- port exposed by the Service
   metricsPort: 80
   # -- annotations added to the operator's service
   annotations: {}
+  # -- appProtocol of the monitoring service
+  metricsAppProtocol: TCP
+  # -- the Service type
+  type: ClusterIP
+  # -- the nodeport to use when service type is LoadBalancer or NodePort. If not set, Kubernetes automatically select one.
+  nodePort:
 
 # -- Prometheus ServiceMonitor configuration -- to install the trivy operator with the ServiceMonitor
 # you must have Prometheus already installed and running. If you do not have Prometheus installed, enabling this will
@@ -197,7 +225,9 @@ trivyOperator:
   configAuditReportsPlugin: "Trivy"
   # -- scanJobCompressLogs control whether scanjob output should be compressed or plain
   scanJobCompressLogs: true
-  # -- scanJobTolerations tolerations to be applied to the scanner pods and node-collector so that they can run on nodes with matching taints
+  # -- scanJobAffinity affinity to be applied to the scanner pods and node-collector
+  scanJobAffinity: []
+  # -- scanJobTolerations tolerations to be applied to the scanner pods so that they can run on nodes with matching taints
   scanJobTolerations: []
   # -- If you do want to specify tolerations, uncomment the following lines, adjust them as necessary, and remove the
   # square brackets after 'scanJobTolerations:'.
@@ -205,7 +235,6 @@ trivyOperator:
   #   operator: "Equal"
   #   value: "value1"
   #   effect: "NoSchedule"
-
   # -- scanJobNodeSelector nodeSelector to be applied to the scanner pods so that they can run on nodes with matching labels
   scanJobNodeSelector: {}
   # -- If you do want to specify nodeSelector, uncomment the following lines, adjust them as necessary, and remove the
@@ -213,6 +242,19 @@ trivyOperator:
   #   nodeType: worker
   #   cpu: sandylake
   #   teamOwner: operators
+
+  # -- scanJobCustomVolumesMount add custom volumes mount to the scan job
+  scanJobCustomVolumesMount: []
+  #  - name: var-lib-etcd
+  #    mountPath: /var/lib/etcd
+  #    readOnly: true
+
+  # -- scanJobCustomVolumes add custom volumes to the scan job
+  scanJobCustomVolumes: []
+  #  - name: var-lib-etcd
+  #    hostPath:
+  #    path: /var/lib/etcd
+
 
   # -- scanJobAutomountServiceAccountToken the flag to enable automount for service account token on scan job
   scanJobAutomountServiceAccountToken: false
@@ -281,7 +323,7 @@ trivy:
     # -- repository of the Trivy image
     repository: aquasecurity/trivy
     # -- tag version of the Trivy image
-    tag: 0.48.1
+    tag: 0.50.2
     # -- imagePullSecret is the secret name to be used when pulling trivy image from private registries example : reg-secret
     # It is the user responsibility to create the secret for the private registry in `trivy-operator` namespace
     imagePullSecret: ~
@@ -306,8 +348,14 @@ trivy:
   # -- storageClassName is the name of the storage class to be used for trivy server PVC. If empty, tries to find default storage class
   storageClassName: ""
 
+  # -- storageSize is the size of the trivy server PVC
+  storageSize: "5Gi"
+
+  # -- labels is the extra labels to be used for trivy server statefulset
+  labels: {}
+
   # -- podLabels is the extra pod labels to be used for trivy server
-  podLabels:
+  podLabels: {}
 
   # -- priorityClassName is the name of the priority class used for trivy server
   priorityClassName: ""
@@ -369,20 +417,36 @@ trivy:
 
   # -- ignoreFile can be used to tell Trivy to ignore vulnerabilities by ID (one per line)
   ignoreFile: ~
-  # ignoreFile: |
-  #   CVE-1970-0001
-  #   CVE-1970-0002
+  # ignoreFile:
+  #   - CVE-1970-0001
+  #   - CVE-1970-0002
 
   # -- ignorePolicy can be used to tell Trivy to ignore vulnerabilities by a policy
   # If multiple policies would match, then the most specific one has precedence over the others.
   # See https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/#by-open-policy-agent for more details.
+  # See https://github.com/aquasecurity/trivy/blob/v0.19.2/contrib/example_policy/basic.rego for more details on ignorePolicy filtering.
   #
   # ignorePolicy.application.my-app-.: |
-  #   # applies to all workloads in namespace "application" with the name pattern "my-app-*"
+  #  package trivy
+
+  #  import data.lib.trivy
+
+  #  default ignore = true
+  # applies to all workloads in namespace "application" with the name pattern "my-app-*"
   # ignorePolicy.kube-system: |
-  #   # applies to all workloads in namespace "kube-system"
+  #  package trivy
+
+  #  import data.lib.trivy
+
+  #  default ignore = true
+  # applies to all workloads in namespace "kube-system"
   # ignorePolicy: |
-  #   # applies to all other workloads
+  #  package trivy
+
+  #  import data.lib.trivy
+
+  #  default ignore = true
+  # applies to all other workloads
 
   # -- vulnType can be used to tell Trivy to filter vulnerabilities by a pkg-type (library, os)
   vulnType: ~
@@ -541,16 +605,16 @@ securityContext:
     drop:
       - ALL
 
-volumeMounts: []
-# Example:
-#  - mountPath: /tmp
-#    name: tmp-data
-#    readOnly: false
+volumeMounts:
+  # do not remove , required for policies bundle
+  - mountPath: /tmp
+    name: cache-policies
+    readOnly: false
 
-volumes: []
-# Example:
-#  - name: tmp-data
-#    emptyDir: {}
+volumes:
+  # do not remove , required for policies bundle
+  - name: cache-policies
+    emptyDir: {}
 
 resources: {}
   # -- We usually recommend not to specify default resources and to leave this as a conscious
@@ -578,18 +642,46 @@ priorityClassName: ""
   # -- automountServiceAccountToken the flag to enable automount for service account token
 automountServiceAccountToken: true
 
+policiesBundle:
+  # -- registry of the policies bundle
+  registry: ghcr.io
+  # -- repository of the policies bundle
+  repository: aquasecurity/trivy-checks
+  # -- tag version of the policies bundle
+  tag: 0
+   # -- registryUser is the user for the registry
+  registryUser: ~
+  # -- registryPassword is the password for the registry
+  registryPassword: ~
+  # -- existingSecret if a secret containing registry credentials that have been created outside the chart (e.g external-secrets, sops, etc...).
+  # Keys must be at least one of the following: policies.bundle.oci.user, policies.bundle.oci.password
+  # Overrides policiesBundle.registryUser, policiesBundle.registryPassword values.
+  # Note: The secret has to be named "trivy-operator".
+  existingSecret: false
+
+
 nodeCollector:
+  # -- useNodeSelector determine if to use nodeSelector (by auto detecting node name) with node-collector scan job
+  useNodeSelector: true
   # -- registry of the node-collector image
   registry: ghcr.io
   # -- repository of the node-collector image
   repository: aquasecurity/node-collector
   # -- tag version of the node-collector image
-  tag: 0.1.1
+  tag: 0.1.4
   # -- imagePullSecret is the secret name to be used when pulling node-collector image from private registries example : reg-secret
   # It is the user responsibility to create the secret for the private registry in `trivy-operator` namespace
   imagePullSecret: ~
   # -- excludeNodes comma-separated node labels that the node-collector job should exclude from scanning (example kubernetes.io/arch=arm64,team=dev)
   excludeNodes:
+  # -- tolerations to be applied to the node-collector so that they can run on nodes with matching taints
+  tolerations: []
+  # -- If you do want to specify tolerations, uncomment the following lines, adjust them as necessary, and remove the
+  # square brackets after 'scanJobTolerations:'.
+  # - key: "key1"
+  #   operator: "Equal"
+  #   value: "value1"
+  #   effect: "NoSchedule"
   # -- node-collector pod volume mounts definition for collecting config files information
   volumeMounts:
     - name: var-lib-etcd

--- a/helmfile.d/upstream/aquasecurity/trivy-operator/values.yaml
+++ b/helmfile.d/upstream/aquasecurity/trivy-operator/values.yaml
@@ -69,6 +69,8 @@ operator:
   vulnerabilityScannerEnabled: true
   # -- the flag to enable sbom generation
   sbomGenerationEnabled: true
+  # -- the flag to enable cluster sbom cache generation
+  clusterSbomCacheEnabled: true
   # -- scannerReportTTL the flag to set how long a report should exist. "" means that the ScannerReportTTL feature is disabled
   scannerReportTTL: "24h"
   # -- cacheReportTTL the flag to set how long a cluster sbom report should exist. "" means that the cacheReportTTL feature is disabled
@@ -279,7 +281,7 @@ trivy:
     # -- repository of the Trivy image
     repository: aquasecurity/trivy
     # -- tag version of the Trivy image
-    tag: 0.47.0
+    tag: 0.48.1
     # -- imagePullSecret is the secret name to be used when pulling trivy image from private registries example : reg-secret
     # It is the user responsibility to create the secret for the private registry in `trivy-operator` namespace
     imagePullSecret: ~
@@ -290,6 +292,13 @@ trivy:
   # -- mode is the Trivy client mode. Either Standalone or ClientServer. Depending
   # on the active mode other settings might be applicable or required.
   mode: Standalone
+
+  # -- sbomSources trivy will try to retrieve SBOM from the specified sources (oci,rekor)
+  sbomSources: ""
+
+  # -- includeDevDeps include development dependencies in the report (supported: npm, yarn) (default: false)
+  # note: this flag is only applicable when trivy.command is set to filesystem
+  includeDevDeps: false
 
   # -- whether to use a storage class for trivy server or emptydir (one mey want to use ephemeral storage)
   storageClassEnabled: true
@@ -430,6 +439,14 @@ trivy:
   dbRegistry: "ghcr.io"
   dbRepository: "aquasecurity/trivy-db"
 
+  # -- The username for dbRepository authentication
+  #
+  dbRepositoryUsername: ~
+
+  # -- The password for dbRepository authentication
+  #
+  dbRepositoryPassword: ~
+
   # -- javaDbRegistry is the registry for the Java vulnerability database.
   javaDbRegistry: "ghcr.io"
   javaDbRepository: "aquasecurity/trivy-java-db"
@@ -567,7 +584,7 @@ nodeCollector:
   # -- repository of the node-collector image
   repository: aquasecurity/node-collector
   # -- tag version of the node-collector image
-  tag: 0.0.9
+  tag: 0.1.1
   # -- imagePullSecret is the secret name to be used when pulling node-collector image from private registries example : reg-secret
   # It is the user responsibility to create the secret for the private registry in `trivy-operator` namespace
   imagePullSecret: ~

--- a/helmfile.d/upstream/index.yaml
+++ b/helmfile.d/upstream/index.yaml
@@ -33,7 +33,7 @@ repositories:
   vmware-tanzu: https://vmware-tanzu.github.io/helm-charts
 
 charts:
-  aquasecurity/trivy-operator: 0.20.1
+  aquasecurity/trivy-operator: 0.22.1
 
   bitnami/fluentd: 5.8.2
   bitnami/thanos: 15.0.5

--- a/helmfile.d/upstream/index.yaml
+++ b/helmfile.d/upstream/index.yaml
@@ -33,7 +33,7 @@ repositories:
   vmware-tanzu: https://vmware-tanzu.github.io/helm-charts
 
 charts:
-  aquasecurity/trivy-operator: 0.19.1
+  aquasecurity/trivy-operator: 0.20.1
 
   bitnami/fluentd: 5.8.2
   bitnami/thanos: 15.0.5

--- a/helmfile.d/values/networkpolicies/common/trivy.yaml.gotmpl
+++ b/helmfile.d/values/networkpolicies/common/trivy.yaml.gotmpl
@@ -6,6 +6,8 @@ policies:
         app.kubernetes.io/name: trivy-operator
       egress:
         - rule: egress-rule-apiserver
+        - rule: egress-rule-dns
+        - rule: egress-rule-trivy
       ingress:
         - rule: ingress-rule-prometheus
           ports:

--- a/helmfile.d/values/trivy/trivy-operator.yaml.gotmpl
+++ b/helmfile.d/values/trivy/trivy-operator.yaml.gotmpl
@@ -32,6 +32,12 @@ trivy:
     mirror:
       {{ toYaml .mirror | nindent 6 }}
   {{- end }}
+  {{- if .Values.trivy.scanner.resources }}
+  resources: {{- toYaml .Values.trivy.scanner.resources | nindent 4 }}
+  {{- end }}
+  {{- if .Values.trivy.scanner.timeout }}
+  timeout: {{- toYaml .Values.trivy.scanner.timeout | nindent 4 }}
+  {{- end }}
 
 operator:
 

--- a/migration/v0.38/apply/10-trivy-operator-upgrade.sh
+++ b/migration/v0.38/apply/10-trivy-operator-upgrade.sh
@@ -8,13 +8,23 @@ source "${ROOT}/scripts/migration/lib.sh"
 run() {
   case "${1:-}" in
   execute)
-
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      if [[ "$(yq_dig sc .trivy.enabled)" == "true" && "$(helm_chart_version sc monitoring trivy-operator)" != "0.22.1" ]]; then
+        log_info "Upgrading trivy-operator in sc"
+        kubectl_do sc delete crd sbomreports.aquasecurity.github.io
+        kubectl_do sc delete crd clustersbomreports.aquasecurity.github.io
+        kubectl_do sc apply -f "${ROOT}"/helmfile.d/upstream/aquasecurity/trivy-operator/crds
+        helmfile_do sc -l name=trivy-operator apply
+      fi
+    fi
     if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
-      log_info "Upgrading trivy-operator"
-      kubectl_do wc delete crd sbomreports.aquasecurity.github.io
-      kubectl_do wc delete crd clustersbomreports.aquasecurity.github.io
-      helmfile_do wc -l name=trivy-operator apply
-      kubectl_do wc apply -f "${ROOT}"/helmfile.d/upstream/aquasecurity/trivy-operator/crds
+      if [[ "$(yq_dig wc .trivy.enabled)" == "true" && "$(helm_chart_version wc monitoring trivy-operator)" != "0.22.1" ]]; then
+        log_info "Upgrading trivy-operator in wc"
+        kubectl_do wc delete crd sbomreports.aquasecurity.github.io
+        kubectl_do wc delete crd clustersbomreports.aquasecurity.github.io
+        kubectl_do wc apply -f "${ROOT}"/helmfile.d/upstream/aquasecurity/trivy-operator/crds
+        helmfile_do wc -l name=trivy-operator apply
+      fi
     fi
     ;;
   rollback)

--- a/migration/v0.38/apply/10-trivy-operator-upgrade.sh
+++ b/migration/v0.38/apply/10-trivy-operator-upgrade.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+run() {
+  case "${1:-}" in
+  execute)
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+      log_info "Upgrading trivy-operator"
+      kubectl_do wc delete crd sbomreports.aquasecurity.github.io
+      kubectl_do wc delete crd clustersbomreports.aquasecurity.github.io
+      helmfile_do wc -l name=trivy-operator apply
+      kubectl_do wc apply -f "${ROOT}"/helmfile.d/upstream/aquasecurity/trivy-operator/crds
+    fi
+    ;;
+  rollback)
+    log_warn "rollback not implemented"
+    ;;
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.38/apply/80-apply.sh
+++ b/migration/v0.38/apply/80-apply.sh
@@ -14,9 +14,11 @@ declare -a skipped_sc
 skipped_sc=(
   "netpol!=service"
   "netpol!=rclone"
+  "app!=trivy-operator"
 )
 declare -a skipped_wc
 skipped_wc=(
+  "app!=trivy-operator"
 )
 
 run() {


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

### Release notes

trivy-operator chart upgrade from v0.19.1 to v0.22.1
trivy-operator app version upgrade from v0.17.1 to 0.20.1

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->

- Upgrades trivy-operator from v0.17.1 to [v0.20.1](https://github.com/aquasecurity/trivy-operator/releases/tag/v0.20.1)
- exposes [scanner resources](https://github.com/elastisys/compliantkubernetes-apps/blob/36842695dd80cf80ebed4fa9d2438190b41ab210/helmfile.d/upstream/aquasecurity/trivy-operator/values.yaml#L381) and [scanner timeout](https://github.com/elastisys/compliantkubernetes-apps/blob/36842695dd80cf80ebed4fa9d2438190b41ab210/helmfile.d/upstream/aquasecurity/trivy-operator/values.yaml#L359) to common-config

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #1909 


#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [x] Any changed pod is covered by Pod Security Admission
  - [x] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [x] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [x] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
- Config checks:
  - [ ] The schema was updated
