### PR TITLE
Allow changes to pods that are missing network policies when the pods are about to be deleted

### DIFF
--- a/helmfile.d/charts/gatekeeper/templates/policies/network-policies.rego
+++ b/helmfile.d/charts/gatekeeper/templates/policies/network-policies.rego
@@ -1,6 +1,10 @@
 package k8sRequireNetworkPolicy
 
 violation[{"msg": msg}] {
+    # allow modification to pod without network policy after it has been marked
+    # for deletion, e.g. changes to finalizers
+    not (input.review.object.metadata.deletionTimestamp)
+
     namespace := input.review.object.metadata.namespace
 
     res = [x | x := allChecks(data.inventory.namespace[namespace]["networking.k8s.io/v1"]["NetworkPolicy"][_])]


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2073

When an application is being deleted using [finalizers](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/), [the requirement for having a network policy](https://github.com/elastisys/compliantkubernetes-apps/blob/main/helmfile.d/charts/gatekeeper/constraints/templates/networkpolicies/constraint.yaml) may prevent modifications to a pod where the corresponding network policy has been deleted, including the change where the `metadata.finalizers[]` property is removed after the finalizer has completed its job.

#### Information to reviewers

I am assuming here that a pod in the process of being deleted can't start doing new things that could violate policies, and that even if it is changed, if it goes back into the normal running state policies will apply.

##### Testing

With the following configuration:

```yaml
# wc-config.yaml
opa:
  networkPolicies:
    enabled: true
    enforcement: deny
```

Create a Deployment (or single Pod)

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  creationTimestamp: null
  labels:
    app: testdeploy
  name: testdeploy
spec:
  replicas: 2
  selector:
    matchLabels:
      app: testdeploy
  strategy: {}
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: testdeploy
    spec:
      containers:
        - image: nginx:1
          name: nginx
          resources: {}
status: {}
```

and a NetworkPolicy

```yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: allow-all-ingress
spec:
  podSelector:
    matchLabels:
      app: testdeploy
  ingress:
    - {}
  policyTypes:
    - Ingress
```

After applying the above and observing that pods have been created, edit one of the pods and add to its metadata:

```yaml
metadata:
  finalizers:
  - kubernetes
```

Then delete the NetworkPolicy, followed by deleting the Deployment.
Observe that the pod remains in a Terminating status as it is blocked from being completely removed by the finalizer.
Now, attempt to remove the `metadata.finalizers` from the pod:

```console
$ kubectl patch pod testdeploy-7fdf9464bc-mc4cl --type json --patch='[{"op":"remove","path":"/metadata/finalizers"}]'
```

Previously this would have been rejected for missing a network policy, after this change it should pass and then the pod will finally be deleted.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [x] The bug fix is covered by regression tests
