### PR TITLE
Add `ck8s ops velero` command and clean up new velero finalizers

### DIFF
--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -11,5 +11,6 @@ pkg:golang/github.com/helmfile/helmfile@v0.162.0
 pkg:golang/github.com/mikefarah/yq/v3@3.4.1
 pkg:golang/github.com/mikefarah/yq/v4@v4.42.1
 pkg:golang/github.com/neilpa/yajsv@v1.4.1
+pkg:golang/github.com/vmware-tanzu/velero@v1.13.0
 pkg:golang/getsops/sops/v3@v3.8.1
 pkg:golang/helm.sh/helm/v3@v3.13.3

--- a/bin/ck8s
+++ b/bin/ck8s
@@ -28,6 +28,7 @@ usage() {
     #       confident that the apply command and migrations are good enough
     #       that direct Helmfile access is not necessary.
     echo "  ops helmfile <wc|sc>                           run helmfile as cluster admin" 1>&2
+    echo "  ops velero <wc|sc>                             run velero as cluster admin" 1>&2
     echo "  s3cmd [cmd]                                    run s3cmd" 1>&2
     echo "  kubeconfig <user|dev|admin>                    generate user kubeconfig, stored at CK8S_CONFIG_PATH/user"
     echo "  completion bash                                output shell completion code for bash" 1>&2
@@ -116,6 +117,11 @@ case "${1}" in
                 [[ "${3}" =~ ^(wc|sc)$ ]] || usage
                 shift 2
                 "${here}/ops.bash" helmfile "${@}"
+            ;;
+            velero)
+                [[ "${3}" =~ ^(wc|sc)$ ]] || usage
+                shift 2
+                "${here}/ops.bash" velero "${@}"
             ;;
             *) usage ;;
         esac

--- a/bin/ops.bash
+++ b/bin/ops.bash
@@ -72,6 +72,17 @@ ops_helmfile() {
         helmfile -f "${here}/../helmfile.d/" -e ${cluster} "${@}"
 }
 
+# Run arbitrary Velero commands as cluster admin.
+ops_velero() {
+    case "${1}" in
+        sc) kubeconfig="${config[kube_config_sc]}" ;;
+        wc) kubeconfig="${config[kube_config_wc]}" ;;
+        *) usage ;;
+    esac
+    shift
+    with_kubeconfig "${kubeconfig}" velero "${@}"
+}
+
 case "${1}" in
     kubectl)
         shift
@@ -88,6 +99,10 @@ case "${1}" in
     helmfile)
         shift
         ops_helmfile "${@}"
+    ;;
+    velero)
+        shift
+        ops_velero "${@}"
     ;;
     *) usage ;;
 esac

--- a/roles/get-requirements.yaml
+++ b/roles/get-requirements.yaml
@@ -4,21 +4,22 @@
   vars:
     install_path: "{{ lookup('env', 'CK8S_INSTALL_PATH', default='/usr/local/bin') }}"
     install_user: "{{ lookup('env','USER') }}"
-    kubectl_version: "{{ requirements['kubectl'].version | regex_replace('^v', '') }}"
-    helm_version: "{{ requirements['helm.sh/helm/v3'].version | regex_replace('^v', '') }}"
-    helmfile_version: "{{ requirements['github.com/helmfile/helmfile'].version | regex_replace('^v', '') }}"
-    helmdiff_version: "{{ requirements['github.com/databus23/helm-diff/v3'].version | regex_replace('^v', '') }}"
-    helmsecrets_version: "{{ requirements['helm-secrets'].version | regex_replace('^v', '') }}"
-    jq_version: "{{ requirements['jq'].version | regex_replace('^jq-', '') }}"
-    s3cmd_version: "{{ requirements['s3cmd'].version }}"
-    sops_version: "{{ requirements['getsops/sops/v3'].version | regex_replace('^v', '') }}"
-    yq_version: "{{ requirements['github.com/mikefarah/yq/v3'].version }}"
-    yq4_version: "{{ requirements['github.com/mikefarah/yq/v4'].version | regex_replace('^v', '') }}"
-    yajsv_version: "{{ requirements['github.com/neilpa/yajsv'].version | regex_replace('^v', '') }}"
-    pwgen_version: "{{ requirements['pwgen'].version }}"
     apache2_utils_version: "{{ requirements['apache2-utils'].version }}"
     curl_version: "{{ requirements['curl'].version }}"
     dnsutils_version: "{{ requirements['dnsutils'].version }}"
+    helm_version: "{{ requirements['helm.sh/helm/v3'].version | regex_replace('^v', '') }}"
+    helmdiff_version: "{{ requirements['github.com/databus23/helm-diff/v3'].version | regex_replace('^v', '') }}"
+    helmfile_version: "{{ requirements['github.com/helmfile/helmfile'].version | regex_replace('^v', '') }}"
+    helmsecrets_version: "{{ requirements['helm-secrets'].version | regex_replace('^v', '') }}"
+    jq_version: "{{ requirements['jq'].version | regex_replace('^jq-', '') }}"
+    kubectl_version: "{{ requirements['kubectl'].version | regex_replace('^v', '') }}"
+    pwgen_version: "{{ requirements['pwgen'].version }}"
+    s3cmd_version: "{{ requirements['s3cmd'].version }}"
+    sops_version: "{{ requirements['getsops/sops/v3'].version | regex_replace('^v', '') }}"
+    velero_version: "{{ requirements['github.com/vmware-tanzu/velero'].version }}"
+    yajsv_version: "{{ requirements['github.com/neilpa/yajsv'].version | regex_replace('^v', '') }}"
+    yq_version: "{{ requirements['github.com/mikefarah/yq/v3'].version }}"
+    yq4_version: "{{ requirements['github.com/mikefarah/yq/v4'].version | regex_replace('^v', '') }}"
     apt_list:
       - curl={{ curl_version }}
       - s3cmd={{ s3cmd_version }}
@@ -85,6 +86,28 @@
           when: (not kubectl_exists.stat.exists) or
             (current_kubectl_version.stdout == "") or
             (kubectl_version | string not in current_kubectl_version.stdout | from_json | json_query('clientVersion.gitVersion'))
+
+    - name: Velero
+      block:
+        - name: Check if Velero exists
+          stat:
+            path: "{{ install_path }}/velero"
+          register: velero_exists
+
+        - name: Check Velero
+          command: "velero version --client-only | grep Version | awk '{print $2}'"
+          register: current_velero_version
+          when: velero_exists.stat.exists
+
+        - name: Get Velero
+          unarchive:
+            src: https://github.com/vmware-tanzu/velero/releases/download/{{ velero_version }}/velero-{{ velero_version }}-linux-amd64.tar.gz
+            dest: "{{ install_path }}"
+            remote_src: yes
+            extra_opts: [--strip-components=1]
+          when: (not velero_exists.stat.exists) or
+            (current_velero_version.stdout == "") or
+            (velero_version | string not in current_velero_version.stdout)
 
     - name: Helm
       block:

--- a/scripts/clean-sc.sh
+++ b/scripts/clean-sc.sh
@@ -33,6 +33,9 @@ if [ -n "${GATE_VALWEBHOOK}" ]; then
     "${here}/.././bin/ck8s" ops kubectl sc delete "${GATE_VALWEBHOOK}"
 fi
 
+# Makes sure to uninstall Velero properly: https://velero.io/docs/v1.13/uninstalling/
+"${here}/.././bin/ck8s" ops velero sc uninstall
+
 # Destroy all helm releases
 "${here}/.././bin/ck8s" ops helmfile sc -l app!=cert-manager destroy
 

--- a/scripts/clean-wc.sh
+++ b/scripts/clean-wc.sh
@@ -45,6 +45,9 @@ fi
 # Might fail to be destroyed the first time, therefore run it once now
 "${here}/.././bin/ck8s" ops helmfile wc -l app=hnc destroy
 
+# Makes sure to uninstall Velero properly: https://velero.io/docs/v1.13/uninstalling/
+"${here}/.././bin/ck8s" ops velero wc uninstall
+
 # Destroy all helm releases
 "${here}/.././bin/ck8s" ops helmfile wc -l app!=cert-manager destroy
 


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice

It is now possible to run `velero` commands with `ck8s ops velero <wc|sc>`

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Running clean script got stuck when trying to delete Velero CRDs after having upgraded to the new Velero chart. This was caused by newly added finalizers to Velero resources (see breaking changes in [this Velero release](https://github.com/vmware-tanzu/velero/releases/tag/v1.12.0)). This PR adds a step for running `velero uninstall` before deleting the `velero` namespace or any of its CRDs, as it is the recommended way according to [their docs](https://velero.io/docs/v1.13/uninstalling/). To achieve this in the clean scripts, a new `ck8s ops` command was added for `velero` to be able to run the `velero` CLI against the correct cluster context.

- Follow up fix from #2031 

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
