### PR TITLE
tests: update velero e2e backup specs and enable user app test

### DIFF
--- a/tests/end-to-end/velero/resources/backup-spec-sc.yaml
+++ b/tests/end-to-end/velero/resources/backup-spec-sc.yaml
@@ -12,10 +12,13 @@ excludedResources:
   - sbomreports.aquasecurity.github.io
   - vulnerabilityreports.aquasecurity.github.io
 hooks: {}
+includedNamespaces:
+  - monitoring
 itemOperationTimeout: 0s
 labelSelector:
   matchLabels:
     velero: backup
 metadata: {}
+snapshotMoveData: false
 storageLocation: default
 ttl: 720h0m0s

--- a/tests/end-to-end/velero/resources/backup-spec-wc.yaml
+++ b/tests/end-to-end/velero/resources/backup-spec-wc.yaml
@@ -1,8 +1,12 @@
 csiSnapshotTimeout: 0s
 excludedNamespaces:
+  - calico-apiserver
+  - calico-system
   - cert-manager
   - falco
   - fluentd
+  - gatekeeper-system
+  - gpu-operator
   - hnc-system
   - ingress-nginx
   - kube-node-lease
@@ -10,9 +14,9 @@ excludedNamespaces:
   - kube-system
   - kured
   - monitoring
+  - openstack-system
   - rook-ceph
   - velero
-  - gatekeeper-system
   - jaeger-system
   - postgres-system
   - rabbitmq-system
@@ -36,5 +40,6 @@ labelSelector:
     - key: compliantkubernetes.io/nobackup
       operator: DoesNotExist
 metadata: {}
+snapshotMoveData: false
 storageLocation: default
 ttl: 720h0m0s

--- a/tests/end-to-end/velero/user-app.bats
+++ b/tests/end-to-end/velero/user-app.bats
@@ -61,8 +61,6 @@ teardown() {
 }
 
 @test "velero backup and restore user application" {
-  # TODO: Remove skip when fixed https://github.com/elastisys/compliantkubernetes-apps/issues/2321
-  skip "This does not currently work and is a known issue"
 
   backup_name="test-backup-$(date +%s)"
   restore_name="test-restore-$(date +%s)"


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Documentation checks:
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required no updates
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required an update - [link to change](set-me\)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
