### PR TITLE
Add extra Application Developer RBAC config

### DIFF
--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -832,6 +832,91 @@ $defs:
         description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
         type: string
     type: object
+  io.k8s.api.rbac.v1.Subject:
+    title: Subject
+    description: Subject contains a reference to the object or user identities a role
+      binding applies to.  This can either hold a direct API object reference, or a
+      value for non-objects such as user and group names.
+    properties:
+      apiGroup:
+        title: Kind
+        description: APIGroup holds the API group of the referenced subject. Defaults
+          to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+          for User and Group subjects.
+        type: string
+      kind:
+        title: Kind
+        description: Kind of object being referenced. Values defined by this API group
+          are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized
+          the kind value, the Authorizer should report an error.
+        type: string
+        enum:
+          - Group
+          - ServiceAccount
+          - User
+      name:
+        title: Name
+        description: Name of the object being referenced.
+        type: string
+      namespace:
+        title: Namespace
+        description: Namespace of the referenced object.  If the object kind is non-namespace,
+          such as "User" or "Group", and this value is not empty the Authorizer should
+          report an error.
+        type: string
+    required:
+    - kind
+    - name
+    type: object
+  io.k8s.api.rbac.v1.PolicyRule:
+    title: PolicyRule
+    description: PolicyRule holds information that describes a policy rule, but does
+      not contain information about who the rule applies to or which namespace the rule
+      applies to.
+    properties:
+      apiGroups:
+        title: APIGroups
+        description: APIGroups is the name of the APIGroup that contains the resources.  If
+          multiple API groups are specified, any action requested against one of the
+          enumerated resources in any API group will be allowed.
+        items:
+          type: string
+        type: array
+      nonResourceURLs:
+        title: NonResourceURLs
+        description: NonResourceURLs is a set of partial urls that a user should have
+          access to.  *s are allowed, but only as the full, final step in the path Since
+          non-resource URLs are not namespaced, this field is only applicable for ClusterRoles
+          referenced from a ClusterRoleBinding. Rules can either apply to API resources
+          (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but
+          not both.
+        items:
+          type: string
+        type: array
+      resourceNames:
+        title: ResourceNames
+        description: ResourceNames is an optional white list of names that the rule
+          applies to.  An empty set means that everything is allowed.
+        items:
+          type: string
+        type: array
+      resources:
+        title: Resources
+        description: Resources is a list of resources this rule applies to.  ResourceAll
+          represents all resources.
+        items:
+          type: string
+        type: array
+      verbs:
+        title: Verbs
+        description: Verbs is a list of Verbs that apply to ALL the ResourceKinds and
+          AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+        items:
+          type: string
+        type: array
+    required:
+    - verbs
+    type: object
   cronSchedule:
     type: string
     pattern: ^(((\*\/)?([0-5]?[0-9])((\,|\-|\/)([0-5]?[0-9]))*|\*)[^\S\r\n]+((\*\/)?((2[0-3]|1[0-9]|[0-9]|00))((\,|\-|\/)(2[0-3]|1[0-9]|[0-9]|00))*|\*)[^\S\r\n]+((\*\/)?([1-9]|[12][0-9]|3[01])((\,|\-|\/)([1-9]|[12][0-9]|3[01]))*|\*)[^\S\r\n]+((\*\/)?([1-9]|1[0-2])((\,|\-|\/)([1-9]|1[0-2]))*|\*|(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec))[^\S\r\n]+((\*\/)?[0-6]((\,|\-|\/)[0-6])*|\*|00|(sun|mon|tue|wed|thu|fri|sat)))$|^@(annually|yearly|monthly|weekly|daily|hourly|reboot)$
@@ -1511,6 +1596,107 @@ properties:
             title: Enable Kafka
             type: boolean
         additionalProperties: false
+      extraRoles:
+        title: Extra Application Developer Roles
+        description: |
+          Configure extra Roles for Application Developers
+          The Roles are added to all Application Developer namespaces configured in user.namespaces
+        type: object
+        properties: {}
+        additionalProperties:
+          properties:
+            rules:
+              title: PolicyRules for this Role
+              description: |
+                PolicyRules for this Role
+                Reference: https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/role-v1/
+              items:
+                $ref: '#/$defs/io.k8s.api.rbac.v1.PolicyRule'
+              type: array
+              default: []
+          additionalProperties: false
+      extraRoleBindings:
+        title: Extra Application Developer RoleBindings
+        description: |
+          Configure extra RoleBindings for Application Developers
+          The RoleBindings are added to all Application Developer namespaces configured in user.namespaces
+        type: object
+        properties: {}
+        additionalProperties:
+          properties:
+            roleRef:
+              title: The reference to a role to use for this RoleBinding
+              description: The reference to a role to use for this RoleBinding
+              type: object
+              properties:
+                name:
+                  title: Name of the Role or ClusterRole to bind subjects with
+                  description: Name of the Role or ClusterRole to bind subjects with
+                  type: string
+                kind:
+                  title: Either ClusterRole or Role
+                  type: string
+                  default: Role
+                  enum:
+                    - ClusterRole
+                    - Role
+              additionalProperties: false
+            subjects:
+              title: Subjects to apply role to
+              description: |
+                Configure Subjects that a role apply to
+                Reference: https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/role-binding-v1/
+              items:
+                $ref: '#/$defs/io.k8s.api.rbac.v1.Subject'
+              type: array
+              default: []
+          additionalProperties: false
+      extraClusterRoles:
+        title: Extra Application Developer ClusterRoles
+        description: |
+          Configure extra ClusterRoles that are not originally part of Welkin
+          These are intended to be used for Application Developers
+        type: object
+        properties: {}
+        additionalProperties:
+          properties:
+            rules:
+              title: PolicyRules for this Role
+              description: |
+                PolicyRules for this ClusterRole
+                Reference: https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1/
+              items:
+                $ref: '#/$defs/io.k8s.api.rbac.v1.PolicyRule'
+              type: array
+              default: []
+          additionalProperties: false
+      extraClusterRoleBindings:
+        title: Extra Application Developer ClusterRoleBindings
+        description: |
+          Configure extra ClusterRoleBindings for Application Developers
+        type: object
+        properties: {}
+        additionalProperties:
+          properties:
+            roleRef:
+              title: The reference to a role to use for this RoleBinding
+              description: The reference to a role to use for this RoleBinding
+              type: object
+              properties:
+                name:
+                  title: Name of the ClusterRole to bind subjects with
+                  type: string
+              additionalProperties: false
+            subjects:
+              title: Subjects to apply role to
+              description: |
+                Configure Subjects that a role apply to
+                Reference: https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/cluster-role-binding-v1/
+              items:
+                $ref: '#/$defs/io.k8s.api.rbac.v1.Subject'
+              type: array
+              default: []
+          additionalProperties: false
   hnc:
     additionalProperties: false
     title: HNC (Hierarchical Namespace Controller) Config

--- a/config/wc-config.yaml
+++ b/config/wc-config.yaml
@@ -73,6 +73,58 @@ user:
   kafka:
     enabled: false
 
+  # Create extra application developer RBAC
+  extraRoles: {}
+  ## Example:
+  # extraRoles:
+  #   example-role:
+  #     rules:
+  #     - apiGroups:
+  #         - ""
+  #       resources:
+  #         - pods
+  #       verbs:
+  #         - get
+  #         - list
+  #         - watch
+
+  extraRoleBindings: {}
+  ## Example:
+  # extraRoleBindings:
+  #   example-rolebinding:
+  #     roleRef:
+  #       name: example-clusterrole
+  #       kind: Role
+  #     subjects:
+  #     - kind: ServiceAccount
+  #       name: example-serviceaccount
+  #       namespace: example-namespace
+
+  extraClusterRoles: {}
+  ## Example:
+  # extraClusterRoles:
+  #   example-clusterrole:
+  #     rules:
+  #     - apiGroups:
+  #         - ""
+  #       resources:
+  #         - pods
+  #       verbs:
+  #         - get
+  #         - list
+  #         - watch
+
+  extraClusterRoleBindings: {}
+  ## Example:
+  # extraClusterRoleBindings:
+  #   example-clusterrolebinding:
+  #     roleRef:
+  #       name: example-clusterrole
+  #     subjects:
+  #     - kind: ServiceAccount
+  #       name: example-serviceaccount
+  #       namespace: example-namespace
+
 falco:
   ## Falco alerting configuration.
   alerts:

--- a/helmfile.d/charts/user-crds/templates/rolebinding.yaml
+++ b/helmfile.d/charts/user-crds/templates/rolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ $namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: {{ $roleBinding.roleRef.kind | default "Role" }}
   name: {{ $roleBinding.roleRef.name }}
 subjects: {{- toYaml $roleBinding.subjects | nindent 2 }}
 {{- end }}

--- a/helmfile.d/charts/user-rbac/templates/clusterrolebindings/user-crds.yaml
+++ b/helmfile.d/charts/user-rbac/templates/clusterrolebindings/user-crds.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.userCRDs.enabled }}
+{{- if and .Values.userCRDs.enabled .Values.userCRDs.resourceNames }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helmfile.d/stacks/rbac.yaml.gotmpl
+++ b/helmfile.d/stacks/rbac.yaml.gotmpl
@@ -51,10 +51,11 @@ templates:
     labels:
       app: dev-rbac
     values:
-      - values/userCRDs/common.yaml.gotmpl
       - values/userCRDs/bitnami/sealedsecrets.yaml.gotmpl
-      - values/userCRDs/mongodbcommunity/mongodb.yaml.gotmpl
+      - values/userCRDs/common.yaml.gotmpl
       - values/userCRDs/flux/fluxv2.yaml.gotmpl
+      - values/userCRDs/mongodbcommunity/mongodb.yaml.gotmpl
+      - values/userCRDs/strimzi/kafka.yaml.gotmpl
 
   dev-rbac-extra:
     inherit: [ template: rbac ]

--- a/helmfile.d/stacks/rbac.yaml.gotmpl
+++ b/helmfile.d/stacks/rbac.yaml.gotmpl
@@ -55,3 +55,16 @@ templates:
       - values/userCRDs/bitnami/sealedsecrets.yaml.gotmpl
       - values/userCRDs/mongodbcommunity/mongodb.yaml.gotmpl
       - values/userCRDs/flux/fluxv2.yaml.gotmpl
+
+  dev-rbac-extra:
+    inherit: [ template: rbac ]
+    condition: ck8sWorkloadCluster.enabled
+    chart: charts/user-crds
+    version: 1.0.0
+    name: dev-rbac-extra
+    needs:
+      - kube-system/user-rbac
+    labels:
+      app: dev-rbac
+    values:
+      - values/dev-rbac-extra.yaml.gotmpl

--- a/helmfile.d/state.yaml
+++ b/helmfile.d/state.yaml
@@ -39,6 +39,7 @@ releases:
   - inherit: [ template: admin-rbac ]
   - inherit: [ template: dev-rbac ]
   - inherit: [ template: dev-rbac-crds ]
+  - inherit: [ template: dev-rbac-extra ]
 
   - inherit: [ template: networkpolicies-common ]
   - inherit: [ template: networkpolicies-service ]

--- a/helmfile.d/values/dev-rbac-extra.yaml.gotmpl
+++ b/helmfile.d/values/dev-rbac-extra.yaml.gotmpl
@@ -1,0 +1,6 @@
+namespaces: {{ toYaml .Values.user.namespaces | nindent 2 }}
+
+roles: {{- toYaml .Values.user.extraRoles | nindent 2 }}
+roleBindings: {{- toYaml .Values.user.extraRoleBindings | nindent 2 }}
+clusterRoles: {{- toYaml .Values.user.extraClusterRoles | nindent 2 }}
+clusterRoleBindings: {{- toYaml .Values.user.extraClusterRoleBindings | nindent 2 }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
As an Platform Administrator, I want a declarative approach for providing additional RBAC to Application Developers without extending the current RBAC provided by Welkin. This can be used for special cases where an application developer might request a service that requires some additional RBAC that they themselves can't delegate.

This also fixes so that  the `user-crds` ClusterRoleBinding is not created unless any userCRD resources have been specified, so now it will be the same check as for the [`user-crds` ClusterRole](https://github.com/elastisys/compliantkubernetes-apps/blob/v0.42.0/helmfile.d/charts/user-rbac/templates/clusterroles/user-crds.yaml#L1).

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Documentation checks:
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required no updates
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required an update - [link to change](set-me\)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
