### PR TITLE
Specify 4 space indentation for policy rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,7 @@ tab_width = 4
 # Setting max_line_length=off would use the local editor default.
 # Therefore, set to a high number to allow long lines.
 max_line_length = 10000
+
+[*.rego]
+indent_style = space
+indent_size = 4

--- a/helmfile.d/charts/gatekeeper/templates/policies/reject-loadbalancer-service.rego
+++ b/helmfile.d/charts/gatekeeper/templates/policies/reject-loadbalancer-service.rego
@@ -1,6 +1,6 @@
 package k8srejectloadbalancerservice
 
 violation[{"msg": msg}] {
-  input.review.object.kind == "Service"; input.review.object.spec.type == "LoadBalancer"
-  msg := "Creation of LoadBalancer Service is not supported. Contact your platform administrator for questions about Load Balancers. Read more at https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-no-load-balancer-service/"
+    input.review.object.kind == "Service"; input.review.object.spec.type == "LoadBalancer"
+    msg := "Creation of LoadBalancer Service is not supported. Contact your platform administrator for questions about Load Balancers. Read more at https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-no-load-balancer-service/"
 }


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [x] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Because we want consistent code style in `.rego` files.
This both tells compatible code editors what the expected indentation should be, as well as enforces it in `pre-commit`.

#### Information to reviewers

Includes fix for one `.rego` file that used 2-space indentation.
All others already use 4-space indentation.

Can be tested by attempting to commit a `.rego` file with e.g. 3 space indentation or tabs etc.

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
