### PR TITLE
apps: dropping some falco rules

### DIFF
--- a/helmfile.d/values/falco/falco-common.yaml.gotmpl
+++ b/helmfile.d/values/falco/falco-common.yaml.gotmpl
@@ -95,6 +95,32 @@ customRules:
   {{- end }}
   overwrites.yaml: |-
     {{- if .Values.falco.rulesFiles.default.enabled }}
+    # Dropping these rules since they are a relatively weak indication of intrusion.
+    # They would also require a significant amount of tuning before they are really useful.
+    - rule: Read sensitive file trusted after startup
+      enabled: false
+      override:
+        enabled: replace
+    - rule: Read sensitive file untrusted
+      enabled: false
+      override:
+        enabled: replace
+
+    # Dropping these rules since they produce significant spam due to false positives.
+    # For the same reasons they are also not a strong indication of intrusion.
+    - rule: Terminal shell in container
+      enabled: false
+      override:
+        enabled: replace
+    - rule: Contact K8S API Server From Container
+      enabled: false
+      override:
+        enabled: replace
+    - rule: Redirect STDOUT/STDIN to Network Connection in Container
+      enabled: false
+      override:
+        enabled: replace
+
     # This will be added in a later falco rules version as well
     # The fix was added upstream here (with a new condition): https://github.com/falcosecurity/rules/pull/177
     - macro: allowed_clear_log_files
@@ -106,7 +132,6 @@ customRules:
 
     # Adding a repository to this list will add an exception to the rules:
     # Run shell untrusted
-    # Contact K8S API Server From Container
     - list: trusted_image_repositories
       items:
         - docker.io/calico/ctl
@@ -164,35 +189,9 @@ customRules:
         - registry.k8s.io/sig-storage/csi-resizer
         - registry.k8s.io/sig-storage/csi-snapshotter
 
-    # Contact K8S API Server From Container
-    - macro: user_known_contact_k8s_api_server_activities
-      condition: >
-        (
-          container.image.repository in (trusted_image_repositories)
-        ) or (
-          container.image.repository = "docker.io/bitnami/kubectl" and
-          k8s.ns.name = "gatekeeper-system" and
-          k8s.pod.name startswith "gatekeeper-templates-wait"
-        ) or (
-          container.image.repository = "gcr.io/tekton-releases/dogfooding/tkn" and
-          k8s.ns.name = "tekton-pipelines" and
-          k8s.pod.name startswith "cleanup-runs"
-        )
-
     # Run shell untrusted
     - macro: user_shell_container_exclusions
       condition: ( container.image.repository in (trusted_image_repositories) )
-
-    # Read sensitive file trusted after startup
-    - macro: user_known_read_sensitive_files_activities
-      condition: ( container.image.repository in (ghcr.io/elastisys/spilo-15, ghcr.io/zalando/spilo-15) )
-
-    # Redirect STDOUT/STDIN to Network Connection in Container
-    - macro: user_known_stand_streams_redirect_activities
-      condition: (
-          (container.image.repository = quay.io/calico/node and proc.name = calico-node) or
-          (container.image.repository = registry.k8s.io/dns/k8s-dns-node-cache and proc.name = node-cache)
-        )
 
     {{- if and .Values.calicoAccountant.enabled (eq .Values.calicoAccountant.backend "nftables") }}
 


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Based on [this internal product management discussion](https://github.com/elastisys/ck8s-arch/issues/235).

This PR drops a few falco rules and removes some of our special modifications to those rules.

Dropping these rules since they are a relatively weak indication of intrusion. They would also require a significant amount of tuning before they are really useful.
- Read sensitive file trusted after startup
- Read sensitive file untrusted

Dropping these rules since they produce significant spam due to false positives. For the same reasons they are also not a strong indication of intrusion.
- Terminal shell in container
- Contact K8S API Server From Container
- Redirect STDOUT/STDIN to Network Connection in Container

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [x] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Documentation checks:
  - [x] The [public documentation](https://github.com/elastisys/compliantkubernetes) required no updates
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required an update - [link to change](set-me\)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
