### PR TITLE
apps: Safeguard to prevent accidental cluster deletion

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -884,6 +884,11 @@ opa:
     enabled: true
     enforcement: warn
 
+  ## Prevent accidental deletion
+  preventAccidentalDeletion:
+    enabled: true
+    enforcement: deny
+
 trivy:
   enabled: true
   # comma separated list of namespaces (or glob patterns) to be excluded from scanning

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -3685,6 +3685,29 @@ properties:
               deny: Deny actions violating the constraint.
               warn: Warn actions violating the constraint.
               dryrun: Dryrun actions violating the constraint.
+      preventAccidentalDeletion:
+        title: Safeguard Prevent Accidental Deletion
+        description: |-
+          Configure constraint to reject deletion of sensitive resources.
+        type: object
+        additionalProperties: false
+        properties:
+          enabled:
+            title: Safeguard Prevent Accidental Deletion
+            type: boolean
+            default: false
+          enforcement:
+            title: Safeguard Prevent Accidental Deletion Enforcement
+            type: string
+            default: deny
+            enum:
+              - deny
+              - warn
+              - dryrun
+            meta:enum:
+              deny: Deny actions violating the constraint.
+              warn: Warn actions violating the constraint.
+              dryrun: Dryrun actions violating the constraint.
       resourceRequests:
         title: Safeguard Resource Requests
         description: |-

--- a/helmfile.d/charts/gatekeeper/constraints/templates/disallow-localhost-seccomp/constraint.yaml
+++ b/helmfile.d/charts/gatekeeper/constraints/templates/disallow-localhost-seccomp/constraint.yaml
@@ -1,9 +1,10 @@
+{{- if .Values.disallowLocalhostSeccomp.enable -}}
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sDisallowLocalhostSeccomp
 metadata:
   name: elastisys-disallow-localhost-seccomp-profile
 spec:
-  enforcementAction: deny
+  enforcementAction: {{ .Values.disallowLocalhostSeccomp.enforcementAction }}
   match:
     kinds:
     - apiGroups:
@@ -36,3 +37,4 @@ spec:
         operator: NotIn
         values:
         - ingress-nginx
+{{- end -}}

--- a/helmfile.d/charts/gatekeeper/constraints/templates/prevent-accidental-deletion/constraint.yaml
+++ b/helmfile.d/charts/gatekeeper/constraints/templates/prevent-accidental-deletion/constraint.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.preventAccidentalDeletion.enable -}}
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPreventAccidentalDeletion
+metadata:
+  name: elastisys-prevent-accidental-deletion
+spec:
+  enforcementAction: {{ .Values.preventAccidentalDeletion.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: ["cluster.x-k8s.io"]
+        kinds:
+          - Cluster
+      - apiGroups: ["infrastructure.cluster.x-k8s.io"]
+        kinds:
+          - OpenStackCluster
+          - AzureCluster
+  parameters:
+    annotation: elastisys.io/ok-to-delete
+    kinds:
+      - Cluster
+      - OpenstackCluster
+      - AzureCluster
+{{- end }}

--- a/helmfile.d/charts/gatekeeper/constraints/values.yaml
+++ b/helmfile.d/charts/gatekeeper/constraints/values.yaml
@@ -17,8 +17,14 @@ rejectLoadBalancerService:
     enable: true
     enforcementAction: dryrun
 minimumDeploymentReplicas:
-    enable: true
+    enable: false
     enforcementAction: warn
+preventAccidentalDeletion:
+    enable: true
+    enforcementAction: deny
+disallowLocalhostSeccomp:
+    enable: false
+    enforcementAction: deny
 
 imageRegistryURL: registry.example.com
 

--- a/helmfile.d/charts/gatekeeper/templates/policies/prevent-accidental-deletion.rego
+++ b/helmfile.d/charts/gatekeeper/templates/policies/prevent-accidental-deletion.rego
@@ -1,0 +1,38 @@
+package k8spreventaccidentaldeletion
+
+import future.keywords.in
+
+violation[{"msg": msg}] {
+
+    input.review.operation == "DELETE"
+    not correct_annotation
+    correct_kind
+
+    msg := sprintf(
+        "%v deletion is not allowed.\nTo bypass the constraint, run:\nkubectl annotate %v -n %v %v %v=anything",
+        [
+            input.review.object.kind,
+            input.review.object.kind,
+            input.review.object.metadata.namespace,
+            input.review.object.metadata.name,
+            input.parameters.annotation
+        ]
+    )
+}
+
+correct_annotation {
+
+    annotations := input.review.object.metadata.annotations
+    value := input.parameters.annotation
+
+    some key, _ in annotations
+    key == value
+}
+
+correct_kind {
+
+    kind := input.review.object.kind
+    kinds := input.parameters.kinds
+
+    kinds[_] == kind
+}

--- a/helmfile.d/charts/gatekeeper/templates/policies/tests/prevent-accidental-deletion.rego
+++ b/helmfile.d/charts/gatekeeper/templates/policies/tests/prevent-accidental-deletion.rego
@@ -1,0 +1,162 @@
+package k8spreventaccidentaldeletion
+
+import future.keywords.every
+
+prevented_kinds := ["Cluster", "OpenStackCluster", "AzureCluster"]
+
+test_delete_resource_without_annotation_is_denied {
+    every i in prevented_kinds {
+        count(violation) == 1 with input as {
+            "review": {
+                "operation": "DELETE",
+                "object": {
+                    "apiVersion": "*",
+                    "kind": i,
+                    "metadata": {
+                        "name": "test-resource",
+                        "namespace": "default",
+                        "annotations": {}
+                    }
+                }
+            },
+            "parameters": {
+                "annotation": "elastisys.io/ok-to-delete",
+                "kinds": prevented_kinds
+            }
+        }
+    }
+}
+
+test_delete_resource_with_annotation_is_allowed {
+    every i in prevented_kinds {
+        count(violation) == 0 with input as {
+            "review": {
+                "operation": "DELETE",
+                "object": {
+                    "apiVersion": "*",
+                    "kind": i,
+                    "metadata": {
+                        "name": "test-resource",
+                        "namespace": "default",
+                        "annotations": {
+                            "elastisys.io/ok-to-delete": "anything"
+                        }
+                    }
+                }
+            },
+            "parameters": {
+                "annotation": "elastisys.io/ok-to-delete",
+                "kinds": prevented_kinds
+            }
+        }
+    }
+}
+
+test_non_delete_operation_without_annotation_is_allowed {
+    every i in prevented_kinds {
+        count(violation) == 0 with input as {
+            "review": {
+                "operation": "UPDATE",
+                "object": {
+                    "apiVersion": "*",
+                    "kind": i,
+                    "metadata": {
+                        "name": "test-resource",
+                        "namespace": "default",
+                        "annotations": {}
+                    }
+                }
+            },
+            "parameters": {
+                "annotation": "elastisys.io/ok-to-delete",
+                "kinds": prevented_kinds
+            }
+        }
+    }
+}
+
+test_without_annotations_field {
+    count(violation) == 1 with input as {
+        "review": {
+            "operation": "DELETE",
+            "object": {
+                "apiVersion": "*",
+                "kind": "Cluster",
+                "metadata": {
+                    "name": "test-resource",
+                    "namespace": "default"
+                }
+            }
+        },
+        "parameters": {
+            "annotation": "elastisys.io/ok-to-delete",
+            "kinds": prevented_kinds
+        }
+    }
+}
+
+test_delete_other_kind_is_allowed {
+    count(violation) == 0 with input as {
+        "review": {
+            "operation": "DELETE",
+            "object": {
+                "apiVersion": "*",
+                "kind": "Pod",
+                "metadata": {
+                    "name": "test-pod",
+                    "namespace": "default",
+                }
+            }
+        },
+        "parameters": {
+            "annotation": "elastisys.io/ok-to-delete",
+            "kinds": prevented_kinds
+        }
+    }
+}
+
+test_some_other_annotation {
+    count(violation) == 0 with input as {
+        "review": {
+            "operation": "DELETE",
+            "object": {
+                "apiVersion": "*",
+                "kind": "Cluster",
+                "metadata": {
+                    "name": "test-resource",
+                    "namespace": "default",
+                    "annotations": {
+                        "elastisys.io/something-else": "test"
+                    }
+                }
+            }
+        },
+        "parameters": {
+            "annotation": "elastisys.io/something-else",
+            "kinds": prevented_kinds
+        }
+    }
+}
+
+test_bad_annotation {
+    count(violation) == 1 with input as {
+        "review": {
+            "operation": "DELETE",
+            "object": {
+                "apiVersion": "*",
+                "kind": "Cluster",
+                "metadata": {
+                    "name": "test-resource",
+                    "namespace": "default",
+                    "annotations": {
+                        "elastisys.io/bad-input": "test"
+                    }
+                }
+            }
+        },
+        "parameters": {
+            "annotation": "elastisys.io/something-else",
+            "kinds": prevented_kinds
+        }
+    }
+}

--- a/helmfile.d/charts/gatekeeper/templates/templates/prevent-accidental-deletion/template.yaml
+++ b/helmfile.d/charts/gatekeeper/templates/templates/prevent-accidental-deletion/template.yaml
@@ -1,0 +1,26 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spreventaccidentaldeletion
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPreventAccidentalDeletion
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+            type: object
+            properties:
+              annotation:
+                description: This annotation allows removal of sensitive resources protected from accidental deletion.
+                type: string
+              kinds:
+                description: A list of resource kinds that will be affected by the constraint.
+                type: array
+                items:
+                  type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ .Files.Get "policies/prevent-accidental-deletion.rego"  | indent 8 }}

--- a/helmfile.d/stacks/gatekeeper.yaml.gotmpl
+++ b/helmfile.d/stacks/gatekeeper.yaml.gotmpl
@@ -49,7 +49,6 @@ templates:
     chart: charts/gatekeeper/constraints
     version: 0.1.0
     name: gatekeeper-constraints
-    condition: ck8sWorkloadCluster.enabled
     needs:
       - gatekeeper-system/gatekeeper-templates # creates gatekeeper/constraints
     values:

--- a/helmfile.d/values/gatekeeper/constraints.yaml.gotmpl
+++ b/helmfile.d/values/gatekeeper/constraints.yaml.gotmpl
@@ -13,10 +13,16 @@ disallowedTags:
 rejectLoadBalancerService:
     enable: {{ .Values.opa.rejectLoadBalancerService.enabled }}
     enforcementAction: {{ .Values.opa.rejectLoadBalancerService.enforcement }}
+preventAccidentalDeletion:
+    enable: {{ .Values.opa.preventAccidentalDeletion.enabled }}
+    enforcementAction: {{ .Values.opa.preventAccidentalDeletion.enforcement }}
 {{- if eq .Environment.Name "workload_cluster" }}
 allowUserCRDs:
     enable: {{ .Values.gatekeeper.allowUserCRDs.enabled }}
     enforcementAction: {{ .Values.gatekeeper.allowUserCRDs.enforcement }}
+disallowLocalhostSeccomp:
+    enable: true
+    enforcementAction: deny
 minimumDeploymentReplicas:
     enable: {{ .Values.opa.minimumDeploymentReplicas.enabled }}
     enforcementAction: {{ .Values.opa.minimumDeploymentReplicas.enforcement }}

--- a/helmfile.d/values/gatekeeper/gatekeeper.yaml.gotmpl
+++ b/helmfile.d/values/gatekeeper/gatekeeper.yaml.gotmpl
@@ -57,7 +57,10 @@ validatingWebhookCustomRules:
       - UPDATE
       - DELETE
     resources:
+      - azureclusters
       - customresourcedefinitions
+      - clusters
+      - openstackclusters
       - secrets
 mutatingWebhookCustomRules:
   - apiGroups:

--- a/helmfile.d/values/gatekeeper/templates.yaml.gotmpl
+++ b/helmfile.d/values/gatekeeper/templates.yaml.gotmpl
@@ -25,6 +25,7 @@ waitFor:
   - k8srejectloadbalancerservice
   - k8srequirenetworkpolicy
   - k8sresourcerequests
+  - k8spreventaccidentaldeletion
 {{- if and (eq .Environment.Name "workload_cluster") }}
   - k8sminimumreplicas
 {{- end }}

--- a/helmfile.d/values/userCRDs/userCRDs.yaml.gotmpl
+++ b/helmfile.d/values/userCRDs/userCRDs.yaml.gotmpl
@@ -1,3 +1,4 @@
+{{- if eq .Environment.Name "workload_cluster" }}
 userCRDs:
   enabled: {{ .Values.gatekeeper.allowUserCRDs.enabled }}
   admin:
@@ -71,3 +72,4 @@ userCRDs:
     {{- if .Values.gatekeeper.allowUserCRDs.extraCRDs }}
     {{- toYaml .Values.gatekeeper.allowUserCRDs.extraCRDs | nindent 4 }}
     {{- end }}
+{{- end }}

--- a/migration/v0.44/apply/20-gatekeeper-crds.sh
+++ b/migration/v0.44/apply/20-gatekeeper-crds.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+run() {
+  case "${1:-}" in
+  execute)
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      log_info "installing gatekeeper crds in service cluster"
+      helmfile_do sc -l name=gatekeeper-templates apply
+    fi
+    if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+      log_info "installing gatekeeper crds in workload cluster"
+      helmfile_do wc -l name=gatekeeper-templates apply
+    fi
+    ;;
+  rollback)
+    log_warn "rollback not implemented"
+    ;;
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.44/apply/80-apply.sh
+++ b/migration/v0.44/apply/80-apply.sh
@@ -10,6 +10,7 @@ source "${ROOT}/scripts/migration/lib.sh"
 declare -a skipped
 skipped=(
   "app!=prometheus"
+  "name!=gatekeeper-templates"
 )
 declare -a skipped_sc
 skipped_sc=(


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
Added safeguard to prevent accidental cluster deletion
...
-->

### Platform Administrator notice
Adds a new gatekeeper policy that protects the resources of kinds `Cluster`, `OpenStackCluster` and `AzureCluster` from deletion. To delete the resources one must add the annotation `elastisys.io/ok-to-delete=""`

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Since we don't ever want to get into the situation that we by accident delete a cluster, we want to have a gatekeeper policy to enforce this. This pr makes the `gatekeeper-constraints` chart install in sc (was previously only wc) and disables all constraints in sc config except for this newly created one.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes: [#37](https://github.com/elastisys/ck8s-cluster-api/issues/37)

#### Information to reviewers

Here's what the safeguard looks like in action:

```bash
➜ k delete cluster -n capi-cluster eliash-wc --dry-run=server
Error from server (Forbidden): admission webhook "validation.gatekeeper.sh" denied the request: [elastisys-prevent-accidental-deletion] Cluster deletion is not allowed.
To bypass the constraint, run:
kubectl annotate Cluster -n capi-cluster eliash-wc elastisys.io/ok-to-delete=""

➜ kubectl annotate Cluster -n capi-cluster eliash-wc elastisys.io/ok-to-delete=""
cluster.cluster.x-k8s.io/eliash-wc labeled

➜ k delete cluster -n capi-cluster eliash-wc --dry-run=server         
cluster.cluster.x-k8s.io "eliash-wc" deleted (server dry run)
```

@elastisys/goto-cluster-api do we want `capi terminate` to encounter this or should i include the labling part in that command?

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [x] The change requires migration steps
    - [x] The change updates CRDs
    - [x] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [x] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [x] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [-] Any changed Pod is covered by Network Policies
    - [x] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [x] The change does not cause any unnecessary Kubernetes audit events
    - [x] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
