### PR TITLE
bin: Naive implementation for explain config or secrets

### DIFF
--- a/bin/ck8s
+++ b/bin/ck8s
@@ -35,6 +35,7 @@ usage() {
     echo "  validate <wc|sc>                               validates config files" 1>&2
     echo "  providers                                      lists supported cloud providers" 1>&2
     echo "  flavors                                        lists supported configuration flavors" 1>&2
+    echo "  explain <config|secrets> [key.to.parameter]    explains the config or secrets" 1>&2
     echo "  update-ips <wc|sc|both> <apply|dry-run>        Automatically fetches and applies the IPs for network policies" 1>&2
     echo "  clean <wc|sc>                                  Cleans the cluster of apps" 1>&2
     echo "  diagnostics <wc|sc>                            Runs diagnostics of apps" 1>&2
@@ -143,6 +144,11 @@ case "${1}" in
         ;;
     providers) echo "${ck8s_cloud_providers[@]}" ;;
     flavors) echo "${ck8s_flavors[@]}" ;;
+    explain)
+        [[ "${2}" =~ ^(config|secrets)$ ]] || usage
+        shift
+        "${here}/explain.bash" "${@}"
+        ;;
     update-ips)
         [[ "${2}" =~ ^(wc|sc|both)$ ]] || usage
         [[ "${3}" =~ ^(apply|dry-run)$ ]] || usage

--- a/bin/explain.bash
+++ b/bin/explain.bash
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+
+# This script takes care of explaining Compliant Kubernetes Apps config and secrets.
+# It's not to be executed on its own but rather via 'ck8s explain'.
+
+set -euo pipefail
+
+declare here root
+here="$(dirname "$(readlink -f "$0")")"
+root="$(dirname "${here}")"
+
+# shellcheck source=bin/common.bash
+source "${here}/common.bash"
+
+usage() {
+  log_error "error: invalid argument: \"${1:-}\""
+  log_error "usage: ck8s explain <config|secrets> [key.to.parameter]"
+  exit 1
+}
+
+# Note:
+# This function does not properly handle the encoding used for special characters within JSON Pointers.
+dereference() {
+  # shellcheck disable=SC2016
+  yq4 '. as $root | with(
+    .. | select(key == "$ref");
+    . = "$root." + (
+      sub("#/", "") | split "/" | with(.[]; . = to_json ) | join "."
+    )
+  ) | with(
+    .. | select(has "$ref");
+    . = eval(."$ref")
+  )' "$1"
+}
+
+hasreference() {
+  # shellcheck disable=SC2016
+  yq4 '[.. | select(key == "$ref")] | length != 0' "$1"
+}
+
+recvdereference() {
+  local data
+  data="$(dereference "$1")"
+
+  while [[ "$(hasreference - <<< "${data}")" == true ]]; do
+    data="$(dereference - <<< "${data}")"
+  done
+
+  echo "${data}"
+}
+
+explain() {
+  local data schema target
+  schema="${1}"
+  target="${2:-}"
+
+  data="$(recvdereference "${schema}")"
+
+  if [[ -n "${target}" ]]; then
+    local -a path
+    readarray -t path <<< "$(yq4 'split "." | .[]' <<< "${target}")"
+
+    for key in "${path[@]}"; do
+      case "$(yq4 ".type" <<< "${data}")" in
+      array)
+        data="$(yq4 ".items.properties.${key}" <<< "${data}")"
+        ;;
+      object)
+        if [[ "${key}" == "additionalProperties" ]]; then
+          data="$(yq4 ".additionalProperties" <<< "${data}")"
+        else
+          data="$(yq4 ".properties.${key}" <<< "${data}")"
+        fi
+        ;;
+      *)
+        log_error "unable to navigate to ${key} on path to ${target} found unnavigable type: $(yq4 ".type" <<< "${data}")"
+        exit 1
+        ;;
+      esac
+
+      if [[ "${data}" == null ]]; then
+        log_error "unable to navigate to ${key} on path to ${target} found nothing"
+        exit 1
+      fi
+    done
+  fi
+
+  local title desc type subtype
+
+  title="$(yq4 ".title // \"${2:-root}\"" <<< "${data}")"
+  desc="$(yq4 '.description // "no description"' <<< "${data}")"
+  type="$(yq4 '.type' <<< "${data}")"
+
+  case "${type}" in
+  array)
+    subtype="$(yq4 '.items.type // "any"' <<< "${data}")"
+    ;;
+  object)
+    if [[ "$(yq4 '.properties // {} | length == 0 and .additionalProperties != false' <<< "${data}")" == "true" ]]; then
+      subtype="$(yq4 '.additionalProperties.type // "any"' <<< "${data}")"
+    fi
+    ;;
+  esac
+
+  if [[ "$(yq4 '.enum // [] | length != 0' <<< "${data}")" == "true" ]]; then
+    subtype="${type}"
+    type="enum"
+  fi
+
+  echo -e "\e[1m${title}\e[22m"
+  echo
+
+  echo "${desc}"
+  echo
+
+  export type subtype
+  case "${subtype:-}" in
+  "object")
+    yq4 --null-input '{"type": strenv(type) + " of " + strenv(subtype) + "s"} | .type line_comment="you can navigate further using .additionalProperties"'
+    ;;
+  "")
+    yq4 --null-input '{"type": strenv(type)}'
+    ;;
+  *)
+    yq4 --null-input '{"type": strenv(type) + " of " + strenv(subtype) + "s"}'
+    ;;
+  esac
+
+  case "${type}" in
+  array)
+    case "$(yq4 '.items.type' <<< "${data}")" in
+    object)
+      echo
+      yq4 '{"properties": .items.properties | keys}' <<< "${data}"
+      ;;
+    esac
+    ;;
+  enum)
+    echo
+    yq4 '{"options": .enum}' <<< "${data}"
+    ;;
+  object)
+    if [[ "$(yq4 '.properties // {} | length != 0' <<< "${data}")" == "true" ]]; then
+      echo
+      yq4 '{"properties": .properties | keys}' <<< "${data}"
+    fi
+    ;;
+  esac
+
+  if [[ "$(yq4 '.default == null' <<< "${data}")" == "false" ]]; then
+    echo
+    yq4 '{"defaults": .default}' <<< "${data}"
+  elif [[ "$(yq4 '(.type == "array") and (.items.properties // {} | length == 0)' <<< "${data}")" == "true" ]]; then
+    echo
+    echo "This array lacks defaults"
+  elif [[ "$(yq4 '(.type == "object") and (.properties // {} | length == 0)' <<< "${data}")" == "true" ]]; then
+    echo
+    echo "This object lacks defaults"
+  elif [[ "${type}" != "array" ]] && [[ "${type}" != "object" ]]; then
+    echo
+    echo "This ${type} lacks defaults"
+  fi
+
+  if [[ "$(yq4 '.examples == null' <<< "${data}")" == "false" ]]; then
+    echo
+    yq4 '{"examples": .examples}' <<< "${data}"
+  fi
+
+  if [[ "$(yq4 '(.type == "array") and (.items.examples // [] | length != 0)' <<< "${data}")" == "true" ]]; then
+    echo
+    yq4 '{"item examples": .items.examples}' <<< "${data}"
+  fi
+}
+
+
+declare schema
+
+case "${1:-}" in
+config)
+  schema="${root}/config/schemas/config.yaml" ;;
+secrets)
+  schema="${root}/config/schemas/secrets.yaml" ;;
+*)
+  usage "${1:-}" ;;
+esac
+
+explain "${schema}" "${2:-}"


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

### What does this PR do / why do we need this PR?

I hacked this together so I might as well share it.

```console
$ ./bin/ck8s explain config
Compliant Kubernetes Apps settings

This describes the structure of the configuration for both the service
cluster and the workload cluster, but keep in mind that each configuration
file will contain different settings.

type: object

properties:
  - global

defaults: null

examples: null
```

#### Information to reviewers

This will most likely become slower as the schema becomes larger as the dereferencing is a bit naive, but it isn't really possible to just do it across the whole file in one go.
Maybe internal anchoring and aliasing might solve it, but I believe that one cannot simply explode recursive references :thinking: 

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [x] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
- Config checks:
  - [ ] The schema was updated
