### PR TITLE
Add extraconfig variable for nodelocaldns hostzone

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -1124,6 +1124,13 @@ nodeLocalDns:
   #      loop
   #      forward . 127.0.0.1:9005
   #      }
+
+  # Configure .53 host zone
+  hostZone:
+    extraConfig: "" #|
+    #   template ANY ANY {
+    #     rcode NXDOMAIN
+    #   }
   resources:
     limits:
       cpu: 100m

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -6849,6 +6849,26 @@ properties:
               loop
               forward . 127.0.0.1:9005
             }
+      hostZone:
+        title: Host zone for node-local-dns
+        description: Configure the host zone for node-local-dns
+        type: object
+        additionalProperties: false
+        properties:
+          extraConfig:
+            title: Extra config for host zone
+            description: |-
+              Configure extra config for the host zone .53 for node-local-dns.
+
+              > [!note]
+              > See [the upstream documentation](https://coredns.io/manual/configuration/) for reference.
+            type: string
+            default: ""
+            examples:
+              - |-
+                template ANY ANY {
+                  rcode NXDOMAIN
+                }
       resources:
         $ref: '#/$defs/kubernetesResourceRequirements'
   externalDns:

--- a/helmfile.d/charts/node-local-dns/templates/node-local-dns.yaml
+++ b/helmfile.d/charts/node-local-dns/templates/node-local-dns.yaml
@@ -98,6 +98,9 @@ data:
         errors {
           {{ .Values.errorConfig }}
         }
+        {{- with .Values.hostZone.extraConfig }}
+        {{- . | nindent 8 }}
+        {{- end }}
         cache 30
         reload
         loop

--- a/helmfile.d/charts/node-local-dns/values.yaml
+++ b/helmfile.d/charts/node-local-dns/values.yaml
@@ -9,6 +9,12 @@ resources:
     cpu: 25m
     memory: 40Mi
 
+hostZone:
+  extraConfig: #|
+    # template ANY ANY {
+    #   rcode NXDOMAIN
+    # }
+
 
 # See docs for details about the config format and options:
 # https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#coredns-configmap-options

--- a/helmfile.d/values/node-local-dns.yaml.gotmpl
+++ b/helmfile.d/values/node-local-dns.yaml.gotmpl
@@ -10,3 +10,8 @@ customConfig: {{ toYaml .Values.nodeLocalDns.customConfig }}
 {{- end }}
 
 resources: {{- toYaml .Values.nodeLocalDns.resources | nindent 2 }}
+
+{{- if dig "nodeLocalDns" "hostZone" "extraConfig" false .Values }}
+hostZone:
+  extraConfig: {{ toYaml .Values.nodeLocalDns.hostZone.extraConfig | nindent 4}}
+{{- end }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Added a new variable to configure extra config to the nodeLocalDns hostzone (.53). See this patch branch as an example of why this would be needed in some environments: https://github.com/elastisys/compliantkubernetes-apps/blob/v0.37.0%2BAAAA-noerror%2Bopensearch-2.13.0/helmfile.d/charts/node-local-dns/templates/node-local-dns.yaml#L101

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
