### PR TITLE
apps: Change default for external traffic policy to local

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -532,7 +532,7 @@ opensearch:
 ## providers supporting it
 ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
 externalTrafficPolicy:
-  local: set-me
+  local: true
 
   ## Source IP range to allow.
   whitelistRange:

--- a/config/providers/aws/common-config.yaml
+++ b/config/providers/aws/common-config.yaml
@@ -24,8 +24,6 @@ networkPolicies:
   ingressNginx:
     ingressOverride:
       enabled: false
-externalTrafficPolicy:
-  local: false
 opa:
   rejectLoadBalancerService:
     enabled: false

--- a/config/providers/azure/common-config.yaml
+++ b/config/providers/azure/common-config.yaml
@@ -25,8 +25,6 @@ networkPolicies:
       enabled: true
       ips:
         - 0.0.0.0/0
-externalTrafficPolicy:
-  local: true
 opa:
   rejectLoadBalancerService:
     enabled: false

--- a/config/providers/baremetal/common-config.yaml
+++ b/config/providers/baremetal/common-config.yaml
@@ -19,8 +19,6 @@ networkPolicies:
       enabled: false
   rookCeph:
     enabled: true
-externalTrafficPolicy:
-  local: false
 opa:
   rejectLoadBalancerService:
     enabled: true

--- a/config/providers/citycloud/common-config.yaml
+++ b/config/providers/citycloud/common-config.yaml
@@ -35,8 +35,6 @@ ingressNginx:
       type: LoadBalancer
       annotations: {}
       allocateLoadBalancerNodePorts: true
-externalTrafficPolicy:
-  local: false
 opa:
   rejectLoadBalancerService:
     enabled: false

--- a/config/providers/elastx/common-config.yaml
+++ b/config/providers/elastx/common-config.yaml
@@ -35,8 +35,6 @@ ingressNginx:
       type: LoadBalancer
       annotations: {}
       allocateLoadBalancerNodePorts: true
-externalTrafficPolicy:
-  local: false
 opa:
   rejectLoadBalancerService:
     enabled: false

--- a/config/providers/exoscale/common-config.yaml
+++ b/config/providers/exoscale/common-config.yaml
@@ -23,8 +23,6 @@ networkPolicies:
       enabled: false
   rookCeph:
     enabled: true
-externalTrafficPolicy:
-  local: false
 opa:
   rejectLoadBalancerService:
     enabled: true

--- a/config/providers/openstack/common-config.yaml
+++ b/config/providers/openstack/common-config.yaml
@@ -35,8 +35,6 @@ ingressNginx:
       type: LoadBalancer
       annotations: {}
       allocateLoadBalancerNodePorts: true
-externalTrafficPolicy:
-  local: false
 opa:
   rejectLoadBalancerService:
     enabled: false

--- a/config/providers/safespring/common-config.yaml
+++ b/config/providers/safespring/common-config.yaml
@@ -32,8 +32,6 @@ ingressNginx:
     service:
       enabled: false
       allocateLoadBalancerNodePorts: true
-externalTrafficPolicy:
-  local: false
 opa:
   rejectLoadBalancerService:
     enabled: true

--- a/config/providers/upcloud/common-config.yaml
+++ b/config/providers/upcloud/common-config.yaml
@@ -28,8 +28,6 @@ ingressNginx:
     service:
       enabled: false
       allocateLoadBalancerNodePorts: true
-externalTrafficPolicy:
-  local: false
 opa:
   rejectLoadBalancerService:
     enabled: true

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -2734,7 +2734,7 @@ properties:
       local:
         title: Local External Traffic Policy
         type: boolean
-        default: false
+        default: true
       whitelistRange:
         title: Allowlist Range
         description: |-


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->


### Release notes

Default external traffic policy is now set to `local`. If your infrastructure doesn't support this, please set `.externalTrafficPolicy.local` to false.

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Documentation checks:
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required no updates
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required an update - [link to change](set-me\)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
