### PR TITLE
apps wc: exclude capi namespaces from hnc

### DIFF
--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -1739,37 +1739,16 @@ properties:
           - resource: networkpolicies
             group: networking.k8s.io
         type: array
-      excludedExtraNamespaces:
-        title: Excluded Extra Namespaces
-        description: |-
-          Extra excluded namespace, here we should add the namespaces that are more likely to change
-
-          [Including and excluding namespaces](https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/docs/user-guide/how-to.md#including-and-excluding-namespaces-from-hnc)
-        items:
-          type: string
-        type: array
       excludedNamespaces:
         title: Excluded Namespaces
         description: |-
-          Excluded namespaces
+          Namespaces excluded by HNC, here you can configure a list of namespaces to exclude from HNC in addition to the default excluded namespaces.
+
+          [Including and excluding namespaces](https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/docs/user-guide/how-to.md#including-and-excluding-namespaces-from-hnc)
         items:
           examples:
-            - alertmanager
-            - cert-manager
-            - falco
-            - fluentd
-            - fluentd-system
-            - gatekeeper-system
-            - hnc-system
-            - ingress-nginx
-            - kube-node-lease
-            - kube-public
-            - kube-system
-            - kured
-            - metallb-system
-            - monitoring
-            - rook-ceph
-            - velero
+            - mongodb-system
+            - sealed-secrets
           type: string
         type: array
       ha:

--- a/config/wc-config.yaml
+++ b/config/wc-config.yaml
@@ -172,27 +172,8 @@ hnc:
   ## Included namespaces, empty string will include all
   includedNamespacesRegex: ""
 
-  ## Excluded namespaces
-  excludedNamespaces:
-    - alertmanager
-    - cert-manager
-    - falco
-    - fluentd
-    - fluentd-system
-    - hnc-system
-    - ingress-nginx
-    - kube-node-lease
-    - kube-public
-    - kube-system
-    - kured
-    - monitoring
-    - rook-ceph
-    - velero
-    - gatekeeper-system
-    - metallb-system
-
   ## Extra excluded namespace, here we should add the namespaces that are more likely to change
-  excludedExtraNamespaces: []
+  excludedNamespaces: []
 
   ## Additional resources to enable opt-in propagation for.
   ## Objects that should be propagated must have one of the annotations listed here https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/docs/user-guide/how-to.md#limit-the-propagation-of-an-object-to-descendant-namespaces

--- a/helmfile.d/values/hnc/controller.yaml.gotmpl
+++ b/helmfile.d/values/hnc/controller.yaml.gotmpl
@@ -4,12 +4,30 @@ excludedNamespaces:
   {{- with .Values.hnc.excludedNamespaces }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
-  {{- with .Values.hnc.excludedExtraNamespaces }}
-  {{- toYaml . | nindent 2 }}
-  {{- end }}
   {{- with (keys .Values.user.constraints) }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+  - alertmanager
+  - calico-apiserver
+  - calico-system
+  - cert-manager
+  - falco
+  - fluentd
+  - fluentd-system
+  - gatekeeper-system
+  - gpu-operator
+  - hnc-system
+  - ingress-nginx
+  - kube-node-lease
+  - kube-public
+  - kube-system
+  - kured
+  - metallb-system
+  - monitoring
+  - openstack-system
+  - rook-ceph
+  - tigera-operator
+  - velero
 
 unpropagatedAnnotations: {{- toYaml .Values.hnc.unpropagatedAnnotations | nindent 2 }}
 managedNamespaceAnnotations: {{- toYaml .Values.hnc.managedNamespaceAnnotations | nindent 2 }}

--- a/migration/v0.43/README.md
+++ b/migration/v0.43/README.md
@@ -82,6 +82,8 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ./bin/ck8s upgrade wc v0.43 apply
     ```
 
+1. The config for `.hnc.excludedExtraNamespaces` has been moved to `.hnc.excludedNamespaces`. As such aliases used for `.hnc.excludedExtraNamespaces` in `$CK8S_CONFIG_PATH/wc-config.yaml` may be overwritten to the actual values, and need to be manually replaced with the alias again if desired.
+
 1. If Tekton is enabled, ensure to add appropriate network policies that allow traffic from Tekton to OpenSearch.
 
     To check if the tekton is enabled, run the following command
@@ -149,6 +151,11 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
     ```bash
     ./migration/v0.43/prepare/10-capacity-alerts.sh
+
+1. Migrate `.hnc.excludedExtraNamespaces` to `.hnc.excludedNamespaces`:
+
+    ```bash
+    ./migration/v0.43/prepare/20-hnc-config.sh
     ```
 
 1. Update apps configuration:

--- a/migration/v0.43/prepare/20-hnc-config.sh
+++ b/migration/v0.43/prepare/20-hnc-config.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+  log_info "operation on workload cluster"
+  if ! yq_null wc .hnc.excludedExtraNamespaces; then
+    if yq_null wc .hnc.excludedNamespaces; then
+      yq_move wc .hnc.excludedExtraNamespaces .hnc.excludedNamespaces
+    else
+      yq4 -i '.hnc.excludedNamespaces = ((.hnc.excludedExtraNamespaces | explode(.)) + (.hnc.excludedNamespaces | explode(.)))' "$CK8S_CONFIG_PATH"/wc-config.yaml
+      yq_remove wc .hnc.excludedExtraNamespaces
+    fi
+  fi
+fi


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [x] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->


### Platform Administrator notice
The `hnc.excludedNamespaces` configuration option has been removed, you can use `hnc.excludedExtraNamespaces` if you need additional excluded namespaces.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Documentation checks:
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required no updates
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required an update - [link to change](set-me\)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
