### PR TITLE
Delete admin-rbac last in clean scripts

### DIFF
--- a/scripts/clean-sc.sh
+++ b/scripts/clean-sc.sh
@@ -37,7 +37,7 @@ fi
 "${here}/.././bin/ck8s" ops velero sc uninstall
 
 # Destroy all helm releases
-"${here}/.././bin/ck8s" ops helmfile sc -l app!=cert-manager destroy
+"${here}/.././bin/ck8s" ops helmfile sc -l app!=cert-manager -l app!=admin-rbac destroy
 
 # Clean up namespaces and any other resources left behind by the apps
 "${here}/.././bin/ck8s" ops kubectl sc delete ns dex opensearch-system harbor fluentd-system gatekeeper-system thanos ingress-nginx monitoring kured falco velero
@@ -132,3 +132,5 @@ if [ -n "$GATE_CONS" ]; then
     # shellcheck disable=SC2086
     "${here}/.././bin/ck8s" ops kubectl sc delete --ignore-not-found=true $GATE_CONS
 fi
+
+"${here}/.././bin/ck8s" ops helmfile sc -l app=admin-rbac destroy

--- a/scripts/clean-wc.sh
+++ b/scripts/clean-wc.sh
@@ -49,7 +49,7 @@ fi
 "${here}/.././bin/ck8s" ops velero wc uninstall
 
 # Destroy all helm releases
-"${here}/.././bin/ck8s" ops helmfile wc -l app!=cert-manager destroy
+"${here}/.././bin/ck8s" ops helmfile wc -l app!=cert-manager -l app!=admin-rbac destroy
 
 # Clean up namespaces and any other resources left behind by the apps
 "${here}/.././bin/ck8s" ops kubectl wc delete ns alertmanager falco fluentd-system fluentd gatekeeper-system hnc-system ingress-nginx monitoring velero kured
@@ -120,3 +120,5 @@ mapfile -t HNC_CRDS < <("${here}/.././bin/ck8s" ops kubectl wc api-resources --a
 if [[ "${#HNC_CRDS[@]}" -gt 0 ]]; then
     "${here}/.././bin/ck8s" ops kubectl wc delete crds "${HNC_CRDS[@]}"
 fi
+
+"${here}/.././bin/ck8s" ops helmfile wc -l app=admin-rbac destroy


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
If cluster admin RBAC does not exist besides the one created with the `admin-rbac` chart part of apps, the clean scripts will not complete since the cluster user might not have permissions anymore:

```console
Error from server (Forbidden): customresourcedefinitions.apiextensions.k8s.io "subnamespaceanchors.hnc.x-k8s.io" is forbidden: User "<cluster-admin-user>" cannot delete resource "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope
```

This PR simply makes it so that the `admin-rbac` chart is deleted last by the clean scripts to ensure that all apps are deleted without relying on RBAC existing outside of the platform.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Documentation checks:
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required no updates
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required an update - [link to change](set-me\)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
