### PR TITLE
Rebrand to Welkin in configuration documentation

### DIFF
--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -1,6 +1,6 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: https://github.com/elastisys/compliantkubernetes-apps/raw/main/config/schemas/config.yaml
-title: Compliant Kubernetes Apps Config
+title: Welkin Apps Config
 description: |-
   This describes the structure of the config for both the service and workload clusters.
 
@@ -1155,7 +1155,7 @@ properties:
       - opsDomain
     properties:
       ck8sVersion:
-        title: Compliant Kubernetes Apps version
+        title: Welkin Apps version
         description: |-
           Use version number if you are exactly at a release tag.
           Otherwise use full commit hash of current commit.
@@ -2103,10 +2103,10 @@ properties:
     additionalProperties: false
     title: Storage Classes Config
     description: |-
-      Configuration options for using block storage in Compliant Kubernetes
+      Configuration options for using block storage in Welkin
     properties:
       default:
-        description: The StorageClass to use for all persistent volumes in Compliant Kubernetes.
+        description: The StorageClass to use for all persistent volumes in Welkin.
         type: string
         default: default
     type: object
@@ -2114,7 +2114,7 @@ properties:
     additionalProperties: false
     title: Object Storage Config
     description: |-
-      Configuration options for using object storage in Compliant Kubernetes
+      Configuration options for using object storage in Welkin
 
       This is used for:
 
@@ -3009,7 +3009,7 @@ properties:
       Some preconfigured services can be found under the key `user`.
 
       > [!note]
-      > See [the admin docs](https://elastisys.io/compliantkubernetes/operator-manual/user-managed-crds/) for context.
+      > See [the admin docs](https://elastisys.io/welkin/operator-manual/user-managed-crds/) for context.
     type: object
     additionalProperties: false
     properties:
@@ -3222,7 +3222,7 @@ properties:
     description: |-
       Configure Open Policy Agent, constraints and mutations enforced by Gatekeeper.
 
-      [Compliant Kubernetes contains multiple safeguards to make it easy to follow security best practices](https://elastisys.io/compliantkubernetes/user-guide/safeguards/).
+      [Welkin contains multiple safeguards to make it easy to follow security best practices](https://elastisys.io/welkin/user-guide/safeguards/).
 
       This includes an implementation of constraints and mutations with similar behaviour as Pod Security Policies, and application developer centric safeguards.
     type: object
@@ -3250,7 +3250,7 @@ properties:
           Configure constraint to disallow configured tags on container images.
 
           > [!note]
-          > See [the dev docs](https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-no-latest-tag/) for context.
+          > See [the dev docs](https://elastisys.io/welkin/user-guide/safeguards/enforce-no-latest-tag/) for context.
         type: object
         additionalProperties: false
         properties:
@@ -3284,7 +3284,7 @@ properties:
           Configure constraint to only allow configured registries for container images.
 
           > [!note]
-          > See [the dev docs](https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-trusted-registries/) for context.
+          > See [the dev docs](https://elastisys.io/welkin/user-guide/safeguards/enforce-trusted-registries/) for context.
         type: object
         additionalProperties: false
         properties:
@@ -3324,7 +3324,7 @@ properties:
           Configure constraint to only allow Deployments and StatefulSets with more than one replica.
 
           > [!note]
-          > See [the dev docs](https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-minimum-replicas/) for context.
+          > See [the dev docs](https://elastisys.io/welkin/user-guide/safeguards/enforce-minimum-replicas/) for context.
         type: object
         additionalProperties: false
         properties:
@@ -3350,7 +3350,7 @@ properties:
           Configure constraint to only allow Pods targeted by NetworkPolicies.
 
           > [!note]
-          > See [the dev docs](https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-networkpolicies/) for context.
+          > See [the dev docs](https://elastisys.io/welkin/user-guide/safeguards/enforce-networkpolicies/) for context.
         type: object
         additionalProperties: false
         properties:
@@ -3378,7 +3378,7 @@ properties:
           Advantageous if the cluster cannot automatically provision LoadBalancers, e.g. because the infrastructure provider do not offer such Kubernetes integration.
 
           > [!note]
-          > See [the dev docs](https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-no-load-balancer-service/) for context.
+          > See [the dev docs](https://elastisys.io/welkin/user-guide/safeguards/enforce-no-load-balancer-service/) for context.
         type: object
         additionalProperties: false
         properties:
@@ -3404,7 +3404,7 @@ properties:
           Configure constraint to only allow Pods configured with resource requests.
 
           > [!note]
-          > See [the dev docs](https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-resources/) for context.
+          > See [the dev docs](https://elastisys.io/welkin/user-guide/safeguards/enforce-resources/) for context.
         additionalProperties: false
         properties:
           enabled:
@@ -3440,7 +3440,7 @@ properties:
               Configure mutations to set time to live on deployed Jobs.
 
               > [!note]
-              > See [the dev docs](https://elastisys.io/compliantkubernetes/user-guide/safeguards/enforce-job-ttl/) for context.
+              > See [the dev docs](https://elastisys.io/welkin/user-guide/safeguards/enforce-job-ttl/) for context.
             type: object
             additionalProperties: false
             properties:
@@ -3563,7 +3563,7 @@ properties:
 
           > [!note]
           > Many of these must be configured to support an air-gapped environment.
-          > See [the admin documentation](https://elastisys.io/compliantkubernetes/operator-manual/air-gapped/#trivy) for reference.
+          > See [the admin documentation](https://elastisys.io/welkin/operator-manual/air-gapped/#trivy) for reference.
         type: object
         additionalProperties: false
         properties:
@@ -3749,7 +3749,7 @@ properties:
     description: |-
       Configure Grafana, the metrics visualisation dashboard.
 
-      Compliant Kubernetes hosts two instances of Grafana one for the Platform Administrator and one for the Application Developer.
+      Welkin hosts two instances of Grafana one for the Platform Administrator and one for the Application Developer.
 
       > [!note]
       > Grafana is installed in the service cluster, so this configuration mainly applies there.
@@ -4181,7 +4181,7 @@ properties:
             title: Proemtheus Storage Enabled
             description: |-
               By default Prometheus instances run without storage and are treated as ephemeral.
-              See [ADR-0007](https://elastisys.io/compliantkubernetes/adr/0007-make-monitoring-forwarders-storage-independent/) for context.
+              See [ADR-0007](https://elastisys.io/welkin/adr/0007-make-monitoring-forwarders-storage-independent/) for context.
             type: boolean
             default: false
           size:
@@ -4811,7 +4811,7 @@ properties:
             releasenotes:
               description: Link to release notes for the component
               examples:
-                - https://elastisys.io/compliantkubernetes/release-notes/
+                - https://elastisys.io/welkin/release-notes/
               format: uri
               type: string
             subdomain:

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -9,7 +9,7 @@ $defs:
   component:
     deprecated: true
     additionalProperties: false
-    description: This is meant to describe the base class if you will, for ck8s resources.
+    description: This is meant to describe the base class if you will, for Welkin resources.
     properties:
       affinity:
         $ref: '#/$defs/io.k8s.api.core.v1.Affinity'

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -1182,7 +1182,7 @@ properties:
         title: Environment name
         type: string
         examples:
-          - my-ck8s-cluster
+          - my-welkin-cluster
       ck8sFlavor:
         type: string
         enum:

--- a/config/schemas/secrets.yaml
+++ b/config/schemas/secrets.yaml
@@ -1,6 +1,6 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: https://github.com/elastisys/compliantkubernetes-apps/raw/main/config/schemas/secrets.yaml
-title: Compliant Kubernetes Apps Secrets
+title: Welkin Apps Secrets
 description: |
   This describes the structure of the secrets for both the service and workload clusters.
 $comment: |
@@ -27,14 +27,14 @@ properties:
   objectStorage:
     title: Object Storage Secrets
     description: |-
-      Configuration options for using object storage in Compliant Kubernetes.
+      Configuration options for using object storage in Welkin.
     type: object
     properties:
       azure:
         additionalProperties: false
         title: Azure Backend Secrets
         description: |-
-          Secrets for using Azure as object storage in Compliant Kubernetes.
+          Secrets for using Azure as object storage in Welkin.
         type: object
         properties:
           storageAccountName:
@@ -47,7 +47,7 @@ properties:
         additionalProperties: false
         title: S3 Backend Secrets
         description: |-
-          Secrets for using S3 as object storage in Compliant Kubernetes.
+          Secrets for using S3 as object storage in Welkin.
         type: object
         properties:
           accessKey:
@@ -60,7 +60,7 @@ properties:
         additionalProperties: false
         title: Swift Backend Secrets
         description: |-
-          Secrets for using Swift as object storage in Compliant Kubernetes.
+          Secrets for using Swift as object storage in Welkin.
 
           > [!important]
           > Currently Harbor only supports `username` and `password` authentication.


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [x] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
The <https://elastisys.io> website was recently rebranded to Welkin. Some part of that website are generated from Apps configuration documentation. Therefore this PR rebrands those part of Apps which end up on <https://elastisys.io>.

Note that, rebranding the source code is out-of-scope of that migration project and is a decision-to-be-taken.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Part of an internal issue

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Documentation checks:
  - [x] The [public documentation](https://github.com/elastisys/compliantkubernetes) required no updates
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required an update - [link to change](set-me\)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
