### PR TITLE
apps sc: Fixed some panels in the kubernetes cluster status dashboard

### DIFF
--- a/helmfile.d/charts/grafana-dashboards/dashboards/kubernetesstatus-dashboard.json
+++ b/helmfile.d/charts/grafana-dashboards/dashboards/kubernetesstatus-dashboard.json
@@ -879,7 +879,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kube_pod_container_resource_requests{cluster=~\"$cluster\", namespace=~\"$namespace\", resource=\"cpu\"} and on (pod, namespace, cluster) kube_pod_status_phase{phase=\"Running\", cluster=~\"$cluster\", namespace=~\"$namespace\"} == 1 ) / sum(kube_node_status_allocatable{cluster=~\"$cluster\", resource=\"cpu\"})",
+          "expr": "sum(kube_pod_container_resource_requests{cluster=~\"$cluster\", namespace=~\"$namespace\", resource=\"cpu\"} and on (pod, namespace, cluster) kube_pod_status_phase{phase=\"Running\", cluster=~\"$cluster\", namespace=~\"$namespace\"} == 1 ) / sum(kube_node_status_allocatable{cluster=~\"$cluster\", resource=\"cpu\"}) or vector(0)",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -953,7 +953,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kube_pod_container_resource_requests{cluster=~\"$cluster\", namespace=~\"$namespace\", resource=\"memory\"} and on (pod, namespace, cluster) kube_pod_status_phase{phase=\"Running\", cluster=~\"$cluster\", namespace=~\"$namespace\"} == 1) / sum(kube_node_status_allocatable{cluster=~\"$cluster\", resource=\"memory\"})",
+          "expr": "sum(kube_pod_container_resource_requests{cluster=~\"$cluster\", namespace=~\"$namespace\", resource=\"memory\"} and on (pod, namespace, cluster) kube_pod_status_phase{phase=\"Running\", cluster=~\"$cluster\", namespace=~\"$namespace\"} == 1) / sum(kube_node_status_allocatable{cluster=~\"$cluster\", resource=\"memory\"}) or vector(0)",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -1016,7 +1016,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(kube_pod_container_info{cluster=~\"$cluster\", namespace=~\"$namespace\", namespace!~\"^${systemNamespaces}\"} and on (pod, namespace, cluster)  kube_pod_status_phase{phase=\"Running\", cluster=~\"$cluster\", namespace=~\"$namespace\"} == 1) - count(kube_pod_container_resource_requests{cluster=~\"$cluster\", namespace=~\"$namespace\", namespace!~\"^${systemNamespaces}\", resource=\"cpu\"} and on (pod, namespace, cluster)  kube_pod_status_phase{phase=\"Running\", cluster=~\"$cluster\", namespace=~\"$namespace\"} == 1)",
+          "expr": "count(kube_pod_container_info{cluster=~\"$cluster\", namespace=~\"$namespace\", namespace!~\"^${systemNamespaces}\"} and on (pod, namespace, cluster)  kube_pod_status_phase{phase=\"Running\", cluster=~\"$cluster\", namespace=~\"$namespace\"} == 1) - (count(kube_pod_container_resource_requests{cluster=~\"$cluster\", namespace=~\"$namespace\", namespace!~\"^${systemNamespaces}\", resource=\"cpu\"} and on (pod, namespace, cluster)  kube_pod_status_phase{phase=\"Running\", cluster=~\"$cluster\", namespace=~\"$namespace\"} == 1) or vector(0))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -1079,7 +1079,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "count(kube_pod_container_info{cluster=~\"$cluster\", namespace=~\"$namespace\", namespace!~\"^${systemNamespaces}\"} and on (pod, namespace, cluster)  kube_pod_status_phase{phase=\"Running\", cluster=~\"$cluster\", namespace=~\"$namespace\"} == 1) - count(kube_pod_container_resource_requests{cluster=~\"$cluster\", namespace=~\"$namespace\", namespace!~\"${systemNamespaces}\", resource=\"memory\"} and on (pod, namespace, cluster)  kube_pod_status_phase{phase=\"Running\", cluster=~\"$cluster\", namespace=~\"$namespace\"} == 1)",
+          "expr": "count(kube_pod_container_info{cluster=~\"$cluster\", namespace=~\"$namespace\", namespace!~\"^${systemNamespaces}\"} and on (pod, namespace, cluster)  kube_pod_status_phase{phase=\"Running\", cluster=~\"$cluster\", namespace=~\"$namespace\"} == 1) - (count(kube_pod_container_resource_requests{cluster=~\"$cluster\", namespace=~\"$namespace\", namespace!~\"${systemNamespaces}\", resource=\"memory\"} and on (pod, namespace, cluster)  kube_pod_status_phase{phase=\"Running\", cluster=~\"$cluster\", namespace=~\"$namespace\"} == 1) or vector(0))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->

When looking at the kubernetes cluster status dashboard, the number and the list didn't add up. So this solves that by returning 0 when there's no pods with requests.
Also fixes a bug where the gauge shows 0 instead of 0%

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
