### PR TITLE
Catch before-all test hook failures in Cypress tests

### DIFF
--- a/tests/bats.lib.bash
+++ b/tests/bats.lib.bash
@@ -239,6 +239,13 @@ cypress_setup() {
     exit 1
   fi
 
+  # Check for "before-all" hook failure
+  if [[ -n "$(jq -r 'select((.[0] == "fail") and (.[1].title | contains("\"before all\" hook for")))' "${CYPRESS_REPORT}")" ]]; then
+    echo "One or more \"before all\" hooks failed" >&2
+    jq -r 'select((.[0] == "fail") and (.[1].title | contains("\"before all\" hook for"))) | .[1].stack' "${CYPRESS_REPORT}"
+    exit 1
+  fi
+
   export CYPRESS_REPORT
 }
 

--- a/tests/end-to-end/grafana/grafana-authentication.cy.js
+++ b/tests/end-to-end/grafana/grafana-authentication.cy.js
@@ -6,7 +6,7 @@ describe("grafana admin authentication", function() {
 
     // Cypress does not like trailing dots
     cy.yqDig("sc", ".grafana.ops.trailingDots")
-      .should("not.equal", "true")
+      .should((value) => assert(value !== "true", ".grafana.ops.trailingDots in sc config must not be 'true'"))
   })
 
   it("can login via static admin user", function() {
@@ -64,7 +64,7 @@ describe("grafana dev authentication", function() {
 
     // Cypress does not like trailing dots
     cy.yqDig("sc", ".grafana.user.trailingDots")
-      .should("not.equal", "true")
+      .should((value) => assert(value !== "true", ".grafana.user.trailingDots in sc config must not be 'true'"))
   })
 
   it("can login via static admin user", function() {


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Before:

```
$ make run-end-to-end/grafana/grafana-authentication.gen.bats
[ck8s] forward your environment and runtime to container compliantkubernetes-apps-tests:main? [y/N]: y
--- run end-to-end/grafana/grafana-authentication.gen.bats
1..4
# cypress run: /home/simon/git/elastisys/compliantkubernetes-apps/tests/end-to-end/grafana/grafana-authentication.cy.js
ok 1 grafana admin authentication can login via static admin user # skip cypress skipped this test
ok 2 grafana admin authentication can login via static dex user # skip cypress skipped this test
ok 3 grafana dev authentication can login via static admin user # skip cypress skipped this test
ok 4 grafana dev authentication can login via static dex user # skip cypress skipped this test
```

After:
```
$ make run-end-to-end/grafana/grafana-authentication.gen.bats
[ck8s] forward your environment and runtime to container compliantkubernetes-apps-tests:main? [y/N]: y
--- run end-to-end/grafana/grafana-authentication.gen.bats
1..4
# cypress run: /home/simon/git/elastisys/compliantkubernetes-apps/tests/end-to-end/grafana/grafana-authentication.cy.js
not ok 1 setup_file failed
# (from function `cypress_teardown' in file end-to-end/grafana/../../bats.lib.bash, line 273,
#  from function `teardown_file' in test file end-to-end/grafana/grafana-authentication.gen.bats, line 15)
#   `cypress_teardown "${ROOT}/tests/end-to-end/grafana/grafana-authentication.cy.js"' failed with status 0
# ~/git/elastisys/compliantkubernetes-apps/tests ~/git/elastisys/compliantkubernetes-apps/tests
# [222:0829/153350.048397:ERROR:node_bindings.cc(305)] Most NODE_OPTIONs are not supported in packaged apps. See documentation for more details.
#
# DevTools listening on ws://127.0.0.1:33549/devtools/browser/62dddf14-d1f3-43c7-9c15-9b76876aa824
# WARNING: Kernel has no file descriptor comparison support: Operation not permitted
# ~/git/elastisys/compliantkubernetes-apps/tests
# One or more "before all" hooks failed
# AssertionError: .grafana.ops.trailingDots in sc config must not be 'true'
#
# Because this error occurred during a `before all` hook we are skipping the remaining tests in the current suite: `grafana admin authentication`
#     at Context.eval (webpack:///./end-to-end/grafana/grafana-authentication.cy.js:9:25)
# AssertionError: .grafana.ops.trailingDots in sc config must not be 'true'
#
# Because this error occurred during a `before all` hook we are skipping the remaining tests in the current suite: `grafana dev authentication`
#     at Context.eval (webpack:///./end-to-end/grafana/grafana-authentication.cy.js:67:25)
# bats warning: Executed 1 instead of expected 4 tests
make: *** [Makefile:92: container-end-to-end/grafana/grafana-authentication.gen.bats] Error 1
make: *** [Makefile:72: run-end-to-end/grafana/grafana-authentication.gen.bats] Error 2
```

#### Information to reviewers

Not sure if there is anything that could be done about the verbosity. For example, is the teardown stuff due to the setup failing or is it always failing but we've not seen it before?

Also, note that the "before-all" hook failure would also match normal tests if they have "before all" in the title. Not sure what to do about that either.

Ideas are welcome!

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
