### PR TITLE
Add flag to include config files for diagnostics script

### DIFF
--- a/bin/ck8s
+++ b/bin/ck8s
@@ -10,37 +10,32 @@ source "${here}/common.bash"
 
 usage() {
     echo "COMMANDS:" 1>&2
-    echo "  init <wc|sc|both> [--generate-new-secrets]              initialize the config path" 1>&2
     echo "  apply <wc|sc> [--sync] [--concurrency=<num>]            deploy the apps" 1>&2
-    echo "  test <wc|sc> [--logging-enabled]                        test the applications" 1>&2
+    echo "  clean <wc|sc>                                           Cleans the cluster of apps" 1>&2
+    echo "  completion bash                                         output shell completion code for bash" 1>&2
+    echo "  diagnostics <wc|sc> [-n namespace] [--include-config]   Runs diagnostics of apps" 1>&2
     echo "  dry-run <wc|sc> [--kubectl]                             runs helmfile diff" 1>&2
+    echo "  explain <config|secrets> [key.to.parameter]             explains the config or secrets" 1>&2
     echo "  fix-psp-violations <wc|sc>                              Checks and restarts pods that violates Pod Security Polices, applicable for new environments" 1>&2
-    echo "  upgrade <wc|sc|both> <vX.Y> prepare                     runs all prepare steps upgrading the configuration" 1>&2
-    echo "  upgrade <wc|sc|both> <vX.Y> apply                       runs all apply steps upgrading the environment" 1>&2
+    echo "  flavors                                                 lists supported configuration flavors" 1>&2
+    echo "  init <wc|sc|both> [--generate-new-secrets]              initialize the config path" 1>&2
+    echo "  install-requirements [--user] [--no-pass]               installs or updates required tools to run compliantkubernetes-apps" 1>&2
+    echo "  k8s-installers                                          lists supported kubernetes installers" 1>&2
+    echo "  kubeconfig <user|dev|admin>                             generate user kubeconfig, stored at CK8S_CONFIG_PATH/user" 1>&2
+    echo "  ops helm <wc|sc>                                        run helm as cluster admin" 1>&2
+    echo "  ops helmfile <wc|sc>                                    run helmfile as cluster admin" 1>&2
+    echo "  ops kubecolor <wc|sc>                                   run kubecolor as cluster admin" 1>&2
+    echo "  ops kubectl <wc|sc>                                     run kubectl as cluster admin" 1>&2
+    echo "  ops velero <wc|sc>                                      run velero as cluster admin" 1>&2
+    echo "  providers                                               lists supported cloud providers" 1>&2
+    echo "  s3cmd [cmd]                                             run s3cmd" 1>&2
     echo "  team add-pgp <fp>                                       add a new PGP key to secrets" 1>&2
     echo "  team remove-pgp <fp>                                    remove a PGP key from secrets and rotate the data encryption key" 1>&2
-    # TODO: We might want to make this command less visible once we have proper
-    #       support for OIDC logins.
-    echo "  ops kubectl <wc|sc>                                     run kubectl as cluster admin" 1>&2
-    echo "  ops kubecolor <wc|sc>                                   run kubecolor as cluster admin" 1>&2
-    echo "  ops helm <wc|sc>                                        run helm as cluster admin" 1>&2
-    # TODO: We might want to make this command less visible once we feel
-    #       confident that the apply command and migrations are good enough
-    #       that direct Helmfile access is not necessary.
-    echo "  ops helmfile <wc|sc>                                    run helmfile as cluster admin" 1>&2
-    echo "  ops velero <wc|sc>                                      run velero as cluster admin" 1>&2
-    echo "  s3cmd [cmd]                                             run s3cmd" 1>&2
-    echo "  kubeconfig <user|dev|admin>                             generate user kubeconfig, stored at CK8S_CONFIG_PATH/user" 1>&2
-    echo "  completion bash                                         output shell completion code for bash" 1>&2
-    echo "  install-requirements [--user] [--no-pass]               installs or updates required tools to run compliantkubernetes-apps" 1>&2
-    echo "  validate <wc|sc>                                        validates config files" 1>&2
-    echo "  providers                                               lists supported cloud providers" 1>&2
-    echo "  flavors                                                 lists supported configuration flavors" 1>&2
-    echo "  k8s-installers                                          lists supported kubernetes installers" 1>&2
+    echo "  test <wc|sc> [--logging-enabled]                        test the applications" 1>&2
     echo "  update-ips <wc|sc|both> <apply|dry-run>                 Automatically fetches and applies the IPs for network policies" 1>&2
-    echo "  explain <config|secrets> [key.to.parameter]             explains the config or secrets" 1>&2
-    echo "  clean <wc|sc>                                           Cleans the cluster of apps" 1>&2
-    echo "  diagnostics <wc|sc> [-n namespace] [--include-config]   Runs diagnostics of apps" 1>&2
+    echo "  upgrade <wc|sc|both> <vX.Y> apply                       runs all apply steps upgrading the environment" 1>&2
+    echo "  upgrade <wc|sc|both> <vX.Y> prepare                     runs all prepare steps upgrading the configuration" 1>&2
+    echo "  validate <wc|sc>                                        validates config files" 1>&2
     exit 1
 }
 

--- a/bin/ck8s
+++ b/bin/ck8s
@@ -10,37 +10,37 @@ source "${here}/common.bash"
 
 usage() {
     echo "COMMANDS:" 1>&2
-    echo "  init <wc|sc|both> [--generate-new-secrets]     initialize the config path" 1>&2
-    echo "  apply <wc|sc> [--sync] [--concurrency=<num>]   deploy the apps" 1>&2
-    echo "  test <wc|sc> [--logging-enabled]               test the applications" 1>&2
-    echo "  dry-run <wc|sc> [--kubectl]                    runs helmfile diff" 1>&2
-    echo "  fix-psp-violations <wc|sc>                     Checks and restarts pods that violates Pod Security Polices, applicable for new environments" 1>&2
-    echo "  upgrade <wc|sc|both> <vX.Y> prepare            runs all prepare steps upgrading the configuration" 1>&2
-    echo "  upgrade <wc|sc|both> <vX.Y> apply              runs all apply steps upgrading the environment" 1>&2
-    echo "  team add-pgp <fp>                              add a new PGP key to secrets" 1>&2
-    echo "  team remove-pgp <fp>                           remove a PGP key from secrets and rotate the data encryption key" 1>&2
+    echo "  init <wc|sc|both> [--generate-new-secrets]              initialize the config path" 1>&2
+    echo "  apply <wc|sc> [--sync] [--concurrency=<num>]            deploy the apps" 1>&2
+    echo "  test <wc|sc> [--logging-enabled]                        test the applications" 1>&2
+    echo "  dry-run <wc|sc> [--kubectl]                             runs helmfile diff" 1>&2
+    echo "  fix-psp-violations <wc|sc>                              Checks and restarts pods that violates Pod Security Polices, applicable for new environments" 1>&2
+    echo "  upgrade <wc|sc|both> <vX.Y> prepare                     runs all prepare steps upgrading the configuration" 1>&2
+    echo "  upgrade <wc|sc|both> <vX.Y> apply                       runs all apply steps upgrading the environment" 1>&2
+    echo "  team add-pgp <fp>                                       add a new PGP key to secrets" 1>&2
+    echo "  team remove-pgp <fp>                                    remove a PGP key from secrets and rotate the data encryption key" 1>&2
     # TODO: We might want to make this command less visible once we have proper
     #       support for OIDC logins.
-    echo "  ops kubectl <wc|sc>                            run kubectl as cluster admin" 1>&2
-    echo "  ops kubecolor <wc|sc>                          run kubecolor as cluster admin" 1>&2
-    echo "  ops helm <wc|sc>                               run helm as cluster admin" 1>&2
+    echo "  ops kubectl <wc|sc>                                     run kubectl as cluster admin" 1>&2
+    echo "  ops kubecolor <wc|sc>                                   run kubecolor as cluster admin" 1>&2
+    echo "  ops helm <wc|sc>                                        run helm as cluster admin" 1>&2
     # TODO: We might want to make this command less visible once we feel
     #       confident that the apply command and migrations are good enough
     #       that direct Helmfile access is not necessary.
-    echo "  ops helmfile <wc|sc>                           run helmfile as cluster admin" 1>&2
-    echo "  ops velero <wc|sc>                             run velero as cluster admin" 1>&2
-    echo "  s3cmd [cmd]                                    run s3cmd" 1>&2
-    echo "  kubeconfig <user|dev|admin>                    generate user kubeconfig, stored at CK8S_CONFIG_PATH/user" 1>&2
-    echo "  completion bash                                output shell completion code for bash" 1>&2
-    echo "  install-requirements [--user] [--no-pass]      installs or updates required tools to run compliantkubernetes-apps" 1>&2
-    echo "  validate <wc|sc>                               validates config files" 1>&2
-    echo "  providers                                      lists supported cloud providers" 1>&2
-    echo "  flavors                                        lists supported configuration flavors" 1>&2
-    echo "  k8s-installers                                 lists supported kubernetes installers" 1>&2
-    echo "  explain <config|secrets> [key.to.parameter]    explains the config or secrets" 1>&2
-    echo "  update-ips <wc|sc|both> <apply|dry-run>        Automatically fetches and applies the IPs for network policies" 1>&2
-    echo "  clean <wc|sc>                                  Cleans the cluster of apps" 1>&2
-    echo "  diagnostics <wc|sc>                            Runs diagnostics of apps" 1>&2
+    echo "  ops helmfile <wc|sc>                                    run helmfile as cluster admin" 1>&2
+    echo "  ops velero <wc|sc>                                      run velero as cluster admin" 1>&2
+    echo "  s3cmd [cmd]                                             run s3cmd" 1>&2
+    echo "  kubeconfig <user|dev|admin>                             generate user kubeconfig, stored at CK8S_CONFIG_PATH/user" 1>&2
+    echo "  completion bash                                         output shell completion code for bash" 1>&2
+    echo "  install-requirements [--user] [--no-pass]               installs or updates required tools to run compliantkubernetes-apps" 1>&2
+    echo "  validate <wc|sc>                                        validates config files" 1>&2
+    echo "  providers                                               lists supported cloud providers" 1>&2
+    echo "  flavors                                                 lists supported configuration flavors" 1>&2
+    echo "  k8s-installers                                          lists supported kubernetes installers" 1>&2
+    echo "  update-ips <wc|sc|both> <apply|dry-run>                 Automatically fetches and applies the IPs for network policies" 1>&2
+    echo "  explain <config|secrets> [key.to.parameter]             explains the config or secrets" 1>&2
+    echo "  clean <wc|sc>                                           Cleans the cluster of apps" 1>&2
+    echo "  diagnostics <wc|sc> [-n namespace] [--include-config]   Runs diagnostics of apps" 1>&2
     exit 1
 }
 


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice

The command usage for `ck8s` has been updated so that all commands are listed in ascending order.

The command `ck8s diagnostics` has a new flag to include config files in the output log file. The command usage has been changed: `ck8s diagnostics <wc|sc> [-n namespace] [--include-config]`

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
This PR adds a new flag for the `ck8s diagnostics` command to include config files for the environment found in `CK8S_CONFIG_PATH`. This PR also adds a flag parser and changes the command usage for specifying a namespace. Also the `ck8s` command usage has been sorted in ascending order as it imo started to feel very cluttered, this way it is a bit easier to follow.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Part of #2154

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
