### PR TITLE
apps: Mirror Bitnami images

### DIFF
--- a/helmfile.d/values/gatekeeper/templates.yaml.gotmpl
+++ b/helmfile.d/values/gatekeeper/templates.yaml.gotmpl
@@ -1,3 +1,7 @@
+image:
+  repository: ghcr.io/elastisys/bitnami/kubectl
+  tag: 1.29.11
+
 waitFor:
   - k8sallowedrepos
   - k8sdisallowedtags

--- a/helmfile.d/values/thanos/query.yaml.gotmpl
+++ b/helmfile.d/values/thanos/query.yaml.gotmpl
@@ -1,5 +1,9 @@
 existingObjstoreSecret: thanos-objectstorage-secret-objstore-secret
 
+image:
+  registry: ghcr.io
+  repository: elastisys/bitnami/thanos
+
 query:
   networkPolicy:
     enabled: false

--- a/helmfile.d/values/thanos/receiver.yaml.gotmpl
+++ b/helmfile.d/values/thanos/receiver.yaml.gotmpl
@@ -1,5 +1,9 @@
 existingObjstoreSecret: thanos-objectstorage-secret-objstore-secret
 
+image:
+  registry: ghcr.io
+  repository: elastisys/bitnami/thanos
+
 query:
   enabled: false
 

--- a/helmfile.d/values/velero-sc.yaml.gotmpl
+++ b/helmfile.d/values/velero-sc.yaml.gotmpl
@@ -175,6 +175,10 @@ containerSecurityContext:
 
 # For kubectl containers
 kubectl:
+  image:
+    repository: ghcr.io/elastisys/bitnami/kubectl
+    tag: 1.29.11
+
   containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsNonRoot: true

--- a/helmfile.d/values/velero-wc.yaml.gotmpl
+++ b/helmfile.d/values/velero-wc.yaml.gotmpl
@@ -181,6 +181,10 @@ containerSecurityContext:
 
 # For kubectl containers
 kubectl:
+  image:
+    repository: ghcr.io/elastisys/bitnami/kubectl
+    tag: 1.29.11
+
   containerSecurityContext:
     allowPrivilegeEscalation: false
     runAsNonRoot: true

--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,10 @@
+# Images
+
+This directory contains images built for Welkin Apps.
+
+Other mirrored images includes:
+
+- `docker.io/bitnami/kubectl` -> `ghcr.io/elastisys/bitnami/kubectl`
+    - used in `gatekeeper-templates` and `velero`
+- `docker.io/bitnami/thanos` -> `ghcr.io/elastisys/bitnami/thanos`
+    - used in `thanos`


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This mirrors the Bitnami images used by Apps to ensure availability after their policy change is in effect starting the 7th.

I should note that this upgrades kubectl used by gatekeeper templates wait, as it was left on 1.25.

- Fixes https://github.com/elastisys/ck8s-issue-tracker/issues/407

#### Information to reviewers

I believe this is it, others that were listed as potential ones to be mirrored:
- fluentd-aggregator
    - is using a custom built image and is missing its containerfile
- elasticsearch-curator
    - is using a custom built image
- minio (as part of the thanos chart)
    - is not used (the minio chart for local-clusters is using another upstream)

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
