### PR TITLE
Support installing requirements without root

### DIFF
--- a/bin/ck8s
+++ b/bin/ck8s
@@ -31,7 +31,7 @@ usage() {
     echo "  s3cmd [cmd]                                    run s3cmd" 1>&2
     echo "  kubeconfig <user|dev|admin>                    generate user kubeconfig, stored at CK8S_CONFIG_PATH/user"
     echo "  completion bash                                output shell completion code for bash" 1>&2
-    echo "  install-requirements                           installs or updates required tools to run compliantkubernetes-apps" 1>&2
+    echo "  install-requirements [--user]                  installs or updates required tools to run compliantkubernetes-apps" 1>&2
     echo "  validate <wc|sc>                               validates config files" 1>&2
     echo "  providers                                      lists supported cloud providers" 1>&2
     echo "  flavors                                        lists supported configuration flavors" 1>&2
@@ -134,7 +134,7 @@ case "${1}" in
         ;;
     install-requirements)
         [ -f "${here}/install-requirements.bash" ] || usage
-        "${here}/install-requirements.bash"
+        "${here}/install-requirements.bash" "${@}"
         ;;
     validate)
         [[ "${2}" =~ ^(wc|sc)$ ]] || usage

--- a/bin/install-requirements.bash
+++ b/bin/install-requirements.bash
@@ -6,4 +6,9 @@ export ANSIBLE_STDOUT_CALLBACK=yaml
 
 echo "This script will install all requirements"
 echo "Enter your password to start the install"
-ansible-playbook -e 'ansible_python_interpreter=/usr/bin/python3' --ask-become-pass --connection local --inventory 127.0.0.1, roles/get-requirements.yaml
+
+if [ "${#}" -ge 2 ] && [ "${2}" = "--user" ]; then
+  ansible-playbook -e 'ansible_python_interpreter=/usr/bin/python3' --ask-become-pass --extra-vars install_path="${HOME}/bin" roles/get-requirements.yaml
+else
+  ansible-playbook -e 'ansible_python_interpreter=/usr/bin/python3' --ask-become-pass --become --become-user root roles/get-requirements.yaml
+fi

--- a/bin/install-requirements.bash
+++ b/bin/install-requirements.bash
@@ -8,7 +8,8 @@ echo "This script will install all requirements"
 echo "Enter your password to start the install"
 
 if [ "${#}" -ge 2 ] && [ "${2}" = "--user" ]; then
-  ansible-playbook -e 'ansible_python_interpreter=/usr/bin/python3' --ask-become-pass --extra-vars install_path="${HOME}/bin" roles/get-requirements.yaml
+  export CK8S_INSTALL_PATH="${CK8S_INSTALL_PATH:-"${HOME}/bin"}"
+  ansible-playbook -e 'ansible_python_interpreter=/usr/bin/python3' --ask-become-pass roles/get-requirements.yaml
 else
   ansible-playbook -e 'ansible_python_interpreter=/usr/bin/python3' --ask-become-pass --become --become-user root roles/get-requirements.yaml
 fi

--- a/roles/get-requirements.yaml
+++ b/roles/get-requirements.yaml
@@ -2,7 +2,7 @@
   connection: local
   hosts: localhost
   vars:
-    install_path: /usr/local/bin
+    install_path: "{{ lookup('env', 'CK8S_INSTALL_PATH', default='/usr/local/bin') }}"
     install_user: "{{ lookup('env','USER') }}"
     kubectl_version: 1.28.6
     helm_version: 3.13.3

--- a/roles/get-requirements.yaml
+++ b/roles/get-requirements.yaml
@@ -1,4 +1,5 @@
 - name: Download compliantkubernetes-apps requirements
+  connection: local
   hosts: localhost
   vars:
     install_path: /usr/local/bin
@@ -45,11 +46,10 @@
         dest: "{{ install_path }}/yajsv"
         version_flag: "-v"
 
-  connection: local
-  become: yes
-  become_user: root
   tasks:
     - name: Install apt-packages
+      become: yes
+      become_user: root
       apt:
         pkg: "{{ apt_list }}"
         update_cache: yes


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Some users like to install their requirements in a user directory without root instead of globally. I found myself parsing the `get-requirements.yaml` file and installing things manually. This makes it useful for me (and others that have the same preference).

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
