### PR TITLE
apps: use node-group label in node resource request alerts

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -415,21 +415,10 @@ prometheus:
     nodeCpuLimit1h: 95
     nodeMemoryLimit1h: 85
     ## for each cpu and memory add the node pattern for which you want to create an alert
-    requestlimit:
-      cpu:
-        - name: worker
-          pattern: ".*-worker-.*"
-          limit: 80
-        - name: elastisys
-          pattern: ".*-elastisys-.*"
-          limit: 80
-      memory:
-        - name: worker
-          pattern: ".*-worker-.*"
-          limit: 80
-        - name: elastisys
-          pattern: ".*-elastisys-.*"
-          limit: 80
+    requestLimit:
+      cpu: 80
+      memory: 80
+    nodeGroupRequestsExcludePattern: ""
   diskAlerts:
     storage:
       predictLinear:

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -4076,7 +4076,7 @@ properties:
             description: Alert when a disk's usage reaches the limit in percent.
             type: number
             default: 75
-          requestlimit:
+          requestLimit:
             title: Capacity Management Alerts Request Limit
             description: Alert when a node's resource requests reaches the limits in percent.
             type: object
@@ -4084,34 +4084,20 @@ properties:
             properties:
               cpu:
                 title: Capacity Management Alerts CPU Request Limit
-                $ref: "#/properties/prometheus/$defs/capacityManagementAlerts/properties/requestlimitList"
+                description: Configure a CPU request percentage limit to alert for.
+                type: number
+                default: 80
               memory:
                 title: Capacity Management Alerts Memory Request Limit
-                $ref: "#/properties/prometheus/$defs/capacityManagementAlerts/properties/requestlimitList"
-          requestlimitList:
-            title: Capacity Management Alerts Request Limit List
-            description: Configure a list of node patterns and request limits to alert for.
-            type: array
-            items:
-              $ref: "#/properties/prometheus/$defs/capacityManagementAlerts/properties/requestlimitTerm"
-          requestlimitTerm:
-            title: Capacity Management Alerts Request Limit Term
-            description: Configure a node pattern and the request limit to alert for.
-            type: object
-            additionalProperties: false
-            properties:
-              name:
-                type: string
-                examples:
-                  - worker
-              pattern:
-                type: string
-                examples:
-                  - .*-worker-.*
-              limit:
+                description: Configure a memory request percentage limit to alert for.
                 type: number
-                examples:
-                  - 80
+                default: 80
+          nodeGroupRequestsExcludePattern:
+            title: Capacity Management Alerts Request Exclude Pattern
+            description: Configure a pattern of node groups to exclude from the resource request alerts. This can be used to exclude certain node groups from request alerts, while still getting usage alerts for those node groups.
+            type: string
+            default: ""
+            examples: ".*redis.*|.*postgres.*"
       diskAlerts:
         title: Disk Alerts
         description: Definitions for disk alerts.
@@ -4421,8 +4407,10 @@ properties:
             $ref: "#/properties/prometheus/$defs/capacityManagementAlerts/properties/persistentVolume"
           disklimit:
             $ref: "#/properties/prometheus/$defs/capacityManagementAlerts/properties/disklimit"
-          requestlimit:
-            $ref: "#/properties/prometheus/$defs/capacityManagementAlerts/properties/requestlimit"
+          requestLimit:
+            $ref: "#/properties/prometheus/$defs/capacityManagementAlerts/properties/requestLimit"
+          nodeGroupRequestsExcludePattern:
+            $ref: "#/properties/prometheus/$defs/capacityManagementAlerts/properties/nodeGroupRequestsExcludePattern"
           usagelimit:
             default: 95
             type: number

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/cluster-capacity-management-alerts.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/cluster-capacity-management-alerts.yaml
@@ -53,55 +53,58 @@ spec:
     {{- end }}
     - alert: NodeGroupCPU{{.Values.capacityManagementAlertsNodeGroupCpuLimit24h}}PercentOver24h
       annotations:
-        message: CPU usage has been over {{.Values.capacityManagementAlertsNodeGroupCpuLimit24h}}% on average over the span of 24h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} on Cluster {{`{{ $labels.cluster }}`}}.
+        message: CPU usage has been over {{.Values.capacityManagementAlertsNodeGroupCpuLimit24h}}% on average over the span of 24h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
       expr: avg by (label_elastisys_io_node_group,cluster) (sum by (instance) (rate(node_cpu_seconds_total{mode!='idle',cluster=~".*"}[24h])) / on (instance) instance:node_num_cpu:sum * on (instance) group_left (label_elastisys_io_node_group,cluster) label_replace(kube_node_labels{label_elastisys_io_node_group!=""}, "instance", "$1", "node", "(.*)")) > {{.Values.capacityManagementAlertsNodeGroupCpuLimit24h}}/100
       for: 5m
       labels:
         severity: warning
     - alert: NodeGroupCPU{{.Values.capacityManagementAlertsNodeGroupCpuLimit1h}}PercentOver1h
       annotations:
-        message: CPU usage has been over {{.Values.capacityManagementAlertsNodeGroupCpuLimit1h}}% on average over the span of 1h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} on Cluster {{`{{ $labels.cluster }}`}}.
+        message: CPU usage has been over {{.Values.capacityManagementAlertsNodeGroupCpuLimit1h}}% on average over the span of 1h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
       expr: avg by (label_elastisys_io_node_group,cluster) (sum by (instance) (rate(node_cpu_seconds_total{mode!='idle',cluster=~".*"}[1h])) / on (instance) instance:node_num_cpu:sum * on (instance) group_left (label_elastisys_io_node_group,cluster) label_replace(kube_node_labels{label_elastisys_io_node_group!=""}, "instance", "$1", "node", "(.*)")) > {{.Values.capacityManagementAlertsNodeGroupCpuLimit1h}}/100
       for: 5m
       labels:
         severity: warning
     - alert: NodeGroupMemory{{.Values.capacityManagementAlertsNodeGroupMemoryLimit24h}}PercentOver24h
       annotations:
-        message: Memory usage has been over {{.Values.capacityManagementAlertsNodeGroupMemoryLimit24h}}% on average over the span of 24h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} on Cluster {{`{{ $labels.cluster }}`}}.
+        message: Memory usage has been over {{.Values.capacityManagementAlertsNodeGroupMemoryLimit24h}}% on average over the span of 24h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
       expr: avg by (label_elastisys_io_node_group,cluster) ((avg_over_time (instance:node_memory_utilisation:ratio{cluster=~".*"}[24h])) * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group!=""}, "instance", "$1", "node", "(.*)")) > {{.Values.capacityManagementAlertsNodeGroupMemoryLimit24h}}/100
       for: 5m
       labels:
         severity: warning
     - alert: NodeGroupMemory{{.Values.capacityManagementAlertsNodeGroupMemoryLimit1h}}PercentOver1h
       annotations:
-        message: Memory usage has been over {{.Values.capacityManagementAlertsNodeGroupMemoryLimit1h}}% on average over the span of 1h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} on Cluster {{`{{ $labels.cluster }}`}}.
+        message: Memory usage has been over {{.Values.capacityManagementAlertsNodeGroupMemoryLimit1h}}% on average over the span of 1h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
       expr: avg by (label_elastisys_io_node_group,cluster) ((avg_over_time (instance:node_memory_utilisation:ratio{cluster=~".*"}[1h])) * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group!=""}, "instance", "$1", "node", "(.*)")) > {{.Values.capacityManagementAlertsNodeGroupMemoryLimit1h}}/100
       for: 5m
       labels:
         severity: warning
     - alert: NodeCPU{{.Values.capacityManagementAlertsNodeCpuLimit1h}}PercentOver1h
       annotations:
-        message: CPU usage has been over {{.Values.capacityManagementAlertsNodeCpuLimit1h}}% on average over the span of 1h for the node {{`{{ $labels.instance }}`}} on Cluster {{`{{ $labels.cluster }}`}}.
+        message: CPU usage has been over {{.Values.capacityManagementAlertsNodeCpuLimit1h}}% on average over the span of 1h for the node {{`{{ $labels.instance }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
       expr: sum by (instance) (rate(node_cpu_seconds_total{mode!='idle',cluster=~".*"}[1h])) / on (instance) instance:node_num_cpu:sum * on (instance) group_left (label_elastisys_io_node_group,cluster) label_replace(kube_node_labels{label_elastisys_io_node_group!=""}, "instance", "$1", "node", "(.*)") > {{.Values.capacityManagementAlertsNodeCpuLimit1h}}/100
       for: 5m
       labels:
         severity: warning
     - alert: NodeMemory{{.Values.capacityManagementAlertsNodeMemoryLimit1h}}PercentOver1h
       annotations:
-        message: Memory usage has been over {{.Values.capacityManagementAlertsNodeMemoryLimit1h}}% on average over the span of 1h for the Node {{`{{ $labels.instance }}`}} on Cluster {{`{{ $labels.cluster }}`}}.
+        message: Memory usage has been over {{.Values.capacityManagementAlertsNodeMemoryLimit1h}}% on average over the span of 1h for the Node {{`{{ $labels.instance }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
       expr: avg_over_time (instance:node_memory_utilisation:ratio{cluster=~".*"}[1h]) * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group!=""}, "instance", "$1", "node", "(.*)") > {{.Values.capacityManagementAlertsNodeMemoryLimit1h}}/100
       for: 5m
       labels:
         severity: warning
-    {{- range $resource, $patterns := .Values.capacityManagementAlertsRequestLimit }}
-    {{- range $pattern := $patterns }}
-    - alert: {{ $resource | title }}Request{{ $pattern.limit }}Percent{{ $pattern.name | title }}
+    - alert: NodeGroupCpuRequest{{ .Values.capacityManagementAlertsCpuRequestLimit }}Percent
       annotations:
-        message: {{ $resource | title }} request has been over {{ $pattern.limit }}% on {{ $pattern.name }} nodes in cluster {{`{{ $labels.cluster }}`}}.
-      expr: sum by(cluster) (kube_pod_container_resource_requests{node=~"{{ $pattern.pattern }}",cluster=~".*",namespace=~".*",resource="{{ $resource }}"} and on(pod, namespace, cluster) kube_pod_status_phase{cluster=~".*",namespace=~".*",phase="Running"} == 1) / sum by(cluster) (kube_node_status_allocatable{node=~"{{ $pattern.pattern }}",cluster=~".*",resource="{{ $resource }}"}) >= {{ $pattern.limit }} / 100
+        message: Average CPU requests is over {{ .Values.capacityManagementAlertsCpuRequestLimit }}% in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
+      expr: avg by (label_elastisys_io_node_group,cluster) (sum by (node,cluster) (kube_pod_container_resource_requests{cluster=~".*",namespace=~".*",resource="cpu"} and on(pod, namespace, cluster) kube_pod_status_phase{cluster=~".*",namespace=~".*",phase="Running"} == 1) / (sum by(node,cluster) (kube_node_status_allocatable{cluster=~".*",resource="cpu"})) * on (node) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group!~'{{ .Values.capacityManagementAlertsRequestsExcludePattern }}'}, "instance", "$1", "node", "(.*)")) >= 20/100
       for: 5m
       labels:
         severity: warning
-    {{- end }}
-    {{- end }}
+    - alert: NodeGroupMemoryRequest{{ .Values.capacityManagementAlertsMemoryRequestLimit }}Percent
+      annotations:
+        message: Average memory requests is over {{ .Values.capacityManagementAlertsMemoryRequestLimit }}% in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
+      expr: avg by (label_elastisys_io_node_group,cluster) (sum by (node,cluster) (kube_pod_container_resource_requests{cluster=~".*",namespace=~".*",resource="memory"} and on(pod, namespace, cluster) kube_pod_status_phase{cluster=~".*",namespace=~".*",phase="Running"} == 1) / (sum by(node,cluster) (kube_node_status_allocatable{cluster=~".*",resource="memory"})) * on (node) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group!~'{{ .Values.capacityManagementAlertsRequestsExcludePattern }}'}, "instance", "$1", "node", "(.*)")) >= 20/100
+      for: 5m
+      labels:
+        severity: warning
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/values.yaml
+++ b/helmfile.d/charts/prometheus-alerts/values.yaml
@@ -141,6 +141,9 @@ capacityManagementAlertsNodeGroupCpuLimit1h: 95
 capacityManagementAlertsNodeGroupMemoryLimit1h: 85
 capacityManagementAlertsNodeCpuLimit1h: 95
 capacityManagementAlertsNodeMemoryLimit1h: 85
+capacityManagementAlertsCpuRequestLimit: 80
+capacityManagementAlertsMemoryRequestLimit: 80
+capacityManagementAlertsRequestsExcludePattern: ""
 
 buckets:
   harbor: set-me

--- a/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
@@ -49,7 +49,9 @@ capacityManagementAlertsPersistentVolumeLimit: {{ .Values.prometheus.capacityMan
 capacityManagementAlertsDiskLimit: {{ .Values.prometheus.capacityManagementAlerts.disklimit }}
 capacityManagementAlertsPredictUsage: {{ .Values.prometheus.capacityManagementAlerts.predictUsage }}
 capacityManagementAlertsUsageLimit: {{ .Values.prometheus.capacityManagementAlerts.usagelimit }}
-capacityManagementAlertsRequestLimit: {{ toYaml .Values.prometheus.capacityManagementAlerts.requestlimit | nindent 2 }}
+capacityManagementAlertsCpuRequestLimit: {{ toYaml .Values.prometheus.capacityManagementAlerts.requestLimit.cpu | nindent 2 }}
+capacityManagementAlertsMemoryRequestLimit: {{ toYaml .Values.prometheus.capacityManagementAlerts.requestLimit.memory | nindent 2 }}
+capacityManagementAlertsRequestsExcludePattern: {{ .Values.prometheus.capacityManagementAlerts.nodeGroupRequestsExcludePattern }}
 capacityManagementAlertsNodeGroupCpuLimit24h: {{ .Values.prometheus.capacityManagementAlerts.nodeGroupCpuLimit24h }}
 capacityManagementAlertsNodeGroupMemoryLimit24h: {{ .Values.prometheus.capacityManagementAlerts.nodeGroupMemoryLimit24h }}
 capacityManagementAlertsNodeGroupCpuLimit1h: {{ .Values.prometheus.capacityManagementAlerts.nodeGroupCpuLimit1h }}

--- a/helmfile.d/values/prometheus-user-alerts-wc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-user-alerts-wc.yaml.gotmpl
@@ -32,7 +32,10 @@ capacityManagementAlertsDiskLimit: {{ .Values.prometheus.capacityManagementAlert
 capacityManagementAlertsPredictUsage: {{ .Values.prometheus.capacityManagementAlerts.predictUsage }}
 capacityManagementAlertsUsageLimit: {{ .Values.prometheus.capacityManagementAlerts.usagelimit }}
 capacityManagementAlertsRequestLimit:
-{{ toYaml .Values.prometheus.capacityManagementAlerts.requestlimit | indent 2 }}
+{{ toYaml .Values.prometheus.capacityManagementAlerts.requestLimit.cpu | indent 2 }}
+capacityManagementAlertsMemoryRequestLimit:
+{{ toYaml .Values.prometheus.capacityManagementAlerts.requestLimit.memory | nindent 2 }}
+capacityManagementAlertsRequestsExcludePattern: {{ .Values.prometheus.capacityManagementAlerts.nodeGroupRequestsExcludePattern }}
 capacityManagementAlertsNodeGroupCpuLimit24h: {{ .Values.prometheus.capacityManagementAlerts.nodeGroupCpuLimit24h }}
 capacityManagementAlertsNodeGroupMemoryLimit24h: {{ .Values.prometheus.capacityManagementAlerts.nodeGroupMemoryLimit24h }}
 capacityManagementAlertsNodeGroupCpuLimit1h: {{ .Values.prometheus.capacityManagementAlerts.nodeGroupCpuLimit1h }}

--- a/migration/v0.43/README.md
+++ b/migration/v0.43/README.md
@@ -116,6 +116,8 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
     This is because of an issue in Harbor where it is saving image data in the path `//docker/` but rclone by default skips the `//` path. So we need to add a manual config to sync that. The default sync job would also remove the docker folder from the destination since it is skipping it in the source, that is why the default job needs to be disabled.
 
+1. The resource request capacity management alerts have been reworked to target the `elastisys.io/node-group` label instead of being based on node name patterns. As such, any previous override config for `prometheus.capacityManagementAlerts.requestLimit` has been removed. These can be manually reconfigured if the new defaults are not suitable.
+
 1. Apply upgrade - _disruptive_
 
     > _Done during maintenance window._
@@ -141,6 +143,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
     ```bash
     export CK8S_CLUSTER=<wc|sc|both>
+    ```
+
+1. Remove outdated capacity alert config:
+
+    ```bash
+    ./migration/v0.43/prepare/10-capacity-alerts.sh
     ```
 
 1. Update apps configuration:

--- a/migration/v0.43/prepare/10-capacity-alerts.sh
+++ b/migration/v0.43/prepare/10-capacity-alerts.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+  log_info "operation on service cluster"
+  yq_remove sc .prometheus.capacityManagementAlerts.requestLimit
+fi
+if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+  log_info "operation on workload cluster"
+  yq_remove wc .prometheus.capacityManagementAlerts.requestLimit
+fi
+
+yq_remove common .prometheus.capacityManagementAlerts.requestLimit


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [x] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice
The resource request capacity management alerts have been reworked to target the `elastisys.io/node-group` label instead of being based on node name patterns. As such, any previous override config for `prometheus.capacityManagementAlerts.requestLimit` will be invalid and needs to be reconfigured or removed to use the new defaults. 

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Update the node resource request capacity alerts to use the `elastisys.io/node-group` label instead of relying on the node names.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2349 

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [x] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [x] The change updates the config *and* the schema
- Documentation checks:
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required no updates
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required an update - [link to change](set-me\)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
