### PR TITLE
feat: exposed customAntiAffinity

### DIFF
--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -1005,6 +1005,15 @@ opensearch:
   ingress:
     maxbodysize: 32m
 
+  customLabelSelector:
+    matchLabels:
+      app.kubernetes.io/name: custom-opensearch
+    matchExpressions:
+      - key: environment
+        operator: In
+        values:
+          - production
+
 opa:
   ## Enable rule that requires pods to come from
   ## the image registry defined by "URL".

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -5300,6 +5300,22 @@ properties:
             $ref: '#/$defs/kubernetesNodeSelector'
           affinity:
             $ref: '#/$defs/io.k8s.api.core.v1.Affinity'
+          customAntiAffinity:
+            title: Custom Anti Affinity
+            description: Define custom anti-affinity rules for OpenSearch.
+            type: object
+            properties:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                description: Hard anti-affinity rules.
+                type: array
+                items:
+                  $ref: '#/$defs/io.k8s.api.core.v1.PodAffinityTerm'
+              preferredDuringSchedulingIgnoredDuringExecution:
+                description: Soft anti-affinity rules.
+                type: array
+                items:
+                  $ref: '#/$defs/io.k8s.api.core.v1.WeightedPodAffinityTerm'
+            additionalProperties: false
       masterNode:
         title: OpenSearch Master Node
         description: |-
@@ -5326,6 +5342,22 @@ properties:
             $ref: '#/$defs/kubernetesTolerations'
           affinity:
             $ref: '#/$defs/io.k8s.api.core.v1.Affinity'
+            customAntiAffinity:
+              title: Custom Anti Affinity
+              description: Define custom anti-affinity rules for OpenSearch.
+              type: object
+              properties:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  description: Hard anti-affinity rules.
+                  type: array
+                  items:
+                    $ref: '#/$defs/io.k8s.api.core.v1.PodAffinityTerm'
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  description: Soft anti-affinity rules.
+                  type: array
+                  items:
+                    $ref: '#/$defs/io.k8s.api.core.v1.WeightedPodAffinityTerm'
+              additionalProperties: false
       dataNode:
         title: OpenSearch Data Node
         description: |-
@@ -5357,6 +5389,22 @@ properties:
             $ref: '#/$defs/kubernetesNodeSelector'
           affinity:
             $ref: '#/$defs/io.k8s.api.core.v1.Affinity'
+          customAntiAffinity:
+            title: Custom Anti Affinity
+            description: Define custom anti-affinity rules for OpenSearch.
+            type: object
+            properties:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                description: Hard anti-affinity rules.
+                type: array
+                items:
+                  $ref: '#/$defs/io.k8s.api.core.v1.PodAffinityTerm'
+              preferredDuringSchedulingIgnoredDuringExecution:
+                description: Soft anti-affinity rules.
+                type: array
+                items:
+                  $ref: '#/$defs/io.k8s.api.core.v1.WeightedPodAffinityTerm'
+            additionalProperties: false
       clientNode:
         title: OpenSearch Client Node
         description: |-
@@ -5383,6 +5431,22 @@ properties:
             $ref: '#/$defs/kubernetesNodeSelector'
           affinity:
             $ref: '#/$defs/io.k8s.api.core.v1.Affinity'
+            customAntiAffinity:
+              title: Custom Anti Affinity
+              description: Define custom anti-affinity rules for OpenSearch.
+              type: object
+              properties:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  description: Hard anti-affinity rules.
+                  type: array
+                  items:
+                    $ref: '#/$defs/io.k8s.api.core.v1.PodAffinityTerm'
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  description: Soft anti-affinity rules.
+                  type: array
+                  items:
+                    $ref: '#/$defs/io.k8s.api.core.v1.WeightedPodAffinityTerm'
+              additionalProperties: false
       extraRoles:
         title: OpenSearch Extra Roles
         description: Configures extra roles for OpenSearch Security.
@@ -5751,6 +5815,30 @@ properties:
               In an air-gapped environment this can be used to install plugins from known sources.
             type: array
         type: object
+      customLabelSelector:
+        title: Custom Label Selector
+        description: |-
+          Custom label selector for pod anti-affinity rules. If not set, defaults to the standard OpenSearch labels.
+        type: object
+        properties:
+          matchLabels:
+            type: object
+            additionalProperties:
+              type: string
+          matchExpressions:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                operator:
+                  type: string
+                  enum: ["In", "NotIn", "Exists", "DoesNotExist"]
+                values:
+                  type: array
+                  items:
+                    type: string
     required:
       - enabled
       - subdomain

--- a/helmfile.d/upstream/opensearch-project/opensearch/templates/statefulset.yaml
+++ b/helmfile.d/upstream/opensearch-project/opensearch/templates/statefulset.yaml
@@ -106,7 +106,12 @@ spec:
       {{- end }}
       affinity:
       {{- end }}
-      {{- if eq .Values.antiAffinity "hard" }}
+      {{- if eq .Values.antiAffinity "custom" }}
+        {{- with .Values.customAntiAffinity }}
+        podAntiAffinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- else if eq .Values.antiAffinity "hard" }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -136,11 +141,6 @@ spec:
                   operator: In
                   values:
                   - {{ include "opensearch.name" . }}
-      {{- else if eq .Values.antiAffinity "custom" }}
-        {{- with .Values.customAntiAffinity }}
-        podAntiAffinity:
-{{ toYaml . | indent 10 }}
-        {{- end }}
       {{- end }}
       {{- with .Values.podAffinity }}
         podAffinity:

--- a/helmfile.d/upstream/opensearch-project/opensearch/values.yaml
+++ b/helmfile.d/upstream/opensearch-project/opensearch/values.yaml
@@ -529,3 +529,13 @@ extraObjects: []
   #      selector:
   #        matchLabels:
   #          {{- include "opensearch.selectorLabels" . | nindent 6 }}
+
+# Custom label selector for pod anti-affinity rules
+customLabelSelector: {}
+  # matchLabels:
+  #   app.kubernetes.io/name: opensearch
+  # matchExpressions:
+  #   - key: app.kubernetes.io/instance
+  #     operator: In
+  #     values:
+  #       - opensearch-master


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Fixes #2365, introduced a customLabel to avoid hardcoding [given here](https://github.com/elastisys/compliantkubernetes-apps/blob/5048f03261b9c1b2b9a3028a17091ce475fa7140/config/sc-config.yaml#L826) for exposing customAntiAffinity

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [ ] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Documentation checks:
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required no updates
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required an update - [link to change](set-me\)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
