### PR TITLE
apps-sc: add policy to reject local storage emptydir

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -889,6 +889,11 @@ opa:
     enabled: true
     enforcement: deny
 
+  ## Enable rule that warns about emptydir with local storage, which can prevent cluster autoscaler from evicting when scaling down
+  rejectLocalStorageEmptyDir:
+    enabled: false
+    enforcement: warn
+
 trivy:
   enabled: true
   # comma separated list of namespaces (or glob patterns) to be excluded from scanning

--- a/config/k8s-installers/capi/wc-config.yaml
+++ b/config/k8s-installers/capi/wc-config.yaml
@@ -1,0 +1,4 @@
+opa:
+  rejectLocalStorageEmptyDir:
+    # In cluster api cluster autoscaler is regularly enabled, which is when we want to have this enabled
+    enabled: true

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -3631,6 +3631,32 @@ properties:
               deny: Deny actions violating the constraint.
               warn: Warn actions violating the constraint.
               dryrun: Dryrun actions violating the constraint.
+      rejectLocalStorageEmptyDir:
+        title: Safeguard Reject Local Storage EmptyDir
+        description: |-
+          Configure constraint to reject usage of local storage emptydir.
+
+          > [!note]
+          > See [the dev docs](https://elastisys.io/welkin/user-guide/safeguards/enforce-no-local-storage-emptydir/) for context.
+        type: object
+        additionalProperties: false
+        properties:
+          enabled:
+            title: Safeguard Rejecting Local Storage EmptyDir Enabled
+            type: boolean
+            default: true
+          enforcement:
+            title: Safeguard Reject Local Storage EmptyDir Enforcement
+            type: string
+            default: warn
+            enum:
+              - deny
+              - warn
+              - dryrun
+            meta:enum:
+              deny: Deny actions violating the constraint.
+              warn: Warn actions violating the constraint.
+              dryrun: Dryrun actions violating the constraint.
       networkPolicies:
         title: Safeguard Network Policies
         description: |-

--- a/helmfile.d/charts/gatekeeper/constraints/templates/reject-local-storage-empty-dir/constraint.yaml
+++ b/helmfile.d/charts/gatekeeper/constraints/templates/reject-local-storage-empty-dir/constraint.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.rejectLocalStorageEmptyDir.enable -}}
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: K8sRejectLocalStorageEmptyDir
+metadata:
+  name: elastisys-reject-local-storage-emptydir
+spec:
+  enforcementAction: {{ .Values.rejectLocalStorageEmptyDir.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod", "ReplicationController"]
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "StatefulSet", "DaemonSet", "ReplicaSet"]
+      - apiGroups: ["extensions"]
+        kinds: ["Deployment", "StatefulSet", "DaemonSet", "ReplicaSet"]
+      - apiGroups: ["batch"]
+        kinds: ["Job", "CronJob"]
+    excludedNamespaces: ["kube-system", "kube-public", "kube-node-lease", "calico-system"]
+    namespaceSelector:
+      matchExpressions:
+      - key: owner
+        operator: NotIn
+        values:
+        - operator
+  parameters:
+    volumeAnnotation: cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes
+    podAnnotation: cluster-autoscaler.kubernetes.io/safe-to-evict
+{{- end }}

--- a/helmfile.d/charts/gatekeeper/constraints/values.yaml
+++ b/helmfile.d/charts/gatekeeper/constraints/values.yaml
@@ -25,6 +25,9 @@ preventAccidentalDeletion:
 disallowLocalhostSeccomp:
     enable: false
     enforcementAction: deny
+rejectLocalStorageEmptyDir:
+    enable: false
+    enforcementAction: warn
 
 imageRegistryURL: registry.example.com
 

--- a/helmfile.d/charts/gatekeeper/templates/policies/reject-local-storage-empty-dir.rego
+++ b/helmfile.d/charts/gatekeeper/templates/policies/reject-local-storage-empty-dir.rego
@@ -1,0 +1,90 @@
+package k8srejectlocalstorageemptydir
+import future.keywords.in
+
+# violation if volume has no medium.
+violation[{"msg": msg}] {
+    volume := get_volumes[_]
+    missing(volume.emptyDir, "medium")
+    not check_volume_in_annotation(get_metadata, volume)
+    not check_pod_annotation(get_metadata)
+    msg := sprintf("The volume <%v> emptyDir is using local storage emptyDir. This can prevent autoscaler from scaling down a node where this is running. Read more about this and possible solutions at https://elastisys.io/welkin/user-guide/safeguards/enforce-no-local-storage-emptydir/",[volume])
+}
+
+# violation if medium is not Memory.
+violation[{"msg": msg}] {
+    volume := get_volumes[_]
+    volume.emptyDir.medium != "Memory"
+    not check_volume_in_annotation(get_metadata, volume)
+    not check_pod_annotation(get_metadata)
+    msg := sprintf("The volume <%v> emptyDir is using local storage emptyDir. This can prevent autoscaler from scaling down a node where this is running. Read more about this and possible solutions at https://elastisys.io/welkin/user-guide/safeguards/enforce-no-local-storage-emptydir/",[volume])
+}
+
+# Get volumes for "Pods"
+get_volumes = res {
+    input.review.object.kind == "Pod"
+    res := input.review.object.spec.volumes
+}
+
+# Get volumes for resources that use pod templates.
+get_volumes = res {
+    kinds := [
+        "Deployment",
+        "StatefulSet",
+        "DaemonSet",
+        "ReplicaSet",
+        "Job",
+        "ReplicationController"
+    ]
+    input.review.object.kind == kinds[_]
+
+    res := input.review.object.spec.template.spec.volumes
+}
+
+# Get volumes for "CronJobs"
+get_volumes = res {
+    input.review.object.kind == "CronJob"
+    res := input.review.object.spec.jobTemplate.spec.template.spec.volumes
+}
+
+# Get metadata for "Pods"
+get_metadata = res {
+    input.review.object.kind == "Pod"
+    res := input.review.object.metadata
+}
+
+# Get metadata for resources that use pod templates.
+get_metadata = res {
+    kinds := [
+        "Deployment",
+        "StatefulSet",
+        "DaemonSet",
+        "ReplicaSet",
+        "Job",
+        "ReplicationController"
+    ]
+    input.review.object.kind == kinds[_]
+
+    res := input.review.object.spec.template.metadata
+}
+
+# Get metadata for "CronJobs"
+get_metadata = res {
+    input.review.object.kind == "CronJob"
+    res := input.review.object.spec.jobTemplate.spec.template.metadata
+}
+
+# Field missing if it does not exist in the object
+missing(obj, field) {
+    not obj[field]
+}
+
+check_volume_in_annotation(metadata, volume) {
+    some annotation_key, annotation_value in metadata.annotations
+    annotation_key == input.parameters.volumeAnnotation
+
+    split(annotation_value, ",")[_] == volume.name
+}
+
+check_pod_annotation(metadata) {
+    metadata.annotations[input.parameters.podAnnotation] == "true"
+}

--- a/helmfile.d/charts/gatekeeper/templates/policies/tests/reject-local-storage-empty-dir.rego
+++ b/helmfile.d/charts/gatekeeper/templates/policies/tests/reject-local-storage-empty-dir.rego
@@ -1,0 +1,393 @@
+package test.k8srejectlocalstorageemptydir
+
+import data.k8srejectlocalstorageemptydir
+
+#
+# Help functions
+#
+
+generate_resources(kind, volumeAnnotation, podAnnotation, annotations, volumes) = obj {
+    kind == "Pod"
+    obj := {
+        "parameters": {
+            "volumeAnnotation": volumeAnnotation,
+            "podAnnotation": podAnnotation
+        },
+        "review": {
+            "object": {
+                "kind": "Pod",
+                "metadata": {
+                    "annotations": annotations
+                },
+                "spec": {
+                    "volumes": volumes
+                }
+            }
+        }
+    }
+}
+generate_resources(kind, volumeAnnotation, podAnnotation, annotations, volumes) = obj {
+    allowed_kinds := [
+        "Deployment",
+        "StatefulSet",
+        "DaemonSet",
+        "ReplicaSet",
+        "Job",
+        "ReplicationController"
+    ]
+    kind == allowed_kinds[_]
+    obj := {
+        "parameters": {
+            "volumeAnnotation": volumeAnnotation,
+            "podAnnotation": podAnnotation
+        },
+        "review": {
+            "object": {
+                "kind": kind,
+                "spec": {
+                    "template": {
+                        "metadata": {
+                            "annotations": annotations
+                        },
+                        "spec": {
+                            "volumes": volumes
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+generate_resources(kind, volumeAnnotation, podAnnotation, annotations, volumes) = obj {
+    kind == "CronJob"
+    obj := {
+        "parameters": {
+            "volumeAnnotation": volumeAnnotation,
+            "podAnnotation": podAnnotation
+        },
+        "review": {
+            "object": {
+                "kind": "CronJob",
+                "spec": {
+                    "jobTemplate": {
+                        "spec": {
+                            "template": {
+                                "metadata": {
+                                    "annotations": annotations
+                                },
+                                "spec": {
+                                    "volumes": volumes
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+kinds := [
+    "Pod",
+    "Deployment",
+    "StatefulSet",
+    "DaemonSet",
+    "ReplicaSet",
+    "Job",
+    "ReplicationController",
+    "CronJob"
+]
+
+#
+# Tests
+#
+
+test_no_volume {
+    res = [test | test = count(k8srejectlocalstorageemptydir.violation) == 0 with input as generate_resources(
+        kinds[_],
+        "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes",
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+        {},
+        []
+    )]
+    all(res)
+}
+
+test_emptydir_memory {
+    res = [test | test = count(k8srejectlocalstorageemptydir.violation) == 0 with input as generate_resources(
+        kinds[_],
+        "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes",
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+        {},
+        [
+            {
+                "name": "emptydir-volume",
+                "emptyDir": {
+                    "sizeLimit": "500Mi",
+                    "medium": "Memory"
+                }
+            }
+        ]
+    )]
+    all(res)
+}
+
+test_emptydir_wrong_medium {
+    res = [test | test = count(k8srejectlocalstorageemptydir.violation) == 1 with input as generate_resources(
+        kinds[_],
+        "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes",
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+        {},
+        [
+            {
+                "name": "emptydir-volume",
+                "emptyDir": {
+                    "sizeLimit": "500Mi",
+                    "medium": "Not-memory"
+                }
+            }
+        ]
+    )]
+    all(res)
+}
+
+test_emptydir_no_annotations {
+
+    res = [test | test = count(k8srejectlocalstorageemptydir.violation) == 1 with input as generate_resources(
+        kinds[_],
+        "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes",
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+        {},
+        [
+            {
+                "name": "emptydir-volume",
+                "emptyDir": {
+                    "sizeLimit": "500Mi"
+                }
+            }
+        ]
+    )]
+    all(res)
+}
+
+# Tests for volume annotation
+test_emptydir_with_volume_annotation {
+    res = [test | test = count(k8srejectlocalstorageemptydir.violation) == 0 with input as generate_resources(
+        kinds[_],
+        "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes",
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+        {
+            "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes": "emptydir-volume"
+        },
+        [
+            {
+                "name": "emptydir-volume",
+                "emptyDir": {
+                    "sizeLimit": "500Mi"
+                }
+            }
+        ]
+    )]
+    all(res)
+}
+
+test_emptydir_with_wrong_volume_annotation_key {
+    res = [test | test = count(k8srejectlocalstorageemptydir.violation) == 1 with input as generate_resources(
+        kinds[_],
+        "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes",
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+        {
+            "bad-annotation": "emptydir-volume"
+        },
+        [
+            {
+                "name": "emptydir-volume",
+                "emptyDir": {
+                    "sizeLimit": "500Mi"
+                }
+            }
+        ]
+    )]
+    all(res)
+}
+
+test_emptydir_with_wrong_volume_annotation_value {
+    res = [test | test = count(k8srejectlocalstorageemptydir.violation) == 1 with input as generate_resources(
+        kinds[_],
+        "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes",
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+        {
+            "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes": "another-volume"
+        },
+        [
+            {
+                "name": "emptydir-volume",
+                "emptyDir": {
+                    "sizeLimit": "500Mi"
+                }
+            }
+        ]
+    )]
+    all(res)
+}
+
+test_emptydir_with_two_allowed_volumes {
+    res = [test | test = count(k8srejectlocalstorageemptydir.violation) == 0 with input as generate_resources(
+        kinds[_],
+        "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes",
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+        {
+            "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes": "allowed_volume1,allowed_volume2"
+        },
+        [
+            {
+                "name": "allowed_volume1",
+                "emptyDir": {
+                    "sizeLimit": "500Mi"
+                }
+            },
+            {
+                "name": "allowed_volume2",
+                "emptyDir": {
+                    "sizeLimit": "500Mi"
+                }
+            }
+        ]
+    )]
+    all(res)
+}
+
+test_emptydir_with_one_allowed_one_disallowed_volumes {
+    res = [test | test = count(k8srejectlocalstorageemptydir.violation) == 1 with input as generate_resources(
+        kinds[_],
+        "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes",
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+        {
+            "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes": "allowed_volume"
+        },
+        [
+            {
+                "name": "allowed_volume",
+                "emptyDir": {
+                    "sizeLimit": "500Mi"
+                }
+            },
+            {
+                "name": "disallowed_volume",
+                "emptyDir": {
+                    "sizeLimit": "500Mi"
+                }
+            }
+        ]
+    )]
+    all(res)
+}
+
+test_emptydir_with_two_disallowed_volumes {
+    res = [test | test = count(k8srejectlocalstorageemptydir.violation) == 2 with input as generate_resources(
+        kinds[_],
+        "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes",
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+        {
+            "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes": ""
+        },
+        [
+            {
+                "name": "disallowed_volume1",
+                "emptyDir": {
+                    "sizeLimit": "500Mi"
+                }
+            },
+            {
+                "name": "disallowed_volume2",
+                "emptyDir": {
+                    "sizeLimit": "500Mi"
+                }
+            }
+        ]
+    )]
+    all(res)
+}
+
+#Tests for pod annotation
+test_emptydir_with_pod_annotation {
+    res = [test | test = count(k8srejectlocalstorageemptydir.violation) == 0 with input as generate_resources(
+        kinds[_],
+        "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes",
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+        {
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
+        },
+        [
+            {
+                "name": "emptydir-volume",
+                "emptyDir": {
+                    "sizeLimit": "500Mi"
+                }
+            }
+        ]
+    )]
+    all(res)
+}
+
+test_emptydir_with_wrong_pod_annotation_key {
+    res = [test | test = count(k8srejectlocalstorageemptydir.violation) == 1 with input as generate_resources(
+        kinds[_],
+        "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes",
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+        {
+            "bad-annotation": "true"
+        },
+        [
+            {
+                "name": "emptydir-volume",
+                "emptyDir": {
+                    "sizeLimit": "500Mi"
+                }
+            }
+        ]
+    )]
+    all(res)
+}
+
+test_emptydir_with_wrong_pod_annotation_value {
+    res = [test | test = count(k8srejectlocalstorageemptydir.violation) == 1 with input as generate_resources(
+        kinds[_],
+        "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes",
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+        {
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "another-value"
+        },
+        [
+            {
+                "name": "emptydir-volume",
+                "emptyDir": {
+                    "sizeLimit": "500Mi"
+                }
+            }
+        ]
+    )]
+    all(res)
+}
+
+#Test for both annotations
+test_emptydir_with_both_annotations {
+    res = [test | test = count(k8srejectlocalstorageemptydir.violation) == 0 with input as generate_resources(
+        kinds[_],
+        "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes",
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+        {
+            "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes": "emptydir-volume",
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
+        },
+        [
+            {
+                "name": "emptydir-volume",
+                "emptyDir": {
+                    "sizeLimit": "500Mi"
+                }
+            }
+        ]
+    )]
+    all(res)
+}

--- a/helmfile.d/charts/gatekeeper/templates/templates/reject-local-storage-empty-dir/template.yaml
+++ b/helmfile.d/charts/gatekeeper/templates/templates/reject-local-storage-empty-dir/template.yaml
@@ -1,0 +1,24 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8srejectlocalstorageemptydir
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sRejectLocalStorageEmptyDir
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+            type: object
+            properties:
+              volumeAnnotation:
+                description: This annotation allows to suppress the warning of the constraint if the violating volumes are listed in the annotation value.
+                type: string
+              podAnnotation:
+                description: This annotation allows to suppress the warning of the constraint if the annotation value is set to "true".
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ .Files.Get "policies/reject-local-storage-empty-dir.rego"  | indent 8 }}

--- a/helmfile.d/values/gatekeeper/constraints.yaml.gotmpl
+++ b/helmfile.d/values/gatekeeper/constraints.yaml.gotmpl
@@ -16,6 +16,9 @@ rejectLoadBalancerService:
 preventAccidentalDeletion:
     enable: {{ .Values.opa.preventAccidentalDeletion.enabled }}
     enforcementAction: {{ .Values.opa.preventAccidentalDeletion.enforcement }}
+rejectLocalStorageEmptyDir:
+    enable: {{ .Values.opa.rejectLocalStorageEmptyDir.enabled }}
+    enforcementAction: {{ .Values.opa.rejectLocalStorageEmptyDir.enforcement }}
 {{- if eq .Environment.Name "workload_cluster" }}
 allowUserCRDs:
     enable: {{ .Values.gatekeeper.allowUserCRDs.enabled }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [x] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->


### Application Developer notice

A new guardrail is added that is enabled by default on ClusterAPI environments. It will by default warn but not deny usage of emptyDir storage, since this can stop cluster autoscaler from scaling down nodes. Read more on [this page](https://elastisys.io/welkin/user-guide/safeguards/enforce-no-local-storage-emptydir/).

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Adds a policy that can reject the use of local storage emptydir volumes (not emptydir that uses memory). This is primarily to avoid situations where the cluster autoscaler cannot scale down a node because it [will not evict pods with local storage](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node).

Part of #2318 

#### Information to reviewers

I will add some more tests as well, but I wanted to get some feedback on the actual policy. But I have done a lot of manual testing as well.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
