### PR TITLE
apps: Add support for ingress to use predifined ips

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -595,6 +595,10 @@ ingressNginx:
       ## ref: https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#restrict-access-for-loadbalancer-service
       loadBalancerSourceRanges: []
 
+      # Set this to use an existing floating ip
+      # If you want to change this then you need to recreate the service
+      loadBalancerIP: ""
+
       # -- Represents the dual-stack-ness requested or required by this Service. Possible values are
       # SingleStack (default), PreferDualStack or RequireDualStack. When utilizing an internal loadbalancer service (ie MetalLB),
       # set this field to "RequireDualStack" if you want both IPv4 and IPv6 connectivity.

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -5900,9 +5900,10 @@ properties:
                 loadBalancerIP:
                   title: Load Balancer IP
                   description: |-
-                    Configure the Load Balancer IP from the list of floating ip's created beforehand via openstack cli.
+                    Configure the Load Balancer IP to use an existing IP if supported by the infrastructure provider.
 
-                    This should be enabled when we want to have predefined ip's for the Load Balancer.
+                    > [!important]
+                    > With OpenStack Octavia the floating IP can be created via the CLI beforehand, and one should set the annotation `loadbalancer.openstack.org/keep-floatingip: "true"` to prevent the floating IP to be deleted.
                   type: string
                   default: ""
                 nodePorts:

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -5897,6 +5897,14 @@ properties:
                   items:
                     type: string
                   default: []
+                loadBalancerIP:
+                  title: Load Balancer IP
+                  description: |-
+                    Configure the Load Balancer IP from the list of floating ip's created beforehand via openstack cli.
+
+                    This should be enabled when we want to have predefined ip's for the Load Balancer.
+                  type: string
+                  default: ""
                 nodePorts:
                   title: Node Ports
                   description: Configure the node ports to allocate for the Service.

--- a/helmfile.d/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile.d/values/ingress-nginx.yaml.gotmpl
@@ -127,6 +127,9 @@ controller:
     {{- with .Values | get "ingressNginx.controller.service.clusterIP" "" }}
     clusterIP: {{ . }}
     {{- end }}
+    {{- with .Values | get "ingressNginx.controller.service.loadBalancerIP" "" }}
+    loadBalancerIP: {{ . }}
+    {{- end }}
 
   metrics:
     enabled: true


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change -->
### Platform Administrator notice

Add support for using predefined IP for the Load Balancer .

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->

This PR enables the option to use an already created floating ip with ingress service .

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [x] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [x] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [x] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
