### PR TITLE
Fixes and improvements to kube-stack-prometheus alerts

### DIFF
--- a/helmfile.d/charts/prometheus-alerts/CHANGELOG.md
+++ b/helmfile.d/charts/prometheus-alerts/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2025.01.03
+
+1. helmfile.d/charts/prometheus-alerts/templates/alerts/alertmanager.rules.yaml
+    - MODIFIED - Added runbookURLs for the alertmanager alerts
+
 ## 2022.12.01
 
 1. helmfile/charts/prometheus-alerts/templates/alerts/kubernetes-system-kubelet.yaml

--- a/helmfile.d/charts/prometheus-alerts/CHANGELOG.md
+++ b/helmfile.d/charts/prometheus-alerts/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 1. helmfile.d/charts/prometheus-alerts/templates/alerts/alertmanager.rules.yaml
     - MODIFIED - Added runbookURLs for the alertmanager alerts
+1. helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-resources.yaml
+    - MODIFIED - KubeCPUOvercommit properly compute per cluster as done upstream
+    - MODIFIED - KubeMemoryOvercommit properly compute per cluster as done upstream
 
 ## 2022.12.01
 

--- a/helmfile.d/charts/prometheus-alerts/CHANGELOG.md
+++ b/helmfile.d/charts/prometheus-alerts/CHANGELOG.md
@@ -7,6 +7,11 @@
 1. helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-resources.yaml
     - MODIFIED - KubeCPUOvercommit properly compute per cluster as done upstream
     - MODIFIED - KubeMemoryOvercommit properly compute per cluster as done upstream
+1. helmfile.d/charts/prometheus-alerts/templates/alerts/kube-state-metrics.yaml
+    - MODIFIED - KubeStateMetricsListErrors properly compute per cluster as done upstream
+    - MODIFIED - KubeStateMetricsWatchErrors properly compute per cluster as done upstream
+    - MODIFIED - KubeStateMetricsShardingMismatch properly compute per cluster as done upstream
+    - MODIFIED - KubeStateMetricsShardsMissing properly compute per cluster as done upstream
 
 ## 2022.12.01
 

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/alertmanager.rules.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/alertmanager.rules.yaml
@@ -28,6 +28,7 @@ spec:
     - alert: AlertmanagerConfigInconsistent
       annotations:
         description: Alertmanager instances within the {{`{{`}}$labels.job{{`}}`}} cluster have different configurations.
+        runbook_url: {{ .Values.defaultRules.runbookUrl }}/alertmanager/alertmanagerconfiginconsistent
         summary: Alertmanager instances within the same cluster have different configurations.
       expr: |-
         count by (cluster,service) (
@@ -40,6 +41,7 @@ spec:
     - alert: AlertmanagerFailedReload
       annotations:
         description: Configuration has failed to load for {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod{{`}}`}}.
+        runbook_url: {{ .Values.defaultRules.runbookUrl }}/alertmanager/alertmanagerfailedreload
         summary: Reloading an Alertmanager configuration has failed.
       expr: |-
         # Without max_over_time, failed scrapes could create false negatives, see
@@ -51,6 +53,7 @@ spec:
     - alert: AlertmanagerMembersInconsistent
       annotations:
         description: Alertmanager {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod{{`}}`}} has only found {{`{{`}} $value {{`}}`}} members of the {{`{{`}}$labels.job{{`}}`}} cluster.
+        runbook_url: {{ .Values.defaultRules.runbookUrl }}/alertmanager/alertmanagermembersinconsistent
         summary: A member of an Alertmanager cluster has not found all other cluster members.
       expr: |-
         # Without max_over_time, failed scrapes could create false negatives, see

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kube-state-metrics.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kube-state-metrics.yaml
@@ -23,9 +23,9 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}kube-state-metrics/kubestatemetricslisterrors
         summary: kube-state-metrics is experiencing errors in list operations.
       expr: |-
-        (sum(rate(kube_state_metrics_list_total{job="kube-state-metrics",result="error"}[5m]))
+        (sum(rate(kube_state_metrics_list_total{job="kube-state-metrics",result="error"}[5m])) by (cluster)
           /
-        sum(rate(kube_state_metrics_list_total{job="kube-state-metrics"}[5m])))
+        sum(rate(kube_state_metrics_list_total{job="kube-state-metrics"}[5m])) by (cluster))
         > 0.01
       for: 15m
       labels:
@@ -39,9 +39,9 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}kube-state-metrics/kubestatemetricswatcherrors
         summary: kube-state-metrics is experiencing errors in watch operations.
       expr: |-
-        (sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics",result="error"}[5m]))
+        (sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics",result="error"}[5m])) by (cluster)
           /
-        sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics"}[5m])))
+        sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics"}[5m])) by (cluster))
         > 0.01
       for: 15m
       labels:
@@ -54,7 +54,7 @@ spec:
         description: kube-state-metrics pods are running with different --total-shards configuration, some Kubernetes objects may be exposed multiple times or not exposed at all.
         runbook_url: {{ .Values.defaultRules.runbookUrl }}kube-state-metrics/kubestatemetricsshardingmismatch
         summary: kube-state-metrics sharding is misconfigured.
-      expr: stdvar (kube_state_metrics_total_shards{job="kube-state-metrics"}) != 0
+      expr: stdvar (kube_state_metrics_total_shards{job="kube-state-metrics"}) by (cluster) != 0
       for: 15m
       labels:
         severity: critical
@@ -67,9 +67,9 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}kube-state-metrics/kubestatemetricsshardsmissing
         summary: kube-state-metrics shards are missing.
       expr: |-
-        2^max(kube_state_metrics_total_shards{job="kube-state-metrics"}) - 1
+        2^max(kube_state_metrics_total_shards{job="kube-state-metrics"}) by (cluster) - 1
           -
-        sum( 2 ^ max by (shard_ordinal) (kube_state_metrics_shard_ordinal{job="kube-state-metrics"}) )
+        sum( 2 ^ max by (shard_ordinal) (kube_state_metrics_shard_ordinal{job="kube-state-metrics"})) by (cluster)
         != 0
       for: 15m
       labels:

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-resources.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-resources.yaml
@@ -23,9 +23,9 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubecpuovercommit
         summary: Cluster has overcommitted CPU resource requests.
       expr: |-
-        sum(namespace_cpu:kube_pod_container_resource_requests:sum{}) - (sum(kube_node_status_allocatable{resource="cpu"}) - max(kube_node_status_allocatable{resource="cpu"})) > 0
+        sum(namespace_cpu:kube_pod_container_resource_requests:sum{}) by (cluster) - (sum(kube_node_status_allocatable{resource="cpu"}) by (cluster) - max(kube_node_status_allocatable{resource="cpu"}) by (cluster)) > 0
         and
-        (sum(kube_node_status_allocatable{resource="cpu"}) - max(kube_node_status_allocatable{resource="cpu"})) > 0
+        (sum(kube_node_status_allocatable{resource="cpu"}) by (cluster) - max(kube_node_status_allocatable{resource="cpu"}) by (cluster)) > 0
       for: 10m
       labels:
         severity: warning
@@ -38,9 +38,9 @@ spec:
         runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubememoryovercommit
         summary: Cluster has overcommitted memory resource requests.
       expr: |-
-        sum(namespace_memory:kube_pod_container_resource_requests:sum{}) - (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"})) > 0
+        sum(namespace_memory:kube_pod_container_resource_requests:sum{}) by (cluster) - (sum(kube_node_status_allocatable{resource="memory"}) by (cluster) - max(kube_node_status_allocatable{resource="memory"}) by (cluster)) > 0
         and
-        (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"})) > 0
+        (sum(kube_node_status_allocatable{resource="memory"}) by (cluster) - max(kube_node_status_allocatable{resource="memory"}) by (cluster)) > 0
       for: 10m
       labels:
         severity: warning

--- a/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -3,6 +3,8 @@ defaultRules:
   create: false
 
 kube-state-metrics:
+  selfMonitor:
+    enabled: true
   resources: {{- toYaml .Values.kubeStateMetrics.resources | nindent 4 }}
   {{- if .Values.clusterApi.enabled }}
   rbac:

--- a/helmfile.d/values/kube-prometheus-stack-wc.yaml.gotmpl
+++ b/helmfile.d/values/kube-prometheus-stack-wc.yaml.gotmpl
@@ -21,6 +21,8 @@ prometheusOperator:
     resources: {{- toYaml .Values.prometheusOperator.prometheusConfigReloader.resources | nindent 6 }}
 
 kube-state-metrics:
+  selfMonitor:
+    enabled: true
   resources: {{- toYaml .Values.kubeStateMetrics.resources | nindent 4 }}
   {{- if .Values.clusterApi.enabled }}
   rbac:

--- a/helmfile.d/values/networkpolicies/common/prometheus.yaml.gotmpl
+++ b/helmfile.d/values/networkpolicies/common/prometheus.yaml.gotmpl
@@ -122,6 +122,7 @@ policies:
         - rule: ingress-rule-prometheus
           ports:
             - tcp: 8080
+            - tcp: 8081
 
     {{- if eq .Environment.Name "service_cluster" }}
     {{- if eq .Values.objectStorage.type "s3" | and .Values.s3Exporter.enabled .Values.networkPolicies.s3Exporter.enabled }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Was looking through some of the alerts and when comparing them to upstream noticed some deviations:
- Some expressions in our alerts are not computer per cluster which is what we want. 
- Noticed that the alertmanager alerts we have did not have the `runbookURL` configured, this PR adds this (the URLs seem to point to actual runbooks).
- We have alerts for[ kube-state-metrics but the metrics used in the queries](https://github.com/elastisys/compliantkubernetes-apps/blob/v0.42.1/helmfile.d/charts/prometheus-alerts/templates/alerts/kube-state-metrics.yaml#L26) are missing due to the self monitoring option for kube-state-metrics being disabled by default. This PR enables it, with it enabled the issue encountered in [this PR](https://github.com/elastisys/compliantkubernetes-apps/pull/2372) fires the kube-state-metrics alerts which it did not previously do. The metrics were exposed on port 8081 so the networkpolicies needed to be updated.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [x] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [x] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
