### PR TITLE
Fix HNC test for space separated user names

### DIFF
--- a/pipeline/test/services/workload-cluster/testHNC.sh
+++ b/pipeline/test/services/workload-cluster/testHNC.sh
@@ -42,8 +42,8 @@ function check_wc_hnc_creation_removal() {
     no_error=true
     debug_msg=""
 
-    user_namespaces=$(yq4 -e '.user.namespaces[]' "${config['config_file_wc']}")
-    user_admin_users=$(yq4 -e '.user.adminUsers[]' "${config['config_file_wc']}")
+    mapfile -t user_namespaces < <(yq4 -e '.user.namespaces[]' "${config['config_file_wc']}")
+    mapfile -t user_admin_users < <(yq4 -e '.user.adminUsers[]' "${config['config_file_wc']}")
 
     VERBS=(
         create
@@ -63,23 +63,23 @@ function check_wc_hnc_creation_removal() {
         velero
     )
 
-    for user in ${user_admin_users}; do
-        for namespace in ${user_namespaces}; do
+    for user in "${user_admin_users[@]}"; do
+        for namespace in "${user_namespaces[@]}"; do
             for verb in "${VERBS[@]}"; do
-                if ! kubectl auth can-i "$verb" "subns" -n "$namespace" --as "$user" >/dev/null 2>&1; then
+                if ! kubectl auth can-i "${verb}" "subns" -n "${namespace}" --as "${user}" >/dev/null 2>&1; then
                     no_error=false
-                    debug_msg+="[ERROR] $user cannot $verb sub namespace under $namespace namespace\n"
+                    debug_msg+="[ERROR] ${user} cannot ${verb} sub namespace under ${namespace} namespace\n"
                 fi
             done
         done
     done
 
-    for user in ${user_admin_users}; do
+    for user in "${user_admin_users[@]}"; do
         for namespace in "${CK8S_NAMESPACES[@]}"; do
             for verb in "${VERBS[@]}"; do
-                if kubectl auth can-i "$verb" "subns" -n "$namespace" --as "$user" >/dev/null 2>&1; then
+                if kubectl auth can-i "${verb}" "subns" -n "${namespace}" --as "${user}" >/dev/null 2>&1; then
                     no_error=false
-                    debug_msg+="[ERROR] $user can $verb subnamespace anchors under $namespace namespace\n"
+                    debug_msg+="[ERROR] ${user} can ${verb} subnamespace anchors under ${namespace} namespace\n"
                 fi
             done
         done
@@ -90,7 +90,7 @@ function check_wc_hnc_creation_removal() {
         echo -e "[DEBUG] Users are able to create/delete subnamespaces anchors"
     else
         echo "failure ❌"
-        echo -e "$debug_msg"
+        echo -e "${debug_msg}"
     fi
 }
 
@@ -110,10 +110,10 @@ function check_wc_hnc_system_namespaces() {
     )
 
     for namespace in "${CK8S_NAMESPACES[@]}"; do
-        hnc_label_exists=$(kubectl get ns "$namespace" -ojson | jq -r '.metadata.labels | .["hnc.x-k8s.io/included-namespace"]')
-        if [[ "$hnc_label_exists" == "true" ]]; then
+        hnc_label_exists=$(kubectl get ns "${namespace}" -ojson | jq -r '.metadata.labels | .["hnc.x-k8s.io/included-namespace"]')
+        if [[ "${hnc_label_exists}" == "true" ]]; then
             no_error=false
-            debug_msg+="[ERROR] The $namespace namespace is labelled by HNC\n"
+            debug_msg+="[ERROR] The ${namespace} namespace is labelled by HNC\n"
         fi
     done
 
@@ -122,6 +122,6 @@ function check_wc_hnc_system_namespaces() {
         echo -e "[DEBUG] No system namespace is labelled by HNC"
     else
         echo "failure ❌"
-        echo -e "$debug_msg"
+        echo -e "${debug_msg}"
     fi
 }


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Previously, the `hnc` test did not handle space separated user names. This PR addresses this and solves this by adding quotes to variables to avoid word splitting

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
- Config checks:
  - [ ] The schema was updated
