### PR TITLE
Incremental version checks during migration

### DIFF
--- a/bin/apply.bash
+++ b/bin/apply.bash
@@ -28,6 +28,12 @@ update_ips_dryrun() {
   fi
 }
 
+check_upgrade() {
+  if get_upgrade_status "${1}" &>/dev/null; then
+    log_fatal "Upgrade ongoing, try again when it has completed or use 'ck8s upgrade unlock'"
+  fi
+}
+
 apps_apply() {
   local suppress
 
@@ -49,6 +55,15 @@ apps_apply() {
 
   if (with_kubeconfig "${config["kube_config_$1"]}" helmfile -f "${here}/../helmfile.d/" -e "$2" "${action}" "${concurrency}" "${suppress:-}"); then
     log_info "---"
+    local current_version
+    current_version="$(get_apps_version "${2}" 2>/dev/null || true)"
+    if [ -z "${current_version}" ]; then
+      current_version="$(get_repo_version)"
+      if [[ "${current_version}" == v* ]]; then
+        set_apps_version "${2}" "${current_version%.*}"
+      fi
+    fi
+    log_info "Current version is ${current_version}"
     log_info "Successful Apps ${action} on ${2/_/ }!"
   else
     log_error "---"
@@ -73,5 +88,7 @@ esac
 
 check_node_label "$1" elastisys.io/node-group
 update_ips_dryrun "$1" "${environment}"
+check_upgrade "$1"
 config_load "$1"
+[[ -z "${CK8S_CI_SKIP_APPLY:-}" ]] || exit 0 # Improve mockability in the future
 apps_apply "$1" "${environment}" "${@:2}"

--- a/bin/ck8s
+++ b/bin/ck8s
@@ -35,8 +35,10 @@ usage() {
   echo "  update-ips <wc|sc|both> <apply|dry-run>         Automatically fetches and applies the IPs for network policies" 1>&2
   echo "  upgrade <wc|sc|both> <vX.Y> apply               runs all apply steps upgrading the environment" 1>&2
   echo "  upgrade <wc|sc|both> <vX.Y> prepare             runs all prepare steps upgrading the configuration" 1>&2
+  echo "  upgrade <wc|sc|both> unlock                     reset an upgrade to allow trying again" 1>&2
   echo "  validate <wc|sc>                                validates config files" 1>&2
   echo "  check-requirements                              check the locally installed tool versions" 1>&2
+  echo "  version <all|both|config|sc|wc>                 shows apps version" 1>&2
   exit 1
 }
 
@@ -83,11 +85,13 @@ dry-run)
   ;;
 upgrade)
   [[ "${2}" =~ ^(wc|sc|both)$ ]] || usage
-  [[ "${3}" =~ ^(v[0-9]+\.[0-9]+)$ ]] || usage
-  [[ "${4}" =~ ^(prepare|apply)$ ]] || usage
+  [[ "${3}" =~ ^(v[0-9]+\.[0-9]+|unlock)$ ]] || usage
+  if [[ "${3}" != "unlock" ]]; then
+    [[ "${4}" =~ ^(prepare|apply)$ ]] || usage
+  fi
   check_tools
   export CK8S_CLUSTER="${2}"
-  "${here}/upgrade.bash" "${3}" "${4}"
+  "${here}/upgrade.bash" "${3}" "${4:-}"
   ;;
 team)
   case "${2}" in
@@ -158,6 +162,19 @@ diagnostics)
   [[ "${2}" =~ ^(wc|sc)$ ]] || usage
   shift
   "${here}/diagnostics.bash" "${@}"
+  ;;
+version) # all|both|sc|wc
+  shift
+  [[ "${1}" =~ ^(all|both|config|wc|sc)$ ]] || usage
+  if [[ "${1}" =~ ^(all|config)$ ]]; then
+    log_info "config version:" "$(yq '.global.ck8sVersion' "${CK8S_CONFIG_PATH}/defaults/common-config.yaml")"
+  fi
+  if [[ "${1}" =~ ^(all|both|sc)$ ]]; then
+    log_info "sc version:" "$(get_apps_version "sc")"
+  fi
+  if [[ "${1}" =~ ^(all|both|wc)$ ]]; then
+    log_info "wc version:" "$(get_apps_version "wc")"
+  fi
   ;;
 *) usage ;;
 esac

--- a/bin/init.bash
+++ b/bin/init.bash
@@ -397,7 +397,7 @@ mkdir -p "${default_config_path}"
 #       for generating user configurations and not store it as a part of
 #       the ck8s configuration.
 mkdir -p "${CK8S_CONFIG_PATH}/user"
-CK8S_VERSION=$(version_get)
+CK8S_VERSION=$(get_repo_version)
 export CK8S_VERSION
 
 generate_default_config "${config[default_common]}"

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -1420,6 +1420,15 @@ properties:
         enum:
           - containerd
           - docker
+      ck8sConfigSerial:
+        title: Timestamp of last migration
+        description: |-
+          This property is used during migrations to track state and ensure that the
+          same version is used during `ck8s upgrade prepare` as during `ck8s upgrade
+          apply`.
+        type: string
+        examples:
+          - "2025-04-29T08:34:21+00:00"
     additionalProperties: false
   clusterApi:
     additionalProperties: false

--- a/scripts/local-clusters/configs/secrets.yaml
+++ b/scripts/local-clusters/configs/secrets.yaml
@@ -2,3 +2,8 @@ objectStorage:
   s3:
     accessKey: minioaccesskey
     secretKey: miniosecretkey
+alerts:
+  opsGenie:
+    apiKey: not-used
+  slack:
+    apiUrl: not-used

--- a/tests/common/bats/env.bash
+++ b/tests/common/bats/env.bash
@@ -106,6 +106,9 @@ env.init() {
     yq.set 'sc' '.alerts.opsGenieHeartbeat.name' '"example-heartbeat-name"'
   fi
 
+  yq.set 'secrets' '["alerts"]["opsGenie"]["apiKey"]' '"ZXhhbXBsZS1hcGlrZXkx"'
+  yq.set 'secrets' '["alerts"]["slack"]["apiUrl"]' '"https://slack.example/channel/ZXhhbXBsZS1jaGFubmVs"'
+
   yq.set 'wc' '.opa.imageRegistry.URL' '["harbor.ck8s.example.com"]'
 
   yq.set 'wc' '.user.adminUsers' '["user@example.com"]'

--- a/tests/common/bats/git-version.bash
+++ b/tests/common/bats/git-version.bash
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+gitversion.setup_mocks() {
+  mock_git="$(mock_create)"
+  export mock_git
+  git() {
+    # shellcheck disable=SC2317
+    "${mock_git}" "${@}"
+  }
+  export -f git
+}
+
+gitversion.mock_static() {
+  mock_set_output "${mock_git}" "${1}"
+}

--- a/tests/integration/general/local-clusters.bats
+++ b/tests/integration/general/local-clusters.bats
@@ -2,25 +2,10 @@
 
 # bats file_tags=general,local-clusters
 
-setup_file() {
-  load "../../bats.lib.bash"
-  load_common "local-cluster.bash"
-
-  export CK8S_AUTO_APPROVE="true"
-
-  local_cluster.setup dev test.dev-ck8s.com
-  local_cluster.create sc single-node-cache
-}
-
 setup() {
   load "../../bats.lib.bash"
   load_assert
   load_detik
-}
-
-teardown_file() {
-  local_cluster.delete sc
-  local_cluster.teardown
 }
 
 helm_status() {

--- a/tests/integration/general/migration/v0.42/apply/00-template.sh
+++ b/tests/integration/general/migration/v0.42/apply/00-template.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+log_info "no operation: this is a test"

--- a/tests/integration/general/migration/v0.42/apply/80-apply.sh
+++ b/tests/integration/general/migration/v0.42/apply/80-apply.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+log_info "no operation: this is a test"

--- a/tests/integration/general/migration/v0.42/prepare/00-template.sh
+++ b/tests/integration/general/migration/v0.42/prepare/00-template.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+# Note: 00-template.sh will be skipped by the upgrade command
+log_info "no operation: this is a test"

--- a/tests/integration/general/migration/v0.42/prepare/50-init.sh
+++ b/tests/integration/general/migration/v0.42/prepare/50-init.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+case "${CK8S_CLUSTER}" in
+both | sc | wc)
+  "${ROOT}/bin/ck8s" init "${CK8S_CLUSTER}"
+  ;;
+*)
+  log_fatal "usage: 50-init.sh <wc|sc|both>"
+  ;;
+esac

--- a/tests/integration/general/migration/v0.43/apply/00-template.sh
+++ b/tests/integration/general/migration/v0.43/apply/00-template.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+log_info "no operation: this is a test"

--- a/tests/integration/general/migration/v0.43/apply/80-apply.sh
+++ b/tests/integration/general/migration/v0.43/apply/80-apply.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+log_info "no operation: this is a test"

--- a/tests/integration/general/migration/v0.43/prepare/00-template.sh
+++ b/tests/integration/general/migration/v0.43/prepare/00-template.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+# Note: 00-template.sh will be skipped by the upgrade command
+log_info "no operation: this is a test"

--- a/tests/integration/general/migration/v0.43/prepare/50-init.sh
+++ b/tests/integration/general/migration/v0.43/prepare/50-init.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+case "${CK8S_CLUSTER}" in
+both | sc | wc)
+  "${ROOT}/bin/ck8s" init "${CK8S_CLUSTER}"
+  ;;
+*)
+  log_fatal "usage: 50-init.sh <wc|sc|both>"
+  ;;
+esac

--- a/tests/integration/general/setup_suite.bash
+++ b/tests/integration/general/setup_suite.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+setup_suite() {
+  export CK8S_AUTO_APPROVE="true"
+
+  load "../../bats.lib.bash"
+  load_common "local-cluster.bash"
+
+  local_cluster.setup dev test.dev-ck8s.com
+  local_cluster.create sc single-node-cache
+}
+
+teardown_suite() {
+  local_cluster.delete sc
+  local_cluster.teardown
+}

--- a/tests/integration/general/upgrade.bats
+++ b/tests/integration/general/upgrade.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+
+# bats file_tags=static,general,bin:upgrade
+
+setup_file() {
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+  export CK8S_AUTO_APPROVE=true
+  export CK8S_CI_SKIP_APPLY=true # quicken the apply step
+
+  MIGRATION_ROOT="${ROOT}/tests/integration/general/migration"
+  export MIGRATION_ROOT
+
+  load "../../bats.lib.bash"
+  load_common "local-cluster.bash"
+  local_cluster.configure_selfsigned
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_common "local-cluster.bash"
+  load_common "git-version.bash"
+  load_common "yq.bash"
+  load_assert
+  load_file
+  load_mock
+
+  env.private
+
+  gitversion.setup_mocks
+
+  # consistent state at start
+  run yq -i '.global.ck8sVersion="v0.41.0"' "${CK8S_CONFIG_PATH}/defaults/common-config.yaml"
+  ck8s ops kubectl sc delete -n kube-system configmap welkin-apps-upgrade --ignore-not-found --wait
+  ck8s ops kubectl sc apply -f - <<EOF
+apiVersion: v1
+data:
+  version: v0.41
+kind: ConfigMap
+metadata:
+  name: welkin-apps-meta
+  namespace: kube-system
+EOF
+}
+
+teardown() {
+  env.teardown
+}
+
+@test "upgrading works" {
+  # test 1, the happy path where everything goes well
+
+  run ck8s version config
+  assert_success
+  assert_output --partial "v0.41"
+
+  gitversion.mock_static "v0.42.0"
+  run ck8s upgrade sc "v0.42" prepare
+  assert_success
+  assert_output --partial "locked for upgrade"
+
+  gitversion.mock_static "v0.42.0"
+  run ck8s upgrade sc "v0.42" apply
+  assert_success
+
+  run ck8s apply sc
+  assert_success
+
+  run ck8s version sc
+  assert_success
+  assert_output --partial "v0.42"
+}
+
+@test "no upgrade apply without upgrade prepare" {
+  # test 2
+
+  gitversion.mock_static "v0.42.0"
+  run ck8s version config
+  assert_success
+  assert_output --partial "v0.41"
+  run ck8s upgrade sc "v0.42" apply
+  assert_failure # because trying to apply 0.42 when config says 0.41
+  assert_output --partial "Upgrade has not been prepared, run 'ck8s upgrade prepare' first"
+}
+
+@test "prevent apply without upgrade apply after upgrade prepare" {
+  # test 3
+
+  gitversion.mock_static "v0.42.0"
+  run ck8s upgrade sc "v0.42" prepare
+  assert_success
+  assert_output --partial "locked for upgrade"
+
+  run ck8s ops kubectl sc get -n kube-system configmap welkin-apps-upgrade -o jsonpath --template='{.data.version}'
+  assert_success
+  assert_output --partial "v0.42"
+
+  # Oops, forgot to ck8s upgrade apply
+
+  run ck8s apply sc
+  assert_failure
+  assert_output --partial "Upgrade ongoing"
+}
+
+@test "prevent a ck8s apply after ck8s upgrade prepare but prepare is not merged" {
+  # test 4
+
+  gitversion.mock_static "v0.42.0"
+  run ck8s version config
+  assert_success
+  assert_output --partial "v0.41"
+
+  run ck8s upgrade sc "v0.42" prepare
+  assert_success
+
+  # someone changes the config
+  run yq -i '.global.ck8sConfigSerial="something"' "${CK8S_CONFIG_PATH}/common-config.yaml"
+
+  run ck8s upgrade sc "v0.42" apply
+  assert_failure
+  assert_output --partial "Config timestamp mismatch"
+
+}
+
+@test "prevent a ck8s apply on an old config after ck8s upgrade apply" {
+  run ck8s ops kubectl sc patch -n kube-system configmap welkin-apps-meta --type=merge --patch '{"data":{"version":"v0.42"}}'
+
+  # accidentally downgrade apps
+  gitversion.mock_static "v0.41.0"
+  run ck8s apply sc
+  assert_failure
+  assert_output --partial "Version mismatch. Run upgrade to update cluster."
+}
+
+@test "prevent prepare when migration already started" {
+  run ck8s version config
+  assert_success
+  assert_output --partial "v0.41"
+
+  gitversion.mock_static "v0.42.0"
+  run ck8s upgrade sc "v0.42" prepare
+  assert_success
+  assert_output --partial "locked for upgrade"
+
+  gitversion.mock_static "v0.42.0"
+  run ck8s upgrade sc "v0.42" prepare
+  assert_failure
+  assert_output --partial "Migration already in progress"
+}
+
+@test "prevent prepare on a different version" {
+  gitversion.mock_static "v0.42.0"
+  run ck8s upgrade sc "v0.42" prepare
+  assert_success
+  assert_output --partial "locked for upgrade"
+
+  gitversion.mock_static "v0.43.0"
+  run ck8s upgrade sc "v0.43" apply
+  assert_failure
+  assert_output --partial "Version mismatch, upgrading to v0.43 but cluster sc was prepared for v0.42"
+}

--- a/tests/unit/general/bin-version.bats
+++ b/tests/unit/general/bin-version.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+# bats file_tags=static,general,bin:version
+
+setup_file() {
+  load "../../bats.lib.bash"
+  load_common "env.bash"
+  load_common "gpg.bash"
+  load_common "yq.bash"
+  load_mock
+
+  gpg.setup
+  env.setup
+  env.init baremetal kubespray prod
+  yq -i '.global.ck8sVersion = "v0.42"' "${CK8S_CONFIG_PATH}/defaults/common-config.yaml"
+
+  mock_kubectl="$(mock_create)"
+  export mock_kubectl
+  kubectl() {
+    # shellcheck disable=SC2317
+    "${mock_kubectl}" "${@}"
+  }
+  export -f kubectl
+  mock_set_output "${mock_kubectl}" "v0.42"
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+}
+
+@test "negative test should show usage" {
+  run ck8s version
+  assert_failure
+  assert_output --partial "version <all|both|config|sc|wc>"
+}
+
+@test "ck8s version all" {
+  run ck8s version all
+  assert_success
+  assert_output --partial "config version: v0.42"
+  assert_output --partial "sc version: v0.42"
+  assert_output --partial "wc version: v0.42"
+}
+
+@test "ck8s version both" {
+  run ck8s version both
+  assert_success
+  assert_output --partial "sc version: v0.42"
+  assert_output --partial "wc version: v0.42"
+}
+
+@test "ck8s version config" {
+  run ck8s version config
+  assert_success
+  assert_output --partial "config version: v0.42"
+}
+
+@test "ck8s version sc" {
+  run ck8s version sc
+  assert_success
+  assert_output --partial "sc version: v0.42"
+}
+
+@test "ck8s version wc" {
+  run ck8s version wc
+  assert_success
+  assert_output --partial "wc version: v0.42"
+}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice

There are now safeguards in place to ensure `ck8s upgrade prepare` and `ck8s upgrade apply` are run in the correct order.

There's also a new `ck8s version` command that reports the verison of apps in the config and cluster(s).

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

- [x] Stores the current version of apps on first install (when running `ck8s apply`)
- [x] Stores the current version of apps in the cluster **after** `ck8s upgrade`
- [x] Ensure that `ck8s upgrade prepare` is run before `ck8s upgrade apply`
- [x] Ensure that `ck8s upgrade apply` is run before `ck8s apply`
- [x] Ensure that apps version and cluster matches on `ck8s apply`
- [x] Ensure the same configuration is used for `ck8s upgrade prepare` and `ck8s upgrade apply`

```mermaid
flowchart TD;
	init[ck8s init];
	apply[ck8s apply];
	uprep[ck8s upgrade prepare];
	uapply[ck8s upgrade apply];
	unlock[ck8s upgrade unlock];

	init --x init
	init --> apply
	init --> uprep
	init --x uapply
	init --x unlock

	apply --x init
	apply --> apply 
	apply --> uprep
	apply --x uapply
	apply --x unlock

	uprep --x init
	uprep --x apply
	uprep --> uprep
	uprep --> uapply
	uprep --> unlock

	uapply --> init
	uapply --> apply
	uapply --> uprep
	uapply --> uapply
	uapply --x unlock
```

<!-- Add description of the change -->
This uses a pair of ConfigMaps in the `kube-system` namespace to keep track of the current version of apps as well as progress during apps upgrades.

- `welkin-apps-meta` stores the current version of apps
	- `.data.version` the version number itself
- `welkin-apps-upgrade` stores details about an in-progress upgrade
	- its existence signifies that `ck8s upgrade ... apply` has started
	- `.data.version` records the version of apps being upgraded to
	- `.data.timestamp` a timestamp also stored in the config at `.global.ck8sLastChange`
	- `.data.last_step` records the last snippet run by `ck8s upgrade ...`
	- configmap is deleted to signify a completed migration

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2315

#### Information to reviewers

Please have a look at the tests and consider whether they have good coverage.

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### integration tests

```bash
time make -C tests run-integration/general/upgrade.bats
```

Note: test \# 3 "no ck8s apply without ck8s upgrade" does not behave correctly for me, insisting that the configmap either exists when it should not or doesn't exist after having been successfully created. eventual consistency or caches?

#### unit tests:

Covers only the `ck8s version` command.

```bash
make -C tests run-unit/general/bin-version.bats
```

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
		- [x] The change affects migration itself :)
    - [ ] The change updates CRDs
    - [x] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
