### PR TITLE
apps sc: dex upgraded to app version 2.40.0 and chart version 0.18.0

### DIFF
--- a/config/schemas/secrets.yaml
+++ b/config/schemas/secrets.yaml
@@ -510,14 +510,17 @@ properties:
                   oneOf:
                     - format: uri
                     - $ref: '#/$defs/encrypted'
-                adminEmail:
-                  title: Connector Admin Email
+                domainToAdminEmail:
+                  title: Connector Admin Emails
                   description: |-
                     Used in `type: google`.
-                  type: string
-                  oneOf:
-                    - format: email
-                    - $ref: '#/$defs/encrypted'
+                  type: object
+                  additionalProperties:
+                    oneOf:
+                      - format: email
+                      - $ref: '#/$defs/encrypted'
+                  propertyNames:
+                    format: domain
                 hostedDomains:
                   title: Connector Hosted Domains
                   description: |-

--- a/config/secrets.yaml
+++ b/config/secrets.yaml
@@ -99,7 +99,8 @@ dex:
     #     redirectURI: https://dex.${BASE_DOMAIN}/callback
     #     # Needed for group support
     #     # serviceAccountFilePath: /etc/dex/google/sa.json
-    #     # adminEmail: admin@example.com
+    #     # domainToAdminEmail:
+    #     #   '*': admin@example.com
     #     hostedDomains:
     #       - example.com # Trusted domains
     #

--- a/helmfile.d/upstream/dexidp/dex/Chart.yaml
+++ b/helmfile.d/upstream/dexidp/dex/Chart.yaml
@@ -1,12 +1,12 @@
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Supporting template evaluation in ingress hosts"
+    - kind: changed
+      description: "Dex 2.40.0 release"
   artifacthub.io/images: |
     - name: dex
-      image: ghcr.io/dexidp/dex:v2.36.0
+      image: ghcr.io/dexidp/dex:v2.40.0
 apiVersion: v2
-appVersion: 2.36.0
+appVersion: 2.40.0
 description: OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable
   connectors.
 home: https://dexidp.io/
@@ -26,4 +26,4 @@ sources:
 - https://github.com/dexidp/dex
 - https://github.com/dexidp/helm-charts/tree/master/charts/dex
 type: application
-version: 0.14.1
+version: 0.18.0

--- a/helmfile.d/upstream/dexidp/dex/README.md
+++ b/helmfile.d/upstream/dexidp/dex/README.md
@@ -1,6 +1,6 @@
 # dex
 
-![version: 0.14.1](https://img.shields.io/badge/version-0.14.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.36.0](https://img.shields.io/badge/app%20version-2.36.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
+![version: 0.18.0](https://img.shields.io/badge/version-0.18.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.40.0](https://img.shields.io/badge/app%20version-2.40.0-informational?style=flat-square) ![kube version: >=1.14.0-0](https://img.shields.io/badge/kube%20version->=1.14.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-dex-informational?style=flat-square)](https://artifacthub.io/packages/helm/dex/dex)
 
 OpenID Connect (OIDC) identity and OAuth 2.0 provider with pluggable connectors.
 
@@ -134,12 +134,16 @@ ingress:
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
 | rbac.create | bool | `true` | Specifies whether RBAC resources should be created. If disabled, the operator is responsible for creating the necessary resources based on the templates. |
 | rbac.createClusterScoped | bool | `true` | Specifies which RBAC resources should be created. If disabled, the operator is responsible for creating the necessary resources (ClusterRole and RoleBinding or CRD's) |
+| deploymentAnnotations | object | `{}` | Annotations to be added to deployment. |
+| deploymentLabels | object | `{}` | Labels to be added to deployment. |
 | podAnnotations | object | `{}` | Annotations to be added to pods. |
+| podLabels | object | `{}` | Labels to be added to pods. |
 | podDisruptionBudget.enabled | bool | `false` | Enable a [pod distruption budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) to help dealing with [disruptions](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/). It is **highly recommended** for webhooks as disruptions can prevent launching new pods. |
 | podDisruptionBudget.minAvailable | int/percentage | `nil` | Number or percentage of pods that must remain available. |
 | podDisruptionBudget.maxUnavailable | int/percentage | `nil` | Number or percentage of pods that can be unavailable. |
 | priorityClassName | string | `""` | Specify a priority class name to set [pod priority](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority). |
 | podSecurityContext | object | `{}` | Pod [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) for details. |
+| revisionHistoryLimit | int | `10` | Define the [count of deployment revisions](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) to be kept. May be set to 0 in case of GitOps deployment approach. |
 | securityContext | object | `{}` | Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details. |
 | service.annotations | object | `{}` | Annotations to be added to the service. |
 | service.type | string | `"ClusterIP"` | Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). |
@@ -160,6 +164,14 @@ ingress:
 | serviceMonitor.interval | duration | `nil` | Prometheus scrape interval. |
 | serviceMonitor.scrapeTimeout | duration | `nil` | Prometheus scrape timeout. |
 | serviceMonitor.labels | object | `{}` | Labels to be added to the ServiceMonitor. |
+| serviceMonitor.annotations | object | `{}` | Annotations to be added to the ServiceMonitor. |
+| serviceMonitor.scheme | string | `""` | HTTP scheme to use for scraping. Can be used with `tlsConfig` for example if using istio mTLS. |
+| serviceMonitor.path | string | `"/metrics"` | HTTP path to scrape for metrics. |
+| serviceMonitor.tlsConfig | object | `{}` | TLS configuration to use when scraping the endpoint. For example if using istio mTLS. |
+| serviceMonitor.bearerTokenFile | string | `nil` | Prometheus scrape bearerTokenFile |
+| serviceMonitor.honorLabels | bool | `false` | HonorLabels chooses the metric's labels on collisions with target labels. |
+| serviceMonitor.metricRelabelings | list | `[]` | Prometheus scrape metric relabel configs to apply to samples before ingestion. |
+| serviceMonitor.relabelings | list | `[]` | Relabel configs to apply to samples before ingestion. |
 | resources | object | No requests or limits. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details. |
 | autoscaling | object | Disabled by default. | Autoscaling configuration (see [values.yaml](values.yaml) for details). |
 | nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) configuration. |

--- a/helmfile.d/upstream/dexidp/dex/ci/label-annotations-values.yaml
+++ b/helmfile.d/upstream/dexidp/dex/ci/label-annotations-values.yaml
@@ -6,5 +6,14 @@ config:
 
   enablePasswordDB: true
 
+deploymentAnnotations:
+  reloader.stakater.com/auto: "true"
+
 podAnnotations:
   vault.security.banzaicloud.io/vault-addr: "https://vault.vault:8200"
+
+deploymentLabels:
+  hello: world
+
+podLabels:
+  hello: world

--- a/helmfile.d/upstream/dexidp/dex/templates/deployment.yaml
+++ b/helmfile.d/upstream/dexidp/dex/templates/deployment.yaml
@@ -4,10 +4,18 @@ metadata:
   name: {{ include "dex.fullname" . }}
   labels:
     {{- include "dex.labels" . | nindent 4 }}
+    {{ with .Values.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{ with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   {{- with .Values.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
@@ -26,6 +34,9 @@ spec:
       {{- end }}
       labels:
         {{- include "dex.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helmfile.d/upstream/dexidp/dex/templates/hpa.yaml
+++ b/helmfile.d/upstream/dexidp/dex/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
+{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: autoscaling/v2
+{{- else -}}
 apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "dex.fullname" . }}
@@ -14,15 +18,33 @@ spec:
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
     {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- else }}
     - type: Resource
       resource:
         name: cpu
         targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
+    {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- else }}
     - type: Resource
       resource:
         name: memory
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
     {{- end }}
 {{- end }}

--- a/helmfile.d/upstream/dexidp/dex/templates/servicemonitor.yaml
+++ b/helmfile.d/upstream/dexidp/dex/templates/servicemonitor.yaml
@@ -2,6 +2,10 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ include "dex.fullname" . }}
   {{- with .Values.serviceMonitor.namespace }}
   namespace: {{ . }}
@@ -17,8 +21,28 @@ spec:
       {{- with .Values.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
+      {{- with .Values.serviceMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.bearerTokenFile }}
+      bearerTokenFile: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml .| nindent 6 }}
+      {{- end }}
       {{- with .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ . }}
+      {{- end }}
+      path: {{ .Values.serviceMonitor.path }}
+      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- tpl (toYaml . | nindent 6) $ }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 6 }}
       {{- end }}
   jobLabel: {{ include "dex.fullname" . }}
   selector:

--- a/helmfile.d/upstream/dexidp/dex/values.yaml
+++ b/helmfile.d/upstream/dexidp/dex/values.yaml
@@ -107,8 +107,17 @@ rbac:
   # If disabled, the operator is responsible for creating the necessary resources (ClusterRole and RoleBinding or CRD's)
   createClusterScoped: true
 
+# -- Annotations to be added to deployment.
+deploymentAnnotations: {}
+
+# -- Labels to be added to deployment.
+deploymentLabels: {}
+
 # -- Annotations to be added to pods.
 podAnnotations: {}
+
+# -- Labels to be added to pods.
+podLabels: {}
 
 podDisruptionBudget:
   # -- Enable a [pod distruption budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) to help dealing with [disruptions](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/).
@@ -128,6 +137,10 @@ priorityClassName: ""
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) for details.
 podSecurityContext: {}
   # fsGroup: 2000
+
+# -- Define the [count of deployment revisions](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) to be kept.
+# May be set to 0 in case of GitOps deployment approach.
+revisionHistoryLimit: 10
 
 # -- Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details.
@@ -214,7 +227,49 @@ serviceMonitor:
   scrapeTimeout:
 
   # -- Labels to be added to the ServiceMonitor.
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
   labels: {}
+
+  # -- Annotations to be added to the ServiceMonitor.
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+  annotations: {}
+
+  # -- HTTP scheme to use for scraping.
+  # Can be used with `tlsConfig` for example if using istio mTLS.
+  scheme: ""
+
+  # -- HTTP path to scrape for metrics.
+  path: /metrics
+
+  # -- TLS configuration to use when scraping the endpoint.
+  # For example if using istio mTLS.
+  ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
+  tlsConfig: {}
+
+  # -- Prometheus scrape bearerTokenFile
+  bearerTokenFile:
+
+  # -- HonorLabels chooses the metric's labels on collisions with target labels.
+  honorLabels: false
+
+  # -- Prometheus scrape metric relabel configs
+  # to apply to samples before ingestion.
+  ## [Metric Relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs)
+  metricRelabelings: []
+  # - action: keep
+  #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
+  #   sourceLabels: [__name__]
+
+  # -- Relabel configs to apply
+  # to samples before ingestion.
+  ## [Relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config)
+  relabelings: []
+  # - sourceLabels: [__meta_kubernetes_pod_node_name]
+  #   separator: ;
+  #   regex: ^(.*)$
+  #   targetLabel: nodename
+  #   replacement: $1
+  #   action: replace
 
 # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details.

--- a/helmfile.d/upstream/index.yaml
+++ b/helmfile.d/upstream/index.yaml
@@ -39,7 +39,7 @@ charts:
   bitnami/fluentd: 5.8.2
   bitnami/thanos: 15.0.5
 
-  dexidp/dex: 0.14.1
+  dexidp/dex: 0.18.0
 
   falcosecurity/falco: 4.2.2
   falcosecurity/falco-exporter: 0.9.11

--- a/migration/v0.40/README.md
+++ b/migration/v0.40/README.md
@@ -115,6 +115,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ./migration/v0.40/prepare/10-set-ck8s-installer.sh
     ```
 
+1. Update the dex config to follow new structure for google admin email:
+
+    ```bash
+    ./migration/v0.40/prepare/20-update-google-dex-config.sh
+    ```
+
 1. Update apps configuration:
 
     This will take a backup into `backups/` before modifying any files.

--- a/migration/v0.40/prepare/20-update-google-dex-config.sh
+++ b/migration/v0.40/prepare/20-update-google-dex-config.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+EDITOR='yq4 -i "with(.dex.connectors[]; with(select(.config | has(\"adminEmail\")); .config.domainToAdminEmail.\"*\" = .config.adminEmail | del(.config.adminEmail)))"' sops "${CK8S_CONFIG_PATH}/secrets.yaml"


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This upgrades dex to app version 2.40.0 and chart version 0.18.0

The google connector config `adminEmail: <email>` has been deprecated in favor of `domainToAdminEmail. '*': <email>`. It is now possible to have different admin emails for different domains, see the upstream PR for more details: https://github.com/dexidp/dex/pull/2911

- Fixes #2024 

#### Information to reviewers

There might be a better way to update the config. The way I have here seems to delete any comments present in the `secrets.yaml` file. Suggestions are very welcome.

I forgot to update the config schema, will do that soon.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [x] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [x] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [x] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
