### PR TITLE
config: move harbor backup schedule and make it configurable

### DIFF
--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -402,6 +402,7 @@ harbor:
   backup:
     enabled: true
     retentionDays: 7
+    schedule: "30 0 * * *"
     ephemeralBackupStore:
       enabled: false
       storageSize: 10Gi

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -832,6 +832,9 @@ $defs:
         description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
         type: string
     type: object
+  cronSchedule:
+    type: string
+    pattern: ^(((\*\/)?([0-5]?[0-9])((\,|\-|\/)([0-5]?[0-9]))*|\*)[^\S\r\n]+((\*\/)?((2[0-3]|1[0-9]|[0-9]|00))((\,|\-|\/)(2[0-3]|1[0-9]|[0-9]|00))*|\*)[^\S\r\n]+((\*\/)?([1-9]|[12][0-9]|3[01])((\,|\-|\/)([1-9]|[12][0-9]|3[01]))*|\*)[^\S\r\n]+((\*\/)?([1-9]|1[0-2])((\,|\-|\/)([1-9]|1[0-2]))*|\*|(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec))[^\S\r\n]+((\*\/)?[0-6]((\,|\-|\/)[0-6])*|\*|00|(sun|mon|tue|wed|thu|fri|sat)))$|^@(annually|yearly|monthly|weekly|daily|hourly|reboot)$
 type: object
 required:
   - global
@@ -1698,8 +1701,9 @@ properties:
             description: |-
               `schedule` defines when the backup job for Harbor will run.
               This should be set to run shortly after Velero backups in the workload cluster, in order to ensure that images needed for Velero backups are backed up in Harbor.
+              Uses the Cron format, see https://en.wikipedia.org/wiki/Cron.
             default: "30 0 * * *"
-            type: string
+            $ref: '#/$defs/cronSchedule'
         type: object
       core:
         title: Core Config
@@ -1813,6 +1817,8 @@ properties:
             title: Schedule
             description: |-
               Defines a CRON schedule when the garbage collection job should run.
+              Uses a special Cron format that adds "seconds" as the first entry.
+              Order: "seconds, minutes, hours, day of month, month, day of week".
             default: 0 0 0 * * SUN
             type: string
         type: object
@@ -2318,9 +2324,11 @@ properties:
             default: false
           defaultSchedule:
             title: Rclone Sync Default Schedule
-            description: Default schedule to run the sync CronJobs.
-            type: string
+            description: |-
+              Default schedule to run the sync CronJobs.
+              Uses the Cron format, see https://en.wikipedia.org/wiki/Cron.
             default: 0 5 * * *
+            $ref: '#/$defs/cronSchedule'
           buckets:
             title: Rclone Sync Buckets
             description: Additional buckets to sync.
@@ -2343,7 +2351,10 @@ properties:
                 schedule:
                   type: string
                   title: Sync schedule for this bucket
-                  description: Defaults to `.objectStorage.sync.defaultSchedule`
+                  description: |-
+                    Defaults to `.objectStorage.sync.defaultSchedule`
+                    Uses the Cron format, see https://en.wikipedia.org/wiki/Cron.
+                  $ref: '#/$defs/cronSchedule'
                 sourceType:
                   type: string
                   title: Type of source
@@ -2565,8 +2576,11 @@ properties:
         default: false
       schedule:
         title: Velero Backup Schedule
+        description: |-
+          Schedule for Velero backup schedule "velero-daily-backup"
+          Uses the Cron format, see https://en.wikipedia.org/wiki/Cron.
         default: 0 0 * * *
-        type: string
+        $ref: '#/$defs/cronSchedule'
       retentionPeriod:
         title: Velero Backup Retention Period
         $ref: '#/$defs/goDuration'
@@ -4914,7 +4928,10 @@ properties:
             type: number
           jobSchedule:
             title: Log Manager Job Schema
-            type: string
+            description: |-
+              Schema for when to run Log Manager Job.
+              Uses the Cron format, see https://en.wikipedia.org/wiki/Cron.
+            $ref: '#/$defs/cronSchedule'
           jobEphemeralVolumes:
             title: Log Manager Job Ephemeral Volume
             description: Configure the job to run with an ephemeral volume if the nodes risk running out of storage.
@@ -5619,8 +5636,11 @@ properties:
             default: 1200
           backupSchedule:
             title: OpenSearch Backup CronJob Schedule
-            type: string
+            description: |-
+              Schedule to trigger Opensearch backups.
+              Uses the Cron format, see https://en.wikipedia.org/wiki/Cron.
             default: 0 */2 * * *
+            $ref: '#/$defs/cronSchedule'
           backupStartingDeadlineSeconds:
             title: OpenSearch Backup Job Starting Deadline
             type: number
@@ -5631,8 +5651,11 @@ properties:
             default: 600
           retentionSchedule:
             title: OpenSearch Retention CronJob Schedule
-            type: string
+            description: |-
+              Schedule to check for and remove old snapshots.
+              Uses the Cron format, see https://en.wikipedia.org/wiki/Cron.
             default: '@daily'
+            $ref: '#/$defs/cronSchedule'
           retentionStartingDeadlineSeconds:
             title: OpenSearch Retention Job Starting Deadline
             type: number

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -1693,6 +1693,13 @@ properties:
               `RetentionDays` defines how old a backup should be before deleting it.
             default: 7
             type: number
+          schedule:
+            title: Schedule for backup job
+            description: |-
+              `schedule` defines when the backup job for Harbor will run.
+              This should be set to run shortly after Velero backups in the workload cluster, in order to ensure that images needed for Velero backups are backed up in Harbor.
+            default: "30 0 * * *"
+            type: string
         type: object
       core:
         title: Core Config

--- a/helmfile.d/charts/harbor/harbor-backup/values.yaml
+++ b/helmfile.d/charts/harbor/harbor-backup/values.yaml
@@ -1,7 +1,7 @@
 pgHostname: harbor-database
 dbPassword: ""
 retentionDays: 7
-schedule: "0 0 * * *"
+schedule: "30 0 * * *"
 s3:
   enabled: false
   accessKey: ""

--- a/helmfile.d/values/harbor/harbor-backup.yaml.gotmpl
+++ b/helmfile.d/values/harbor/harbor-backup.yaml.gotmpl
@@ -7,6 +7,7 @@
 
 dbPassword: {{ .Values.harbor.internal.databasePassword }}
 retentionDays: {{ .Values.harbor.backup.retentionDays }}
+schedule: {{ .Values.harbor.backup.schedule | quote }}
 {{ if eq .Values.objectStorage.type "s3" -}}
 s3:
   enabled: true


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->

Default harbor backup schedule moved to after defaut velero schedule. This should ensure that images needed for resources in velero backup are present in harbor backup.

Also made the schedule configurable.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Documentation checks:
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required no updates
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required an update - [link to change](set-me\)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
