### PR TITLE
Don't get Cluster API resource metrics in workload cluster

### DIFF
--- a/helmfile.d/stacks/monitoring-prometheus.yaml.gotmpl
+++ b/helmfile.d/stacks/monitoring-prometheus.yaml.gotmpl
@@ -14,7 +14,7 @@ templates:
     needs:
       - monitoring/networkpolicy
       - monitoring/podsecuritypolicy
-      {{- if .Values | get "clusterApi.enabled" false }}
+      {{- if and (.Values | get "ck8sManagementCluster.enabled" false) (.Values | get "clusterApi.enabled" false) }}
       - monitoring/kube-state-metrics-extra-resource-metrics
       {{- end }}
     values:
@@ -90,6 +90,7 @@ templates:
 
   kube-state-metrics-extra-resources:
     inherit: [ template: prometheus ]
+    condition: ck8sManagementCluster.enabled
     installed: {{ .Values | get "clusterApi.enabled" "false" }}
     chart: charts/kube-state-metrics-extra-resource-metrics
     version: 0.1.0

--- a/helmfile.d/values/kube-prometheus-stack-wc.yaml.gotmpl
+++ b/helmfile.d/values/kube-prometheus-stack-wc.yaml.gotmpl
@@ -22,47 +22,6 @@ prometheusOperator:
 
 kube-state-metrics:
   resources: {{- toYaml .Values.kubeStateMetrics.resources | nindent 4 }}
-  {{- if .Values.clusterApi.enabled }}
-  rbac:
-    extraRules:
-      - apiGroups:
-          - apiextensions.k8s.io
-        resources:
-          - customresourcedefinitions
-        verbs:
-          - list
-          - watch
-      - apiGroups:
-          - cluster.x-k8s.io
-        resources:
-          - clusters
-          - machinedeployments
-          - machinesets
-          - machines
-          - machinehealthchecks
-          - machinepools
-        verbs:
-          - get
-          - list
-          - watch
-      - apiGroups:
-          - controlplane.cluster.x-k8s.io
-        resources:
-          - kubeadmcontrolplanes
-        verbs:
-          - get
-          - list
-          - watch
-  volumeMounts:
-    - mountPath: /etc/config
-      name: kube-state-metrics-clusterapi-volume
-  volumes:
-    - configMap:
-        name: kube-state-metrics-clusterapi
-      name: kube-state-metrics-clusterapi-volume
-  extraArgs:
-    - "--custom-resource-state-config-file=/etc/config/clusterapi-metrics.yaml"
-  {{- end }}
 
   metricLabelsAllowlist:
   - nodes=[topology.kubernetes.io/zone,elastisys.io/node-group,node.kubernetes.io/instance-type]


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

*Optional*: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change   <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security     <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr]()      <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Noticed a bunch of error logs in my Cluster API workload cluster from kube-state-metrics pod:

```console
E1217 14:47:13.509297       1 reflector.go:158] "Unhandled Error" err="pkg/mod/k8s.io/client-go@v0.31.2/tools/cache/reflector.go:243: Failed to watch cluster.x-k8s.io/v1beta1, Kind=Machine: failed to list cluster.x-k8s.io/v1beta1, Kind=Machine: the server could not find the requested resource" logger="UnhandledError"
```

I do not believe we ever have Cluster API resources in the workload clusters so this PR removes the configuration for getting metrics for Cluster API resources in the workload cluster.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
  <!-- Example of commit message prefixes:
  - all: changes to multiple areas
  - apps: changes to applications running in all clusters
  - apps sc: changes to applications running in the service cluster
  - apps wc: changes to applications running in the workload cluster
  - bin: changes to management binaries or scripts
  - config: changes to configuration
  - docs: changes to documentation
  - release: release related
  - scripts: changes to other scripts
  - tests: changes to tests
  -->
- Change checks:
  - [x] The change is transparent
  - [ ] The change is disruptive
  - [ ] The change requires no migration steps
  - [ ] The change requires migration steps
  - [ ] The change upgrades CRDs
  - [ ] The change updates the config *and* the schema
- Documentation checks:
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required no updates
  - [ ] The [public documentation](https://github.com/elastisys/compliantkubernetes) required an update - [link to change](set-me\)
- Metrics checks:
  - [ ] The metrics are still exposed and present in Grafana after the change
  - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts are not affected)
  - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts were fixed)
- Logs checks:
  - [x] The logs do not show any errors after the change
- Pod Security Policy checks:
  - [ ] Any changed pod is covered by Pod Security Admission
  - [ ] Any changed pod is covered by Gatekeeper Pod Security Policies
  - [ ] The change does not cause any pods to be blocked by Pod Security Admission or Policies
- Network Policy checks:
  - [ ] Any changed pod is covered by Network Policies
  - [ ] The change does not cause any dropped packets in the `NetworkPolicy Dashboard`
- Audit checks:
  - [ ] The change does not cause any unnecessary Kubernetes audit events
  - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
  - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
  - [ ] The bug fix is covered by regression tests
