### PR TITLE
apps-sc: expose thanos receiveDistributor configs

### DIFF
--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -575,7 +575,7 @@ thanos:
     # It needs to write to (REPLICATION_FACTOR + 1)/2 nodes for success.
     # For more info: https://thanos.io/v0.24/proposals-done/201812-thanos-remote-receive.md/#replication
     replicationFactor: 1
-
+    replicaCount: 1
     resources:
       requests:
         cpu: 150m
@@ -583,6 +583,7 @@ thanos:
       limits:
         cpu: 1000m
         memory: 1Gi
+    extraFlags: [] #use extraflags when you want to add more command line flags to the component.
 
   ruler:
     # Enables the ruler component

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -4873,6 +4873,15 @@ properties:
         type: object
         additionalProperties: false
         properties:
+          replicaCount:
+            title: Thanos receiveDistributor Replicas
+            type: integer
+            default: 1
+          extraFlags:
+            title: Thanos receiveDistributor extraFlags
+            description: |-
+              When set, the arguments will be passed onto the component as command-line flags. Refer to the [upstream doc](https://github.com/bitnami/charts/blob/main/bitnami/thanos/README.md#adding-extra-flags) for more details.
+            type: array
           replicationFactor:
             title: Thanos Replication Factor
             description: Requires that incoming remote write requests are replicated `(replicationFactor + 1) / 2`.

--- a/helmfile.d/values/thanos/receiver.yaml.gotmpl
+++ b/helmfile.d/values/thanos/receiver.yaml.gotmpl
@@ -130,6 +130,7 @@ receiveDistributor:
 
   resources: {{- toYaml .Values.thanos.receiveDistributor.resources | nindent 4 }}
   replicationFactor: {{  .Values.thanos.receiveDistributor.replicationFactor }}
+  replicaCount: {{ .Values.thanos.receiveDistributor.replicaCount }}
 
   containerSecurityContext:
     capabilities:
@@ -137,6 +138,10 @@ receiveDistributor:
         - ALL
     seccompProfile:
       type: RuntimeDefault
+  {{- if .Values.thanos.receiveDistributor.extraFlags }}
+  extraFlags:
+    {{- toYaml .Values.thanos.receiveDistributor.extraFlags | nindent 4 }}
+  {{ end }}
 
 ruler:
   networkPolicy:


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Not having these variables is stopping us from performing some tests, so I've added these variables so people can work on using different hashrings algorithm.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #



#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
