### PR TITLE
Replace ck8s with Welkin in tests

### DIFF
--- a/tests/common/bats/gpg.bash
+++ b/tests/common/bats/gpg.bash
@@ -7,7 +7,7 @@ gpg.auto_generate_key() {
   gpg --batch --generate-key <<EOF
 Key-Type: RSA
 Key-Length: 4096
-Name-Real: Compliant Kubernetes / Apps / Tests
+Name-Real: Welkin / Apps / Tests
 Name-Email: support@elastisys.com
 Expire-Date: 1d
 %no-protection

--- a/tests/end-to-end/grafana/authentication.cy.js
+++ b/tests/end-to-end/grafana/authentication.cy.js
@@ -93,7 +93,7 @@ describe("grafana dev authentication", function() {
     cy.contains("Home")
       .should("exist")
 
-    cy.contains("Welcome to Compliant Kubernetes")
+    cy.contains("Welcome to Welkin")
       .should("exist")
   })
 
@@ -122,7 +122,7 @@ describe("grafana dev authentication", function() {
     cy.contains("Home")
       .should("exist")
 
-    cy.contains("Welcome to Compliant Kubernetes")
+    cy.contains("Welcome to Welkin")
       .should("exist")
   })
 })

--- a/tests/end-to-end/grafana/dashboards.cy.js
+++ b/tests/end-to-end/grafana/dashboards.cy.js
@@ -86,7 +86,7 @@ describe("grafana dev dashboards", function() {
   beforeEach(function() {
     cy.grafanaDexStaticLogin(this.ingress)
 
-    cy.contains("Welcome to Compliant Kubernetes")
+    cy.contains("Welcome to Welkin")
       .should("exist")
   })
 

--- a/tests/end-to-end/grafana/datasources.cy.js
+++ b/tests/end-to-end/grafana/datasources.cy.js
@@ -80,7 +80,7 @@ describe("grafana dev datasources", function() {
   beforeEach(function() {
     cy.grafanaDexStaticLogin(this.ingress)
 
-    cy.contains("Welcome to Compliant Kubernetes")
+    cy.contains("Welcome to Welkin")
       .should("exist")
 
     cy.on('uncaught:exception', (err, runnable) => {

--- a/tests/end-to-end/opensearch/authentication.cy.js
+++ b/tests/end-to-end/opensearch/authentication.cy.js
@@ -43,7 +43,7 @@ describe("opensearch admin authentication", function() {
     cy.contains("Loading OpenSearch Dashboards")
       .should("not.exist")
 
-    cy.contains("Welcome to Compliant Kubernetes")
+    cy.contains("Welcome to Welkin")
       .should("exist")
   })
 })

--- a/tests/end-to-end/opensearch/dashboards.cy.js
+++ b/tests/end-to-end/opensearch/dashboards.cy.js
@@ -32,7 +32,7 @@ function opensearchDexStaticLogin(cy, ingress) {
     cy.contains("loading opensearch dashboards", opt)
       .should("not.exist")
 
-    cy.contains("Welcome to Compliant Kubernetes")
+    cy.contains("Welcome to Welkin")
       .should("be.visible")
   })
 
@@ -41,7 +41,7 @@ function opensearchDexStaticLogin(cy, ingress) {
   cy.contains("loading opensearch dashboards", opt)
   .should("not.exist")
 
-  cy.contains("Welcome to Compliant Kubernetes")
+  cy.contains("Welcome to Welkin")
     .should("be.visible")
 }
 


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->

The end-to-end tests for Grafana failed as they look for `Compliant Kubernetes` in the welcome dashboard, which has been updated to use `Welkin`:

```console
# cypress run: /home/anders/ck8s/compliantkubernetes-apps/tests/end-to-end/grafana/authentication.cy.js
ok 1 grafana admin authentication can login via static admin user
ok 2 grafana admin authentication can login via static dex user
not ok 3 grafana dev authentication can login via static admin user
# (from function `fail' in file /usr/local/lib/bats/support/src/error.bash, line 40,
#  from function `cypress_test' in file end-to-end/grafana/../../bats.lib.bash, line 262,
#  in test file end-to-end/grafana/authentication.gen.bats, line 27)
#   `cypress_test "grafana dev authentication can login via static admin user"' failed
# AssertionError: Timed out retrying after 10000ms: Expected to find content: 'Welcome to Compliant Kubernetes' but never did.
```

This PR updates the test to fix this.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
