### PR TITLE
scripts: Use local caches for local clusters

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -37,6 +37,11 @@ This requires that `kind` is installed and that either `podman` or `docker` is a
 > 1. the kind-config/local-cluster-profile must not bind the ingress controller to the same address, and
 > 1. the node-local-dns config must be updated to point towards the correct clusters.
 
+> [!tip]
+> Since local clusters are effectively ephemeral they can pull a lot of images and `kind` has no build in system to manage images.
+> So, for the local clusters script there are commands to create and delete local pull through registry caches for a few upstream registries.
+> Commands to do so is `./scripts/local-cluster.sh cache <create|delete>`, then one can make use of the local cluster profiles `<single|multi>-node-cache` that are prepared to use it by default.
+
 ```sh
 # with CK8S_CONFIG_PATH and CK8S_PGP_FP set
 ./scripts/local-cluster.sh config <name> <apps-flavor> <domain>

--- a/scripts/local-clusters/profiles/multi-node-cache.yaml
+++ b/scripts/local-clusters/profiles/multi-node-cache.yaml
@@ -1,0 +1,52 @@
+# all-in-one cluster with cache
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
+networking:
+  disableDefaultCNI: true
+  ipFamily: ipv4
+  podSubnet: 10.244.0.0/16
+  serviceSubnet: 10.96.0.0/12
+nodes:
+  - role: control-plane
+    extraMounts:
+      - containerPath: /etc/containerd/certs.d
+        hostPath: ${ROOT}/scripts/local-clusters/registries
+        readOnly: true
+  - role: worker
+    extraMounts:
+      - containerPath: /etc/containerd/certs.d
+        hostPath: ${ROOT}/scripts/local-clusters/registries
+        readOnly: true
+    extraPortMappings:
+      # Expose local resolve
+      - containerPort: 30053
+        hostPort: 53
+        listenAddress: 127.0.64.43
+        protocol: UDP
+      - containerPort: 30053
+        hostPort: 53
+        listenAddress: 127.0.64.43
+        protocol: TCP
+      # Expose local ingress
+      - containerPort: 30080
+        hostPort: 80
+        listenAddress: 127.0.64.43
+        protocol: TCP
+      - containerPort: 30443
+        hostPort: 443
+        listenAddress: 127.0.64.43
+        protocol: TCP
+  - role: worker
+    extraMounts:
+      - containerPath: /etc/containerd/certs.d
+        hostPath: ${ROOT}/scripts/local-clusters/registries
+        readOnly: true
+  - role: worker
+    extraMounts:
+      - containerPath: /etc/containerd/certs.d
+        hostPath: ${ROOT}/scripts/local-clusters/registries
+        readOnly: true

--- a/scripts/local-clusters/profiles/single-node-cache.yaml
+++ b/scripts/local-clusters/profiles/single-node-cache.yaml
@@ -1,0 +1,42 @@
+# all-in-one cluster with cache
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
+networking:
+  disableDefaultCNI: true
+  ipFamily: ipv4
+  podSubnet: 10.244.0.0/16
+  serviceSubnet: 10.96.0.0/12
+nodes:
+  - role: control-plane
+    extraMounts:
+      - containerPath: /etc/containerd/certs.d
+        hostPath: ${ROOT}/scripts/local-clusters/registries
+        readOnly: true
+  - role: worker
+    extraMounts:
+      - containerPath: /etc/containerd/certs.d
+        hostPath: ${ROOT}/scripts/local-clusters/registries
+        readOnly: true
+    extraPortMappings:
+      # Expose local resolve
+      - containerPort: 30053
+        hostPort: 53
+        listenAddress: 127.0.64.43
+        protocol: UDP
+      - containerPort: 30053
+        hostPort: 53
+        listenAddress: 127.0.64.43
+        protocol: TCP
+      # Expose local ingress
+      - containerPort: 30080
+        hostPort: 80
+        listenAddress: 127.0.64.43
+        protocol: TCP
+      - containerPort: 30443
+        hostPort: 443
+        listenAddress: 127.0.64.43
+        protocol: TCP

--- a/scripts/local-clusters/registries/docker.io/hosts.toml
+++ b/scripts/local-clusters/registries/docker.io/hosts.toml
@@ -1,0 +1,6 @@
+server = "https://docker.io"
+
+[host."http://local-cache-docker-io:5000"]
+  capabilities = ["pull", "resolve"]
+[host."https://registry-1.docker.io"]
+  capabilities = ["pull", "resolve"]

--- a/scripts/local-clusters/registries/ghcr.io/hosts.toml
+++ b/scripts/local-clusters/registries/ghcr.io/hosts.toml
@@ -1,0 +1,6 @@
+server = "https://ghcr.io"
+
+[host."http://local-cache-ghcr-io:5000"]
+  capabilities = ["pull", "resolve"]
+[host."https://ghcr.io"]
+  capabilities = ["pull", "resolve"]

--- a/scripts/local-clusters/registries/quay.io/hosts.toml
+++ b/scripts/local-clusters/registries/quay.io/hosts.toml
@@ -1,0 +1,6 @@
+server = "https://quay.io"
+
+[host."http://local-cache-quay-io:5000"]
+  capabilities = ["pull", "resolve"]
+[host."https://quay.io"]
+  capabilities = ["pull", "resolve"]


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

### What does this PR do / why do we need this PR?

This adds functions to the local clusters script to setup and use local caches for container images.

#### Information to reviewers

```bash
./scripts/local-cluster.sh cache create
./scripts/local-cluster.sh create local-cluster single-node-cache
# See initial upstream pull of images
./scripts/local-cluster.sh delete local-cluster
./scripts/local-cluster.sh create local-cluster multi-node-cache
# See **no** upstream pull of images
./scripts/local-cluster.sh cache delete
```

To add new ones one must add a new `hosts.toml` and the script should pick it up automagically.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
- Config checks:
  - [ ] The schema was updated
