### PR TITLE
Enable OAuth PKCE in Grafana

### DIFF
--- a/helmfile.d/values/grafana/grafana-ops.yaml.gotmpl
+++ b/helmfile.d/values/grafana/grafana-ops.yaml.gotmpl
@@ -112,6 +112,7 @@ grafana.ini:
   auth.generic_oauth:
     name: dex
     enabled: {{ .Values.grafana.ops.oidc.enabled }}
+    use_pkce: true
     client_id: grafana-ops
     client_secret: $__env{opsClientSecret}
     scopes: {{ .Values.grafana.ops.oidc.scopes }}

--- a/helmfile.d/values/grafana/grafana-user.yaml.gotmpl
+++ b/helmfile.d/values/grafana/grafana-user.yaml.gotmpl
@@ -107,6 +107,7 @@ grafana.ini:
     enabled: true
     client_id: grafana
     client_secret: $__env{clientSecret}
+    use_pkce: true
     scopes: {{ .Values.grafana.user.oidc.scopes }}
     auth_url: https://{{ .Values.dex.subdomain }}.{{ .Values.global.baseDomain }}{{ $trailingDot }}/auth
     token_url: http://dex.dex.svc.cluster.local{{ $trailingDot }}:5556/token


### PR DESCRIPTION
OAuth security improvement

<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This enables the OAuth 2.0 [PKCE](https://oauth.net/2/pkce/) feature in Grafana marginally improving security when logging in with Dex.
PKCE is considered [best current practice](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics-29).

#### Information to reviewers

1. Login should still work.
2. In the network tab of browser developer console, the URL query component of the initial redirect to Dex should contain something like `code_challenge=KP8UuYMCTWa4MjH8qjFpe_Pq_Yghs9d4s0ztJBaeOXY&code_challenge_method=S256`

![image](https://github.com/elastisys/compliantkubernetes-apps/assets/197474/f9befc70-e6ec-4936-8838-995e832aad83)


<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
