### PR TITLE
config: Open cert-manager netpols by default

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -1048,6 +1048,9 @@ networkPolicies:
     letsencrypt:
       ips:
         - set-me-if-(.networkPolicies.certManager.enabled)
+    # Configure this if HTTP-01 challenges need to be enabled in cert-manager for other endpoints than the ingress-controller
+    http01:
+      ips: []
     # Configure this if DNS-01 challenges are enabled in cert-manager
     dns01:
       ips: []

--- a/config/flavors/dev/common-config.yaml
+++ b/config/flavors/dev/common-config.yaml
@@ -9,3 +9,16 @@ prometheus:
 
 velero:
   enabled: false
+
+networkPolicies:
+  # ADR: https://elastisys.io/compliantkubernetes/adr/0051-open-cert-manager-netpols/
+  certManager:
+    letsencrypt:
+      ips:
+        - 0.0.0.0/0
+    http01:
+      ips:
+        - 0.0.0.0/0
+    dns01:
+      ips:
+        - 0.0.0.0/0

--- a/config/flavors/prod/common-config.yaml
+++ b/config/flavors/prod/common-config.yaml
@@ -6,3 +6,16 @@ prometheus:
     size: 15Gi
   retention:
     size: 12GiB
+
+networkPolicies:
+  # ADR: https://elastisys.io/compliantkubernetes/adr/0051-open-cert-manager-netpols/
+  certManager:
+    letsencrypt:
+      ips:
+        - 0.0.0.0/0
+    http01:
+      ips:
+        - 0.0.0.0/0
+    dns01:
+      ips:
+        - 0.0.0.0/0

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -6225,6 +6225,14 @@ properties:
             additionalProperties: false
             properties:
               ips: true
+          http01:
+            title: Network Policies cert-manager HTTP-01
+            description: Configure network policy rule to allow cert-manager perform HTTP-01 challenges on other endpoints than the ingress-controller.
+            type: object
+            additionalProperties: false
+            properties:
+              ips:
+                $ref: '#/$defs/iplist'
           dns01:
             title: Network Policies cert-manager DNS-01
             description: Configure network policy rule to allow cert-manager perform DNS-01 challenges.

--- a/helmfile.d/values/networkpolicies/common/cert-manager.yaml.gotmpl
+++ b/helmfile.d/values/networkpolicies/common/cert-manager.yaml.gotmpl
@@ -31,6 +31,16 @@ policies:
           ports:
             - tcp: 443
         {{- end }}
+        {{- with .Values | get "networkPolicies.certManager.http01.ips" list }}
+        - name: egress-rule-http01
+          peers:
+            {{- range . }}
+            - cidr: {{ . }}
+            {{- end }}
+          ports:
+            - tcp: 443
+            - tcp: 80
+        {{- end }}
         {{- with .Values | get "networkPolicies.certManager.dns01.ips" list }}
         - name: egress-rule-dns01
           peers:

--- a/migration/v0.41/README.md
+++ b/migration/v0.41/README.md
@@ -82,6 +82,24 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ./bin/ck8s upgrade wc v0.41 apply
     ```
 
+1. For `dev` and `prod` flavours: The default network policies for cert-manager has changed, and now it is allowed egress to:
+
+    - `0.0.0.0/0:53/udp`
+    - `0.0.0.0/0:53/tcp`
+    - `0.0.0.0/0:80/tcp`
+    - `0.0.0.0/0:443/tcp`
+
+    To allow it to perform any DNS-01 or HTTP-01 challenge by default.
+    If you have previously overridden it you can remove the overrides to opt into the new defaults, and if you want to restrict it you need to configure the network policies manually.
+
+    To remove previous overrides:
+
+    ```bash
+    yq4 -i 'del(.networkPolicies.certManager)' "${CK8S_CONFIG_PATH}/common-config.yaml"
+    yq4 -i 'del(.networkPolicies.certManager)' "${CK8S_CONFIG_PATH}/sc-config.yaml"
+    yq4 -i 'del(.networkPolicies.certManager)' "${CK8S_CONFIG_PATH}/wc-config.yaml"
+    ```
+
 1. If Tekton is enabled, ensure to add appropriate network policies for the pipeline.
 
   To check if the tekton is enabled, run the following command

--- a/scripts/run-from-container.sh
+++ b/scripts/run-from-container.sh
@@ -63,7 +63,7 @@ else
 fi
 
 declare -a args
-args=("--rm")
+args=("--init" "--rm")
 
 if [[ -t 1 ]] && [[ -z "${CI:-}" ]]; then
   args+=("-it")

--- a/tests/unit/general/bin-conditional-set-me.bats
+++ b/tests/unit/general/bin-conditional-set-me.bats
@@ -11,7 +11,7 @@ setup_file() {
   gpg.setup
   env.setup
 
-  env.init baremetal kubespray dev --skip-issuers --skip-network-policies
+  env.init baremetal kubespray air-gapped --skip-issuers --skip-network-policies
 }
 
 teardown_file() {
@@ -101,11 +101,11 @@ _refute_condition_and_warn() {
 # bats test_tags=conditional_set_me_slack_alerts
 @test "conditional-set-me - singular conditions: slack alerts" {
 
-  yq.set common .alerts.alertTo \"slack\"
+  yq.set sc .alerts.alertTo \"slack\"
   run _apply_normalise_sc
   _assert_condition_and_warn .\"alerts\".\"slack\".\"channel\"
 
-  yq.set common .alerts.alertTo \"\"
+  yq.set sc .alerts.alertTo \"\"
   run _apply_normalise_sc
   _refute_condition_and_warn .\"alerts\".\"slack\".\"channel\"
 }


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [x] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [x] [kind/adr](https://elastisys.io/compliantkubernetes/adr/0051-open-cert-manager-netpols/)      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice

The default network policies for cert-manager has changed in `dev` and `prod` flavours allowing all egress traffic on `53/tcp`, `53/udp`, `80/tcp`, and `443/tcp` to provide a better certificate management experience for application developers.

### Application Developer notice

The default network policies for cert-manager has changed in `dev` and `prod` flavours allowing it to use most DNS-01 resolvers by default, and improving the experience when debugging HTTP-01 challenges.

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This changes the network policies for cert-manager to fulfil ADR-0051, see link above.

Air-gapped is of course left to be set manually.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [x] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
