### PR TITLE
Fix update-ips fetch swift url

### DIFF
--- a/tests/common/bats/update-ips.bash
+++ b/tests/common/bats/update-ips.bash
@@ -26,6 +26,20 @@ update_ips.setup_mocks() {
   export -f kubectl
 }
 
+update_ips.setup_mktemp_mock(){
+  mock_mktemp="$(mock_create)"
+  export mock_mktemp
+  mktemp() {
+    # shellcheck disable=SC2317
+    touch /tmp/tmp.mock_headers
+    # shellcheck disable=SC2317
+    "${mock_mktemp}" "${@}"
+  }
+  export -f mktemp
+
+  mock_set_output "${mock_mktemp}" /tmp/tmp.mock_headers
+}
+
 update_ips.assert_mocks_none() {
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
   assert_equal "$(mock_get_call_num "${mock_dig}")" 0
@@ -63,7 +77,7 @@ update_ips.mock_maximal() {
   # main swift
 
   # GET /auth/tokens
-  mock_set_output "${mock_curl}" '\n\n\n\n\n\n\n\n\n\n\n\n\n\n[{"catalog":[{"type": "object-store", "name": "swift", "endpoints": [{"interface":"public", "region": "swift-region", "url": "https://swift.foo.dev-ck8s.com:91011"}]}]}]' 1
+  mock_set_output "${mock_curl}" '{"token":{"catalog":[{"type": "object-store", "name": "swift", "endpoints": [{"interface":"public", "region": "swift-region", "url": "https://swift.foo.dev-ck8s.com:91011"}]}]}}' 1
   # DELETE /auth/tokens
   mock_set_output "${mock_curl}" "" 2
   mock_set_output "${mock_dig}" "127.1.0.4" 4 # keystone endpoint
@@ -76,7 +90,7 @@ update_ips.mock_maximal() {
   # rclone sync swift
 
   # GET /auth/tokens
-  mock_set_output "${mock_curl}" '\n\n\n\n\n\n\n\n\n\n\n\n\n\n[{"catalog":[{"type": "object-store", "name": "swift", "endpoints": [{"interface":"public", "region": "swift-region", "url": "https://swift.foo.dev-ck8s.com"}]}]}]' 3
+  mock_set_output "${mock_curl}" '{"token":{"catalog":[{"type": "object-store", "name": "swift", "endpoints": [{"interface":"public", "region": "swift-region", "url": "https://swift.foo.dev-ck8s.com"}]}]}}' 3
   # DELETE /auth/tokens
   mock_set_output "${mock_curl}" "" 4
 
@@ -98,7 +112,7 @@ update_ips.mock_rclone_s3_and_swift() {
   update_ips.mock_rclone_s3
 
   # GET /auth/tokens
-  mock_set_output "${mock_curl}" '\n\n\n\n\n\n\n\n\n\n\n\n\n\n[{"catalog":[{"type": "object-store", "name": "swift", "endpoints": [{"interface":"public", "region": "swift-region", "url": "https://swift.foo.dev-ck8s.com"}]}]}]' 1
+  mock_set_output "${mock_curl}" '{"token":{"catalog":[{"type": "object-store", "name": "swift", "endpoints": [{"interface":"public", "region": "swift-region", "url": "https://swift.foo.dev-ck8s.com"}]}]}}' 1
   mock_set_output "${mock_curl}" "" 2 # DELETE /auth/tokens
 
   mock_set_output "${mock_dig}" "127.0.0.5" 5 # networkPolicies.rclone.sync.objectStorageSwift.ips keystone endpoint
@@ -109,7 +123,7 @@ update_ips.mock_rclone_swift() {
   update_ips.mock_minimal
 
   # GET /auth/tokens
-  mock_set_output "${mock_curl}" '\n\n\n\n\n\n\n\n\n\n\n\n\n\n[{"catalog":[{"type": "object-store", "name": "swift", "endpoints": [{"interface":"public", "region": "swift-region", "url": "https://swift.foo.dev-ck8s.com"}]}]}]' 1
+  mock_set_output "${mock_curl}" '{"token":{"catalog":[{"type": "object-store", "name": "swift", "endpoints": [{"interface":"public", "region": "swift-region", "url": "https://swift.foo.dev-ck8s.com"}]}]}}' 1
   mock_set_output "${mock_curl}" "" 2 # DELETE /auth/tokens
 
   mock_set_output "${mock_dig}" "127.0.0.5" 4 # networkPolicies.rclone.sync.objectStorageSwift.ips keystone endpoint
@@ -120,7 +134,7 @@ update_ips.mock_swift() {
   update_ips.mock_minimal
 
   # GET /auth/tokens
-  mock_set_output "${mock_curl}" '\n\n\n\n\n\n\n\n\n\n\n\n\n\n[{"catalog":[{"type": "object-store", "name": "swift", "endpoints": [{"interface":"public", "region": "swift-region", "url": "https://swift.foo.dev-ck8s.com:91011"}]}]}]' 1
+  mock_set_output "${mock_curl}" '{"token":{"catalog":[{"type": "object-store", "name": "swift", "endpoints": [{"interface":"public", "region": "swift-region", "url": "https://swift.foo.dev-ck8s.com:91011"}]}]}}' 1
   mock_set_output "${mock_curl}" "" 2 # DELETE /auth/tokens
 
   mock_set_output "${mock_dig}" "127.0.0.4" 4 # keystone endpoint
@@ -224,7 +238,7 @@ update_ips.assert_rclone_swift() {
   assert_equal "$(yq4 '.networkPolicies.rclone.sync.objectStorage' "${CK8S_CONFIG_PATH}/sc-config.yaml")" "null"
 
   # GET /auth/tokens
-  mock_set_output "${mock_curl}" '\n\n\n\n\n\n\n\n\n\n\n\n\n\n[{"catalog":[{"type": "object-store", "name": "swift", "endpoints": [{"interface":"public", "region": "swift-region", "url": "https://swift.foo.dev-ck8s.com"}]}]}]' 1
+  mock_set_output "${mock_curl}" '{"token":{"catalog":[{"type": "object-store", "name": "swift", "endpoints": [{"interface":"public", "region": "swift-region", "url": "https://swift.foo.dev-ck8s.com"}]}]}}' 1
   mock_set_output "${mock_curl}" "" 2 # DELETE /auth/tokens
   mock_set_output "${mock_dig}" "127.0.0.4" 4 # keystone endpoint
   mock_set_output "${mock_dig}" "127.0.0.5" 5 # swift endpoint

--- a/tests/unit/general/bin-update-ips-rclone.bats
+++ b/tests/unit/general/bin-update-ips-rclone.bats
@@ -392,6 +392,8 @@ _test_apply_rclone_sync_s3_and_swift() {
 @test "ck8s update-ips gets swift url for rclone sync" {
   _setup_swift '.objectStorage.sync.destinationType'
 
+  update_ips.setup_mktemp_mock
+
   mock_set_output "${mock_dig}" ""
 
   run ck8s update-ips both apply

--- a/tests/unit/general/bin-update-ips-swift.bats
+++ b/tests/unit/general/bin-update-ips-swift.bats
@@ -169,6 +169,7 @@ _test_apply_swift_application_credential_id() {
   yq.set sc .harbor.persistence.type '"swift"'
 
   update_ips.mock_swift
+  update_ips.setup_mktemp_mock
 
   sops --set '["objectStorage"]["swift"]["username"] "swift-username"' "${CK8S_CONFIG_PATH}/secrets.yaml"
   sops --set '["objectStorage"]["swift"]["password"] "swift-password"' "${CK8S_CONFIG_PATH}/secrets.yaml"

--- a/tests/unit/general/resources/get-swift-url.out
+++ b/tests/unit/general/resources/get-swift-url.out
@@ -1,4 +1,4 @@
--i -s -H Content-Type: application/json -d 
+-s -D /tmp/tmp.mock_headers -H Content-Type: application/json -d 
         {
           "auth": {
             "identity": {


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

I noticed that the update-ips did not find the swift url. 
Im unsure if it is my version of curl that returns 1 less line. 
If that is the case, we probably need to find a more stable way extract the url from the response.

```
curl --version
curl 7.88.1 (x86_64-pc-linux-gnu) libcurl/7.88.1 OpenSSL/3.0.8 zlib/1.2.13 brotli/1.0.9 zstd/1.5.4 libidn2/2.3.3 libpsl/0.21.2 (+libidn2/2.3.3) libssh/0.10.4/openssl/zlib nghttp2/1.52.0 librtmp/2.3
Release-Date: 2023-02-20
Protocols: dict file ftp ftps gopher gophers http https imap imaps ldap ldaps mqtt pop3 pop3s rtmp rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli GSS-API HSTS HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM NTLM_WB PSL SPNEGO SSL threadsafe TLS-SRP UnixSockets zstd

```


#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Documentation checks:
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required no updates
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required an update - [link to change](set-me\)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
