### PR TITLE
apps sc: add sub path and name suffix to rclone jobs, harbor restore support azure

### DIFF
--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -54,9 +54,12 @@ objectStorage:
     ## Restore targets
     targets: []
       # - destinationName: <bucket-or-container-name>
-      #   # destinationType: <object-storage-type> # optional - defaults to main object storage type
-      #   # sourceName: <bucket-or-container-name> # optional - defaults to destination name
-      #   # sourceType: <object-storage-type> # optional - defaults to sync object storage type
+      #   # destinationType: <object-storage-type> # Optional: if set supported values are 's3', 'azure' or 'swift'. Defaults to value of 'objectStorage.type'
+      #   # destinationPath: /folder/name # Optional: Only sync items from this path. Defaults to ""
+      #   # sourceName: <bucket-or-container-name> # Defaults to value of 'destinationName'
+      #   # sourceType: <object-storage-type> # Optional: if set supported values are 's3', 'azure' or 'swift'. Defaults to value of 'objectStorage.sync.destinationType'
+      #   # sourcePath: /folder/name # Optional: Only sync items from this path. Defaults to ""
+      #   # nameSuffix: custom-name # Optional: Used to add a special suffix to the cronjob name. Defaults to "custom"
 
   ## Off-site backup replication between two providers or regions using rclone sync
   sync:
@@ -64,7 +67,8 @@ objectStorage:
     enabled: false
     dryrun: false
 
-    ## If Harbor or Thanos are using Swift then we will automatically use Swift for the sync of Harbor or Thanos, regardless of the value set for destinationType.
+    ## If Harbor or Thanos are using Swift then we will automatically use Swift for the sync of Harbor or Thanos with 'syncDefaultBuckets', regardless of the value set for destinationType.
+    ## Supported values are 's3', 'azure', 'swift'
     destinationType: s3
     # secondaryUrl: set-me if regionEndpoint and or authUrl does not have all the relevant ips and or ports used for rclone-sync networkpolicy.
     # s3:
@@ -87,11 +91,15 @@ objectStorage:
 
     ## Buckets to sync.
     buckets: []
-      # - source: source-bucket
-      #   # destination: destination-bucket # if unset it will be the same as 'source'
-      #   # schedule: 0 5 * * *             # if unset it will be the same as 'defaultSchedule'
-      #   # sourceType: Optional but if included it uses s3 or swift
-      #   # destinationType: Optional but if included it uses s3 or swift.
+      # - source: <bucket-or-container-name>
+      #   # destination: <bucket-or-container-name> # Defaults to value of 'source'
+      #   # schedule: 0 5 * * * # Defaults to value of 'objectStorage.sync.defaultSchedule'
+      #   # sourceType: <object-storage-type> # Optional: if set supported values are 's3', 'azure' or 'swift'. Defaults to value of 'objectStorage.type'
+      #   # sourcePath: /folder/name # Optional: Only sync items from this path. Defaults to ""
+      #   # destinationType: <object-storage-type> # Optional: if set supported values are 's3', 'azure' or 'swift'. Defaults to value of 'objectStorage.sync.destinationType'
+      #   # destinationPath: /folder/name # Optional: Only sync items from this path. Defaults to ""
+      #   # nameSuffix: custom-name # Optional: Used to add a special suffix to the cronjob name. Defaults to "custom"
+
     # Encrypt (symmetric) before syncing
     encrypt:
       enabled: false

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -1143,6 +1143,44 @@ allOf:
                   ips:
                     title: Network Policies Ingress Override IPs
                     $ref: '#/$defs/iplist'
+- if:
+    allOf:
+      - properties:
+          harbor:
+            properties:
+              persistence:
+                properties:
+                  type:
+                    const: objectStorage
+          objectStorage:
+            properties:
+              type:
+                const: azure
+      - anyOf:
+          - properties:
+              objectStorage:
+                properties:
+                  sync:
+                    properties:
+                      enabled:
+                        const: true
+          - properties:
+              objectStorage:
+                properties:
+                  restore:
+                    properties:
+                      enabled:
+                        const: true
+                      addTargetsFromSync:
+                        const: true
+  then:
+    properties:
+      objectStorage:
+        properties:
+          sync:
+            properties:
+              syncDefaultBuckets:
+                const: false
 properties:
   global:
     title: Global options
@@ -2339,6 +2377,19 @@ properties:
               description: |-
                 List of buckets to sync when `syncDefaultBuckets` is false
               type: object
+              examples:
+              - source: azure-environment-harbor
+                sourceType: azure
+                sourcePath: //docker
+                destinationPath: /docker
+                destinationType: s3
+                nameSuffix: docker
+              - source: azure-environemnt-harbor
+                sourceType: azure
+                sourcePath: /backups
+                destinationPath: /backups
+                destinationType: s3
+                nameSuffix: backups
               required:
                 - source
               properties:
@@ -2362,6 +2413,13 @@ properties:
                     - s3
                     - swift
                     - azure
+                sourcePath:
+                  type: string
+                  title: Path to sync from
+                  description: |-
+                    Rclone will sync all files from this path.
+                    Defaults to "" (root of bucket).
+                  default: ""
                 destinationType:
                   type: string
                   title: Type of destination
@@ -2369,6 +2427,19 @@ properties:
                     - s3
                     - swift
                     - azure
+                destinationPath:
+                  type: string
+                  title: Path to sync to
+                  description: |-
+                    Rclone will sync files to this patch.
+                    Defaults to "" (root of bucket).
+                  default: ""
+                nameSuffix:
+                  type: string
+                  title: Suffix to cronjob name
+                  description: |-
+                    Suffix added to the end of cronjob name.
+                    Defaults to "custom". The default buckets have "default" as suffix
               additionalProperties: false
           destinationType:
             title: Rclone Sync Destination Type
@@ -2472,6 +2543,13 @@ properties:
                     - s3
                     - swift
                     - azure
+                destinationPath:
+                  type: string
+                  title: Path to restore to
+                  description: |-
+                    Rclone will sync files to this patch.
+                    Defaults to "" (root of bucket).
+                  default: ""
                 sourceName:
                   type: string
                   title: Source bucket to sync
@@ -2482,6 +2560,19 @@ properties:
                     - s3
                     - swift
                     - azure
+                sourcePath:
+                  type: string
+                  title: Path to sync from
+                  description: |-
+                    Rclone will sync all files from this path.
+                    Defaults to "" (root of bucket).
+                  default: ""
+                nameSuffix:
+                  type: string
+                  title: Suffix to cronjob name
+                  description: |-
+                    Suffix added to the end of cronjob name.
+                    Defaults to "custom".
               additionalProperties: false
           timestamp:
             title: Rclone Restore Timestamp

--- a/helmfile.d/charts/rclone/templates/cronjobs.yaml
+++ b/helmfile.d/charts/rclone/templates/cronjobs.yaml
@@ -5,7 +5,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels: {{- include "rclone.labels" $ | nindent 4 }}
-  name: {{ printf "%s-%s" (include "rclone.fullname" $) .destinationName | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-%s-%s" (include "rclone.fullname" $) .destinationName .nameSuffix | trunc 63 | trimSuffix "-" }}
 spec:
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: {{ $.Values.failedJobsHistoryLimit }}
@@ -38,14 +38,14 @@ spec:
               args:
                 - sync
                 {{- if get . "sourceCrypt" | default false }}
-                - "decrypt-{{ .sourceName }}:"
+                - "decrypt-{{ .sourceName }}:{{ .sourcePath }}"
                 {{- else }}
-                - "source-{{ .sourceType }}:{{ .sourceName }}"
+                - "source-{{ .sourceType }}:{{ .sourceName }}{{ .sourcePath }}"
                 {{- end }}
                 {{- if get . "destinationCrypt" | default false }}
-                - "encrypt-{{ .destinationName }}:"
+                - "encrypt-{{ .destinationName }}:{{ .destinationPath }}"
                 {{- else }}
-                - "destination-{{ .destinationType }}:{{ .destinationName }}"
+                - "destination-{{ .destinationType }}:{{ .destinationName }}{{ .destinationPath }}"
                 {{- end }}
                 - --log-level
                 - INFO

--- a/helmfile.d/charts/rclone/values.yaml
+++ b/helmfile.d/charts/rclone/values.yaml
@@ -37,12 +37,15 @@ crypt:
 # - Providers translate into the configured provider
 targets:
   - destinationName: dn
+    destinationPath: ""
     destinationCrypt: false
     destinationProvider: dp
     sourceName: sn
+    sourcePath: ""
     sourceCrypt: false
     sourceProvider: sp
     schedule: ""
+    nameSuffix: "default"
 
 # Configure rclone providers
 # Prefix destination providers with "destination-" and source providers with "source-"

--- a/helmfile.d/values/rclone/restore.yaml.gotmpl
+++ b/helmfile.d/values/rclone/restore.yaml.gotmpl
@@ -30,33 +30,42 @@ targets:
 
     {{- $destinations = append $destinations $destinationType }}
     destinationType: {{ $destinationType }}
+    destinationPath: ""
     sourceName: {{ $value }}
     sourceCrypt: {{ $crypt | get "enabled" false }}
     {{- $sources = append $sources $sourceType }}
     sourceType: {{ $sourceType }}
+    sourcePath: ""
+    nameSuffix: default
   {{- end }}
   {{- end }}
 
   {{- range $sync.buckets }}
   - destinationName: {{ .source }}
-    {{- $destinations = get "sourceType" $main.type . | append $destinations }}
-    destinationType: {{ get "sourceType" $main.type . }}
-    sourceName: {{ get "destination" .source . }}
+    {{- $destinations = . | get "sourceType" $main.type | append $destinations }}
+    destinationType: {{ . | get "sourceType" $main.type }}
+    destinationPath: {{ . | get "sourcePath" "" }}
+    sourceName: {{ . | get "destination" .source }}
     sourceCrypt: {{ $crypt | get "enabled" false }}
-    {{- $sources = get "destinationType" $sync.destinationType . | append $sources }}
-    sourceType: {{ get "destinationType" $sync.destinationType . }}
+    {{- $sources = . | get "destinationType" $sync.destinationType | append $sources }}
+    sourceType: {{ . | get "destinationType" $sync.destinationType }}
+    sourcePath: {{ . | get "destinationPath" "" }}
+    nameSuffix: {{ . | get "nameSuffix" "custom" }}
   {{- end }}
 
   {{- end }}
 
   {{- range $restore.targets }}
   - destinationName: {{ .destinationName }}
-    {{- $destinations = get "destinationType" $main.type . | append $destinations }}
-    destinationType: {{ get "destinationType" $main.type . }}
-    sourceName: {{ get "sourceName" .destinationName . }}
+    {{- $destinations = . | get "destinationType" $main.type | append $destinations }}
+    destinationType: {{ . | get "destinationType" $main.type }}
+    destinationPath: {{ . | get "destinationPath" "" }}
+    sourceName: {{ . | get "sourceName" .destinationName }}
     sourceCrypt: {{ $crypt | get "enabled" false }}
-    {{- $sources = get "sourceType" $sync.destinationType . | append $sources }}
-    sourceType: {{ get "sourceType" $sync.destinationType . }}
+    {{- $sources = . | get "sourceType" $sync.destinationType | append $sources }}
+    sourceType: {{ . | get "sourceType" $sync.destinationType }}
+    sourcePath: {{ . | get "sourcePath" "" }}
+    nameSuffix: {{ . | get "nameSuffix" "custom" }}
   {{- end }}
 
 providers:

--- a/helmfile.d/values/rclone/sync.yaml.gotmpl
+++ b/helmfile.d/values/rclone/sync.yaml.gotmpl
@@ -35,23 +35,29 @@ targets:
 
     {{- $destinations = append $destinations $destinationType }}
     destinationType: {{ $destinationType }}
+    destinationPath: ""
     sourceName: {{ $value }}
     {{- $sources = append $sources $sourceType }}
     sourceType: {{ $sourceType }}
+    sourcePath: ""
+    nameSuffix: default
   {{- end }}
   {{- end }}
 
   {{- range $sync.buckets }}
-  - destinationName: {{ get "destination" .source . }}
+  - destinationName: {{ . | get "destination" .source }}
     destinationCrypt: {{ $crypt | get "enabled" false }}
-    {{- $destinations = get "destinationType" $sync.destinationType . | append $destinations }}
-    destinationType: {{ get "destinationType" $sync.destinationType . }}
+    {{- $destinations = . | get "destinationType" $sync.destinationType | append $destinations }}
+    destinationType: {{ . | get "destinationType" $sync.destinationType }}
+    destinationPath: {{ . | get "destinationPath" "" }}
     sourceName: {{ .source }}
-    {{- $sources = get "sourceType" $main.type . | append $sources }}
-    sourceType: {{ get "sourceType" $main.type . }}
-    {{- with get "schedule" "" . }}
+    {{- $sources = . | get "sourceType" $main.type | append $sources }}
+    sourceType: {{ . | get "sourceType" $main.type }}
+    sourcePath: {{ . | get "sourcePath" "" }}
+    {{- with . | get "schedule" "" }}
     schedule: {{ . }}
     {{- end }}
+    nameSuffix: {{ . | get "nameSuffix" "custom" }}
   {{- end }}
 
 providers:

--- a/restore/harbor/harbor-rclone-azure.yaml
+++ b/restore/harbor/harbor-rclone-azure.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+stringData:
+  rclone.conf: |-
+    [azure]
+    account = ${AZURE_ACCOUNT}
+    key = ${AZURE_KEY}
+    type = azureblob
+kind: Secret
+metadata:
+  name: harbor-restore-rclone-move
+  namespace: harbor
+type: Opaque
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: harbor-restore-rclone-move
+  namespace: harbor
+spec:
+  activeDeadlineSeconds: 14400
+  selector:
+    matchLabels:
+      job-name: harbor-restore-rclone-move
+  template:
+    metadata:
+      labels:
+        job-name: harbor-restore-rclone-move
+    spec:
+      containers:
+      - args:
+        - move
+        - azure:${S3_BUCKET}/docker
+        - azure:${S3_BUCKET}//docker
+        - --log-level
+        - INFO
+        image: ghcr.io/elastisys/rclone-sync:1.63.0
+        imagePullPolicy: IfNotPresent
+        name: rclone
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 500Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /home/rclone/.config/rclone/
+          name: config
+      restartPolicy: Never
+      volumes:
+      - name: config
+        secret:
+          defaultMode: 420
+          secretName: harbor-restore-rclone-move
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-harbor-restore-rclone-move-egress
+  namespace: harbor
+spec:
+  policyTypes:
+    - Egress
+  podSelector:
+    matchLabels:
+      job-name: harbor-restore-rclone-move
+  egress:
+  - {}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Harbor in azure puts image data at `<bucket-name>//docker/` instead of `<bucket-name>/docker/`. This causes issues both when restoring data to harbor in azure and when rclone is syncing from azure.

Restoring from s3 to azure:
When rcloning to azure from s3 rclone will by default put the data at the same folder as in s3 (`<bucket-name>/docker/`). So then we need to move it to the correct folder for azure. This is done with the new rclone move job in `restore/harbor/`. 

Rclone syncing from azure:
When running rclone sync on a harbor bucket in azure, then rclone will by default ignore the image folder because of the `//` in the path. This can be fixed by running a rclone sync job that specifically targets `<bucket-name>//docker` in the source. Then send it to `<bucket-name>//docker/` if the destination is azure and `<bucket-name>/docker/` if the destination is s3 (note that sending to `//docker` in s3 will translate into `/docker`, but in the next sync rclone will not find anything in `//docker` so it will send all files again). However, the default rclone sync job for harbor will then delete everything in the `docker` folder at the destination (because it is skipping that folder at the source). So we need to disable the default sync jobs and instead create a second custom job for harbor that is syncing `/backups` as well (the only other folder in the bucket).

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2303 

#### Information to reviewers

At time of writing this PR I still need to do some updates to the config schema, do some documentation updates, and add maybe add migration for running azure clusters. But the code should be complete.

I have tested the following things that are expected to work:

- Syncing from s3 to azure and then using the restore script to move the folders and see that harbor works as expected.
- Syncing from azure to s3 with the custom sync jobs
- Syncing from azure to s3 with encryption
- Running restore job from encrypted backup using addTargetsFromSync
- Maybe something more as well :slightly_smiling_face: 

Example of sync config from azure to s3:

```yaml
objectStorage:
  sync:
    enabled: true
    destinationType: s3
    syncDefaultBuckets: false
    buckets:
      - source: viktor-harbor
        sourcePath: //docker
        destinationPath: /docker
        nameSuffix: docker
      - source: viktor-harbor
        sourcePath: /backups
        destinationPath: /backups
        nameSuffix: backups
    # config for the other default buckets need to be added here as well
```

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Documentation checks:
  - [x] The [public documentation](https://github.com/elastisys/compliantkubernetes) required no updates
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required an update - [link to change](set-me\)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [ ] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
