### PR TITLE
Add falco exception for calico-accountant with nftables

### DIFF
--- a/helmfile.d/values/falco/falco-common.yaml.gotmpl
+++ b/helmfile.d/values/falco/falco-common.yaml.gotmpl
@@ -13,13 +13,13 @@ falco:
     enabled: true
 
   rules_file:
-    {{- if eq .Values.falco.rulesFiles.default.enabled true }}
+    {{- if .Values.falco.rulesFiles.default.enabled }}
     - /etc/falco/falco_rules.yaml
     {{end}}
-    {{- if eq .Values.falco.rulesFiles.incubating.enabled true }}
+    {{- if .Values.falco.rulesFiles.incubating.enabled }}
     - /etc/falco/falco-incubating_rules.yaml
     {{end}}
-    {{- if eq .Values.falco.rulesFiles.sandbox.enabled true }}
+    {{- if .Values.falco.rulesFiles.sandbox.enabled }}
     - /etc/falco/falco-sandbox_rules.yaml
     {{end}}
     - /etc/falco/falco_rules.local.yaml
@@ -74,13 +74,13 @@ falcoctl:
     artifact:
       install:
         refs:
-          {{- if eq .Values.falco.rulesFiles.default.enabled true }}
+          {{- if .Values.falco.rulesFiles.default.enabled }}
           - falco-rules:{{.Values.falco.rulesFiles.default.version}}
           {{end}}
-          {{- if eq .Values.falco.rulesFiles.incubating.enabled true }}
+          {{- if .Values.falco.rulesFiles.incubating.enabled }}
           - falco-incubating-rules:{{.Values.falco.rulesFiles.incubating.version}}
           {{end}}
-          {{- if eq .Values.falco.rulesFiles.sandbox.enabled true }}
+          {{- if .Values.falco.rulesFiles.sandbox.enabled }}
           - falco-sandbox-rules:{{.Values.falco.rulesFiles.sandbox.version}}
           {{end}}
     {{- with .Values.falco.customIndexes }}
@@ -92,7 +92,7 @@ customRules:
     {{ toYaml .Values.falco.customRules | nindent 2}}
   {{- end }}
   overwrites.yaml: |-
-    {{- if eq  .Values.falco.rulesFiles.default.enabled true }}
+    {{- if .Values.falco.rulesFiles.default.enabled }}
     # This will be added in a later falco rules version as well
     # The fix was added upstream here (with a new condition): https://github.com/falcosecurity/rules/pull/177
     - macro: allowed_clear_log_files
@@ -164,9 +164,18 @@ customRules:
           (container.image.repository = quay.io/calico/node and proc.name = calico-node) or
           (container.image.repository = registry.k8s.io/dns/k8s-dns-node-cache and proc.name = node-cache)
         )
+
+    {{- if and .Values.calicoAccountant.enabled (eq .Values.calicoAccountant.backend "nftables") }}
+
+    # Drop and execute new binary in container
+    - list: known_drop_and_execute_containers
+      items:
+        - ghcr.io/elastisys/calico-accountant
+    {{- end }}
     {{- end }}
 
-    {{- if eq .Values.falco.rulesFiles.incubating.enabled true }}
+    {{- if .Values.falco.rulesFiles.incubating.enabled }}
+
     # Change thread namespace
     - macro: user_known_change_thread_namespace_activities
       condition: (
@@ -272,7 +281,7 @@ customRules:
         condition: append
     {{- end }}
 
-    {{- if eq .Values.falco.rulesFiles.sandbox.enabled true }}
+    {{- if .Values.falco.rulesFiles.sandbox.enabled }}
     # Decoding Payload in Container
     - list: known_decode_payload_containers
       items: [ghcr.io/aquasecurity/trivy]


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

When running with `calicoAccountant.backend=nftables` a `Drop and execute new binary in container` event is triggered by Falco when [calico-accountant calls `iptables`](https://github.com/elastisys/compliantkubernetes-apps/blob/v0.37.0/helmfile.d/charts/calico-accountant/templates/daemonset.yaml#L22-L25). This adds an exception to Falco rules for calico-accountant only when `backend` is set to `nftables`.

#### Information to reviewers

The additional new lines added were to keep the rules in the generated override configmap equally spaced. :)

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
- Config checks:
  - [ ] The schema was updated
