### PR TITLE
Fix config schema

### DIFF
--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -4283,7 +4283,8 @@ properties:
             description: Configure a pattern of node groups to exclude from the resource request alerts. This can be used to exclude certain node groups from request alerts, while still getting usage alerts for those node groups.
             type: string
             default: ""
-            examples: ".*redis.*|.*postgres.*"
+            examples:
+              - ".*redis.*|.*postgres.*"
       diskAlerts:
         title: Disk Alerts
         description: Definitions for disk alerts.


### PR DESCRIPTION
It seems like jsonschema2md ironically doesn't validate the schema of the input it receives. :)

It fails horribly with:

```
file:///home/cklein/elastisys/welkin/node_modules/@adobe/jsonschema2md/lib/markdownBuilder.js:697
        ...schema[keyword`examples`].map((example) => paragraph(code('yaml', yaml.dump(example, undefined, 2)))),
                                     ^

TypeError: schema[keyword].map is not a function or its return value is not iterable
    at makeexamples (file:///home/cklein/elastisys/welkin/node_modules/@adobe/jsonschema2md/lib/markdownBuilder.js:697:38)
    at file:///home/cklein/elastisys/welkin/node_modules/@adobe/jsonschema2md/lib/markdownBuilder.js:762:14
    at Array.map (<anonymous>)
    at makeproplist (file:///home/cklein/elastisys/welkin/node_modules/@adobe/jsonschema2md/lib/markdownBuilder.js:750:54)
    at file:///home/cklein/elastisys/welkin/node_modules/@adobe/jsonschema2md/lib/markdownBuilder.js:831:16
    at Array.map (<anonymous>)
    at makedefinitions (file:///home/cklein/elastisys/welkin/node_modules/@adobe/jsonschema2md/lib/markdownBuilder.js:818:10)
    at file:///home/cklein/elastisys/welkin/node_modules/@adobe/jsonschema2md/lib/markdownBuilder.js:888:10
    at /home/cklein/elastisys/welkin/node_modules/ferrum/src/sequence.js:1234:12
    at /home/cklein/elastisys/welkin/node_modules/ferrum/src/sequence.js:807:5
```

I added `console.log(schema[keyword`examples`]);` before the failing line and, long story short, it seems like jsonschema2md expects a list of examples and not a string.

<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

See above

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

I tested this PR as follows:

```console
git clone --depth 1 git@github.com:elastisys/welkin
cd welkin
nodeenv .env
. .env/bin/activate
npm ci

# Next command generates schema documentation using this PR and does not fail
OVERRIDE_REF_NAME=ck/fix-schema ./scripts/jsonschema2md.sh 

# Next command generates schema documentation without this PR and fails
./scripts/jsonschema2md.sh
```

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
