### PR TITLE
config: change default destination sync type to azure for azure

### DIFF
--- a/config/providers/azure/sc-config.yaml
+++ b/config/providers/azure/sc-config.yaml
@@ -9,3 +9,8 @@ fluentd:
       # azcopy is used by az CLI for downloading files
       azureCopyBufferGB: 0.3
       azureCopyConcurrency: 8
+
+objectStorage:
+  sync:
+    ## If Harbor or Thanos are using Swift then we will automatically use Swift for the sync of Harbor or Thanos, regardless of the value set for destinationType.
+    destinationType: azure

--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -64,8 +64,7 @@ objectStorage:
     enabled: false
     dryrun: false
 
-    ## Only 's3' is currently supported for `.objectStorage.sync.destinationType` as not all default buckets applications have swift support.
-    ## If Harbor or Thanos are using swift then we will automatically use swift for the sync, regardless of the value set for type.
+    ## If Harbor or Thanos are using Swift then we will automatically use Swift for the sync of Harbor or Thanos, regardless of the value set for destinationType.
     destinationType: s3
     # secondaryUrl: set-me if regionEndpoint and or authUrl does not have all the relevant ips and or ports used for rclone-sync networkpolicy.
     # s3:

--- a/migration/v0.42/README.md
+++ b/migration/v0.42/README.md
@@ -127,6 +127,15 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     export CK8S_CLUSTER=<wc|sc|both>
     ```
 
+1. Update `objectStorage.sync.destinationType` for Azure clusters
+
+    Ensure that `objectStorage.sync.destinationType` keeps current value for Azure clusters that have sync enabled.
+    Default is updated to `azure` for Azure clusters.
+
+    ```bash
+    ./migration/v0.42/prepare/40-azure-sync-destination-type.sh
+    ```
+
 1. Update apps configuration:
 
     This will take a backup into `backups/` before modifying any files.

--- a/migration/v0.42/prepare/40-azure-sync-destination-type.sh
+++ b/migration/v0.42/prepare/40-azure-sync-destination-type.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+log_info "configuring object storage sync type on Azure"
+if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+  cloud_provider=$(yq_dig sc .global.ck8sCloudProvider)
+  if [[ "${cloud_provider}" != "azure" ]]; then
+    log_info "not running on Azure, skipping"
+    exit 0
+  fi
+
+  if yq_check sc .objectStorage.sync.enabled true; then
+    if yq_null sc .objectStorage.sync.destinationType; then
+      log_info "objectStorage sync is enabled, will keep previous default destinationType: s3"
+      yq_add sc .objectStorage.sync.destinationType "\"s3\""
+    else
+      log_info "sync destinationType already has an override, skipping"
+    fi
+  else
+    log_info "object storage sync is not enabled, will use new default destinationType: azure"
+  fi
+fi


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->

Changed the default `objectStorage.sync.destinationType` to azure, for azure clusters. Having this default to s3 caused issues with network policies / update-ips for clusters that are only using azure storage.

#### Information to reviewers

Init and migration script tested, but I have not re-tested using destinationType as azure. 

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [x] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Documentation checks:
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required no updates
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required an update - [link to change](set-me\)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
