### PR TITLE
Add config option to allow internal traffic to Prometheus

### DIFF
--- a/config/config/wc-config.yaml
+++ b/config/config/wc-config.yaml
@@ -300,6 +300,15 @@ networkPolicies:
   alertmanager:
     enabled: true
 
+  prometheus:
+    # This feature can be enabled to create Network Policies that allow internal traffic to Prometheus.
+    # Access is granted to:
+    # Pods with the label `elastisys.io/prometheus-access: allow` that belong to a namespace from a configurable list of namespaces
+    internalAccess:
+      enabled: false
+      # A list of namespaces from which to allow traffic from pods that have the required label.
+      namespaces: []
+
 ## Open Policy Agent Gatekeeper configuration
 gatekeeper:
   allowUserCRDs:

--- a/helmfile.d/values/networkpolicies/common/prometheus.yaml.gotmpl
+++ b/helmfile.d/values/networkpolicies/common/prometheus.yaml.gotmpl
@@ -33,6 +33,18 @@ policies:
         - rule: ingress-rule-apiserver
           ports:
             - tcp: 9090
+        {{- if and .Values.networkPolicies.prometheus.internalAccess.enabled .Values.networkPolicies.prometheus.internalAccess.namespaces }}
+        - name: ingress-rule-internal-prometheus
+          peers:
+            {{- range $namespace := .Values.networkPolicies.prometheus.internalAccess.namespaces }}
+            - namespaceSelectorLabels:
+                kubernetes.io/metadata.name: {{ $namespace }}
+              podSelectorLabels:
+                elastisys.io/prometheus-access: allow
+            {{- end }}
+          ports:
+            - tcp: 9090
+        {{- end }}
         {{- end }}
         - rule: ingress-rule-blackbox
           ports:


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [x] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice
It is now possible to allow internal traffic to WC Prometheus from Pods with the label `elastisys.io/prometheus-access: allow` in a configurable list of namespaces. This can be configured under `.networkPolicies.prometheus.internalAccess.enabled` and  `.networkPolicies.prometheus.internalAccess.namespaces`.

### Application Developer notice
There is a new feature to allow certain Pods access to Prometheus, e.g. for [remote-read ](https://prometheus.io/docs/prometheus/latest/querying/remote_read_api/) or [federation](https://prometheus.io/docs/prometheus/latest/federation/) from another Prometheus instance. This feature has to be enabled by a Platform Administrator, who will require a list of namespaces to allow access from. You must also label each Pod that should have access with `elastisys.io/prometheus-access: allow`.

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Added a config option to allow internal traffic to WC Prometheus from Pods with the label `elastisys.io/prometheus-access: allow`, that belong to a configurable list of namespaces. This feature is disabled by default and requires a Platform Administrator to enable it.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2117 

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [x] Any changed pod is covered by Network Policies
  - [x] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
- Config checks:
  - [ ] The schema was updated
