### PR TITLE
Rclone sync fixes

### DIFF
--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -2262,6 +2262,39 @@ properties:
             description: Additional buckets to sync.
             type: array
             default: []
+            items:
+              title: Buckets to sync
+              description: |-
+                List of buckets to sync when `syncDefaultBuckets` is false
+              type: object
+              required:
+                - source
+              properties:
+                source:
+                  type: string
+                  title: Source bucket to sync
+                destination:
+                  type: string
+                  title: Destination bucket to sync
+                schedule:
+                  type: string
+                  title: Sync schedule for this bucket
+                  description: Defaults to `.objectStorage.sync.defaultSchedule`
+                sourceType:
+                  type: string
+                  title: Type of source
+                  examples:
+                    - s3
+                    - swift
+                    - azure
+                destinationType:
+                  type: string
+                  title: Type of destination
+                  examples:
+                    - s3
+                    - swift
+                    - azure
+              additionalProperties: false
           destinationType:
             title: Rclone Sync Destination Type
             description: |-
@@ -2305,6 +2338,15 @@ properties:
                 type: boolean
                 default: false
             type: object
+          sourceType:
+            title: Rclone Sync Source Type
+            description: Object storage type to use. Defaults to .objectStorage.type
+            type: string
+            examples:
+              - azure
+              - gcs
+              - s3
+              - swift
       restore:
         additionalProperties: false
         title: Rclone Restore Config
@@ -2337,6 +2379,35 @@ properties:
             description: Targets to restore
             type: array
             default: []
+            items:
+              title: Rclone restore target
+              description: |-
+                Details of a bucket to restore.
+              type: object
+              required:
+                - destinationName
+              properties:
+                destinationName:
+                  type: string
+                  title: Destination bucket to sync
+                destinationType:
+                  type: string
+                  title: Type of destination
+                  examples:
+                    - s3
+                    - swift
+                    - azure
+                sourceName:
+                  type: string
+                  title: Source bucket to sync
+                sourceType:
+                  type: string
+                  title: Type of source
+                  examples:
+                    - s3
+                    - swift
+                    - azure
+              additionalProperties: false
           timestamp:
             title: Rclone Restore Timestamp
             description: |-

--- a/helmfile.d/values/networkpolicies/service/rclone.yaml.gotmpl
+++ b/helmfile.d/values/networkpolicies/service/rclone.yaml.gotmpl
@@ -34,8 +34,8 @@ policies:
     {{- if $sync.syncDefaultBuckets }}
     {{- range $key, $value := $main.buckets }}
 
-    {{- $destinationType := $main.type }}
-    {{- $sourceType := $sync.destinationType }}
+    {{- $destinationType := $sync.destinationType }}
+    {{- $sourceType := $main.type }}
 
     {{- if eq $key "harbor" }}
     {{- $destinationType = $.Values.harbor.persistence.type | replace "objectStorage" "" | default $destinationType }}

--- a/helmfile.d/values/rclone/sync.yaml.gotmpl
+++ b/helmfile.d/values/rclone/sync.yaml.gotmpl
@@ -56,7 +56,7 @@ targets:
 
 providers:
   {{- if not $destinations }}
-  {{ fail "rclone-restore configured without destinations" }}
+  {{ fail "rclone-sync configured without destinations" }}
   {{- end }}
 
   {{- $providers := merge dict $sync }}
@@ -66,7 +66,7 @@ providers:
   {{- end }}
 
   {{- if not $sources }}
-  {{ fail "rclone-restore configured without sources" }}
+  {{ fail "rclone-sync configured without sources" }}
   {{- end }}
 
   {{- $providers := merge dict $main }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

A collection of fixes discovered while testing rclone sync from azure to s3.

- Template issue when `.objectStorage.sync.syncDefaultBuckets` was set to `true` instead of using `.objectStorage.sync.buckets[]`
- Occurences of `rclone-restore` in `rclone-sync` templates
- Schema added for `.objectStorage.sync.buckets[]` and `...restore.targets[]` items.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Discovered while working on #2206

#### Information to reviewers

- Try `ck8s ops helmfile template -l app=rclone` with `.objectStorage.sync.syncDefaultBuckets=true` and some `.objectStorage.buckets`

- Try `ck8s validate` with various rclone configurations

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
