### PR TITLE
Upgrade ingress-nginx chart to 4.11.2 and app to 1.11.2

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -632,6 +632,7 @@ ingressNginx:
     tolerations: []
     affinity: {}
     nodeSelector: {}
+    topologySpreadConstraints: []
 
 ## Configuration for Velero and node-agent.
 ## Check out https://compliantkubernetes.io/user-guide/backup/ to see what's included in backups.

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -5937,6 +5937,8 @@ properties:
             $ref: '#/$defs/kubernetesNodeSelector'
           affinity:
             $ref: '#/$defs/io.k8s.api.core.v1.Affinity'
+          topologySpreadConstraints:
+            $ref: '#/$defs/kubernetesTopologySpreadConstraints'
   issuers:
     title: Issuers Config
     description: Configure issuers for cert-manager.

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/Chart.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/Chart.yaml
@@ -1,10 +1,9 @@
 annotations:
-  artifacthub.io/changes: |-
-    - "update web hook cert gen to latest release v20231226-1a7112e06"
-    - "Update Ingress-Nginx version controller-v1.9.6"
+  artifacthub.io/changes: |
+    - Update Ingress-Nginx version controller-v1.11.2
   artifacthub.io/prerelease: "false"
 apiVersion: v2
-appVersion: 1.9.6
+appVersion: 1.11.2
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and
   load balancer
 home: https://github.com/kubernetes/ingress-nginx
@@ -12,12 +11,15 @@ icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/5
 keywords:
 - ingress
 - nginx
-kubeVersion: '>=1.20.0-0'
+kubeVersion: '>=1.21.0-0'
 maintainers:
+- name: cpanato
+- name: Gacko
+- name: puerco
 - name: rikatz
 - name: strongjz
 - name: tao12345666333
 name: ingress-nginx
 sources:
 - https://github.com/kubernetes/ingress-nginx
-version: 4.9.1
+version: 4.11.2

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/OWNERS
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/OWNERS
@@ -1,4 +1,4 @@
-# See the OWNERS docs: https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+# See the OWNERS docs: https://www.kubernetes.dev/docs/guide/owners
 
 approvers:
 - ingress-nginx-helm-maintainers

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/README.md
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/README.md
@@ -2,7 +2,7 @@
 
 [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 
-![Version: 4.9.1](https://img.shields.io/badge/Version-4.9.1-informational?style=flat-square) ![AppVersion: 1.9.6](https://img.shields.io/badge/AppVersion-1.9.6-informational?style=flat-square)
+![Version: 4.11.2](https://img.shields.io/badge/Version-4.11.2-informational?style=flat-square) ![AppVersion: 1.11.2](https://img.shields.io/badge/AppVersion-1.11.2-informational?style=flat-square)
 
 To use, add `ingressClassName: nginx` spec field or the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
 
@@ -10,7 +10,7 @@ This chart bootstraps an ingress-nginx deployment on a [Kubernetes](http://kuber
 
 ## Requirements
 
-Kubernetes: `>=1.20.0-0`
+Kubernetes: `>=1.21.0-0`
 
 ## Get Repo Info
 
@@ -253,17 +253,23 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.admissionWebhooks.namespaceSelector | object | `{}` |  |
 | controller.admissionWebhooks.objectSelector | object | `{}` |  |
 | controller.admissionWebhooks.patch.enabled | bool | `true` |  |
-| controller.admissionWebhooks.patch.image.digest | string | `"sha256:25d6a5f11211cc5c3f9f2bf552b585374af287b4debf693cacbe2da47daa5084"` |  |
+| controller.admissionWebhooks.patch.image.digest | string | `"sha256:a320a50cc91bd15fd2d6fa6de58bd98c1bd64b9a6f926ce23a600d87043455a3"` |  |
 | controller.admissionWebhooks.patch.image.image | string | `"ingress-nginx/kube-webhook-certgen"` |  |
 | controller.admissionWebhooks.patch.image.pullPolicy | string | `"IfNotPresent"` |  |
 | controller.admissionWebhooks.patch.image.registry | string | `"registry.k8s.io"` |  |
-| controller.admissionWebhooks.patch.image.tag | string | `"v20231226-1a7112e06"` |  |
+| controller.admissionWebhooks.patch.image.tag | string | `"v1.4.3"` |  |
 | controller.admissionWebhooks.patch.labels | object | `{}` | Labels to be added to patch job resources |
 | controller.admissionWebhooks.patch.networkPolicy.enabled | bool | `false` | Enable 'networkPolicy' or not |
 | controller.admissionWebhooks.patch.nodeSelector."kubernetes.io/os" | string | `"linux"` |  |
 | controller.admissionWebhooks.patch.podAnnotations | object | `{}` |  |
 | controller.admissionWebhooks.patch.priorityClassName | string | `""` | Provide a priority class name to the webhook patching job # |
+| controller.admissionWebhooks.patch.rbac | object | `{"create":true}` | Admission webhook patch job RBAC |
+| controller.admissionWebhooks.patch.rbac.create | bool | `true` | Create RBAC or not |
 | controller.admissionWebhooks.patch.securityContext | object | `{}` | Security context for secret creation & webhook patch pods |
+| controller.admissionWebhooks.patch.serviceAccount | object | `{"automountServiceAccountToken":true,"create":true,"name":""}` | Admission webhook patch job service account |
+| controller.admissionWebhooks.patch.serviceAccount.automountServiceAccountToken | bool | `true` | Auto-mount service account token or not |
+| controller.admissionWebhooks.patch.serviceAccount.create | bool | `true` | Create a service account or not |
+| controller.admissionWebhooks.patch.serviceAccount.name | string | `""` | Custom service account name |
 | controller.admissionWebhooks.patch.tolerations | list | `[]` |  |
 | controller.admissionWebhooks.patchWebhookJob.name | string | `"patch"` |  |
 | controller.admissionWebhooks.patchWebhookJob.resources | object | `{}` |  |
@@ -285,7 +291,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.autoscaling.targetCPUUtilizationPercentage | int | `50` |  |
 | controller.autoscaling.targetMemoryUtilizationPercentage | int | `50` |  |
 | controller.autoscalingTemplate | list | `[]` |  |
-| controller.config | object | `{}` | Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/ |
+| controller.config | object | `{}` | Global configuration passed to the ConfigMap consumed by the controller. Values may contain Helm templates. Ref.: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/ |
 | controller.configAnnotations | object | `{}` | Annotations to be added to the controller config configuration configmap. |
 | controller.configMapNamespace | string | `""` | Allows customization of the configmap / nginx-configmap namespace; defaults to $(POD_NAMESPACE) |
 | controller.containerName | string | `"controller"` | Configures the controller container name |
@@ -293,9 +299,11 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.containerSecurityContext | object | `{}` | Security context for controller containers |
 | controller.customTemplate.configMapKey | string | `""` |  |
 | controller.customTemplate.configMapName | string | `""` |  |
+| controller.disableLeaderElection | bool | `false` | This configuration disable Nginx Controller Leader Election |
 | controller.dnsConfig | object | `{}` | Optionally customize the pod dnsConfig. |
 | controller.dnsPolicy | string | `"ClusterFirst"` | Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'. By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller to keep resolving names inside the k8s network, use ClusterFirstWithHostNet. |
 | controller.electionID | string | `""` | Election ID to use for status update, by default it uses the controller name combined with a suffix of 'leader' |
+| controller.electionTTL | string | `""` | Duration a leader election is valid before it's getting re-elected, e.g. `15s`, `10m` or `1h`. (Default: 30s) |
 | controller.enableAnnotationValidations | bool | `false` |  |
 | controller.enableMimalloc | bool | `true` | Enable mimalloc as a drop-in replacement for malloc. # ref: https://github.com/microsoft/mimalloc # |
 | controller.enableTopologyAwareRouting | bool | `false` | This configuration enables Topology Aware Routing feature, used together with service annotation service.kubernetes.io/topology-mode="auto" Defaults to false |
@@ -317,8 +325,8 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.hostname | object | `{}` | Optionally customize the pod hostname. |
 | controller.image.allowPrivilegeEscalation | bool | `false` |  |
 | controller.image.chroot | bool | `false` |  |
-| controller.image.digest | string | `"sha256:1405cc613bd95b2c6edd8b2a152510ae91c7e62aea4698500d23b2145960ab9c"` |  |
-| controller.image.digestChroot | string | `"sha256:7eb46ff733429e0e46892903c7394aff149ac6d284d92b3946f3baf7ff26a096"` |  |
+| controller.image.digest | string | `"sha256:d5f8217feeac4887cb1ed21f27c2674e58be06bd8f5184cacea2a69abaf78dce"` |  |
+| controller.image.digestChroot | string | `"sha256:21b55a2f0213a18b91612a8c0850167e00a8e34391fd595139a708f9c047e7a8"` |  |
 | controller.image.image | string | `"ingress-nginx/controller"` |  |
 | controller.image.pullPolicy | string | `"IfNotPresent"` |  |
 | controller.image.readOnlyRootFilesystem | bool | `false` |  |
@@ -326,14 +334,17 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.image.runAsNonRoot | bool | `true` |  |
 | controller.image.runAsUser | int | `101` |  |
 | controller.image.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| controller.image.tag | string | `"v1.9.6"` |  |
+| controller.image.tag | string | `"v1.11.2"` |  |
 | controller.ingressClass | string | `"nginx"` | For backwards compatibility with ingress.class annotation, use ingressClass. Algorithm is as follows, first ingressClassName is considered, if not present, controller looks for ingress.class annotation |
 | controller.ingressClassByName | bool | `false` | Process IngressClass per name (additionally as per spec.controller). |
-| controller.ingressClassResource.controllerValue | string | `"k8s.io/ingress-nginx"` | Controller-value of the controller that is processing this ingressClass |
-| controller.ingressClassResource.default | bool | `false` | Is this the default ingressClass for the cluster |
-| controller.ingressClassResource.enabled | bool | `true` | Is this ingressClass enabled or not |
-| controller.ingressClassResource.name | string | `"nginx"` | Name of the ingressClass |
-| controller.ingressClassResource.parameters | object | `{}` | Parameters is a link to a custom resource containing additional configuration for the controller. This is optional if the controller does not require extra parameters. |
+| controller.ingressClassResource | object | `{"aliases":[],"annotations":{},"controllerValue":"k8s.io/ingress-nginx","default":false,"enabled":true,"name":"nginx","parameters":{}}` | This section refers to the creation of the IngressClass resource. IngressClasses are immutable and cannot be changed after creation. We do not support namespaced IngressClasses, yet, so a ClusterRole and a ClusterRoleBinding is required. |
+| controller.ingressClassResource.aliases | list | `[]` | Aliases of this IngressClass. Creates copies with identical settings but the respective alias as name. Useful for development environments with only one Ingress Controller but production-like Ingress resources. `default` gets enabled on the original IngressClass only. |
+| controller.ingressClassResource.annotations | object | `{}` | Annotations to be added to the IngressClass resource. |
+| controller.ingressClassResource.controllerValue | string | `"k8s.io/ingress-nginx"` | Controller of the IngressClass. An Ingress Controller looks for IngressClasses it should reconcile by this value. This value is also being set as the `--controller-class` argument of this Ingress Controller. Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class |
+| controller.ingressClassResource.default | bool | `false` | If true, Ingresses without `ingressClassName` get assigned to this IngressClass on creation. Ingress creation gets rejected if there are multiple default IngressClasses. Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class |
+| controller.ingressClassResource.enabled | bool | `true` | Create the IngressClass or not |
+| controller.ingressClassResource.name | string | `"nginx"` | Name of the IngressClass |
+| controller.ingressClassResource.parameters | object | `{}` | A link to a custom resource containing additional configuration for the controller. This is optional if the controller consuming this IngressClass does not require additional parameters. Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class |
 | controller.keda.apiVersion | string | `"keda.sh/v1alpha1"` |  |
 | controller.keda.behavior | object | `{}` |  |
 | controller.keda.cooldownPeriod | int | `300` |  |
@@ -389,11 +400,11 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.opentelemetry.containerSecurityContext.runAsUser | int | `65532` | The image's default user, inherited from its base image `cgr.dev/chainguard/static`. |
 | controller.opentelemetry.containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | controller.opentelemetry.enabled | bool | `false` |  |
-| controller.opentelemetry.image.digest | string | `"sha256:13bee3f5223883d3ca62fee7309ad02d22ec00ff0d7033e3e9aca7a9f60fd472"` |  |
+| controller.opentelemetry.image.digest | string | `"sha256:f7604ac0547ed64d79b98d92133234e66c2c8aade3c1f4809fed5eec1fb7f922"` |  |
 | controller.opentelemetry.image.distroless | bool | `true` |  |
-| controller.opentelemetry.image.image | string | `"ingress-nginx/opentelemetry"` |  |
+| controller.opentelemetry.image.image | string | `"ingress-nginx/opentelemetry-1.25.3"` |  |
 | controller.opentelemetry.image.registry | string | `"registry.k8s.io"` |  |
-| controller.opentelemetry.image.tag | string | `"v20230721-3e2062ee5"` |  |
+| controller.opentelemetry.image.tag | string | `"v20240813-b933310d"` |  |
 | controller.opentelemetry.name | string | `"opentelemetry"` |  |
 | controller.opentelemetry.resources | object | `{}` |  |
 | controller.podAnnotations | object | `{}` | Annotations to be added to controller pods # |
@@ -474,7 +485,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | controller.udp.configMapNamespace | string | `""` | Allows customization of the udp-services-configmap; defaults to $(POD_NAMESPACE) |
 | controller.updateStrategy | object | `{}` | The update strategy to apply to the Deployment or DaemonSet # |
 | controller.watchIngressWithoutClass | bool | `false` | Process Ingress objects without ingressClass annotation/ingressClassName field Overrides value for --watch-ingress-without-class flag of the controller binary Defaults to false |
-| defaultBackend.affinity | object | `{}` |  |
+| defaultBackend.affinity | object | `{}` | Affinity and anti-affinity rules for server scheduling to nodes # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | defaultBackend.autoscaling.annotations | object | `{}` |  |
 | defaultBackend.autoscaling.enabled | bool | `false` |  |
 | defaultBackend.autoscaling.maxReplicas | int | `2` |  |
@@ -530,6 +541,7 @@ As of version `1.26.0` of this chart, by simply not providing any clusterIP valu
 | defaultBackend.serviceAccount.create | bool | `true` |  |
 | defaultBackend.serviceAccount.name | string | `""` |  |
 | defaultBackend.tolerations | list | `[]` | Node tolerations for server scheduling to nodes with taints # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
+| defaultBackend.topologySpreadConstraints | list | `[]` | Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in. Ref.: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/ |
 | defaultBackend.updateStrategy | object | `{}` | The update strategy to apply to the Deployment or DaemonSet # |
 | dhParam | string | `""` | A base64-encoded Diffie-Hellman parameter. This can be generated with: `openssl dhparam 4096 2> /dev/null | base64` # Ref: https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/ssl-dh-param |
 | imagePullSecrets | list | `[]` | Optional array of imagePullSecrets containing private registry credentials # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/helm-chart-4.10.0.md
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/helm-chart-4.10.0.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.10.0
+
+* - "Update Ingress-Nginx version controller-v1.10.0"
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.9.1...helm-chart-4.10.0

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/helm-chart-4.10.1.md
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/helm-chart-4.10.1.md
@@ -1,0 +1,11 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.10.1
+
+* - "update post submit helm ci and clean up (#11221)"
+* - "refactor helm ci tests part I (#11188)"
+* - "Update Ingress-Nginx version controller-v1.10.1"
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.10.0...helm-chart-4.10.1

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/helm-chart-4.10.2.md
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/helm-chart-4.10.2.md
@@ -1,0 +1,18 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.10.2
+
+* Chores: Align security contacts & chart maintainers to actual owners. (#11480)
+* Fix helm install on cloud provider admonition block (#11412)
+* edited helm-install tips (#11411)
+* added info for aws helm install (#11410)
+* add workflow to helm release and update ct for branch (#11317)
+* Merge pull request #11277 from strongjz/chart-1.10.1 (#11314)
+* release helm chart from release branch (#11278)
+* update post submit helm ci and clean up (#11221)
+* refactor helm ci tests part I (#11188)
+* Update Ingress-Nginx version controller-v1.10.2
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.10.1...helm-chart-4.10.2

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/helm-chart-4.11.0.md
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/helm-chart-4.11.0.md
@@ -1,0 +1,18 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.11.0
+
+* Chores: Align security contacts & chart maintainers to actual owners. (#11465)
+* Merge pull request #11277 from strongjz/chart-1.10.1 (#11415)
+* Fix helm install on cloud provider admonition block (#11394)
+* edited helm-install tips (#11393)
+* added info for aws helm install (#11390)
+* add workflow to helm release and update ct for branch (#11378)
+* release helm chart from release branch (#11276)
+* update post submit helm ci and clean up (#11220)
+* refactor helm ci tests part I (#11178)
+* Update Ingress-Nginx version controller-v1.11.0
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.10.2...helm-chart-4.11.0

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/helm-chart-4.11.1.md
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/helm-chart-4.11.1.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.11.1
+
+* Update Ingress-Nginx version controller-v1.11.1
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.11.0...helm-chart-4.11.1

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/helm-chart-4.11.2.md
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/changelog/helm-chart-4.11.2.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents all notable changes to [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
+
+### 4.11.2
+
+* Update Ingress-Nginx version controller-v1.11.2
+
+**Full Changelog**: https://github.com/kubernetes/ingress-nginx/compare/helm-chart-4.11.1...helm-chart-4.11.2

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/_helpers.tpl
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/_helpers.tpl
@@ -168,6 +168,17 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create the name of the admission webhook patch job service account to use
+*/}}
+{{- define "ingress-nginx.admissionWebhooks.patch.serviceAccountName" -}}
+{{- if .Values.controller.admissionWebhooks.patch.serviceAccount.create -}}
+    {{ default (include "ingress-nginx.admissionWebhooks.fullname" .) .Values.controller.admissionWebhooks.patch.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.controller.admissionWebhooks.patch.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified admission webhook secret creation job name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
@@ -231,25 +242,6 @@ Return the appropriate apiGroup for PodSecurityPolicy.
 {{- else -}}
 {{- print "extensions" -}}
 {{- end -}}
-{{- end -}}
-
-{{/*
-Check the ingress controller version tag is at most three versions behind the last release
-*/}}
-{{- define "isControllerTagValid" -}}
-{{- if not (semverCompare ">=0.27.0-0" .Values.controller.image.tag) -}}
-{{- fail "Controller container image tag should be 0.27.0 or higher" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-IngressClass parameters.
-*/}}
-{{- define "ingressClass.parameters" -}}
-  {{- if .Values.controller.ingressClassResource.parameters -}}
-          parameters:
-{{ toYaml .Values.controller.ingressClassResource.parameters | indent 4}}
-  {{ end }}
 {{- end -}}
 
 {{/*

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/_params.tpl
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/_params.tpl
@@ -29,7 +29,7 @@
 - --watch-namespace={{ default "$(POD_NAMESPACE)" .Values.controller.scope.namespace }}
 {{- end }}
 {{- if and (not .Values.controller.scope.enabled) .Values.controller.scope.namespaceSelector }}
-- --watch-namespace-selector={{ default "" .Values.controller.scope.namespaceSelector }}
+- --watch-namespace-selector={{ .Values.controller.scope.namespaceSelector }}
 {{- end }}
 {{- if and .Values.controller.reportNodeInternalIp .Values.controller.hostNetwork }}
 - --report-node-internal-ip-address={{ .Values.controller.reportNodeInternalIp }}
@@ -54,8 +54,17 @@
 {{- if .Values.controller.watchIngressWithoutClass }}
 - --watch-ingress-without-class=true
 {{- end }}
+{{- if not .Values.controller.metrics.enabled }}
+- --enable-metrics={{ .Values.controller.metrics.enabled }}
+{{- end }}
 {{- if .Values.controller.enableTopologyAwareRouting }}
 - --enable-topology-aware-routing=true
+{{- end }}
+{{- if .Values.controller.disableLeaderElection }}
+- --disable-leader-election=true
+{{- end }}
+{{- if .Values.controller.electionTTL }}
+- --election-ttl={{ .Values.controller.electionTTL }}
 {{- end }}
 {{- range $key, $value := .Values.controller.extraArgs }}
 {{- /* Accept keys without values or with false as value */}}

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/admission-webhooks/job-patch/clusterrole.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/admission-webhooks/job-patch/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled (not .Values.controller.admissionWebhooks.certManager.enabled) -}}
+{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled .Values.controller.admissionWebhooks.patch.rbac.create (not .Values.controller.admissionWebhooks.certManager.enabled) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled (not .Values.controller.admissionWebhooks.certManager.enabled) -}}
+{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled .Values.controller.admissionWebhooks.patch.rbac.create (not .Values.controller.admissionWebhooks.certManager.enabled) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -18,6 +18,6 @@ roleRef:
   name: {{ include "ingress-nginx.admissionWebhooks.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "ingress-nginx.admissionWebhooks.fullname" . }}
+    name: {{ include "ingress-nginx.admissionWebhooks.patch.serviceAccountName" . }}
     namespace: {{ include "ingress-nginx.namespace" . }}
 {{- end }}

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -66,7 +66,7 @@ spec:
           resources: {{ toYaml .Values.controller.admissionWebhooks.createSecretJob.resources | nindent 12 }}
           {{- end }}
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "ingress-nginx.admissionWebhooks.fullname" . }}
+      serviceAccountName: {{ include "ingress-nginx.admissionWebhooks.patch.serviceAccountName" . }}
     {{- if .Values.controller.admissionWebhooks.patch.nodeSelector }}
       nodeSelector: {{ toYaml .Values.controller.admissionWebhooks.patch.nodeSelector | nindent 8 }}
     {{- end }}

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -68,7 +68,7 @@ spec:
           resources: {{ toYaml .Values.controller.admissionWebhooks.patchWebhookJob.resources | nindent 12 }}
           {{- end }}
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "ingress-nginx.admissionWebhooks.fullname" . }}
+      serviceAccountName: {{ include "ingress-nginx.admissionWebhooks.patch.serviceAccountName" . }}
     {{- if .Values.controller.admissionWebhooks.patch.nodeSelector }}
       nodeSelector: {{ toYaml .Values.controller.admissionWebhooks.patch.nodeSelector | nindent 8 }}
     {{- end }}

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/admission-webhooks/job-patch/role.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/admission-webhooks/job-patch/role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled (not .Values.controller.admissionWebhooks.certManager.enabled) -}}
+{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled .Values.controller.admissionWebhooks.patch.rbac.create (not .Values.controller.admissionWebhooks.certManager.enabled) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/admission-webhooks/job-patch/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled (not .Values.controller.admissionWebhooks.certManager.enabled) -}}
+{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled .Values.controller.admissionWebhooks.patch.rbac.create (not .Values.controller.admissionWebhooks.certManager.enabled) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -19,6 +19,6 @@ roleRef:
   name: {{ include "ingress-nginx.admissionWebhooks.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "ingress-nginx.admissionWebhooks.fullname" . }}
+    name: {{ include "ingress-nginx.admissionWebhooks.patch.serviceAccountName" . }}
     namespace: {{ include "ingress-nginx.namespace" . }}
 {{- end }}

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/admission-webhooks/job-patch/serviceaccount.yaml
@@ -1,8 +1,8 @@
-{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled (not .Values.controller.admissionWebhooks.certManager.enabled) -}}
+{{- if and .Values.controller.admissionWebhooks.enabled .Values.controller.admissionWebhooks.patch.enabled .Values.controller.admissionWebhooks.patch.serviceAccount.create (not .Values.controller.admissionWebhooks.certManager.enabled) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "ingress-nginx.admissionWebhooks.fullname" . }}
+  name: {{ include "ingress-nginx.admissionWebhooks.patch.serviceAccountName" . }}
   namespace: {{ include "ingress-nginx.namespace" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
@@ -13,4 +13,5 @@ metadata:
     {{- with .Values.controller.admissionWebhooks.patch.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+automountServiceAccountToken: {{ .Values.controller.admissionWebhooks.patch.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-configmap.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-configmap.yaml
@@ -24,5 +24,5 @@ data:
   ssl-dh-param: {{ include "ingress-nginx.namespace" . }}/{{ include "ingress-nginx.controller.fullname" . }}
 {{- end }}
 {{- range $key, $value := .Values.controller.config }}
-  {{- $key | nindent 2 }}: {{ $value | quote }}
+  {{- $key | nindent 2 }}: {{ tpl (toString $value) $ | quote }}
 {{- end }}

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-daemonset.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-daemonset.yaml
@@ -1,5 +1,4 @@
 {{- if eq .Values.controller.kind "DaemonSet" -}}
-{{- include  "isControllerTagValid" . -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -203,7 +202,7 @@ spec:
       tolerations: {{ toYaml .Values.controller.tolerations | nindent 8 }}
     {{- end }}
     {{- if .Values.controller.affinity }}
-      affinity: {{ toYaml .Values.controller.affinity | nindent 8 }}
+      affinity: {{ tpl (toYaml .Values.controller.affinity) $ | nindent 8 }}
     {{- end }}
     {{- if .Values.controller.topologySpreadConstraints }}
       topologySpreadConstraints: {{ tpl (toYaml .Values.controller.topologySpreadConstraints) $ | nindent 8 }}

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-deployment.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-deployment.yaml
@@ -1,5 +1,4 @@
 {{- if eq .Values.controller.kind "Deployment" -}}
-{{- include  "isControllerTagValid" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,7 +18,7 @@ spec:
     matchLabels:
       {{- include "ingress-nginx.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: controller
-  {{- if not (or .Values.controller.autoscaling.enabled .Values.controller.keda.enabled) }}
+  {{- if eq .Values.controller.autoscaling.enabled .Values.controller.keda.enabled }}
   replicas: {{ .Values.controller.replicaCount }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
@@ -206,7 +205,7 @@ spec:
       tolerations: {{ toYaml .Values.controller.tolerations | nindent 8 }}
     {{- end }}
     {{- if .Values.controller.affinity }}
-      affinity: {{ toYaml .Values.controller.affinity | nindent 8 }}
+      affinity: {{ tpl (toYaml .Values.controller.affinity) $ | nindent 8 }}
     {{- end }}
     {{- if .Values.controller.topologySpreadConstraints }}
       topologySpreadConstraints: {{ tpl (toYaml .Values.controller.topologySpreadConstraints) $ | nindent 8 }}

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-ingressclass-aliases.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-ingressclass-aliases.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.controller.ingressClassResource.enabled -}}
+{{- range .Values.controller.ingressClassResource.aliases }}
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    {{- include "ingress-nginx.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: controller
+    {{- with $.Values.controller.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ . }}
+  {{- if $.Values.controller.ingressClassResource.annotations }}
+  annotations: {{ toYaml $.Values.controller.ingressClassResource.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  controller: {{ $.Values.controller.ingressClassResource.controllerValue }}
+  {{- with $.Values.controller.ingressClassResource.parameters }}
+  parameters: {{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-ingressclass.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-ingressclass.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.controller.ingressClassResource.enabled -}}
-# We don't support namespaced ingressClass yet
-# So a ClusterRole and a ClusterRoleBinding is required
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
@@ -11,11 +9,18 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   name: {{ .Values.controller.ingressClassResource.name }}
-{{- if .Values.controller.ingressClassResource.default }}
+  {{- if or .Values.controller.ingressClassResource.default .Values.controller.ingressClassResource.annotations }}
   annotations:
+    {{- if .Values.controller.ingressClassResource.default }}
     ingressclass.kubernetes.io/is-default-class: "true"
-{{- end }}
+    {{- end }}
+    {{- if .Values.controller.ingressClassResource.annotations }}
+    {{- toYaml .Values.controller.ingressClassResource.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   controller: {{ .Values.controller.ingressClassResource.controllerValue }}
-  {{ template "ingressClass.parameters" . }}
+  {{- with .Values.controller.ingressClassResource.parameters }}
+  parameters: {{ toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-keda.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-keda.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.controller.keda.enabled (eq .Values.controller.kind "Deployment") -}}
+{{- if and (eq .Values.controller.kind "Deployment") .Values.controller.keda.enabled (not .Values.controller.autoscaling.enabled) -}}
 apiVersion: {{ .Values.controller.keda.apiVersion }}
 kind: ScaledObject
 metadata:

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-poddisruptionbudget.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-poddisruptionbudget.yaml
@@ -1,4 +1,13 @@
-{{- if or (and .Values.controller.autoscaling.enabled (gt (.Values.controller.autoscaling.minReplicas | int) 1)) (and (not .Values.controller.autoscaling.enabled) (gt (.Values.controller.replicaCount | int) 1)) }}
+# PDB is not supported for DaemonSets.
+# https://github.com/kubernetes/kubernetes/issues/108124
+{{- if eq .Values.controller.kind "Deployment" }}
+{{- $replicas := .Values.controller.replicaCount }}
+{{- if and .Values.controller.autoscaling.enabled (not .Values.controller.keda.enabled) }}
+{{- $replicas = .Values.controller.autoscaling.minReplicas }}
+{{- else if and .Values.controller.keda.enabled (not .Values.controller.autoscaling.enabled) }}
+{{- $replicas = .Values.controller.keda.minReplicas }}
+{{- end }}
+{{- if gt ($replicas | int) 1 }}
 apiVersion: {{ ternary "policy/v1" "policy/v1beta1" (semverCompare ">=1.21.0-0" .Capabilities.KubeVersion.Version) }}
 kind: PodDisruptionBudget
 metadata:
@@ -23,4 +32,5 @@ spec:
   {{- else if .Values.controller.maxUnavailable }}
   maxUnavailable: {{ .Values.controller.maxUnavailable }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-prometheusrules.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-prometheusrules.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Values.controller.metrics.enabled ) ( .Values.controller.metrics.prometheusRule.enabled ) ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) -}}
+{{- if and .Values.controller.metrics.enabled .Values.controller.metrics.prometheusRule.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-service-internal.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-service-internal.yaml
@@ -58,7 +58,7 @@ spec:
       port: {{ .Values.controller.service.internal.ports.http | default .Values.controller.service.ports.http }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.internal.targetPorts.http | default .Values.controller.service.targetPorts.http }}
-    {{- if and (semverCompare ">=1.20" .Capabilities.KubeVersion.Version) (.Values.controller.service.internal.appProtocol) }}
+    {{- if and (semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version) (.Values.controller.service.internal.appProtocol) }}
       appProtocol: http
     {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.internal.nodePorts.http))) }}
@@ -70,7 +70,7 @@ spec:
       port: {{ .Values.controller.service.internal.ports.https | default .Values.controller.service.ports.https }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.internal.targetPorts.https | default .Values.controller.service.targetPorts.https }}
-    {{- if and (semverCompare ">=1.20" .Capabilities.KubeVersion.Version) (.Values.controller.service.internal.appProtocol) }}
+    {{- if and (semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version) (.Values.controller.service.internal.appProtocol) }}
       appProtocol: https
     {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.internal.nodePorts.https))) }}

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-service-webhook.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-service-webhook.yaml
@@ -31,7 +31,7 @@ spec:
     - name: https-webhook
       port: 443
       targetPort: webhook
-    {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
+    {{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
       appProtocol: https
     {{- end }}
   selector:

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-service.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/controller-service.yaml
@@ -58,7 +58,7 @@ spec:
       port: {{ .Values.controller.service.ports.http }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.http }}
-    {{- if and (semverCompare ">=1.20" .Capabilities.KubeVersion.Version) (.Values.controller.service.appProtocol) }}
+    {{- if and (semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version) (.Values.controller.service.appProtocol) }}
       appProtocol: http
     {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.http))) }}
@@ -70,7 +70,7 @@ spec:
       port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.https }}
-    {{- if and (semverCompare ">=1.20" .Capabilities.KubeVersion.Version) (.Values.controller.service.appProtocol) }}
+    {{- if and (semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version) (.Values.controller.service.appProtocol) }}
       appProtocol: https
     {{- end }}
     {{- if (and $setNodePorts (not (empty .Values.controller.service.nodePorts.https))) }}

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/default-backend-deployment.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/default-backend-deployment.yaml
@@ -107,7 +107,10 @@ spec:
       tolerations: {{ toYaml .Values.defaultBackend.tolerations | nindent 8 }}
     {{- end }}
     {{- if .Values.defaultBackend.affinity }}
-      affinity: {{ toYaml .Values.defaultBackend.affinity | nindent 8 }}
+      affinity: {{ tpl (toYaml .Values.defaultBackend.affinity) $ | nindent 8 }}
+    {{- end }}
+    {{- if .Values.defaultBackend.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ tpl (toYaml .Values.defaultBackend.topologySpreadConstraints) $ | nindent 8 }}
     {{- end }}
       terminationGracePeriodSeconds: 60
     {{- if .Values.defaultBackend.extraVolumes }}

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/default-backend-hpa.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/default-backend-hpa.yaml
@@ -21,18 +21,18 @@ spec:
   minReplicas: {{ .Values.defaultBackend.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.defaultBackend.autoscaling.maxReplicas }}
   metrics:
-  {{- with .Values.defaultBackend.autoscaling.targetCPUUtilizationPercentage }}
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ . }}
-  {{- end }}
   {{- with .Values.defaultBackend.autoscaling.targetMemoryUtilizationPercentage }}
   - type: Resource
     resource:
       name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ . }}
+  {{- end }}
+  {{- with .Values.defaultBackend.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
       target:
         type: Utilization
         averageUtilization: {{ . }}

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/default-backend-service.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/templates/default-backend-service.yaml
@@ -32,7 +32,7 @@ spec:
       port: {{ .Values.defaultBackend.service.servicePort }}
       protocol: TCP
       targetPort: http
-    {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
+    {{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
       appProtocol: http
     {{- end }}
   selector:

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/admission-webhooks/job-patch/clusterrole_test.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/admission-webhooks/job-patch/clusterrole_test.yaml
@@ -1,0 +1,11 @@
+suite: Admission Webhooks > Patch Job > ClusterRole
+templates:
+  - admission-webhooks/job-patch/clusterrole.yaml
+
+tests:
+  - it: should not create a ClusterRole if `controller.admissionWebhooks.patch.rbac.create` is false
+    set:
+      controller.admissionWebhooks.patch.rbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/admission-webhooks/job-patch/clusterrolebinding_test.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/admission-webhooks/job-patch/clusterrolebinding_test.yaml
@@ -1,0 +1,11 @@
+suite: Admission Webhooks > Patch Job > ClusterRoleBinding
+templates:
+  - admission-webhooks/job-patch/clusterrolebinding.yaml
+
+tests:
+  - it: should not create a ClusterRoleBinding if `controller.admissionWebhooks.patch.rbac.create` is false
+    set:
+      controller.admissionWebhooks.patch.rbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/admission-webhooks/job-patch/role_test.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/admission-webhooks/job-patch/role_test.yaml
@@ -1,0 +1,11 @@
+suite: Admission Webhooks > Patch Job > Role
+templates:
+  - admission-webhooks/job-patch/role.yaml
+
+tests:
+  - it: should not create a Role if `controller.admissionWebhooks.patch.rbac.create` is false
+    set:
+      controller.admissionWebhooks.patch.rbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/admission-webhooks/job-patch/rolebinding_test.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/admission-webhooks/job-patch/rolebinding_test.yaml
@@ -1,0 +1,11 @@
+suite: Admission Webhooks > Patch Job > RoleBinding
+templates:
+  - admission-webhooks/job-patch/rolebinding.yaml
+
+tests:
+  - it: should not create a RoleBinding if `controller.admissionWebhooks.patch.rbac.create` is false
+    set:
+      controller.admissionWebhooks.patch.rbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/admission-webhooks/job-patch/serviceaccount_test.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/admission-webhooks/job-patch/serviceaccount_test.yaml
@@ -1,0 +1,47 @@
+suite: Admission Webhooks > Patch Job > ServiceAccount
+templates:
+  - admission-webhooks/job-patch/serviceaccount.yaml
+
+tests:
+  - it: should not create a ServiceAccount if `controller.admissionWebhooks.patch.serviceAccount.create` is false
+    set:
+      controller.admissionWebhooks.patch.serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a ServiceAccount if `controller.admissionWebhooks.patch.serviceAccount.create` is true
+    set:
+      controller.admissionWebhooks.patch.serviceAccount.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: ingress-nginx-admission
+
+  - it: should create a ServiceAccount with specified name if `controller.admissionWebhooks.patch.serviceAccount.name` is set
+    set:
+      controller.admissionWebhooks.patch.serviceAccount.name: ingress-nginx-admission-test-sa
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: ingress-nginx-admission-test-sa
+
+  - it: should create a ServiceAccount with token auto-mounting disabled if `controller.admissionWebhooks.patch.serviceAccount.automountServiceAccountToken` is false
+    set:
+      controller.admissionWebhooks.patch.serviceAccount.automountServiceAccountToken: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: automountServiceAccountToken
+          value: false

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/controller-configmap_test.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/controller-configmap_test.yaml
@@ -12,3 +12,20 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-ingress-nginx-controller
+
+  - it: should create a ConfigMap with templated values if `controller.config` contains templates
+    set:
+      controller.config:
+        global-rate-limit-memcached-host: "memcached.{{ .Release.Namespace }}.svc.kubernetes.local"
+        global-rate-limit-memcached-port: 11211
+        use-gzip: true
+    asserts:
+      - equal:
+          path: data.global-rate-limit-memcached-host
+          value: memcached.NAMESPACE.svc.kubernetes.local
+      - equal:
+          path: data.global-rate-limit-memcached-port
+          value: "11211"
+      - equal:
+          path: data.use-gzip
+          value: "true"

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/controller-deployment_test.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/controller-deployment_test.yaml
@@ -21,6 +21,52 @@ tests:
           path: spec.replicas
           value: 3
 
+  - it: should create a Deployment without replicas if `controller.autoscaling.enabled` is true
+    set:
+      controller.autoscaling.enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  - it: should create a Deployment without replicas if `controller.keda.enabled` is true
+    set:
+      controller.keda.enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  - it: should create a Deployment with replicas if `controller.autoscaling.enabled` is true and `controller.keda.enabled` is true
+    set:
+      controller.autoscaling.enabled: true
+      controller.keda.enabled: true
+    asserts:
+      - exists:
+          path: spec.replicas
+
+  - it: should create a Deployment with argument `--enable-metrics=false` if `controller.metrics.enabled` is false
+    set:
+      controller.metrics.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-metrics=false
+
+  - it: should create a Deployment without argument `--enable-metrics=false` if `controller.metrics.enabled` is true
+    set:
+      controller.metrics.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --enable-metrics=false
+
+  - it: should create a Deployment with argument `--controller-class=k8s.io/ingress-nginx-internal` if `controller.ingressClassResource.controllerValue` is "k8s.io/ingress-nginx-internal"
+    set:
+      controller.ingressClassResource.controllerValue: k8s.io/ingress-nginx-internal
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --controller-class=k8s.io/ingress-nginx-internal
+
   - it: should create a Deployment with resource limits if `controller.resources.limits` is set
     set:
       controller.resources.limits.cpu: 500m
@@ -32,3 +78,94 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
           value: 512Mi
+
+  - it: should create a Deployment with topology spread constraints if `controller.topologySpreadConstraints` is set
+    set:
+      controller.topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: '{{ include "ingress-nginx.name" . }}'
+              app.kubernetes.io/instance: '{{ .Release.Name }}'
+              app.kubernetes.io/component: controller
+          topologyKey: topology.kubernetes.io/zone
+          maxSkew: 1
+          whenUnsatisfiable: ScheduleAnyway
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: '{{ include "ingress-nginx.name" . }}'
+              app.kubernetes.io/instance: '{{ .Release.Name }}'
+              app.kubernetes.io/component: controller
+          topologyKey: kubernetes.io/hostname
+          maxSkew: 1
+          whenUnsatisfiable: ScheduleAnyway
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints
+          value:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: ingress-nginx
+                  app.kubernetes.io/instance: RELEASE-NAME
+                  app.kubernetes.io/component: controller
+              topologyKey: topology.kubernetes.io/zone
+              maxSkew: 1
+              whenUnsatisfiable: ScheduleAnyway
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: ingress-nginx
+                  app.kubernetes.io/instance: RELEASE-NAME
+                  app.kubernetes.io/component: controller
+              topologyKey: kubernetes.io/hostname
+              maxSkew: 1
+              whenUnsatisfiable: ScheduleAnyway
+
+  - it: should create a Deployment with affinity if `controller.affinity` is set
+    set:
+      controller.affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - '{{ include "ingress-nginx.name" . }}'
+                  - key: app.kubernetes.io/instance
+                    operator: In
+                    values:
+                      - '{{ .Release.Name }}'
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - controller
+              topologyKey: kubernetes.io/hostname
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity
+          value:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                      - key: app.kubernetes.io/name
+                        operator: In
+                        values:
+                          - ingress-nginx
+                      - key: app.kubernetes.io/instance
+                        operator: In
+                        values:
+                          - RELEASE-NAME
+                      - key: app.kubernetes.io/component
+                        operator: In
+                        values:
+                          - controller
+                  topologyKey: kubernetes.io/hostname
+
+  - it: should create a Deployment with a custom tag if `controller.image.tag` is set
+    set:
+      controller.image.tag: my-little-custom-tag
+      controller.image.digest: sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.k8s.io/ingress-nginx/controller:my-little-custom-tag@sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/controller-hpa_test.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/controller-hpa_test.yaml
@@ -3,9 +3,8 @@ templates:
   - controller-hpa.yaml
 
 tests:
-  - it: should create a HPA if `controller.kind` is "Deployment" and `controller.autoscaling.enabled` is true
+  - it: should create an HPA if `controller.autoscaling.enabled` is true
     set:
-      controller.kind: Deployment
       controller.autoscaling.enabled: true
     asserts:
       - hasDocuments:
@@ -15,3 +14,18 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-ingress-nginx-controller
+
+  - it: should not create an HPA if `controller.autoscaling.enabled` is true and `controller.keda.enabled` is true
+    set:
+      controller.autoscaling.enabled: true
+      controller.keda.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create an HPA if `controller.kind` is "DaemonSet"
+    set:
+      controller.kind: DaemonSet
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/controller-ingressclass-aliases_test.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/controller-ingressclass-aliases_test.yaml
@@ -1,0 +1,110 @@
+suite: Controller > IngressClass > Aliases
+templates:
+  - controller-ingressclass-aliases.yaml
+
+tests:
+  - it: should not create IngressClass aliases
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create an IngressClass alias with name "nginx-alias" if `controller.ingressClassResource.aliases` is set
+    set:
+      controller.ingressClassResource.aliases:
+        - nginx-alias
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: IngressClass
+      - equal:
+          path: metadata.name
+          value: nginx-alias
+
+  - it: should create an IngressClass alias without annotation `ingressclass.kubernetes.io/is-default-class` if `controller.ingressClassResource.default` is true
+    set:
+      controller.ingressClassResource.aliases:
+        - nginx-alias
+      controller.ingressClassResource.default: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: IngressClass
+      - equal:
+          path: metadata.name
+          value: nginx-alias
+      - notExists:
+          path: metadata.annotations["ingressclass.kubernetes.io/is-default-class"]
+
+  - it: should create an IngressClass alias with annotations if `controller.ingressClassResource.annotations` is set
+    set:
+      controller.ingressClassResource.aliases:
+        - nginx-alias
+      controller.ingressClassResource.annotations:
+        my-fancy-annotation: has-a-value
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: IngressClass
+      - equal:
+          path: metadata.name
+          value: nginx-alias
+      - equal:
+          path: metadata.annotations.my-fancy-annotation
+          value: has-a-value
+
+  - it: should create an IngressClass alias with controller "k8s.io/ingress-nginx-internal" if `controller.ingressClassResource.controllerValue` is "k8s.io/ingress-nginx-internal"
+    set:
+      controller.ingressClassResource.aliases:
+        - nginx-alias
+      controller.ingressClassResource.controllerValue: k8s.io/ingress-nginx-internal
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: IngressClass
+      - equal:
+          path: metadata.name
+          value: nginx-alias
+      - equal:
+          path: spec.controller
+          value: k8s.io/ingress-nginx-internal
+
+  - it: should create an IngressClass alias with parameters if `controller.ingressClassResource.parameters` is set
+    set:
+      controller.ingressClassResource.aliases:
+        - nginx-alias
+      controller.ingressClassResource.parameters:
+        apiGroup: k8s.example.com
+        kind: IngressParameters
+        name: external-lb
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: IngressClass
+      - equal:
+          path: metadata.name
+          value: nginx-alias
+      - equal:
+          path: spec.parameters
+          value:
+            apiGroup: k8s.example.com
+            kind: IngressParameters
+            name: external-lb
+
+  - it: should create two IngressClass aliases if `controller.ingressClassResource.aliases` has two elements
+    set:
+      controller.ingressClassResource.aliases:
+        - nginx-alias-1
+        - nginx-alias-2
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: IngressClass
+      - matchRegex:
+          path: metadata.name
+          pattern: nginx-alias-(1|2)

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/controller-ingressclass_test.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/controller-ingressclass_test.yaml
@@ -1,0 +1,93 @@
+suite: Controller > IngressClass
+templates:
+  - controller-ingressclass.yaml
+
+tests:
+  - it: should create an IngressClass
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: IngressClass
+      - equal:
+          path: metadata.name
+          value: nginx
+
+  - it: should create an IngressClass with name "nginx-internal" if `controller.ingressClassResource.name` is "nginx-internal"
+    set:
+      controller.ingressClassResource.name: nginx-internal
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: IngressClass
+      - equal:
+          path: metadata.name
+          value: nginx-internal
+
+  - it: "should create an IngressClass with annotation `ingressclass.kubernetes.io/is-default-class: \"true\"` if `controller.ingressClassResource.default` is true"
+    set:
+      controller.ingressClassResource.default: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: IngressClass
+      - equal:
+          path: metadata.name
+          value: nginx
+      - equal:
+          path: metadata.annotations["ingressclass.kubernetes.io/is-default-class"]
+          value: "true"
+
+  - it: should create an IngressClass with annotations if `controller.ingressClassResource.annotations` is set
+    set:
+      controller.ingressClassResource.annotations:
+        my-fancy-annotation: has-a-value
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: IngressClass
+      - equal:
+          path: metadata.name
+          value: nginx
+      - equal:
+          path: metadata.annotations.my-fancy-annotation
+          value: has-a-value
+
+  - it: should create an IngressClass with controller "k8s.io/ingress-nginx-internal" if `controller.ingressClassResource.controllerValue` is "k8s.io/ingress-nginx-internal"
+    set:
+      controller.ingressClassResource.controllerValue: k8s.io/ingress-nginx-internal
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: IngressClass
+      - equal:
+          path: metadata.name
+          value: nginx
+      - equal:
+          path: spec.controller
+          value: k8s.io/ingress-nginx-internal
+
+  - it: should create an IngressClass with parameters if `controller.ingressClassResource.parameters` is set
+    set:
+      controller.ingressClassResource.parameters:
+        apiGroup: k8s.example.com
+        kind: IngressParameters
+        name: external-lb
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: IngressClass
+      - equal:
+          path: metadata.name
+          value: nginx
+      - equal:
+          path: spec.parameters
+          value:
+            apiGroup: k8s.example.com
+            kind: IngressParameters
+            name: external-lb

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/controller-keda_test.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/controller-keda_test.yaml
@@ -3,9 +3,8 @@ templates:
   - controller-keda.yaml
 
 tests:
-  - it: should create a ScaledObject if `controller.kind` is "Deployment" and `controller.keda.enabled` is true
+  - it: should create a ScaledObject if `controller.keda.enabled` is true
     set:
-      controller.kind: Deployment
       controller.keda.enabled: true
     asserts:
       - hasDocuments:
@@ -15,3 +14,18 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-ingress-nginx-controller
+
+  - it: should not create a ScaledObject if `controller.keda.enabled` is true and `controller.autoscaling.enabled` is true
+    set:
+      controller.keda.enabled: true
+      controller.autoscaling.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create a ScaledObject if `controller.kind` is "DaemonSet"
+    set:
+      controller.kind: DaemonSet
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/controller-poddisruptionbudget_test.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/controller-poddisruptionbudget_test.yaml
@@ -1,0 +1,73 @@
+suite: Controller > PodDisruptionBudget
+templates:
+  - controller-poddisruptionbudget.yaml
+
+tests:
+  - it: should create a PodDisruptionBudget if `controller.replicaCount` is greater than 1
+    set:
+      controller.replicaCount: 2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ingress-nginx-controller
+
+  - it: should not create a PodDisruptionBudget if `controller.replicaCount` is less than or equal 1
+    set:
+      controller.replicaCount: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a PodDisruptionBudget if `controller.autoscaling.enabled` is true and `controller.autoscaling.minReplicas` is greater than 1
+    set:
+      controller.autoscaling.enabled: true
+      controller.autoscaling.minReplicas: 2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ingress-nginx-controller
+
+  - it: should not create a PodDisruptionBudget if `controller.autoscaling.enabled` is true and `controller.autoscaling.minReplicas` is less than or equal 1
+    set:
+      controller.autoscaling.enabled: true
+      controller.autoscaling.minReplicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a PodDisruptionBudget if `controller.keda.enabled` is true and `controller.keda.minReplicas` is greater than 1
+    set:
+      controller.keda.enabled: true
+      controller.keda.minReplicas: 2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ingress-nginx-controller
+
+  - it: should not create a PodDisruptionBudget if `controller.keda.enabled` is true and `controller.keda.minReplicas` is less than or equal 1
+    set:
+      controller.keda.enabled: true
+      controller.keda.minReplicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create a PodDisruptionBudget if `controller.autoscaling.enabled` is true and `controller.keda.enabled` is true
+    set:
+      controller.autoscaling.enabled: true
+      controller.keda.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/default-backend-deployment_test.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/tests/default-backend-deployment_test.yaml
@@ -1,52 +1,49 @@
-suite: Controller > DaemonSet
+suite: Default Backend > Deployment
 templates:
-  - controller-daemonset.yaml
+  - default-backend-deployment.yaml
 
 tests:
-  - it: should create a DaemonSet if `controller.kind` is "DaemonSet"
+  - it: should not create a Deployment if `defaultBackend.enabled` is false
     set:
-      controller.kind: DaemonSet
+      defaultBackend.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a Deployment if `defaultBackend.enabled` is true
+    set:
+      defaultBackend.enabled: true
     asserts:
       - hasDocuments:
           count: 1
       - isKind:
-          of: DaemonSet
+          of: Deployment
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-ingress-nginx-controller
+          value: RELEASE-NAME-ingress-nginx-defaultbackend
 
-  - it: should create a DaemonSet with argument `--enable-metrics=false` if `controller.metrics.enabled` is false
+  - it: should create a Deployment with 3 replicas if `defaultBackend.replicaCount` is 3
     set:
-      controller.kind: DaemonSet
-      controller.metrics.enabled: false
+      defaultBackend.enabled: true
+      defaultBackend.replicaCount: 3
     asserts:
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: --enable-metrics=false
+      - equal:
+          path: spec.replicas
+          value: 3
 
-  - it: should create a DaemonSet without argument `--enable-metrics=false` if `controller.metrics.enabled` is true
+  - it: should create a Deployment without replicas if `defaultBackend.autoscaling.enabled` is true
     set:
-      controller.kind: DaemonSet
-      controller.metrics.enabled: true
+      defaultBackend.enabled: true
+      defaultBackend.autoscaling.enabled: true
     asserts:
-      - notContains:
-          path: spec.template.spec.containers[0].args
-          content: --enable-metrics=false
+      - notExists:
+          path: spec.replicas
 
-  - it: should create a DaemonSet with argument `--controller-class=k8s.io/ingress-nginx-internal` if `controller.ingressClassResource.controllerValue` is "k8s.io/ingress-nginx-internal"
+  - it: should create a Deployment with resource limits if `defaultBackend.resources.limits` is set
     set:
-      controller.kind: DaemonSet
-      controller.ingressClassResource.controllerValue: k8s.io/ingress-nginx-internal
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: --controller-class=k8s.io/ingress-nginx-internal
-
-  - it: should create a DaemonSet with resource limits if `controller.resources.limits` is set
-    set:
-      controller.kind: DaemonSet
-      controller.resources.limits.cpu: 500m
-      controller.resources.limits.memory: 512Mi
+      defaultBackend.enabled: true
+      defaultBackend.resources.limits.cpu: 500m
+      defaultBackend.resources.limits.memory: 512Mi
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
@@ -55,15 +52,15 @@ tests:
           path: spec.template.spec.containers[0].resources.limits.memory
           value: 512Mi
 
-  - it: should create a DaemonSet with topology spread constraints if `controller.topologySpreadConstraints` is set
+  - it: should create a Deployment with topology spread constraints if `defaultBackend.topologySpreadConstraints` is set
     set:
-      controller.kind: DaemonSet
-      controller.topologySpreadConstraints:
+      defaultBackend.enabled: true
+      defaultBackend.topologySpreadConstraints:
         - labelSelector:
             matchLabels:
               app.kubernetes.io/name: '{{ include "ingress-nginx.name" . }}'
               app.kubernetes.io/instance: '{{ .Release.Name }}'
-              app.kubernetes.io/component: controller
+              app.kubernetes.io/component: default-backend
           topologyKey: topology.kubernetes.io/zone
           maxSkew: 1
           whenUnsatisfiable: ScheduleAnyway
@@ -71,7 +68,7 @@ tests:
             matchLabels:
               app.kubernetes.io/name: '{{ include "ingress-nginx.name" . }}'
               app.kubernetes.io/instance: '{{ .Release.Name }}'
-              app.kubernetes.io/component: controller
+              app.kubernetes.io/component: default-backend
           topologyKey: kubernetes.io/hostname
           maxSkew: 1
           whenUnsatisfiable: ScheduleAnyway
@@ -83,7 +80,7 @@ tests:
                 matchLabels:
                   app.kubernetes.io/name: ingress-nginx
                   app.kubernetes.io/instance: RELEASE-NAME
-                  app.kubernetes.io/component: controller
+                  app.kubernetes.io/component: default-backend
               topologyKey: topology.kubernetes.io/zone
               maxSkew: 1
               whenUnsatisfiable: ScheduleAnyway
@@ -91,15 +88,15 @@ tests:
                 matchLabels:
                   app.kubernetes.io/name: ingress-nginx
                   app.kubernetes.io/instance: RELEASE-NAME
-                  app.kubernetes.io/component: controller
+                  app.kubernetes.io/component: default-backend
               topologyKey: kubernetes.io/hostname
               maxSkew: 1
               whenUnsatisfiable: ScheduleAnyway
 
-  - it: should create a DaemonSet with affinity if `controller.affinity` is set
+  - it: should create a Deployment with affinity if `defaultBackend.affinity` is set
     set:
-      controller.kind: DaemonSet
-      controller.affinity:
+      defaultBackend.enabled: true
+      defaultBackend.affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -115,7 +112,7 @@ tests:
                   - key: app.kubernetes.io/component
                     operator: In
                     values:
-                      - controller
+                      - default-backend
               topologyKey: kubernetes.io/hostname
     asserts:
       - equal:
@@ -136,15 +133,5 @@ tests:
                       - key: app.kubernetes.io/component
                         operator: In
                         values:
-                          - controller
+                          - default-backend
                   topologyKey: kubernetes.io/hostname
-
-  - it: should create a DaemonSet with a custom tag if `controller.image.tag` is set
-    set:
-      controller.kind: DaemonSet
-      controller.image.tag: my-little-custom-tag
-      controller.image.digest: sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].image
-          value: registry.k8s.io/ingress-nginx/controller:my-little-custom-tag@sha256:faa2d18687f734994b6bd9e309e7a73852a81c30e1b8f63165fcd4f0a087e3cd

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/values.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/values.yaml
@@ -26,9 +26,9 @@ controller:
     ## for backwards compatibility consider setting the full image url via the repository value below
     ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
     ## repository:
-    tag: "v1.9.6"
-    digest: sha256:1405cc613bd95b2c6edd8b2a152510ae91c7e62aea4698500d23b2145960ab9c
-    digestChroot: sha256:7eb46ff733429e0e46892903c7394aff149ac6d284d92b3946f3baf7ff26a096
+    tag: "v1.11.2"
+    digest: sha256:d5f8217feeac4887cb1ed21f27c2674e58be06bd8f5184cacea2a69abaf78dce
+    digestChroot: sha256:21b55a2f0213a18b91612a8c0850167e00a8e34391fd595139a708f9c047e7a8
     pullPolicy: IfNotPresent
     runAsNonRoot: true
     # www-data -> uid 101
@@ -45,7 +45,8 @@ controller:
   containerPort:
     http: 80
     https: 443
-  # -- Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
+  # -- Global configuration passed to the ConfigMap consumed by the controller. Values may contain Helm templates.
+  # Ref.: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
   config: {}
   # -- Annotations to be added to the controller config configuration configmap.
   configAnnotations: {}
@@ -83,6 +84,10 @@ controller:
   # -- This configuration enables Topology Aware Routing feature, used together with service annotation service.kubernetes.io/topology-mode="auto"
   # Defaults to false
   enableTopologyAwareRouting: false
+  # -- This configuration disable Nginx Controller Leader Election
+  disableLeaderElection: false
+  # -- Duration a leader election is valid before it's getting re-elected, e.g. `15s`, `10m` or `1h`. (Default: 30s)
+  electionTTL: ""
   # -- This configuration defines if Ingress Controller should allow users to set
   # their own *-snippet annotations, otherwise this is forbidden / dropped
   # when users add those annotations.
@@ -108,21 +113,39 @@ controller:
     enabled: false
   # -- Election ID to use for status update, by default it uses the controller name combined with a suffix of 'leader'
   electionID: ""
-  ## This section refers to the creation of the IngressClass resource
-  ## IngressClass resources are supported since k8s >= 1.18 and required since k8s >= 1.19
+  # -- This section refers to the creation of the IngressClass resource.
+  # IngressClasses are immutable and cannot be changed after creation.
+  # We do not support namespaced IngressClasses, yet, so a ClusterRole and a ClusterRoleBinding is required.
   ingressClassResource:
-    # -- Name of the ingressClass
+    # -- Name of the IngressClass
     name: nginx
-    # -- Is this ingressClass enabled or not
+    # -- Create the IngressClass or not
     enabled: true
-    # -- Is this the default ingressClass for the cluster
+    # -- If true, Ingresses without `ingressClassName` get assigned to this IngressClass on creation.
+    # Ingress creation gets rejected if there are multiple default IngressClasses.
+    # Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class
     default: false
-    # -- Controller-value of the controller that is processing this ingressClass
-    controllerValue: "k8s.io/ingress-nginx"
-    # -- Parameters is a link to a custom resource containing additional
-    # configuration for the controller. This is optional if the controller
-    # does not require extra parameters.
+    # -- Annotations to be added to the IngressClass resource.
+    annotations: {}
+    # -- Controller of the IngressClass. An Ingress Controller looks for IngressClasses it should reconcile by this value.
+    # This value is also being set as the `--controller-class` argument of this Ingress Controller.
+    # Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class
+    controllerValue: k8s.io/ingress-nginx
+    # -- Aliases of this IngressClass. Creates copies with identical settings but the respective alias as name.
+    # Useful for development environments with only one Ingress Controller but production-like Ingress resources.
+    # `default` gets enabled on the original IngressClass only.
+    aliases: []
+    # aliases:
+    # - nginx-alias-1
+    # - nginx-alias-2
+    # -- A link to a custom resource containing additional configuration for the controller.
+    # This is optional if the controller consuming this IngressClass does not require additional parameters.
+    # Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class
     parameters: {}
+    # parameters:
+    #   apiGroup: k8s.example.com
+    #   kind: IngressParameters
+    #   name: external-lb
   # -- For backwards compatibility with ingress.class annotation, use ingressClass.
   # Algorithm is as follows, first ingressClassName is considered, if not present, controller looks for ingress.class annotation
   ingressClass: nginx
@@ -237,11 +260,11 @@ controller:
   #         - key: app.kubernetes.io/name
   #           operator: In
   #           values:
-  #           - ingress-nginx
+  #           - '{{ include "ingress-nginx.name" . }}'
   #         - key: app.kubernetes.io/instance
   #           operator: In
   #           values:
-  #           - ingress-nginx
+  #           - '{{ .Release.Name }}'
   #         - key: app.kubernetes.io/component
   #           operator: In
   #           values:
@@ -256,16 +279,16 @@ controller:
   #       - key: app.kubernetes.io/name
   #         operator: In
   #         values:
-  #         - ingress-nginx
+  #         - '{{ include "ingress-nginx.name" . }}'
   #       - key: app.kubernetes.io/instance
   #         operator: In
   #         values:
-  #         - ingress-nginx
+  #         - '{{ .Release.Name }}'
   #       - key: app.kubernetes.io/component
   #         operator: In
   #         values:
   #         - controller
-  #     topologyKey: "kubernetes.io/hostname"
+  #     topologyKey: kubernetes.io/hostname
 
   # -- Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
@@ -683,12 +706,12 @@ controller:
     name: opentelemetry
     image:
       registry: registry.k8s.io
-      image: ingress-nginx/opentelemetry
+      image: ingress-nginx/opentelemetry-1.25.3
       ## for backwards compatibility consider setting the full image url via the repository value below
       ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
       ## repository:
-      tag: "v20230721-3e2062ee5"
-      digest: sha256:13bee3f5223883d3ca62fee7309ad02d22ec00ff0d7033e3e9aca7a9f60fd472
+      tag: v20240813-b933310d
+      digest: sha256:f7604ac0547ed64d79b98d92133234e66c2c8aade3c1f4809fed5eec1fb7f922
       distroless: true
     containerSecurityContext:
       runAsNonRoot: true
@@ -781,8 +804,8 @@ controller:
         ## for backwards compatibility consider setting the full image url via the repository value below
         ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
         ## repository:
-        tag: v20231226-1a7112e06
-        digest: sha256:25d6a5f11211cc5c3f9f2bf552b585374af287b4debf693cacbe2da47daa5084
+        tag: v1.4.3
+        digest: sha256:a320a50cc91bd15fd2d6fa6de58bd98c1bd64b9a6f926ce23a600d87043455a3
         pullPolicy: IfNotPresent
       # -- Provide a priority class name to the webhook patching job
       ##
@@ -799,6 +822,18 @@ controller:
       labels: {}
       # -- Security context for secret creation & webhook patch pods
       securityContext: {}
+      # -- Admission webhook patch job RBAC
+      rbac:
+        # -- Create RBAC or not
+        create: true
+      # -- Admission webhook patch job service account
+      serviceAccount:
+        # -- Create a service account or not
+        create: true
+        # -- Custom service account name
+        name: ""
+        # -- Auto-mount service account token or not
+        automountServiceAccountToken: true
     # Use certmanager to generate webhook certs
     certManager:
       enabled: false
@@ -976,7 +1011,68 @@ defaultBackend:
   #    value: "value"
   #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
+  # -- Affinity and anti-affinity rules for server scheduling to nodes
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+  # # An example of preferred pod anti-affinity, weight is in the range 1-100
+  # podAntiAffinity:
+  #   preferredDuringSchedulingIgnoredDuringExecution:
+  #   - weight: 100
+  #     podAffinityTerm:
+  #       labelSelector:
+  #         matchExpressions:
+  #         - key: app.kubernetes.io/name
+  #           operator: In
+  #           values:
+  #           - '{{ include "ingress-nginx.name" . }}'
+  #         - key: app.kubernetes.io/instance
+  #           operator: In
+  #           values:
+  #           - '{{ .Release.Name }}'
+  #         - key: app.kubernetes.io/component
+  #           operator: In
+  #           values:
+  #           - default-backend
+  #       topologyKey: kubernetes.io/hostname
+
+  # # An example of required pod anti-affinity
+  # podAntiAffinity:
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #   - labelSelector:
+  #       matchExpressions:
+  #       - key: app.kubernetes.io/name
+  #         operator: In
+  #         values:
+  #         - '{{ include "ingress-nginx.name" . }}'
+  #       - key: app.kubernetes.io/instance
+  #         operator: In
+  #         values:
+  #         - '{{ .Release.Name }}'
+  #       - key: app.kubernetes.io/component
+  #         operator: In
+  #         values:
+  #         - default-backend
+  #     topologyKey: kubernetes.io/hostname
+
+  # -- Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
+  # Ref.: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  topologySpreadConstraints: []
+  # - labelSelector:
+  #     matchLabels:
+  #       app.kubernetes.io/name: '{{ include "ingress-nginx.name" . }}'
+  #       app.kubernetes.io/instance: '{{ .Release.Name }}'
+  #       app.kubernetes.io/component: default-backend
+  #   topologyKey: topology.kubernetes.io/zone
+  #   maxSkew: 1
+  #   whenUnsatisfiable: ScheduleAnyway
+  # - labelSelector:
+  #     matchLabels:
+  #       app.kubernetes.io/name: '{{ include "ingress-nginx.name" . }}'
+  #       app.kubernetes.io/instance: '{{ .Release.Name }}'
+  #       app.kubernetes.io/component: default-backend
+  #   topologyKey: kubernetes.io/hostname
+  #   maxSkew: 1
+  #   whenUnsatisfiable: ScheduleAnyway
   # -- Security context for default backend pods
   podSecurityContext: {}
   # -- Security context for default backend containers
@@ -1077,13 +1173,13 @@ imagePullSecrets: []
 ## Ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/exposing-tcp-udp-services.md
 ##
 tcp: {}
-#  8080: "default/example-tcp-svc:9000"
+#  "8080": "default/example-tcp-svc:9000"
 
 # -- UDP service key-value pairs
 ## Ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/exposing-tcp-udp-services.md
 ##
 udp: {}
-#  53: "kube-system/kube-dns:53"
+#  "53": "kube-system/kube-dns:53"
 
 # -- Prefix for TCP and UDP ports names in ingress controller service
 ## Some cloud providers, like Yandex Cloud may have a requirements for a port name regex to support cloud load balancer integration

--- a/helmfile.d/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile.d/values/ingress-nginx.yaml.gotmpl
@@ -172,3 +172,5 @@ defaultBackend:
   nodeSelector: {{- toYaml .Values.ingressNginx.defaultBackend.nodeSelector | nindent 4 }}
 
   resources: {{- toYaml .Values.ingressNginx.defaultBackend.resources | nindent 4 }}
+
+  topologySpreadConstraints: {{- toYaml .Values.ingressNginx.defaultBackend.topologySpreadConstraints | nindent 4 }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

### Release notes
Drops support for Kubernetes v1.25, adds support for Kubernetes v1.30.
Nginx version upgrade to `1.25.5`.

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Upgrades ingress-nginx to chart version 4.11.2 and app version 1.11.2.
Also exposed `topologySpreadConstraints` for default backend to apps config since this was also exposed in upstream values.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2163 

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [x] The change updates the config *and* the schema
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [x] Any changed pod is covered by Pod Security Admission
  - [x] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [x] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [x] Any changed pod is covered by Network Policies
  - [x] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [x] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
