### PR TITLE
Upgrade Grafana to 11.3.0 and chart to 8.5.9 to fix CVE-2024-9264

### DIFF
--- a/helmfile.d/upstream/grafana/grafana/Chart.yaml
+++ b/helmfile.d/upstream/grafana/grafana/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/grafana/grafana
 apiVersion: v2
-appVersion: 11.2.1
+appVersion: 11.3.0
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.com
 icon: https://artifacthub.io/image/b4fed1a7-6c8f-4945-b99d-096efa3e4116
@@ -32,4 +32,4 @@ sources:
 - https://github.com/grafana/grafana
 - https://github.com/grafana/helm-charts
 type: application
-version: 8.5.2
+version: 8.5.9

--- a/helmfile.d/upstream/grafana/grafana/README.md
+++ b/helmfile.d/upstream/grafana/grafana/README.md
@@ -165,7 +165,7 @@ need to instead set `global.imageRegistry`.
 | `lifecycleHooks`                          | Lifecycle hooks for podStart and preStop [Example](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/#define-poststart-and-prestop-handlers)     | `{}`                                                    |
 | `sidecar.image.registry`                  | Sidecar image registry                        | `quay.io`                          |
 | `sidecar.image.repository`                | Sidecar image repository                      | `kiwigrid/k8s-sidecar`                          |
-| `sidecar.image.tag`                       | Sidecar image tag                             | `1.26.0`                                                |
+| `sidecar.image.tag`                       | Sidecar image tag                             | `1.28.0`                                                |
 | `sidecar.image.sha`                       | Sidecar image sha (optional)                  | `""`                                                    |
 | `sidecar.imagePullPolicy`                 | Sidecar image pull policy                     | `IfNotPresent`                                          |
 | `sidecar.resources`                       | Sidecar resources                             | `{}`                                                    |

--- a/helmfile.d/upstream/grafana/grafana/templates/_config.tpl
+++ b/helmfile.d/upstream/grafana/grafana/templates/_config.tpl
@@ -13,6 +13,8 @@ grafana.ini: |
   {{- if not (kindIs "map" $elemVal) }}
   {{- if kindIs "invalid" $elemVal }}
   {{ $elem }} =
+  {{- else if kindIs "slice" $elemVal }}
+  {{ $elem }} = {{ toJson $elemVal }}
   {{- else if kindIs "string" $elemVal }}
   {{ $elem }} = {{ tpl $elemVal $ }}
   {{- else }}
@@ -26,6 +28,8 @@ grafana.ini: |
   {{- range $elem, $elemVal := $value }}
   {{- if kindIs "invalid" $elemVal }}
   {{ $elem }} =
+  {{- else if kindIs "slice" $elemVal }}
+  {{ $elem }} = {{ toJson $elemVal }}
   {{- else if kindIs "string" $elemVal }}
   {{ $elem }} = {{ tpl $elemVal $ }}
   {{- else }}

--- a/helmfile.d/upstream/grafana/grafana/templates/_pod.tpl
+++ b/helmfile.d/upstream/grafana/grafana/templates/_pod.tpl
@@ -649,6 +649,9 @@ containers:
     volumeMounts:
       - name: sc-datasources-volume
         mountPath: "/etc/grafana/provisioning/datasources"
+      {{- with .Values.sidecar.datasources.extraMounts }}
+      {{- toYaml . | trim | nindent 6 }}
+      {{- end }}
 {{- end}}
 {{- if .Values.sidecar.notifiers.enabled }}
   - name: {{ include "grafana.name" . }}-sc-notifiers
@@ -753,6 +756,9 @@ containers:
     volumeMounts:
       - name: sc-notifiers-volume
         mountPath: "/etc/grafana/provisioning/notifiers"
+      {{- with .Values.sidecar.notifiers.extraMounts }}
+      {{- toYaml . | trim | nindent 6 }}
+      {{- end }}
 {{- end}}
 {{- if .Values.sidecar.plugins.enabled }}
   - name: {{ include "grafana.name" . }}-sc-plugins
@@ -857,6 +863,9 @@ containers:
     volumeMounts:
       - name: sc-plugins-volume
         mountPath: "/etc/grafana/provisioning/plugins"
+      {{- with .Values.sidecar.plugins.extraMounts }}
+      {{- toYaml . | trim | nindent 6 }}
+      {{- end }}
 {{- end}}
   - name: {{ .Chart.Name }}
     {{- $registry := .Values.global.imageRegistry | default .Values.image.registry -}}

--- a/helmfile.d/upstream/grafana/grafana/templates/deployment.yaml
+++ b/helmfile.d/upstream/grafana/grafana/templates/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and (not .Values.autoscaling.enabled) (.Values.replicas) }}
+  {{- if (not .Values.autoscaling.enabled) }}
   replicas: {{ .Values.replicas }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}

--- a/helmfile.d/upstream/grafana/grafana/values.yaml
+++ b/helmfile.d/upstream/grafana/grafana/values.yaml
@@ -861,7 +861,7 @@ sidecar:
     # -- The Docker registry
     registry: quay.io
     repository: kiwigrid/k8s-sidecar
-    tag: 1.27.4
+    tag: 1.28.0
     sha: ""
   imagePullPolicy: IfNotPresent
   resources: {}
@@ -923,7 +923,7 @@ sidecar:
     # This is needed if skipReload is true, to load any alerts defined at startup time.
     # Deploy the alert sidecar as an initContainer.
     initAlerts: false
-    # Additional alert sidecar volume mounts
+    # Additional alerts sidecar volume mounts
     extraMounts: []
     # Sets the size limit of the alert sidecar emptyDir volume
     sizeLimit: {}
@@ -1001,7 +1001,7 @@ sidecar:
       allowUiUpdates: false
       # allow Grafana to replicate dashboard structure from filesystem
       foldersFromFilesStructure: false
-    # Additional dashboard sidecar volume mounts
+    # Additional dashboards sidecar volume mounts
     extraMounts: []
     # Sets the size limit of the dashboard sidecar emptyDir volume
     sizeLimit: {}
@@ -1056,6 +1056,8 @@ sidecar:
     # This is needed if skipReload is true, to load any datasources defined at startup time.
     # Deploy the datasources sidecar as an initContainer.
     initDatasources: false
+    # Additional datasources sidecar volume mounts
+    extraMounts: []
     # Sets the size limit of the datasource sidecar emptyDir volume
     sizeLimit: {}
   plugins:
@@ -1096,6 +1098,8 @@ sidecar:
     # Deploy the datasource sidecar as an initContainer in addition to a container.
     # This is needed if skipReload is true, to load any plugins defined at startup time.
     initPlugins: false
+    # Additional plugins sidecar volume mounts
+    extraMounts: []
     # Sets the size limit of the plugin sidecar emptyDir volume
     sizeLimit: {}
   notifiers:
@@ -1136,6 +1140,8 @@ sidecar:
     # Deploy the notifier sidecar as an initContainer in addition to a container.
     # This is needed if skipReload is true, to load any notifiers defined at startup time.
     initNotifiers: false
+    # Additional notifiers sidecar volume mounts
+    extraMounts: []
     # Sets the size limit of the notifier sidecar emptyDir volume
     sizeLimit: {}
 

--- a/helmfile.d/upstream/index.yaml
+++ b/helmfile.d/upstream/index.yaml
@@ -46,7 +46,7 @@ charts:
 
   goharbor/harbor: 1.15.0
 
-  grafana/grafana: 8.5.2
+  grafana/grafana: 8.5.9
 
   jetstack/cert-manager: v1.12.8
 


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [x] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

### Security notice

Upgrades Grafana to `11.3.0` to fix CVE-2024-9264

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
This PR upgrades the Grafana chart to v8.5.9 which upgrades the Grafana image to `11.3.0` containing a critical severity fix for [CVE-2024-9264](https://grafana.com/blog/2024/10/17/grafana-security-release-critical-severity-fix-for-cve-2024-9264/). The CVE is only exploitable if `duckdb` binary is available, which is not packaged by default and as such not in Welkin either (by default). The `k8s-sidecar` image has also been updated with this change from `v1.27.4` to `v1.28.0` which contains fixes for high and critical CVEs.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

There seems to be an issue with this image causing a bunch of warning logs when accessing dashboards:

```console
logger=base.plugin.context t=2024-10-21T07:28:46.027774702Z level=warn msg="Could not create user agent" error="invalid user agent format"
```

Already exists an issue for this: https://github.com/grafana/grafana/issues/95006

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Documentation checks:
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required no updates
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required an update - [link to change](set-me\)
- Metrics checks:
  - [x] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
