### PR TITLE
config: add openstack as a provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Currently we support four cloud providers:
 - Citycloud/Cleura
 - Elastx
 - UpCloud
+- Azure
+- Aws
+- Openstack
 - In addition to this we support running Compliant Kubernetes on bare metal (beta).
 
 ## Setup
@@ -127,7 +130,7 @@ You configure ExternalDNS later in the process.
     #
     # If 'none', no infra provider tailored configuration will be performed!
     #
-    export CK8S_CLOUD_PROVIDER=[exoscale|safespring|citycloud|elastx|upcloud|azure|aws|baremetal|none]
+    export CK8S_CLOUD_PROVIDER=[exoscale|safespring|citycloud|elastx|upcloud|azure|aws|baremetal|openstack|none]
     export CK8S_K8S_INSTALLER=[kubespray|capi] # set this to whichever installer was used for the kubernetes layer
     ```
 

--- a/bin/common.bash
+++ b/bin/common.bash
@@ -5,33 +5,18 @@
 # are used throughout all of the scripts.
 
 : "${CK8S_CONFIG_PATH:?Missing CK8S_CONFIG_PATH}"
+here="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+root_path="${here}/.."
 
 # shellcheck disable=SC2034
-ck8s_cloud_providers=(
-    "aws"
-    "azure"
-    "baremetal"
-    "citycloud"
-    "exoscale"
-    "safespring"
-    "upcloud"
-    "elastx"
-    "azure"
-    "none"
-)
+mapfile -t ck8s_cloud_providers < <(find "${root_path}/config/providers" -mindepth 1 -maxdepth 1 -type d -printf '%f\n')
+ck8s_cloud_providers+=( "none" )
 
 # shellcheck disable=SC2034
-ck8s_flavors=(
-    "dev"
-    "prod"
-    "air-gapped"
-)
+mapfile -t ck8s_flavors < <(find "${root_path}/config/flavors" -mindepth 1 -maxdepth 1 -type d -printf '%f\n')
 
 # shellcheck disable=SC2034
-ck8s_k8s_installers=(
-    "capi"
-    "kubespray"
-)
+mapfile -t ck8s_k8s_installers < <(find "${root_path}/config/k8s-installers" -mindepth 1 -maxdepth 1 -type d -printf '%f\n')
 
 CK8S_AUTO_APPROVE=${CK8S_AUTO_APPROVE:-"false"}
 
@@ -40,8 +25,6 @@ mkdir -p "${CK8S_CONFIG_PATH}"
 CK8S_CONFIG_PATH=$(readlink -f "${CK8S_CONFIG_PATH}")
 export CK8S_CONFIG_PATH
 
-here="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-root_path="${here}/.."
 config_template_path="${root_path}/config"
 # TODO: these are used by sourced scripts.
 # Should we export all "externally" used variables?

--- a/config/providers/openstack/common-config.yaml
+++ b/config/providers/openstack/common-config.yaml
@@ -1,0 +1,42 @@
+openstackMonitoring:
+  enabled: true
+storageClasses:
+  default: cinder-csi
+networkPolicies:
+  kubeSystem:
+    openstack:
+      enabled: true
+      ips:
+        - set-me
+      ports:
+        - 5000
+        - 8774
+        - 8776
+  global:
+    externalLoadBalancer: false
+    ingressUsingHostNetwork: false
+  ingressNginx:
+    enabled: true
+    ingressOverride:
+      enabled: false
+objectStorage:
+  type: s3
+  s3:
+    region: set-me
+    regionEndpoint: set-me
+    forcePathStyle: true
+ingressNginx:
+  controller:
+    config:
+      useProxyProtocol: false
+    useHostPort: false
+    service:
+      enabled: true
+      type: LoadBalancer
+      annotations: {}
+      allocateLoadBalancerNodePorts: true
+externalTrafficPolicy:
+  local: false
+opa:
+  rejectLoadBalancerService:
+    enabled: false

--- a/config/providers/openstack/sc-config.yaml
+++ b/config/providers/openstack/sc-config.yaml
@@ -1,0 +1,4 @@
+harbor:
+  persistence:
+    type: objectStorage
+    disableRedirect: true

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -1131,6 +1131,7 @@ properties:
           - none
           - safespring
           - upcloud
+          - openstack
       ck8sEnvironmentName:
         title: Environment name
         type: string

--- a/tests/unit/bin/init/template.bats.gotmpl
+++ b/tests/unit/bin/init/template.bats.gotmpl
@@ -47,7 +47,7 @@ teardown_file() {
 
 # These tests are generated into these files:
 {{- range $ck8sK8sInstaller := coll.Slice "kubespray" "capi" }}
-{{- range $provider := coll.Slice "aws" "baremetal" "citycloud" "elastx" "exoscale" "safespring" "upcloud" }}
+{{- range $provider := coll.Slice "aws" "baremetal" "citycloud" "elastx" "exoscale" "safespring" "upcloud" "openstack" }}
 {{- range $flavor := coll.Slice "air-gapped" "dev" "prod" }}
 {{- $file := tmpl.Path | path.Dir }}
 {{- $file = printf "test-%s-%s-%s.gen.bats" $ck8sK8sInstaller $provider $flavor | path.Join $file }}

--- a/tests/unit/bin/init/template.gen.bats
+++ b/tests/unit/bin/init/template.gen.bats
@@ -22,6 +22,9 @@
 # - tests/unit/bin/init/test-kubespray-upcloud-air-gapped.gen.bats
 # - tests/unit/bin/init/test-kubespray-upcloud-dev.gen.bats
 # - tests/unit/bin/init/test-kubespray-upcloud-prod.gen.bats
+# - tests/unit/bin/init/test-kubespray-openstack-air-gapped.gen.bats
+# - tests/unit/bin/init/test-kubespray-openstack-dev.gen.bats
+# - tests/unit/bin/init/test-kubespray-openstack-prod.gen.bats
 # - tests/unit/bin/init/test-capi-aws-air-gapped.gen.bats
 # - tests/unit/bin/init/test-capi-aws-dev.gen.bats
 # - tests/unit/bin/init/test-capi-aws-prod.gen.bats
@@ -43,3 +46,6 @@
 # - tests/unit/bin/init/test-capi-upcloud-air-gapped.gen.bats
 # - tests/unit/bin/init/test-capi-upcloud-dev.gen.bats
 # - tests/unit/bin/init/test-capi-upcloud-prod.gen.bats
+# - tests/unit/bin/init/test-capi-openstack-air-gapped.gen.bats
+# - tests/unit/bin/init/test-capi-openstack-dev.gen.bats
+# - tests/unit/bin/init/test-capi-openstack-prod.gen.bats

--- a/tests/unit/bin/init/test-capi-openstack-air-gapped.gen.bats
+++ b/tests/unit/bin/init/test-capi-openstack-air-gapped.gen.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/bin/init/template.bats.gotmpl
+
+# bats file_tags=static,bin:init,openstack
+
+setup_file() {
+  load "../../../common/lib"
+  load "../../../common/lib/env"
+  load "../../../common/lib/gpg"
+
+  gpg.setup
+  env.setup
+
+  env.init air-gapped openstack capi
+}
+
+setup() {
+  load "../../../common/lib"
+  load "../../../common/lib/env"
+  load "script"
+
+  common_setup
+  env.private
+}
+
+teardown() {
+  env.teardown
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "init is successful - capi:openstack:air-gapped" {
+  test_init_successful
+}
+
+@test "init is idempotent - capi:openstack:air-gapped" {
+  test_init_idempotent
+}

--- a/tests/unit/bin/init/test-capi-openstack-dev.gen.bats
+++ b/tests/unit/bin/init/test-capi-openstack-dev.gen.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/bin/init/template.bats.gotmpl
+
+# bats file_tags=static,bin:init,openstack
+
+setup_file() {
+  load "../../../common/lib"
+  load "../../../common/lib/env"
+  load "../../../common/lib/gpg"
+
+  gpg.setup
+  env.setup
+
+  env.init dev openstack capi
+}
+
+setup() {
+  load "../../../common/lib"
+  load "../../../common/lib/env"
+  load "script"
+
+  common_setup
+  env.private
+}
+
+teardown() {
+  env.teardown
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "init is successful - capi:openstack:dev" {
+  test_init_successful
+}
+
+@test "init is idempotent - capi:openstack:dev" {
+  test_init_idempotent
+}

--- a/tests/unit/bin/init/test-capi-openstack-prod.gen.bats
+++ b/tests/unit/bin/init/test-capi-openstack-prod.gen.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/bin/init/template.bats.gotmpl
+
+# bats file_tags=static,bin:init,openstack
+
+setup_file() {
+  load "../../../common/lib"
+  load "../../../common/lib/env"
+  load "../../../common/lib/gpg"
+
+  gpg.setup
+  env.setup
+
+  env.init prod openstack capi
+}
+
+setup() {
+  load "../../../common/lib"
+  load "../../../common/lib/env"
+  load "script"
+
+  common_setup
+  env.private
+}
+
+teardown() {
+  env.teardown
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "init is successful - capi:openstack:prod" {
+  test_init_successful
+}
+
+@test "init is idempotent - capi:openstack:prod" {
+  test_init_idempotent
+}

--- a/tests/unit/bin/init/test-kubespray-openstack-air-gapped.gen.bats
+++ b/tests/unit/bin/init/test-kubespray-openstack-air-gapped.gen.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/bin/init/template.bats.gotmpl
+
+# bats file_tags=static,bin:init,openstack
+
+setup_file() {
+  load "../../../common/lib"
+  load "../../../common/lib/env"
+  load "../../../common/lib/gpg"
+
+  gpg.setup
+  env.setup
+
+  env.init air-gapped openstack kubespray
+}
+
+setup() {
+  load "../../../common/lib"
+  load "../../../common/lib/env"
+  load "script"
+
+  common_setup
+  env.private
+}
+
+teardown() {
+  env.teardown
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "init is successful - kubespray:openstack:air-gapped" {
+  test_init_successful
+}
+
+@test "init is idempotent - kubespray:openstack:air-gapped" {
+  test_init_idempotent
+}

--- a/tests/unit/bin/init/test-kubespray-openstack-dev.gen.bats
+++ b/tests/unit/bin/init/test-kubespray-openstack-dev.gen.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/bin/init/template.bats.gotmpl
+
+# bats file_tags=static,bin:init,openstack
+
+setup_file() {
+  load "../../../common/lib"
+  load "../../../common/lib/env"
+  load "../../../common/lib/gpg"
+
+  gpg.setup
+  env.setup
+
+  env.init dev openstack kubespray
+}
+
+setup() {
+  load "../../../common/lib"
+  load "../../../common/lib/env"
+  load "script"
+
+  common_setup
+  env.private
+}
+
+teardown() {
+  env.teardown
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "init is successful - kubespray:openstack:dev" {
+  test_init_successful
+}
+
+@test "init is idempotent - kubespray:openstack:dev" {
+  test_init_idempotent
+}

--- a/tests/unit/bin/init/test-kubespray-openstack-prod.gen.bats
+++ b/tests/unit/bin/init/test-kubespray-openstack-prod.gen.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/bin/init/template.bats.gotmpl
+
+# bats file_tags=static,bin:init,openstack
+
+setup_file() {
+  load "../../../common/lib"
+  load "../../../common/lib/env"
+  load "../../../common/lib/gpg"
+
+  gpg.setup
+  env.setup
+
+  env.init prod openstack kubespray
+}
+
+setup() {
+  load "../../../common/lib"
+  load "../../../common/lib/env"
+  load "script"
+
+  common_setup
+  env.private
+}
+
+teardown() {
+  env.teardown
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "init is successful - kubespray:openstack:prod" {
+  test_init_successful
+}
+
+@test "init is idempotent - kubespray:openstack:prod" {
+  test_init_idempotent
+}

--- a/tests/unit/validate/template.bats.gotmpl
+++ b/tests/unit/validate/template.bats.gotmpl
@@ -74,7 +74,7 @@ teardown_file() {
 
 # These tests are generated into these files:
 {{- range $ck8sK8sInstaller := coll.Slice "kubespray" "capi" }}
-{{- range $provider := coll.Slice "aws" "baremetal" "citycloud" "elastx" "exoscale" "safespring" "upcloud" }}
+{{- range $provider := coll.Slice "aws" "baremetal" "citycloud" "elastx" "exoscale" "safespring" "upcloud" "openstack" }}
 {{- range $flavor := coll.Slice "air-gapped" "dev" "prod" }}
 {{- $file := tmpl.Path | path.Dir }}
 {{- $file = printf "test-%s-%s-%s.gen.bats" $ck8sK8sInstaller $provider $flavor | path.Join $file }}

--- a/tests/unit/validate/template.gen.bats
+++ b/tests/unit/validate/template.gen.bats
@@ -22,6 +22,9 @@
 # - tests/unit/validate/test-kubespray-upcloud-air-gapped.gen.bats
 # - tests/unit/validate/test-kubespray-upcloud-dev.gen.bats
 # - tests/unit/validate/test-kubespray-upcloud-prod.gen.bats
+# - tests/unit/validate/test-kubespray-openstack-air-gapped.gen.bats
+# - tests/unit/validate/test-kubespray-openstack-dev.gen.bats
+# - tests/unit/validate/test-kubespray-openstack-prod.gen.bats
 # - tests/unit/validate/test-capi-aws-air-gapped.gen.bats
 # - tests/unit/validate/test-capi-aws-dev.gen.bats
 # - tests/unit/validate/test-capi-aws-prod.gen.bats
@@ -43,3 +46,6 @@
 # - tests/unit/validate/test-capi-upcloud-air-gapped.gen.bats
 # - tests/unit/validate/test-capi-upcloud-dev.gen.bats
 # - tests/unit/validate/test-capi-upcloud-prod.gen.bats
+# - tests/unit/validate/test-capi-openstack-air-gapped.gen.bats
+# - tests/unit/validate/test-capi-openstack-dev.gen.bats
+# - tests/unit/validate/test-capi-openstack-prod.gen.bats

--- a/tests/unit/validate/test-capi-openstack-air-gapped.gen.bats
+++ b/tests/unit/validate/test-capi-openstack-air-gapped.gen.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/validate/template.bats.gotmpl
+
+# bats file_tags=static,openstack
+
+setup_file() {
+  # Not supported right now, might be able to leverage env.cache with some adaptions
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../common/lib"
+  load "../../common/lib/env"
+  load "../../common/lib/gpg"
+
+  gpg.setup
+  env.setup
+
+  env.init air-gapped openstack capi
+}
+
+setup() {
+  load "../../common/lib"
+  load "script"
+
+  common_setup
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "configuration is valid - capi:openstack:air-gapped - service cluster" {
+  run ck8s validate sc <<< $'y\n'
+
+  assert_success
+}
+
+@test "configuration is valid - capi:openstack:air-gapped - workload cluster" {
+  run ck8s validate wc <<< $'y\n'
+
+  assert_success
+}
+
+@test "configuration is invalid - capi:openstack:air-gapped - service cluster" {
+  run yq_set 'sc' '.global.baseDomain' '"this is not a valid hostname"'
+  run ck8s validate sc <<< $'y\n'
+
+  assert_output --partial 'global.baseDomain'
+}
+
+@test "configuration is invalid - capi:openstack:air-gapped - workload cluster" {
+  run yq_set 'wc' '.global.baseDomain' '"this is not a valid hostname"'
+  run ck8s validate wc <<< $'y\n'
+
+  assert_output --partial '"this is not a valid hostname"'
+}
+
+@test "manifests are valid - capi:openstack:air-gapped - service cluster" {
+  run helmfile_template_kubeconform service_cluster
+
+  assert_success
+}
+
+@test "manifests are valid - capi:openstack:air-gapped - workload cluster" {
+  run helmfile_template_kubeconform workload_cluster
+
+  assert_success
+}

--- a/tests/unit/validate/test-capi-openstack-dev.gen.bats
+++ b/tests/unit/validate/test-capi-openstack-dev.gen.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/validate/template.bats.gotmpl
+
+# bats file_tags=static,openstack
+
+setup_file() {
+  # Not supported right now, might be able to leverage env.cache with some adaptions
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../common/lib"
+  load "../../common/lib/env"
+  load "../../common/lib/gpg"
+
+  gpg.setup
+  env.setup
+
+  env.init dev openstack capi
+}
+
+setup() {
+  load "../../common/lib"
+  load "script"
+
+  common_setup
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "configuration is valid - capi:openstack:dev - service cluster" {
+  run ck8s validate sc <<< $'y\n'
+
+  assert_success
+}
+
+@test "configuration is valid - capi:openstack:dev - workload cluster" {
+  run ck8s validate wc <<< $'y\n'
+
+  assert_success
+}
+
+@test "configuration is invalid - capi:openstack:dev - service cluster" {
+  run yq_set 'sc' '.global.baseDomain' '"this is not a valid hostname"'
+  run ck8s validate sc <<< $'y\n'
+
+  assert_output --partial 'global.baseDomain'
+}
+
+@test "configuration is invalid - capi:openstack:dev - workload cluster" {
+  run yq_set 'wc' '.global.baseDomain' '"this is not a valid hostname"'
+  run ck8s validate wc <<< $'y\n'
+
+  assert_output --partial '"this is not a valid hostname"'
+}
+
+@test "manifests are valid - capi:openstack:dev - service cluster" {
+  run helmfile_template_kubeconform service_cluster
+
+  assert_success
+}
+
+@test "manifests are valid - capi:openstack:dev - workload cluster" {
+  run helmfile_template_kubeconform workload_cluster
+
+  assert_success
+}

--- a/tests/unit/validate/test-capi-openstack-prod.gen.bats
+++ b/tests/unit/validate/test-capi-openstack-prod.gen.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/validate/template.bats.gotmpl
+
+# bats file_tags=static,openstack
+
+setup_file() {
+  # Not supported right now, might be able to leverage env.cache with some adaptions
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../common/lib"
+  load "../../common/lib/env"
+  load "../../common/lib/gpg"
+
+  gpg.setup
+  env.setup
+
+  env.init prod openstack capi
+}
+
+setup() {
+  load "../../common/lib"
+  load "script"
+
+  common_setup
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "configuration is valid - capi:openstack:prod - service cluster" {
+  run ck8s validate sc <<< $'y\n'
+
+  assert_success
+}
+
+@test "configuration is valid - capi:openstack:prod - workload cluster" {
+  run ck8s validate wc <<< $'y\n'
+
+  assert_success
+}
+
+@test "configuration is invalid - capi:openstack:prod - service cluster" {
+  run yq_set 'sc' '.global.baseDomain' '"this is not a valid hostname"'
+  run ck8s validate sc <<< $'y\n'
+
+  assert_output --partial 'global.baseDomain'
+}
+
+@test "configuration is invalid - capi:openstack:prod - workload cluster" {
+  run yq_set 'wc' '.global.baseDomain' '"this is not a valid hostname"'
+  run ck8s validate wc <<< $'y\n'
+
+  assert_output --partial '"this is not a valid hostname"'
+}
+
+@test "manifests are valid - capi:openstack:prod - service cluster" {
+  run helmfile_template_kubeconform service_cluster
+
+  assert_success
+}
+
+@test "manifests are valid - capi:openstack:prod - workload cluster" {
+  run helmfile_template_kubeconform workload_cluster
+
+  assert_success
+}

--- a/tests/unit/validate/test-kubespray-openstack-air-gapped.gen.bats
+++ b/tests/unit/validate/test-kubespray-openstack-air-gapped.gen.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/validate/template.bats.gotmpl
+
+# bats file_tags=static,openstack
+
+setup_file() {
+  # Not supported right now, might be able to leverage env.cache with some adaptions
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../common/lib"
+  load "../../common/lib/env"
+  load "../../common/lib/gpg"
+
+  gpg.setup
+  env.setup
+
+  env.init air-gapped openstack kubespray
+}
+
+setup() {
+  load "../../common/lib"
+  load "script"
+
+  common_setup
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "configuration is valid - kubespray:openstack:air-gapped - service cluster" {
+  run ck8s validate sc <<< $'y\n'
+
+  assert_success
+}
+
+@test "configuration is valid - kubespray:openstack:air-gapped - workload cluster" {
+  run ck8s validate wc <<< $'y\n'
+
+  assert_success
+}
+
+@test "configuration is invalid - kubespray:openstack:air-gapped - service cluster" {
+  run yq_set 'sc' '.global.baseDomain' '"this is not a valid hostname"'
+  run ck8s validate sc <<< $'y\n'
+
+  assert_output --partial 'global.baseDomain'
+}
+
+@test "configuration is invalid - kubespray:openstack:air-gapped - workload cluster" {
+  run yq_set 'wc' '.global.baseDomain' '"this is not a valid hostname"'
+  run ck8s validate wc <<< $'y\n'
+
+  assert_output --partial '"this is not a valid hostname"'
+}
+
+@test "manifests are valid - kubespray:openstack:air-gapped - service cluster" {
+  run helmfile_template_kubeconform service_cluster
+
+  assert_success
+}
+
+@test "manifests are valid - kubespray:openstack:air-gapped - workload cluster" {
+  run helmfile_template_kubeconform workload_cluster
+
+  assert_success
+}

--- a/tests/unit/validate/test-kubespray-openstack-dev.gen.bats
+++ b/tests/unit/validate/test-kubespray-openstack-dev.gen.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/validate/template.bats.gotmpl
+
+# bats file_tags=static,openstack
+
+setup_file() {
+  # Not supported right now, might be able to leverage env.cache with some adaptions
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../common/lib"
+  load "../../common/lib/env"
+  load "../../common/lib/gpg"
+
+  gpg.setup
+  env.setup
+
+  env.init dev openstack kubespray
+}
+
+setup() {
+  load "../../common/lib"
+  load "script"
+
+  common_setup
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "configuration is valid - kubespray:openstack:dev - service cluster" {
+  run ck8s validate sc <<< $'y\n'
+
+  assert_success
+}
+
+@test "configuration is valid - kubespray:openstack:dev - workload cluster" {
+  run ck8s validate wc <<< $'y\n'
+
+  assert_success
+}
+
+@test "configuration is invalid - kubespray:openstack:dev - service cluster" {
+  run yq_set 'sc' '.global.baseDomain' '"this is not a valid hostname"'
+  run ck8s validate sc <<< $'y\n'
+
+  assert_output --partial 'global.baseDomain'
+}
+
+@test "configuration is invalid - kubespray:openstack:dev - workload cluster" {
+  run yq_set 'wc' '.global.baseDomain' '"this is not a valid hostname"'
+  run ck8s validate wc <<< $'y\n'
+
+  assert_output --partial '"this is not a valid hostname"'
+}
+
+@test "manifests are valid - kubespray:openstack:dev - service cluster" {
+  run helmfile_template_kubeconform service_cluster
+
+  assert_success
+}
+
+@test "manifests are valid - kubespray:openstack:dev - workload cluster" {
+  run helmfile_template_kubeconform workload_cluster
+
+  assert_success
+}

--- a/tests/unit/validate/test-kubespray-openstack-prod.gen.bats
+++ b/tests/unit/validate/test-kubespray-openstack-prod.gen.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+
+# Generated from tests/unit/validate/template.bats.gotmpl
+
+# bats file_tags=static,openstack
+
+setup_file() {
+  # Not supported right now, might be able to leverage env.cache with some adaptions
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../common/lib"
+  load "../../common/lib/env"
+  load "../../common/lib/gpg"
+
+  gpg.setup
+  env.setup
+
+  env.init prod openstack kubespray
+}
+
+setup() {
+  load "../../common/lib"
+  load "script"
+
+  common_setup
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "configuration is valid - kubespray:openstack:prod - service cluster" {
+  run ck8s validate sc <<< $'y\n'
+
+  assert_success
+}
+
+@test "configuration is valid - kubespray:openstack:prod - workload cluster" {
+  run ck8s validate wc <<< $'y\n'
+
+  assert_success
+}
+
+@test "configuration is invalid - kubespray:openstack:prod - service cluster" {
+  run yq_set 'sc' '.global.baseDomain' '"this is not a valid hostname"'
+  run ck8s validate sc <<< $'y\n'
+
+  assert_output --partial 'global.baseDomain'
+}
+
+@test "configuration is invalid - kubespray:openstack:prod - workload cluster" {
+  run yq_set 'wc' '.global.baseDomain' '"this is not a valid hostname"'
+  run ck8s validate wc <<< $'y\n'
+
+  assert_output --partial '"this is not a valid hostname"'
+}
+
+@test "manifests are valid - kubespray:openstack:prod - service cluster" {
+  run helmfile_template_kubeconform service_cluster
+
+  assert_success
+}
+
+@test "manifests are valid - kubespray:openstack:prod - workload cluster" {
+  run helmfile_template_kubeconform workload_cluster
+
+  assert_success
+}


### PR DESCRIPTION
OAuth security improvement<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [x] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Adds openstack as a generic provider.
For situations when apps is deployed on a openstack cloud but not safespring, elastx or citycloud. 

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
