### PR TITLE
psps: allow matchexpressions in gatekeeper mutation for runasuser

### DIFF
--- a/helmfile.d/charts/gatekeeper/podsecuritypolicies/templates/_.tpl
+++ b/helmfile.d/charts/gatekeeper/podsecuritypolicies/templates/_.tpl
@@ -41,6 +41,12 @@ kinds:
 namespaces:
   - {{ .namespace }}
 labelSelector:
+  {{- if .labels }}
   matchLabels:
     {{- toYaml .labels | nindent 4 }}
+  {{- end }}
+  {{- if .expressions }}
+  matchExpressions:
+    {{- toYaml .expressions | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helmfile.d/charts/gatekeeper/podsecuritypolicies/templates/custom/mutations/run-as-user.yaml
+++ b/helmfile.d/charts/gatekeeper/podsecuritypolicies/templates/custom/mutations/run-as-user.yaml
@@ -12,7 +12,7 @@ spec:
       kinds: ["Pod"]
       versions: ["v1"]
   match:
-    {{- dict "namespace" $namespace "labels" $value.podSelectorLabels | include "podsecuritypolicies.renderMatchInclusion" | nindent 4 }}
+    {{- dict "namespace" $namespace "labels" $value.podSelectorLabels "expressions" $value.podSelectorExpressions | include "podsecuritypolicies.renderMatchInclusion" | nindent 4 }}
   location: "spec.containers[name: *].securityContext.runAsUser"
   parameters:
     assign:
@@ -31,7 +31,7 @@ spec:
       kinds: ["Pod"]
       versions: ["v1"]
   match:
-    {{- dict "namespace" $namespace "labels" $value.podSelectorLabels | include "podsecuritypolicies.renderMatchInclusion" | nindent 4 }}
+    {{- dict "namespace" $namespace "labels" $value.podSelectorLabels "expressions" $value.podSelectorExpressions | include "podsecuritypolicies.renderMatchInclusion" | nindent 4 }}
   location: "spec.ephemeralContainers[name: *].securityContext.runAsUser"
   parameters:
     assign:
@@ -50,7 +50,7 @@ spec:
       kinds: ["Pod"]
       versions: ["v1"]
   match:
-    {{- dict "namespace" $namespace "labels" $value.podSelectorLabels | include "podsecuritypolicies.renderMatchInclusion" | nindent 4 }}
+    {{- dict "namespace" $namespace "labels" $value.podSelectorLabels "expressions" $value.podSelectorExpressions | include "podsecuritypolicies.renderMatchInclusion" | nindent 4 }}
   location: "spec.initContainers[name: *].securityContext.runAsUser"
   parameters:
     assign:

--- a/helmfile.d/charts/gatekeeper/podsecuritypolicies/templates/custom/users.yaml
+++ b/helmfile.d/charts/gatekeeper/podsecuritypolicies/templates/custom/users.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ printf "users-%s-%s" $.Release.Namespace $name | trunc 63 }}
 spec:
   match:
-    {{- dict "namespace" $namespace "labels" $value.podSelectorLabels | include "podsecuritypolicies.renderMatchInclusion" | nindent 4 }}
+    {{- dict "namespace" $namespace "labels" $value.podSelectorLabels "expressions" $value.podSelectorExpressions | include "podsecuritypolicies.renderMatchInclusion" | nindent 4 }}
   parameters:
     runAsUser:
       {{- with $value.allow.runAsUser }}

--- a/helmfile.d/charts/gatekeeper/podsecuritypolicies/values.yaml
+++ b/helmfile.d/charts/gatekeeper/podsecuritypolicies/values.yaml
@@ -3,6 +3,10 @@
 #   <service-name>:
 #     podSelectorLabels:
 #       foo: bar
+#     podSelectorExpressions:
+#       - key: "foo"
+#         operator: "In"
+#         values: ["bar"]
 #     # Every "allow" is an override, and is optional.
 #     # If a override is NOT part of "allow", the default constraint is applied
 #     allow:

--- a/helmfile.d/values/podsecuritypolicies/common/velero.yaml.gotmpl
+++ b/helmfile.d/values/podsecuritypolicies/common/velero.yaml.gotmpl
@@ -16,3 +16,20 @@ constraints:
           rule: RunAsAny
         privileged: true
         allowPrivilegeEscalation: true
+    data-download:
+      podSelectorExpressions:
+        - key: velero.io/data-download
+          operator: Exists
+      allow:
+        runAsUser:
+          rule: RunAsNonRoot
+      mutation:
+        runAsUser: 1000
+    data-upload:
+      podSelectorLabels:
+        velero.io/exposer-pod-group: snapshot-exposer
+      allow:
+        runAsUser:
+          rule: RunAsNonRoot
+      mutation:
+        runAsUser: 1000


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2075

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
