### PR TITLE
Declare requirements as PURLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+__pycache__

--- a/README.md
+++ b/README.md
@@ -58,18 +58,8 @@ The apps are installed using a combination of helm charts and manifests with the
 
 ### :wrench: Requirements :wrench:
 
-- [compliantkubernetes-kubespray][compliantkubernetes-kubespray] environment
-- [kubectl](https://github.com/kubernetes/kubernetes/releases) (tested with 1.24.4)
-- [helm](https://github.com/helm/helm/releases) (tested with 3.8.0)
-- [helmfile](https://github.com/helmfile/helmfile) (tested with v0.154.0)
-- [helm-diff](https://github.com/databus23/helm-diff) (tested with 3.5.0)
-- [helm-secrets](https://github.com/futuresimple/helm-secrets) (tested with 3.12.0)
-- [jq](https://github.com/stedolan/jq) (tested with jq-1.6)
-- [sops](https://github.com/getsops/sops) (tested with 3.7.3)
-- [s3cmd](https://s3tools.org/s3cmd) available directly in Ubuntus repositories (tested with 2.0.1)
-- [yq4](https://github.com/mikefarah/yq) (tested with 4.26.1)
-- [pwgen](https://sourceforge.net/projects/pwgen/) available directly in Ubuntus repositories (tested with 2.08)
-- [htpasswd](https://httpd.apache.org/docs/2.4/programs/htpasswd.html) available directly in Ubuntus repositories (tested with 2.4.41)
+To operate compliantkubernetes-apps some tools need to be installed.
+They are declared in the file [REQUIREMENTS](./REQUIREMENTS) as [PURLs](https://github.com/package-url/purl-spec).
 
 Install the requirements to use compliantkubernetes-apps:
 

--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -1,0 +1,15 @@
+pkg:deb/ubuntu/apache2-utils@2.4.52-1ubuntu4.9?arch=amd64&distro=jammy
+pkg:deb/ubuntu/curl@7.81.0-1ubuntu1.16?arch=amd64&distro=jammy
+pkg:deb/ubuntu/dnsutils@1:9.18.18-0ubuntu0.22.04.2?arch=amd64&distro=jammy
+pkg:deb/ubuntu/pwgen@2.08-2build1?arch=amd64&distro=jammy
+pkg:deb/ubuntu/s3cmd@2.2.0-1?arch=amd64&distro=jammy
+pkg:generic/kubectl@v1.28.6
+pkg:github/jkroepke/helm-secrets@v4.5.1
+pkg:github/jqlang/jq@jq-1.6
+pkg:golang/github.com/databus23/helm-diff/v3@v3.9.4
+pkg:golang/github.com/helmfile/helmfile@v0.162.0
+pkg:golang/github.com/mikefarah/yq/v3@3.4.1
+pkg:golang/github.com/mikefarah/yq/v4@v4.42.1
+pkg:golang/github.com/neilpa/yajsv@v1.4.1
+pkg:golang/getsops/sops/v3@v3.8.1
+pkg:golang/helm.sh/helm/v3@v3.13.3

--- a/roles/get-requirements.yaml
+++ b/roles/get-requirements.yaml
@@ -4,23 +4,25 @@
   vars:
     install_path: "{{ lookup('env', 'CK8S_INSTALL_PATH', default='/usr/local/bin') }}"
     install_user: "{{ lookup('env','USER') }}"
-    kubectl_version: 1.28.6
-    helm_version: 3.13.3
-    helmfile_version: 0.162.0
-    helmdiff_version: 3.9.4
-    helmsecrets_version: 4.5.1
-    jq_version: 1.6
-    s3cmd_version: 2.*
-    sops_version: 3.8.1
-    yq_version: 3.4.1
-    yq4_version: 4.42.1
-    yajsv_version: 1.4.1
-    pwgen_version: 2.08*
-    apache2_utils_version: 2.4.*
+    kubectl_version: "{{ requirements['kubectl'].version | regex_replace('^v', '') }}"
+    helm_version: "{{ requirements['helm.sh/helm/v3'].version | regex_replace('^v', '') }}"
+    helmfile_version: "{{ requirements['github.com/helmfile/helmfile'].version | regex_replace('^v', '') }}"
+    helmdiff_version: "{{ requirements['github.com/databus23/helm-diff/v3'].version | regex_replace('^v', '') }}"
+    helmsecrets_version: "{{ requirements['helm-secrets'].version | regex_replace('^v', '') }}"
+    jq_version: "{{ requirements['jq'].version | regex_replace('^jq-', '') }}"
+    s3cmd_version: "{{ requirements['s3cmd'].version }}"
+    sops_version: "{{ requirements['getsops/sops/v3'].version | regex_replace('^v', '') }}"
+    yq_version: "{{ requirements['github.com/mikefarah/yq/v3'].version }}"
+    yq4_version: "{{ requirements['github.com/mikefarah/yq/v4'].version | regex_replace('^v', '') }}"
+    yajsv_version: "{{ requirements['github.com/neilpa/yajsv'].version | regex_replace('^v', '') }}"
+    pwgen_version: "{{ requirements['pwgen'].version }}"
+    apache2_utils_version: "{{ requirements['apache2-utils'].version }}"
+    curl_version: "{{ requirements['curl'].version }}"
+    dnsutils_version: "{{ requirements['dnsutils'].version }}"
     apt_list:
-      - curl
+      - curl={{ curl_version }}
       - s3cmd={{ s3cmd_version }}
-      - dnsutils
+      - dnsutils={{ dnsutils_version }}
       - apache2-utils={{ apache2_utils_version }}
       - pwgen={{ pwgen_version }}
     get_url_list:
@@ -47,6 +49,14 @@
         version_flag: "-v"
 
   tasks:
+    - name: Parse requirement PURLs
+      command: ../scripts/requirements/parse.py
+      register: parse_requirements_result
+
+    - name: Set requirements facts
+      set_fact:
+        requirements: "{{ parse_requirements_result.stdout | from_json }}"
+
     - name: Install apt-packages
       become: yes
       become_user: root

--- a/scripts/requirements/packageurl.py
+++ b/scripts/requirements/packageurl.py
@@ -1,0 +1,549 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) the purl authors
+# SPDX-License-Identifier: MIT
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Visit https://github.com/package-url/packageurl-python for support and
+# download.
+
+import string
+from collections import namedtuple
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import AnyStr
+from typing import Dict
+from typing import Optional
+from typing import Tuple
+from typing import Union
+from typing import overload
+from urllib.parse import quote as _percent_quote
+from urllib.parse import unquote as _percent_unquote
+from urllib.parse import urlsplit as _urlsplit
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Iterable
+
+    from typing_extensions import Literal
+
+# Python 3
+basestring = (
+    bytes,
+    str,
+)  # NOQA
+
+"""
+A purl (aka. Package URL) implementation as specified at:
+https://github.com/package-url/purl-spec
+"""
+
+
+def quote(s: AnyStr) -> str:
+    """
+    Return a percent-encoded unicode string, except for colon :, given an `s`
+    byte or unicode string.
+    """
+    if isinstance(s, str):
+        s_bytes = s.encode("utf-8")
+    else:
+        s_bytes = s
+    quoted = _percent_quote(s_bytes)
+    if not isinstance(quoted, str):
+        quoted = quoted.decode("utf-8")
+    quoted = quoted.replace("%3A", ":")
+    return quoted
+
+
+def unquote(s: AnyStr) -> str:
+    """
+    Return a percent-decoded unicode string, given an `s` byte or unicode
+    string.
+    """
+    unquoted = _percent_unquote(s)  # type:ignore[arg-type]  # typeshed is incorrect here
+    if not isinstance(unquoted, str):
+        unquoted = unquoted.decode("utf-8")
+    return unquoted
+
+
+@overload
+def get_quoter(encode: bool = True) -> "Callable[[AnyStr], str]": ...
+
+
+@overload
+def get_quoter(encode: None) -> "Callable[[str], str]": ...
+
+
+def get_quoter(
+    encode: Optional[bool] = True,
+) -> "Union[Callable[[AnyStr], str], Callable[[str], str]]":
+    """
+    Return quoting callable given an `encode` tri-boolean (True, False or None)
+    """
+    if encode is True:
+        return quote
+    elif encode is False:
+        return unquote
+    elif encode is None:
+        return lambda x: x
+
+
+def normalize_type(type: Optional[AnyStr], encode: Optional[bool] = True) -> Optional[str]:  # NOQA
+    if not type:
+        return None
+    if not isinstance(type, str):
+        type_str = type.decode("utf-8")  # NOQA
+    else:
+        type_str = type
+
+    quoter = get_quoter(encode)
+    type_str = quoter(type_str)  # NOQA
+    return type_str.strip().lower() or None
+
+
+def normalize_namespace(
+    namespace: Optional[AnyStr], ptype: Optional[str], encode: Optional[bool] = True
+) -> Optional[str]:  # NOQA
+    if not namespace:
+        return None
+    if not isinstance(namespace, str):
+        namespace_str = namespace.decode("utf-8")
+    else:
+        namespace_str = namespace
+
+    namespace_str = namespace_str.strip().strip("/")
+    if ptype in ("bitbucket", "github", "pypi", "gitlab"):
+        namespace_str = namespace_str.lower()
+    segments = [seg for seg in namespace_str.split("/") if seg.strip()]
+    segments_quoted = map(get_quoter(encode), segments)
+    return "/".join(segments_quoted) or None
+
+
+def normalize_name(
+    name: Optional[AnyStr], ptype: Optional[str], encode: Optional[bool] = True
+) -> Optional[str]:  # NOQA
+    if not name:
+        return None
+    if not isinstance(name, str):
+        name_str = name.decode("utf-8")
+    else:
+        name_str = name
+
+    quoter = get_quoter(encode)
+    name_str = quoter(name_str)
+    name_str = name_str.strip().strip("/")
+    if ptype in ("bitbucket", "github", "pypi", "gitlab"):
+        name_str = name_str.lower()
+    if ptype == "pypi":
+        name_str = name_str.replace("_", "-")
+    return name_str or None
+
+
+def normalize_version(
+    version: Optional[AnyStr], encode: Optional[bool] = True
+) -> Optional[str]:  # NOQA
+    if not version:
+        return None
+    if not isinstance(version, str):
+        version_str = version.decode("utf-8")
+    else:
+        version_str = version
+
+    quoter = get_quoter(encode)
+    version_str = quoter(version_str.strip())
+    return version_str or None
+
+
+@overload
+def normalize_qualifiers(
+    qualifiers: Union[AnyStr, Dict[str, str], None], encode: "Literal[True]" = ...
+) -> Optional[str]: ...
+
+
+@overload
+def normalize_qualifiers(
+    qualifiers: Union[AnyStr, Dict[str, str], None], encode: "Optional[Literal[False]]"
+) -> Optional[Dict[str, str]]: ...
+
+
+@overload
+def normalize_qualifiers(
+    qualifiers: Union[AnyStr, Dict[str, str], None], encode: Optional[bool] = ...
+) -> Union[str, Dict[str, str], None]: ...
+
+
+def normalize_qualifiers(
+    qualifiers: Union[AnyStr, Dict[str, str], None], encode: Optional[bool] = True
+) -> Union[str, Dict[str, str], None]:  # NOQA
+    """
+    Return normalized `qualifiers` as a mapping (or as a string if `encode` is
+    True). The `qualifiers` arg is either a mapping or a string.
+    Always return a mapping if decode is True (and never None).
+    Raise ValueError on errors.
+    """
+    if not qualifiers:
+        return None if encode else dict()
+
+    if isinstance(qualifiers, basestring):
+        if not isinstance(qualifiers, str):
+            qualifiers_str = qualifiers.decode("utf-8")
+        else:
+            qualifiers_str = qualifiers
+        # decode string to list of tuples
+        qualifiers_list = qualifiers_str.split("&")
+        if not all("=" in kv for kv in qualifiers_list):
+            raise ValueError(
+                f"Invalid qualifier. Must be a string of key=value pairs:{repr(qualifiers_list)}"
+            )
+        qualifiers_parts = [kv.partition("=") for kv in qualifiers_list]
+        qualifiers_pairs: "Iterable[Tuple[str, str]]" = [(k, v) for k, _, v in qualifiers_parts]
+    elif isinstance(qualifiers, dict):
+        qualifiers_pairs = qualifiers.items()
+    else:
+        raise ValueError(f"Invalid qualifier. Must be a string or dict:{repr(qualifiers)}")
+
+    quoter = get_quoter(encode)
+    qualifiers_map = {
+        k.strip().lower(): quoter(v)
+        for k, v in qualifiers_pairs
+        if k and k.strip() and v and v.strip()
+    }
+
+    valid_chars = string.ascii_letters + string.digits + ".-_"
+    for key in qualifiers_map:
+        if not key:
+            raise ValueError("A qualifier key cannot be empty")
+
+        if "%" in key:
+            raise ValueError(f"A qualifier key cannot be percent encoded: {repr(key)}")
+
+        if " " in key:
+            raise ValueError(f"A qualifier key cannot contain spaces: {repr(key)}")
+
+        if not all(c in valid_chars for c in key):
+            raise ValueError(
+                f"A qualifier key must be composed only of ASCII letters and numbers"
+                f"period, dash and underscore: {repr(key)}"
+            )
+
+        if key[0] in string.digits:
+            raise ValueError(f"A qualifier key cannot start with a number: {repr(key)}")
+
+    qualifiers_map = dict(sorted(qualifiers_map.items()))
+    if encode:
+        qualifiers_list = [f"{key}={value}" for key, value in qualifiers_map.items()]
+        qualifiers_str = "&".join(qualifiers_list)
+        return qualifiers_str or None
+    else:
+        return qualifiers_map
+
+
+def normalize_subpath(
+    subpath: Optional[AnyStr], encode: Optional[bool] = True
+) -> Optional[str]:  # NOQA
+    if not subpath:
+        return None
+    if not isinstance(subpath, str):
+        subpath_str = subpath.decode("utf-8")
+    else:
+        subpath_str = subpath
+
+    quoter = get_quoter(encode)
+    segments = subpath_str.split("/")
+    segments = [quoter(s) for s in segments if s.strip() and s not in (".", "..")]
+    subpath_str = "/".join(segments)
+    return subpath_str or None
+
+
+@overload
+def normalize(
+    type: Optional[AnyStr],
+    namespace: Optional[AnyStr],
+    name: Optional[AnyStr],
+    version: Optional[AnyStr],
+    qualifiers: Union[AnyStr, Dict[str, str], None],
+    subpath: Optional[AnyStr],
+    encode: "Literal[True]" = ...,
+) -> Tuple[str, Optional[str], str, Optional[str], Optional[str], Optional[str]]: ...
+
+
+@overload
+def normalize(
+    type: Optional[AnyStr],
+    namespace: Optional[AnyStr],
+    name: Optional[AnyStr],
+    version: Optional[AnyStr],
+    qualifiers: Union[AnyStr, Dict[str, str], None],
+    subpath: Optional[AnyStr],
+    encode: "Optional[Literal[False]]",
+) -> Tuple[str, Optional[str], str, Optional[str], Optional[Dict[str, str]], Optional[str]]: ...
+
+
+@overload
+def normalize(
+    type: Optional[AnyStr],
+    namespace: Optional[AnyStr],
+    name: Optional[AnyStr],
+    version: Optional[AnyStr],
+    qualifiers: Union[AnyStr, Dict[str, str], None],
+    subpath: Optional[AnyStr],
+    encode: Optional[bool] = ...,
+) -> Tuple[
+    str, Optional[str], str, Optional[str], Union[str, Dict[str, str], None], Optional[str]
+]: ...
+
+
+def normalize(
+    type: Optional[AnyStr],
+    namespace: Optional[AnyStr],
+    name: Optional[AnyStr],
+    version: Optional[AnyStr],
+    qualifiers: Union[AnyStr, Dict[str, str], None],
+    subpath: Optional[AnyStr],
+    encode: Optional[bool] = True,
+) -> Tuple[
+    Optional[str],
+    Optional[str],
+    Optional[str],
+    Optional[str],
+    Union[str, Dict[str, str], None],
+    Optional[str],
+]:  # NOQA
+    """
+    Return normalized purl components
+    """
+    type_norm = normalize_type(type, encode)  # NOQA
+    namespace_norm = normalize_namespace(namespace, type_norm, encode)
+    name_norm = normalize_name(name, type_norm, encode)
+    version_norm = normalize_version(version, encode)
+    qualifiers_norm = normalize_qualifiers(qualifiers, encode)
+    subpath_norm = normalize_subpath(subpath, encode)
+    return type_norm, namespace_norm, name_norm, version_norm, qualifiers_norm, subpath_norm
+
+
+class PackageURL(
+    namedtuple("PackageURL", ("type", "namespace", "name", "version", "qualifiers", "subpath"))
+):
+    """
+    A purl is a package URL as defined at
+    https://github.com/package-url/purl-spec
+    """
+
+    name: str
+    namespace: Optional[str]
+    qualifiers: Union[str, Dict[str, str], None]
+    subpath: Optional[str]
+    type: str
+    version: Optional[str]
+
+    def __new__(
+        self,
+        type: Optional[AnyStr] = None,
+        namespace: Optional[AnyStr] = None,
+        name: Optional[AnyStr] = None,  # NOQA
+        version: Optional[AnyStr] = None,
+        qualifiers: Union[AnyStr, Dict[str, str], None] = None,
+        subpath: Optional[AnyStr] = None,
+    ) -> "PackageURL":  # this should be 'Self' https://github.com/python/mypy/pull/13133
+        required = dict(type=type, name=name)
+        for key, value in required.items():
+            if value:
+                continue
+            raise ValueError(f"Invalid purl: {key} is a required argument.")
+
+        strings = dict(
+            type=type,
+            namespace=namespace,
+            name=name,
+            version=version,
+            subpath=subpath,
+        )
+
+        for key, value in strings.items():
+            if value and isinstance(value, basestring) or not value:
+                continue
+            raise ValueError(f"Invalid purl: {key} argument must be a string: {repr(value)}.")
+
+        if qualifiers and not isinstance(
+            qualifiers,
+            (
+                basestring,
+                dict,
+            ),
+        ):
+            raise ValueError(
+                f"Invalid purl: qualifiers argument must be a dict or a string: {repr(qualifiers)}."
+            )
+
+        (
+            type_norm,
+            namespace_norm,
+            name_norm,
+            version_norm,
+            qualifiers_norm,
+            subpath_norm,
+        ) = normalize(  # NOQA
+            type, namespace, name, version, qualifiers, subpath, encode=None
+        )
+
+        return super().__new__(
+            PackageURL,
+            type=type_norm,
+            namespace=namespace_norm,
+            name=name_norm,
+            version=version_norm,
+            qualifiers=qualifiers_norm,
+            subpath=subpath_norm,
+        )
+
+    def __str__(self, *args: Any, **kwargs: Any) -> str:
+        return self.to_string()
+
+    def __hash__(self) -> int:
+        return hash(self.to_string())
+
+    def to_dict(self, encode: Optional[bool] = False, empty: Any = None) -> Dict[str, Any]:
+        """
+        Return an ordered dict of purl components as {key: value}.
+        If `encode` is True, then "qualifiers" are encoded as a normalized
+        string. Otherwise, qualifiers is a mapping.
+        You can provide a value for `empty` to be used in place of default None.
+        """
+        data = self._asdict()
+        if encode:
+            data["qualifiers"] = normalize_qualifiers(self.qualifiers, encode=encode)
+
+        for field, value in data.items():
+            data[field] = value or empty
+
+        return data
+
+    def to_string(self) -> str:
+        """
+        Return a purl string built from components.
+        """
+        type, namespace, name, version, qualifiers, subpath = normalize(  # NOQA
+            self.type,
+            self.namespace,
+            self.name,
+            self.version,
+            self.qualifiers,
+            self.subpath,
+            encode=True,
+        )
+
+        purl = ["pkg:", type, "/"]
+
+        if namespace:
+            purl.append(namespace)
+            purl.append("/")
+
+        purl.append(name)
+
+        if version:
+            purl.append("@")
+            purl.append(version)
+
+        if qualifiers:
+            purl.append("?")
+            purl.append(qualifiers)
+
+        if subpath:
+            purl.append("#")
+            purl.append(subpath)
+
+        return "".join(purl)
+
+    @classmethod
+    def from_string(cls, purl: str) -> "PackageURL":
+        """
+        Return a PackageURL object parsed from a string.
+        Raise ValueError on errors.
+        """
+        if not purl or not isinstance(purl, str) or not purl.strip():
+            raise ValueError("A purl string argument is required.")
+
+        scheme, sep, remainder = purl.partition(":")
+        if not sep or scheme != "pkg":
+            raise ValueError(f'purl is missing the required "pkg" scheme component: {repr(purl)}.')
+
+        # this strip '/, // and /// as possible in :// or :///
+        remainder = remainder.strip().lstrip("/")
+
+        version: Optional[str]  # this line is just for type hinting
+        subpath: Optional[str]  # this line is just for type hinting
+
+        type, sep, remainder = remainder.partition("/")  # NOQA
+        if not type or not sep:
+            raise ValueError(f"purl is missing the required type component: {repr(purl)}.")
+
+        type = type.lower()
+
+        scheme, authority, path, qualifiers_str, subpath = _urlsplit(
+            url=remainder, scheme="", allow_fragments=True
+        )
+
+        if scheme or authority:
+            msg = (
+                f'Invalid purl {repr(purl)} cannot contain a "user:pass@host:port" '
+                f"URL Authority component: {repr(authority)}."
+            )
+            raise ValueError(msg)
+
+        path = path.lstrip("/")
+
+        namespace: Optional[str] = ""
+        # NPM purl have a namespace in the path
+        # and the namespace in an npm purl is
+        # different from others because it starts with `@`
+        # so we need to handle this case separately
+        if type == "npm" and path.startswith("@"):
+            namespace, sep, path = path.partition("/")
+
+        remainder, sep, version = path.rpartition("@")
+        if not sep:
+            remainder = version
+            version = None
+
+        ns_name = remainder.strip().strip("/")
+        ns_name_parts = ns_name.split("/")
+        ns_name_parts = [seg for seg in ns_name_parts if seg and seg.strip()]
+        name = ""
+        if not namespace and len(ns_name_parts) > 1:
+            name = ns_name_parts[-1]
+            ns = ns_name_parts[0:-1]
+            namespace = "/".join(ns)
+        elif len(ns_name_parts) == 1:
+            name = ns_name_parts[0]
+
+        if not name:
+            raise ValueError(f"purl is missing the required name component: {repr(purl)}")
+
+        type, namespace, name, version, qualifiers, subpath = normalize(  # NOQA
+            type,
+            namespace,
+            name,
+            version,
+            qualifiers_str,
+            subpath,
+            encode=False,
+        )
+
+        return PackageURL(type, namespace, name, version, qualifiers, subpath)

--- a/scripts/requirements/parse.py
+++ b/scripts/requirements/parse.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import json
+from pathlib import Path
+
+from packageurl import PackageURL
+
+purls = {}
+
+with (Path(__file__).parent / "../../REQUIREMENTS").open() as file:
+  for line in file:
+    purl = PackageURL.from_string(line)
+    name = purl.name
+    # Workaround for golang PURLs
+    # See: https://github.com/package-url/purl-spec/issues/63
+    if purl.type == "golang":
+      name = f"{purl.namespace}/{purl.name}"
+    purls[name] = purl.to_dict()
+
+print(json.dumps(purls))


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This PR declares ck8s-apps requirements as [PURLs](https://github.com/package-url/purl-spec). PURL (Package URL) is a standardized way of identifying software from different ecosystems.

I believe this will benefit us in that the requirements aren't sprawling all over the place and not declared deeply in some script.

Later this could also make it easier to replace Ansible as the installation mechanism (if we want to get rid of that) with something more lightweight as well as, and even more importantly, making vulnerability scanning easy.

#### Information to reviewers

I pinned the deb packages to Ubuntu 22.04. I'm not sure if this is still what we officially support or if it's something else? Please let me know if this is incorrect or if you have any ideas on how to improve this!

The PURLs now are also a mix of source packages and binary packages. I think vulnerabilities are usually targeting source packages but it would be nice to capture them all. Let me know if you have ideas in this regard as well!

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
