### PR TITLE
Fix falco condition for gatekeeper constraints api call

### DIFF
--- a/helmfile.d/values/falco/falco-common.yaml.gotmpl
+++ b/helmfile.d/values/falco/falco-common.yaml.gotmpl
@@ -152,7 +152,7 @@ customRules:
         ) or (
           proc.cmdline startswith "kubectl patch secret -n argocd-system argocd-manager-config -p"
         ) or (
-          proc.cmdline glob "kubectl get crd *.constraints.gatekeeper.sh -o jsonpath={.status.conditions[?(@.type=="Established")].status}"
+          proc.cmdline glob 'kubectl get crd *.constraints.gatekeeper.sh -o jsonpath={.status.conditions[?(@.type=="Established")].status}'
         )
 
     # Run shell untrusted


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

When deploying Falco with the most recent changes, the pods got this error:

```
Tue May 14 09:49:08 2024: Falco version: 0.37.1 (x86_64)
...
Tue May 14 09:49:09 2024: Loading rules from file /etc/falco/rules.d/overwrites.yaml
Error: /etc/falco/rules.d/overwrites.yaml: Invalid
1 Errors:
In rules content: (/etc/falco/rules.d/overwrites.yaml:0:0)
    macro 'user_known_contact_k8s_api_server_activities': (/etc/falco/rules.d/overwrites.yaml:50:2)
    macro condition: (/etc/falco/rules.d/overwrites.yaml:51:13)
    condition expression: ("(   container.ima...":59:122)
------
)
^
------
LOAD_ERR_COMPILE_CONDITION (Error compiling condition): expected a ')' token
```
Checking the conditions for `user_known_contact_k8s_api_server_activities`, the error seems to have been caused by not escaping quotations inside a string. Using single quotes instead solved the issue.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
