### PR TITLE
Use file with GPG keys for diagnostics script and other improvements

### DIFF
--- a/bin/diagnostics.bash
+++ b/bin/diagnostics.bash
@@ -120,18 +120,18 @@ run_diagnostics() {
     printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
     if [ -d "${CK8S_CONFIG_PATH}/capi" ]; then
         # shellcheck disable=SC2002
-        capi_version=$(cat "${CK8S_CONFIG_PATH}"/capi/defaults/values.yaml | yq4 '.clusterApiVersion')
+        capi_version=$(cat "${CK8S_CONFIG_PATH}/capi/defaults/values.yaml" | yq4 '.clusterApiVersion')
         echo "CAPI version: ${capi_version}"
-    elif [ -d "${CK8S_CONFIG_PATH}/sc-config" ]; then
+    elif [ -d "${CK8S_CONFIG_PATH}/${cluster}-config" ]; then
         # shellcheck disable=SC2002
-        kubespray_version=$(cat "${CK8S_CONFIG_PATH}"/sc-config/group_vars/all/ck8s-kubespray-general.yaml | yq4 '.ck8sKubesprayVersion')
+        kubespray_version=$(cat "${CK8S_CONFIG_PATH}/${cluster}-config/group_vars/all/ck8s-kubespray-general.yaml" | yq4 '.ck8sKubesprayVersion')
         echo "Kubespray version: ${kubespray_version}"
     else
         echo "Can't find config directory"
     fi
     printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
     # shellcheck disable=SC2002
-    apps_version=$(cat "${CK8S_CONFIG_PATH}"/defaults/common-config.yaml | yq4 '.global.ck8sVersion')
+    apps_version=$(cat "${CK8S_CONFIG_PATH}/defaults/common-config.yaml" | yq4 '.global.ck8sVersion')
     echo "Apps version: ${apps_version}"
     printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
     # -- Nodes --
@@ -219,7 +219,7 @@ run_diagnostics() {
     # -- Helm --
     printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
     echo -e "\nFetching Helm releases that are not deployed (<helm>)"
-    helm=$("${here}"/ops.bash helm wc list -A --all -o yaml | yq4 '.[] | select(.status != "deployed")')
+    helm=$("${here}"/ops.bash helm "${cluster}" list -A --all -o yaml | yq4 '.[] | select(.status != "deployed")')
     if [ -z "${helm}" ]; then
         echo -e "All charts are deployed"
     else

--- a/tests/end-to-end/general/bin-diagnostics.bats
+++ b/tests/end-to-end/general/bin-diagnostics.bats
@@ -8,6 +8,8 @@ setup() {
   load_file
 
   export CK8S_AUTO_APPROVE=true
+  CK8S_PGP_FP=$(yq4 '.creation_rules[].pgp' "${CK8S_CONFIG_PATH}/.sops.yaml")
+  export CK8S_PGP_FP
 
   with_kubeconfig sc
 }
@@ -19,6 +21,7 @@ setup() {
 }
 
 @test "ck8s diagnostics creates diagnostics file" {
+  echo "If this test gets stuck here for too long, visit \"http://localhost:8000\" in your browser in case you need to authenticate" >&3
   run ck8s diagnostics sc
   assert_success
 


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice

The diagnostics script now assumes to retrieve GPG keys from a file `$CK8S_CONFIG_PATH/diagnostics_receiver.gpg` if the `CK8S_PGP_FP` environment variable is not set.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Want to simplify the usage of the diagnostics script, the script will now by default import GPG keys from a file `$CK8S_CONFIG_PATH/diagnostics_receiver.gpg` and use their fingerprints if `CK8S_PGP_FP` is not already set.

- Follow up of https://github.com/elastisys/ck8s-issue-tracker/issues/258

#### Information to reviewers

I am planning to update the public docs to reflect this change.

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
