### PR TITLE
Add Velero e2e tests

### DIFF
--- a/scripts/run-from-container.sh
+++ b/scripts/run-from-container.sh
@@ -65,7 +65,7 @@ fi
 declare -a args
 args=("--init" "--rm")
 
-if [[ -t 1 ]] && [[ -z "${CI:-}" ]]; then
+if [[ -t 0 ]] && [[ -t 1 ]] && [[ -z "${CI:-}" ]]; then
   args+=("-it")
 fi
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -102,5 +102,11 @@ RUN curl -LOs "https://github.com/kubernetes-sigs/kind/releases/download/v${KIND
     install -Tm 755 kind-linux-amd64 /usr/local/bin/kind && \
     rm kind-linux-amd64
 
+ARG VELERO_VERSION="1.13.0"
+RUN curl -LOs "https://github.com/vmware-tanzu/velero/releases/download/v${VELERO_VERSION}/velero-v${VELERO_VERSION}-linux-amd64.tar.gz" && \
+  tar -zxvf "velero-v${VELERO_VERSION}-linux-amd64.tar.gz" "velero-v${VELERO_VERSION}-linux-amd64" && \
+  install -Tm 755 "velero-v${VELERO_VERSION}-linux-amd64/velero" /usr/local/bin/velero && \
+  rm -r "velero-v${VELERO_VERSION}-linux-amd64.tar.gz" "velero-v${VELERO_VERSION}-linux-amd64"
+
 ENV DOCS_PATH="/usr/local/share/docs"
 RUN git clone --depth 1 https://github.com/elastisys/compliantkubernetes.git "${DOCS_PATH}"

--- a/tests/common/bats/ctr.bash
+++ b/tests/common/bats/ctr.bash
@@ -13,7 +13,6 @@ ctr() {
 ctr.insecure() {
   if docker version >/dev/null 2>&1 && [[ ! "$(docker version)" =~ Podman ]]; then
     docker --tlsverify=false "${@}"
-    echo "${ctr_insecure+"--tlsverify=false"}"
   else
     podman "${1}" --tls-verify=false "${@:2}"
   fi

--- a/tests/common/bats/harbor.bash
+++ b/tests/common/bats/harbor.bash
@@ -258,10 +258,10 @@ harbor.create_pull_secret() {
   with_kubeconfig "${1}"
   with_namespace "${2}"
 
-  kubectl -n "${NAMESPACE}" create secret ctr-registry pull-secret \
-    "--ctr-server=${harbor_endpoint}" \
-    "--ctr-username=${harbor_robot_fullname}" \
-    "--ctr-password=$(<"${harbor_robot_secret_path}")"
+  kubectl -n "${NAMESPACE}" create secret docker-registry pull-secret \
+    "--docker-server=${harbor_endpoint}" \
+    "--docker-username=${harbor_robot_fullname}" \
+    "--docker-password=$(<"${harbor_robot_secret_path}")"
 
   kubectl -n "${NAMESPACE}" patch serviceaccount default -p '{"imagePullSecrets": [{"name": "pull-secret"}]}'
 }

--- a/tests/end-to-end/velero/backup-restore-sc.gen.bats
+++ b/tests/end-to-end/velero/backup-restore-sc.gen.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+# Generated from tests/end-to-end/velero/backup-restore.bats.gotmpl
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+  load "./common.bash"
+}
+
+@test "velero backup spec sc" {
+  run velero_backups_spec sc
+  assert_success
+  assert_output "$(cat "${BATS_TEST_DIRNAME}/resources/backup-spec-sc.yaml")"
+}
+
+@test "velero backup and restore sc" {
+  backup_name="test-backup-$(date +%s)"
+  restore_name="test-restore-$(date +%s)"
+
+  run velero_backup_create sc "${backup_name}"
+  assert_success
+
+  run velero_backup_get_phase sc "${backup_name}"
+  assert_success
+  assert_output Completed
+
+  run velero_restore_create sc "${restore_name}" "${backup_name}"
+  assert_success
+
+  run velero_restore_get_phase sc "${restore_name}"
+  assert_success
+  assert_output Completed
+}

--- a/tests/end-to-end/velero/backup-restore-wc.gen.bats
+++ b/tests/end-to-end/velero/backup-restore-wc.gen.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+# Generated from tests/end-to-end/velero/backup-restore.bats.gotmpl
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+  load "./common.bash"
+}
+
+@test "velero backup spec wc" {
+  run velero_backups_spec wc
+  assert_success
+  assert_output "$(cat "${BATS_TEST_DIRNAME}/resources/backup-spec-wc.yaml")"
+}
+
+@test "velero backup and restore wc" {
+  backup_name="test-backup-$(date +%s)"
+  restore_name="test-restore-$(date +%s)"
+
+  run velero_backup_create wc "${backup_name}"
+  assert_success
+
+  run velero_backup_get_phase wc "${backup_name}"
+  assert_success
+  assert_output Completed
+
+  run velero_restore_create wc "${restore_name}" "${backup_name}"
+  assert_success
+
+  run velero_restore_get_phase wc "${restore_name}"
+  assert_success
+  assert_output Completed
+}

--- a/tests/end-to-end/velero/backup-restore.bats.gotmpl
+++ b/tests/end-to-end/velero/backup-restore.bats.gotmpl
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+{{- define "template" -}}
+#!/usr/bin/env bats
+
+# Generated from {{ tmpl.Path }}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+  load "./common.bash"
+}
+
+@test "velero backup spec {{ .cluster }}" {
+  run velero_backups_spec {{ .cluster }}
+  assert_success
+  assert_output "$(cat "${BATS_TEST_DIRNAME}/resources/backup-spec-{{ .cluster }}.yaml")"
+}
+
+@test "velero backup and restore {{ .cluster }}" {
+  backup_name="test-backup-$(date +%s)"
+  restore_name="test-restore-$(date +%s)"
+
+  run velero_backup_create {{ .cluster }} "${backup_name}"
+  assert_success
+
+  run velero_backup_get_phase {{ .cluster }} "${backup_name}"
+  assert_success
+  assert_output Completed
+
+  run velero_restore_create {{ .cluster }} "${restore_name}" "${backup_name}"
+  assert_success
+
+  run velero_restore_get_phase {{ .cluster }} "${restore_name}"
+  assert_success
+  assert_output Completed
+}
+{{ end }}
+
+# These tests are generated into these files:
+{{- range $cluster := coll.Slice "sc" "wc" }}
+{{- $file := path.Join (tmpl.Path | path.Dir) (printf "./backup-restore-%s.gen.bats" $cluster) }}
+# - {{ $file }}
+{{- coll.Dict "cluster" $cluster | tmpl.Exec "template" | file.Write $file }}
+{{- end }}

--- a/tests/end-to-end/velero/backup-restore.gen.bats
+++ b/tests/end-to-end/velero/backup-restore.gen.bats
@@ -1,0 +1,5 @@
+#!/usr/bin/env bats
+
+# These tests are generated into these files:
+# - tests/end-to-end/velero/backup-restore-sc.gen.bats
+# - tests/end-to-end/velero/backup-restore-wc.gen.bats

--- a/tests/end-to-end/velero/common.bash
+++ b/tests/end-to-end/velero/common.bash
@@ -1,0 +1,19 @@
+velero_backups_spec() {
+  ck8s ops velero "${1}" backup create --from-schedule velero-daily-backup -o yaml 2>/dev/null | yq4 .spec
+}
+
+velero_backup_create() {
+  ck8s ops velero "${1}" backup create "${2}" --from-schedule velero-daily-backup --wait
+}
+
+velero_backup_get_phase() {
+  ck8s ops velero "${1}" backup get "${2}" -o json 2>/dev/null | jq -r .status.phase
+}
+
+velero_restore_create() {
+  ck8s ops velero "${1}" restore create "${2}" --from-backup "${3}" --wait
+}
+
+velero_restore_get_phase() {
+  ck8s ops velero "${1}" restore get "${2}" -o json 2>/dev/null | jq -r .status.phase
+}

--- a/tests/end-to-end/velero/resources/backup-spec-sc.yaml
+++ b/tests/end-to-end/velero/resources/backup-spec-sc.yaml
@@ -1,0 +1,21 @@
+csiSnapshotTimeout: 0s
+excludedResources:
+  - clustercompliancereports.aquasecurity.github.io
+  - clusterconfigauditreports.aquasecurity.github.io
+  - clusterinfraassessmentreports.aquasecurity.github.io
+  - clusterrbacassessmentreports.aquasecurity.github.io
+  - clustersbomreports.aquasecurity.github.io
+  - configauditreports.aquasecurity.github.io
+  - exposedsecretreports.aquasecurity.github.io
+  - infraassessmentreports.aquasecurity.github.io
+  - rbacassessmentreports.aquasecurity.github.io
+  - sbomreports.aquasecurity.github.io
+  - vulnerabilityreports.aquasecurity.github.io
+hooks: {}
+itemOperationTimeout: 0s
+labelSelector:
+  matchLabels:
+    velero: backup
+metadata: {}
+storageLocation: default
+ttl: 720h0m0s

--- a/tests/end-to-end/velero/resources/backup-spec-wc.yaml
+++ b/tests/end-to-end/velero/resources/backup-spec-wc.yaml
@@ -1,0 +1,40 @@
+csiSnapshotTimeout: 0s
+excludedNamespaces:
+  - cert-manager
+  - falco
+  - fluentd
+  - hnc-system
+  - ingress-nginx
+  - kube-node-lease
+  - kube-public
+  - kube-system
+  - kured
+  - monitoring
+  - rook-ceph
+  - velero
+  - gatekeeper-system
+  - jaeger-system
+  - postgres-system
+  - rabbitmq-system
+  - redis-system
+excludedResources:
+  - clustercompliancereports.aquasecurity.github.io
+  - clusterconfigauditreports.aquasecurity.github.io
+  - clusterinfraassessmentreports.aquasecurity.github.io
+  - clusterrbacassessmentreports.aquasecurity.github.io
+  - clustersbomreports.aquasecurity.github.io
+  - configauditreports.aquasecurity.github.io
+  - exposedsecretreports.aquasecurity.github.io
+  - infraassessmentreports.aquasecurity.github.io
+  - rbacassessmentreports.aquasecurity.github.io
+  - sbomreports.aquasecurity.github.io
+  - vulnerabilityreports.aquasecurity.github.io
+hooks: {}
+itemOperationTimeout: 0s
+labelSelector:
+  matchExpressions:
+    - key: compliantkubernetes.io/nobackup
+      operator: DoesNotExist
+metadata: {}
+storageLocation: default
+ttl: 720h0m0s

--- a/tests/end-to-end/velero/resources/test-application.yaml
+++ b/tests/end-to-end/velero/resources/test-application.yaml
@@ -1,0 +1,48 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: velero-test
+  namespace: velero-test
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: velero-test
+  namespace: velero-test
+spec:
+  containers:
+  - image: ${image}
+    args:
+      - sleep
+      - "3600"
+    name: velero-test
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+    securityContext:
+      runAsUser: 1000
+    volumeMounts:
+      - name: velero-test
+        mountPath: /test
+  volumes:
+    - name: velero-test
+      persistentVolumeClaim:
+        claimName: velero-test
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: velero-test
+  namespace: velero-test
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/tests/end-to-end/velero/resources/test-namespace.yaml
+++ b/tests/end-to-end/velero/resources/test-namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: hnc.x-k8s.io/v1alpha2
+kind: SubnamespaceAnchor
+metadata:
+  name: velero-test
+  namespace: production

--- a/tests/end-to-end/velero/user-app.bats
+++ b/tests/end-to-end/velero/user-app.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+
+create_test_namespace() {
+  kubectl apply -f "${BATS_TEST_DIRNAME}/resources/test-namespace.yaml" --wait
+}
+
+wait_test_namespace() {
+  kubectl wait --for jsonpath='{.status.phase}'=Active namespace/velero-test
+}
+
+delete_test_namespace() {
+  kubectl delete -f "${BATS_TEST_DIRNAME}/resources/test-namespace.yaml" --wait
+}
+
+create_test_application() {
+  image="${1}" envsubst < "${BATS_TEST_DIRNAME}/resources/test-application.yaml" | kubectl apply -f - --wait
+}
+
+wait_test_application() {
+  kubectl -n velero-test wait --for=condition=Ready pod/velero-test --timeout=120s
+}
+
+delete_test_application() {
+  kubectl delete -f "${BATS_TEST_DIRNAME}/resources/test-application.yaml" --wait
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+  load_common "yq.bash"
+  load_common "ctr.bash"
+  load_common "harbor.bash"
+  load "./common.bash"
+
+  harbor.load_env velero-test
+  harbor.setup_project
+  ctr pull alpine:3.20.2
+  # Harbor variables are defined in `harbor.load_env`.
+  # shellcheck disable=SC2154
+  image="${harbor_endpoint}/${harbor_project}/alpine:3.20.2"
+  ctr tag alpine:3.20.2 "${image}"
+  ctr push "${image}"
+
+  with_kubeconfig wc
+
+  create_test_namespace
+  wait_test_namespace
+
+  harbor.create_pull_secret wc velero-test
+
+  create_test_application "${image}"
+  wait_test_application
+}
+
+teardown() {
+  delete_test_application
+
+  delete_test_namespace
+
+  harbor.teardown_project
+}
+
+@test "velero backup and restore user application" {
+  # TODO: Remove skip when fixed https://github.com/elastisys/compliantkubernetes-apps/issues/2321
+  skip "This does not currently work and is a known issue"
+
+  backup_name="test-backup-$(date +%s)"
+  restore_name="test-restore-$(date +%s)"
+
+  run kubectl -n velero-test exec velero-test -- touch /test/hello
+  assert_success
+
+  run velero_backup_create wc "${backup_name}"
+  assert_success
+
+  run velero_backup_get_phase wc "${backup_name}"
+  assert_success
+  assert_output Completed
+
+  delete_test_application
+  delete_test_namespace
+
+  run velero_restore_create wc "${restore_name}" "${backup_name}"
+  assert_success
+
+  run velero_restore_get_phase wc "${restore_name}"
+  assert_success
+  assert_output Completed
+
+  wait_test_namespace
+  wait_test_application
+
+  run kubectl -n velero-test exec velero-test -- test -f /test/hello
+  assert_success
+}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

- Fixes #1850 

#### Information to reviewers

Added all QA and Velero GOTOs so that I get feedback from both parties. Does the tests look correct, does the test fixes look correct, am I testing Velero correctly and does it cover everything we want tested with Velero?

Me and @aarnq talked offline and decided that modifying the cluster config during the tests isn't a good idea. So to test both Restic and Kopia it's up to the tester to reconfigure the cluster and run the tests twice.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
