### PR TITLE
docs: move cert-manager netpol migration step to v0.42

### DIFF
--- a/migration/v0.41/README.md
+++ b/migration/v0.41/README.md
@@ -82,24 +82,6 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ./bin/ck8s upgrade wc v0.41 apply
     ```
 
-1. For `dev` and `prod` flavours: The default network policies for cert-manager has changed, and now it is allowed egress to:
-
-    - `0.0.0.0/0:53/udp`
-    - `0.0.0.0/0:53/tcp`
-    - `0.0.0.0/0:80/tcp`
-    - `0.0.0.0/0:443/tcp`
-
-    To allow it to perform any DNS-01 or HTTP-01 challenge by default.
-    If you have previously overridden it you can remove the overrides to opt into the new defaults, and if you want to restrict it you need to configure the network policies manually.
-
-    To remove previous overrides:
-
-    ```bash
-    yq4 -i 'del(.networkPolicies.certManager)' "${CK8S_CONFIG_PATH}/common-config.yaml"
-    yq4 -i 'del(.networkPolicies.certManager)' "${CK8S_CONFIG_PATH}/sc-config.yaml"
-    yq4 -i 'del(.networkPolicies.certManager)' "${CK8S_CONFIG_PATH}/wc-config.yaml"
-    ```
-
 1. If Tekton is enabled, ensure to add appropriate network policies for the pipeline.
 
   To check if the tekton is enabled, run the following command

--- a/migration/v0.42/README.md
+++ b/migration/v0.42/README.md
@@ -82,6 +82,24 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ./bin/ck8s upgrade wc v0.42 apply
     ```
 
+1. For `dev` and `prod` flavours: The default network policies for cert-manager has changed, and now it is allowed egress to:
+
+    - `0.0.0.0/0:53/udp`
+    - `0.0.0.0/0:53/tcp`
+    - `0.0.0.0/0:80/tcp`
+    - `0.0.0.0/0:443/tcp`
+
+    To allow it to perform any DNS-01 or HTTP-01 challenge by default.
+    If you have previously overridden it you can remove the overrides to opt into the new defaults, and if you want to restrict it you need to configure the network policies manually.
+
+    To remove previous overrides:
+
+    ```bash
+    yq4 -i 'del(.networkPolicies.certManager)' "${CK8S_CONFIG_PATH}/common-config.yaml"
+    yq4 -i 'del(.networkPolicies.certManager)' "${CK8S_CONFIG_PATH}/sc-config.yaml"
+    yq4 -i 'del(.networkPolicies.certManager)' "${CK8S_CONFIG_PATH}/wc-config.yaml"
+    ```
+
 1. Apply upgrade - *disruptive*
 
     > *Done during maintenance window.*


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [x] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Move migration step to v0.42 as the change didn't make it into apps v0.41

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Documentation checks:
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required no updates
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required an update - [link to change](set-me\)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
