### PR TITLE
apps: change query expression for LessKubeletsThanNodes alerts

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -399,6 +399,12 @@ prometheus:
   nodeSelector: {}
   webhookAlerts:
     enabled: true
+  # Split alerts for autoscaled node from normal node
+  # TODO: .autoscaledNodeGroupAlerts.groupLabel must have value if autoscaledNodeGroupAlerts is enabled, can be configured with a different label in the future
+  autoscaledNodeGroupAlerts:
+    enabled: true
+    groupLabel: "node-restriction.kubernetes.io/autoscaled-node-type"
+    groupLabelValues: []
   ## Predictive alert if the resource usage will hit the set percentage in 3 days
   capacityManagementAlerts:
     enabled: true

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -4440,6 +4440,23 @@ properties:
             items:
               title: S3 Bucket Name
               type: string
+      autoscaledNodeGroupAlerts:
+        title: Autoscaled NodeGroup Alerts
+        description: Configure whether to split KubeletDownForXm alerts into autoscaled and non-autoscaled nodes groups.
+        type: object
+        additionalProperties: false
+        properties:
+          groupLabel:
+            title: Autoscaled node group label
+            description: The label to identity whether a node belongs to an autoscaled node group.
+            type: string
+            default: "node-restriction.kubernetes.io/autoscaled-node-type"
+          groupLabelValues:
+            title: Autoscaled node group label values
+            description: The label values to a autoscaled node group if their are multiple autoscaled node groups.
+            type: array
+            items:
+              type: string
     additionalProperties: false
     properties:
       replicas:
@@ -4615,6 +4632,19 @@ properties:
             title: Webhook Alerts Enabled
             type: boolean
             default: true
+      autoscaledNodeGroupAlerts:
+        title: Autoscaled NodeGroup Alerts
+        description: Configure whether to split KubeletDownForXm alerts into autoscaled and non-autoscaled nodes groups.
+        type: object
+        properties:
+          enabled:
+            title: Enabled aleter splitting for autoscaled nodes.
+            type: boolean
+            default: true
+          groupLabel:
+            $ref: "#/properties/prometheus/$defs/autoscaledNodeGroupAlerts/properties/groupLabel"
+          groupLabelValues:
+            $ref: "#/properties/prometheus/$defs/autoscaledNodeGroupAlerts/properties/groupLabelValues"
       resources:
         $ref: '#/$defs/kubernetesResourceRequirements'
       tolerations:

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system-kubelet.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system-kubelet.yaml
@@ -176,28 +176,85 @@ spec:
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
-    - alert: LessKubeletsThanNodes
+{{- if .Values.autoscaledNodeGroupAlerts.enabled }}
+    - alert: KubletDownForAutoscaledNodeFor15m
       annotations:
-        description: There are less kubelets than nodes for the last 5m.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/LessKubeletsThanNodes
-        summary: There are less kubelets than nodes for the last 5m.
-      expr: up{job="kubelet", metrics_path="/metrics"} == 0
+        description: The kubelet job of an existing autoscaled node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 15m.
+        summary: The kubelet job of an existing autoscaled cluster {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.node }}`}} is down for the last 15m.
+      expr: |-
+          sum by (node, cluster) (kube_node_info and on (node) up{job="kubelet",metrics_path="/metrics"} == 0)
+          and on (node)
+          kube_node_labels{ {{ .Values.autoscaledNodeGroupAlerts.groupLabel }}{{ .Values.autoscaledNodeGroupAlerts.groupLabelValue.regex }} }
+      for: 15m
+      labels:
+        severity: warning
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+    - alert: KubletDownForAutoscaledNodeFor30m
+      annotations:
+        description: The kubelet job of an existing autoscaled node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 30m.
+        summary: The kubelet job of an existing autoscaled node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 30m.
+      expr: |-
+          sum by (node, cluster) (kube_node_info and on (node) up{job="kubelet",metrics_path="/metrics"} == 0)
+          and on (node)
+          kube_node_labels{ {{ .Values.autoscaledNodeGroupAlerts.groupLabel }}{{ .Values.autoscaledNodeGroupAlerts.groupLabelValue.regex }} }
+      for: 30m
+      labels:
+        severity: critical
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+    - alert: KubletDownForNonAutoscaledNodeFor5m
+      annotations:
+        description: The kubelet job of an existing non-autoscaled node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 5m.
+        summary: The kubelet job of an existing non-autoscaled node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 5m.
+      expr: |-
+          sum by (node, cluster) (kube_node_info and on (node) up{job="kubelet",metrics_path="/metrics"} == 0)
+          unless on (node)
+          kube_node_labels{ {{ .Values.autoscaledNodeGroupAlerts.groupLabel }}{{ .Values.autoscaledNodeGroupAlerts.groupLabelValue.regex }} }
       for: 5m
       labels:
         severity: warning
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
-    - alert: LessKubeletsThanNodes
+    - alert: KubletDownForNonAutoscaledNodeFor15m
       annotations:
-        description: There are less kubelets than nodes for the last 15m.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/LessKubeletsThanNodes
-        summary: There are less kubelets than nodes for the last 15m.
-      expr: up{job="kubelet", metrics_path="/metrics"} == 0
+        description: The kubelet job of an existing non-autoscaled node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 15m.
+        summary: The kubelet job of an existing non-autoscaled node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 15m.
+      expr: |-
+          sum by (node, cluster) (kube_node_info and on (node) up{job="kubelet",metrics_path="/metrics"} == 0)
+          unless on (node)
+          kube_node_labels{ {{ .Values.autoscaledNodeGroupAlerts.groupLabel }}{{ .Values.autoscaledNodeGroupAlerts.groupLabelValue.regex }} }
       for: 15m
       labels:
         severity: critical
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+{{- else }}
+    - alert: KubeletDownFor5m
+      annotations:
+        description: The kubelet job of an existing node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 5m.
+        summary: The kubelet job of an existing node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 5m.
+      expr: sum by (node, cluster) (kube_node_info and on (node) up{job="kubelet",metrics_path="/metrics"} == 0)
+      for: 5m
+      labels:
+        severity: warning
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
+    - alert: KubeletDownFor15m
+      annotations:
+        description: The kubelet job of an existing node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 15m.
+        summary: The kubelet job of an existing node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 15m.
+      expr: sum by (node, cluster) (kube_node_info and on (node) up{job="kubelet",metrics_path="/metrics"} == 0)
+      for: 15m
+      labels:
+        severity: critical
+{{- if .Values.defaultRules.additionalRuleLabels }}
+{{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/values.yaml
+++ b/helmfile.d/charts/prometheus-alerts/values.yaml
@@ -19,6 +19,12 @@ s3BucketAlerts:
     count: 1638400
   exclude: []
 
+autoscaledNodeGroupAlerts:
+  enabled: true
+  groupLabel: set-me
+  groupLabelValue:
+    regex: set-me
+
 diskAlerts:
   storage:
     #  - hours: 24 # How many hours to predict over

--- a/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -47,8 +47,14 @@ kube-state-metrics:
   extraArgs:
     - "--custom-resource-state-config-file=/etc/config/clusterapi-metrics.yaml"
   {{- end }}
+  {{- if .Values.prometheus.autoscaledNodeGroupAlerts.enabled }}
+  metricLabelsAllowlist:
+  - nodes=[topology.kubernetes.io/zone,elastisys.io/node-group,{{ .Values.prometheus.autoscaledNodeGroupAlerts.groupLabel }}]
+  {{- else }}
   metricLabelsAllowlist:
   - nodes=[topology.kubernetes.io/zone,elastisys.io/node-group]
+  {{- end }}
+
 kubeApiServer:
   serviceMonitor:
     metricRelabelings:

--- a/helmfile.d/values/kube-prometheus-stack-wc.yaml.gotmpl
+++ b/helmfile.d/values/kube-prometheus-stack-wc.yaml.gotmpl
@@ -25,8 +25,13 @@ kube-state-metrics:
     enabled: true
   resources: {{- toYaml .Values.kubeStateMetrics.resources | nindent 4 }}
 
+  {{- if .Values.prometheus.autoscaledNodeGroupAlerts.enabled }}
+  metricLabelsAllowlist:
+  - nodes=[topology.kubernetes.io/zone,elastisys.io/node-group,node.kubernetes.io/instance-type,{{ .Values.prometheus.autoscaledNodeGroupAlerts.groupLabel }}]
+  {{- else }}
   metricLabelsAllowlist:
   - nodes=[topology.kubernetes.io/zone,elastisys.io/node-group,node.kubernetes.io/instance-type]
+  {{- end }}
 
 prometheus-node-exporter:
   resources: {{- toYaml .Values.prometheusNodeExporter.resources | nindent 4 }}

--- a/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
@@ -4,6 +4,14 @@
 
 # TODO: We should update the rules for things with set namespace and job name to be able to monitor instances in the workload cluster.
 
+# Get and transform autoscaledNodeGroupAlerts label and values
+{{- $groupLabel := .Values.prometheus.autoscaledNodeGroupAlerts.groupLabel -}}
+{{- $transformedGroupLabel := $groupLabel | replace "." "_" | replace "/" "_" | replace "-" "_" -}}
+{{- $groupLabel := printf "label_%s" $transformedGroupLabel -}}
+
+{{- $groupLabelValueArray := .Values.prometheus.autoscaledNodeGroupAlerts.groupLabelValues -}}
+{{- $groupLabelValueArrayRegex := join "|" $groupLabelValueArray -}}
+
 osNodeCount: {{ add .Values.opensearch.dataNode.count .Values.opensearch.clientNode.count .Values.opensearch.masterNode.count }}
 osIndexAlerts: {{ toYaml .Values.opensearch.promIndexAlerts | nindent 2 }}
 
@@ -90,3 +98,14 @@ harbor:
   redis:
     type: {{ .Values.harbor.redis.type }}
   alerts: {{ toYaml .Values.harbor.alerts | nindent 4 }}
+
+autoscaledNodeGroupAlerts:
+  enabled: {{ .Values.prometheus.autoscaledNodeGroupAlerts.enabled }}
+  groupLabel: {{ $groupLabel }}
+  {{- if $groupLabelValueArrayRegex }}
+  groupLabelValue:
+    regex: '=~"{{ $groupLabelValueArrayRegex }}"'
+  {{- else }}
+  groupLabelValue:
+    regex: '!=""'
+  {{- end }}

--- a/helmfile.d/values/prometheus-user-alerts-wc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-user-alerts-wc.yaml.gotmpl
@@ -1,5 +1,13 @@
 # Note: These values are used for setting up alerts for the *user*.
 
+# Get and transform autoscaledNodeGroupAlerts label and values
+{{- $groupLabel := .Values.prometheus.autoscaledNodeGroupAlerts.groupLabel -}}
+{{- $transformedGroupLabel := $groupLabel | replace "." "_" | replace "/" "_" | replace "-" "_" -}}
+{{- $groupLabel := printf "label_%s" $transformedGroupLabel -}}
+
+{{- $groupLabelValueArray := .Values.prometheus.autoscaledNodeGroupAlerts.groupLabelValues -}}
+{{- $groupLabelValueArrayRegex := join "|" $groupLabelValueArray -}}
+
 osNodeCount: 0
 alertmanagerJob: alertmanager-operated
 alertmanagerNamespace: alertmanager
@@ -42,3 +50,14 @@ capacityManagementAlertsNodeGroupCpuLimit1h: {{ .Values.prometheus.capacityManag
 capacityManagementAlertsNodeGroupMemoryLimit1h: {{ .Values.prometheus.capacityManagementAlerts.nodeGroupMemoryLimit1h }}
 capacityManagementAlertsNodeCpuLimit1h: {{ .Values.prometheus.capacityManagementAlerts.nodeCpuLimit1h }}
 capacityManagementAlertsNodeMemoryLimit1h: {{ .Values.prometheus.capacityManagementAlerts.nodeMemoryLimit1h }}
+
+autoscaledNodeGroupAlerts:
+  enabled: {{ .Values.prometheus.autoscaledNodeGroupAlerts.enabled }}
+  groupLabel: {{ $groupLabel }}
+  {{- if $groupLabelValueArrayRegex }}
+  groupLabelValue:
+    regex: '=~"{{ $groupLabelValueArrayRegex }}"'
+  {{- else }}
+  groupLabelValue:
+    regex: '!=""'
+  {{- end }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
This change should mitigate the chances of false firing the **LessKubeletsThanNodes** alerts during autoscaling process.
The old query checks if there's any kubelet job down.
The new query compare the number of running kubelet jobs and the total number of nodes in the cluster, and triggers the alerts when the former is less than the latter.
The **LessKubeletsThanNodes** alerts is split into two based on the label `node-restriction.kubernetes.io/autoscaled-node-type`, which indicates if a node belongs to an autoscaling group or not.
1. **LessKubeletsThanNonautoscalableNodes**: Checks nodes without the mentioned label, P2 alerts has 5m pending time, P1 alert has 15m pending time.
2.  **LessKubeletsThanAutoscalableNodes**: Checks nodes with the mentioned label, P2 alerts has 15m pending time, P1 alert has 30m pending time.

NOTE: Currently the alerts does not check the values of the label, only checks if the label exits or not.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes https://github.com/elastisys/ck8s-cluster-api/issues/276

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->
See the comment section of the issue for more details. 
#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
