### PR TITLE
Add changelog for release v0.42.0

### DIFF
--- a/helmfile.d/charts/grafana-dashboards/files/welcome.md
+++ b/helmfile.d/charts/grafana-dashboards/files/welcome.md
@@ -4,29 +4,28 @@
 
 Here you can find the most relevant features and changes for the last couple of releases of Compliant Kubernetes
 
+- Upgraded Grafana to v11.2.3. **[v0.42]**
+  - Drops support for dashboards using Angular plugins. See [here](https://grafana.com/docs/grafana/latest/developers/angular_deprecation/) for more information.
+- Upgraded Falco to v0.38.2. **[v0.42]**
 - Updated Grafana dashboards containing deprecated panels. **[v0.41]**
 - Grafana was upgraded to v10.4.7. **[v0.41]**
 - Ingress-nginx was upgraded to v1.11.2. **[v0.41]**
   - Drops support for Kubernetes v1.25 and adds support for v1.30.
 - NodeLocal DNS was upgraded to v1.23.1. **[v0.41]**
-- Disabled kured alerts in WC. **[v0.40]**
-- Opensearch and Opensearch dashboards was upgraded to v2.15.0. **[v0.40]**
-- Harbor was upgraded to v2.11.0. **[v0.40]**
-- Dex was upgraded to v2.40.0. **[v0.40]**
 
 ## Public docs
 
-In case you get lost, don't forget to check out the [public docs](https://elastisys.io/compliantkubernetes/). Here are the most common topics:
+In case you get lost, don't forget to check out the [public docs](https://elastisys.io/welkin/). Here are the most common topics:
 
-- [Getting started](https://elastisys.io/compliantkubernetes/user-guide/prepare/)
-- [Maintenance expectations](https://elastisys.io/compliantkubernetes/user-guide/maintenance/)
-- [Adding extra workload admins](https://elastisys.io/compliantkubernetes/user-guide/delegation/#kubernetes-api)
-- [Troubleshooting](https://elastisys.io/compliantkubernetes/user-guide/troubleshooting/)
-- [FAQ](https://elastisys.io/compliantkubernetes/user-guide/faq/)
+- [Getting started](https://elastisys.io/welkin/user-guide/prepare/)
+- [Maintenance expectations](https://elastisys.io/welkin/user-guide/maintenance/)
+- [Adding extra workload admins](https://elastisys.io/welkin/user-guide/delegation/#kubernetes-api)
+- [Troubleshooting](https://elastisys.io/welkin/user-guide/troubleshooting/)
+- [FAQ](https://elastisys.io/welkin/user-guide/faq/)
 
 ## Compliant Kubernetes Version
 
-- Apps: **{{ .Values.dashboard.ck8sVersion }}** - [Release Notes](https://elastisys.io/compliantkubernetes/release-notes/)
+- Apps: **{{ .Values.dashboard.ck8sVersion }}** - [Release Notes](https://elastisys.io/welkin/release-notes/)
 
 {{ $baseDomain := .Values.baseDomain }}
 {{ range .Values.dashboard.extraVersions }}

--- a/helmfile.d/charts/opensearch/configurer/files/dashboards-resources/welcome.md
+++ b/helmfile.d/charts/opensearch/configurer/files/dashboards-resources/welcome.md
@@ -4,29 +4,28 @@
 
 Here you can find the most relevant features and changes for the last couple of releases of Compliant Kubernetes
 
+- Upgraded Grafana to v11.2.3. **[v0.42]**
+  - Drops support for dashboards using Angular plugins. See [here](https://grafana.com/docs/grafana/latest/developers/angular_deprecation/) for more information.
+- Upgraded Falco to v0.38.2. **[v0.42]**
 - Updated Grafana dashboards containing deprecated panels. **[v0.41]**
 - Grafana was upgraded to v10.4.7. **[v0.41]**
 - Ingress-nginx was upgraded to v1.11.2. **[v0.41]**
   - Drops support for Kubernetes v1.25 and adds support for v1.30.
 - NodeLocal DNS was upgraded to v1.23.1. **[v0.41]**
-- Disabled kured alerts in WC. **[v0.40]**
-- Opensearch and Opensearch dashboards was upgraded to v2.15.0. **[v0.40]**
-- Harbor was upgraded to v2.11.0. **[v0.40]**
-- Dex was upgraded to v2.40.0. **[v0.40]**
 
 ## Public docs
 
-In case you get lost, don't forget to check out the [public docs](https://elastisys.io/compliantkubernetes/). Here are the most common topics:
+In case you get lost, don't forget to check out the [public docs](https://elastisys.io/welkin/). Here are the most common topics:
 
-- [Getting started](https://elastisys.io/compliantkubernetes/user-guide/prepare/)
-- [Maintenance expectations](https://elastisys.io/compliantkubernetes/user-guide/maintenance/)
-- [Adding extra workload admins](https://elastisys.io/compliantkubernetes/user-guide/delegation/#kubernetes-api)
-- [Troubleshooting](https://elastisys.io/compliantkubernetes/user-guide/troubleshooting/)
-- [FAQ](https://elastisys.io/compliantkubernetes/user-guide/faq/)
+- [Getting started](https://elastisys.io/welkin/user-guide/prepare/)
+- [Maintenance expectations](https://elastisys.io/welkin/user-guide/maintenance/)
+- [Adding extra workload admins](https://elastisys.io/welkin/user-guide/delegation/#kubernetes-api)
+- [Troubleshooting](https://elastisys.io/welkin/user-guide/troubleshooting/)
+- [FAQ](https://elastisys.io/welkin/user-guide/faq/)
 
 ## Compliant Kubernetes Version
 
-- Apps: **{{ .Values.dashboard.ck8sVersion }}** - [Release Notes](https://elastisys.io/compliantkubernetes/release-notes/)
+- Apps: **{{ .Values.dashboard.ck8sVersion }}** - [Release Notes](https://elastisys.io/welkin/release-notes/)
 
 ## Web Portals
 


### PR DESCRIPTION
Just wanted to have some more eyes on the public facing changelog. [Here's](https://github.com/elastisys/compliantkubernetes-apps/blob/staging-0.42.0/changelog/0.42.md) the full changelog for reference