### PR TITLE
apps: gatekeeper policy to reject pods without controller

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -927,6 +927,10 @@ opa:
   rejectLocalStorageEmptyDir:
     enabled: false
     enforcement: warn
+  ## Enable rule that warns about pods without a controller, which can prevent cluster autoscaler from evicting when scaling down
+  rejectPodWithoutController:
+    enabled: false
+    enforcement: warn
 
 trivy:
   enabled: true

--- a/config/k8s-installers/capi/wc-config.yaml
+++ b/config/k8s-installers/capi/wc-config.yaml
@@ -2,3 +2,6 @@ opa:
   rejectLocalStorageEmptyDir:
     # In cluster api cluster autoscaler is regularly enabled, which is when we want to have this enabled
     enabled: true
+  rejectPodWithoutController:
+    # In cluster api cluster autoscaler is regularly enabled, which is when we want to have this enabled
+    enabled: true

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -3637,9 +3637,35 @@ properties:
           enabled:
             title: Safeguard Rejecting Local Storage EmptyDir Enabled
             type: boolean
-            default: true
+            default: false
           enforcement:
             title: Safeguard Reject Local Storage EmptyDir Enforcement
+            type: string
+            default: warn
+            enum:
+              - deny
+              - warn
+              - dryrun
+            meta:enum:
+              deny: Deny actions violating the constraint.
+              warn: Warn actions violating the constraint.
+              dryrun: Dryrun actions violating the constraint.
+      rejectPodWithoutController:
+        title: Safeguard Reject Pod Without Controller
+        description: |-
+          Configure constraint to reject pods without a controller.
+
+          > [!note]
+          > See [the dev docs](https://elastisys.io/welkin/user-guide/safeguards/enforce-no-pod-without-controller) for context.
+        type: object
+        additionalProperties: false
+        properties:
+          enabled:
+            title: Safeguard Reject Pod Without Controller Enabled
+            type: boolean
+            default: false
+          enforcement:
+            title: Safeguard Reject Pod Without Controller Enforcement
             type: string
             default: warn
             enum:

--- a/helmfile.d/charts/gatekeeper/constraints/templates/reject-pod-without-controller/constraint.yaml
+++ b/helmfile.d/charts/gatekeeper/constraints/templates/reject-pod-without-controller/constraint.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rejectPodWithoutController.enable -}}
+apiVersion: constraints.gatekeeper.sh/v1alpha1
+kind: K8sRejectPodWithoutController
+metadata:
+  name: elastisys-reject-pod-without-controller
+spec:
+  enforcementAction: {{ .Values.rejectPodWithoutController.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    excludedNamespaces: ["kube-system", "kube-public", "kube-node-lease", "calico-system"]
+    namespaceSelector:
+      matchExpressions:
+      - key: owner
+        operator: NotIn
+        values:
+        - operator
+  parameters:
+    annotation: "cluster-autoscaler.kubernetes.io/safe-to-evict"
+{{- end }}

--- a/helmfile.d/charts/gatekeeper/constraints/values.yaml
+++ b/helmfile.d/charts/gatekeeper/constraints/values.yaml
@@ -28,6 +28,9 @@ disallowLocalhostSeccomp:
 rejectLocalStorageEmptyDir:
     enable: false
     enforcementAction: warn
+rejectPodWithoutController:
+    enable: false
+    enforcementAction: warn
 
 imageRegistryURL: registry.example.com
 

--- a/helmfile.d/charts/gatekeeper/templates/policies/reject-pod-without-controller.rego
+++ b/helmfile.d/charts/gatekeeper/templates/policies/reject-pod-without-controller.rego
@@ -1,0 +1,28 @@
+package k8srejectpodwithoutcontroller
+
+metadata := input.review.object.metadata
+
+# violation if pod has no ownerReferences.
+violation[{"msg": msg}] {
+    input.review.object.kind == "Pod"
+	missing(metadata, "ownerReferences")
+    not check_annotation
+    msg := sprintf("The Pod <%v> does not have any ownerReferences. This can prevent autoscaler from scaling down a node where this is running. Read more about this and possible solutions at https://elastisys.io/welkin/user-guide/safeguards/enforce-no-pod-without-controller",[metadata.name])
+}
+
+# violation if ownerReferences is empty.
+violation[{"msg": msg}] {
+    input.review.object.kind == "Pod"
+	metadata.ownerReferences == []
+    not check_annotation
+    msg := sprintf("The Pod <%v> does not have any ownerReferences. This can prevent autoscaler from scaling down a node where this is running. Read more about this and possible solutions at https://elastisys.io/welkin/user-guide/safeguards/enforce-no-pod-without-controller",[metadata.name])
+}
+
+# Field missing if it does not exist in the object
+missing(obj, field) {
+    not obj[field]
+}
+
+check_annotation {
+	metadata.annotations[input.parameters.annotation] == "true"
+}

--- a/helmfile.d/charts/gatekeeper/templates/policies/tests/reject-pod-without-controller.rego
+++ b/helmfile.d/charts/gatekeeper/templates/policies/tests/reject-pod-without-controller.rego
@@ -1,0 +1,99 @@
+package test.k8srejectpodwithoutcontroller
+
+import data.k8srejectpodwithoutcontroller
+
+#
+# Help functions
+#
+
+generate_pod(annotation, metadata) = obj {
+	obj := {
+		"parameters": {
+			"annotation": annotation
+		},
+		"review": {
+			"object": {
+				"kind": "Pod",
+				"metadata": metadata
+			}
+		}
+	}
+}
+
+#
+# Tests
+#
+
+test_with_owner_reference {
+    count(k8srejectpodwithoutcontroller.violation) == 0 with input as generate_pod(
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+		{
+			"name": "pod-name",
+			"ownerReferences": [
+				{
+					"apiVersion": "apps/v1",
+					"blockOwnerDeletion": "true",
+					"controller": "true",
+					"kind": "ReplicaSet",
+					"name": "replicaset-name",
+					"uid": "uid"
+				}
+			]
+		}
+    )
+}
+
+test_without_owner_reference {
+    count(k8srejectpodwithoutcontroller.violation) == 1 with input as generate_pod(
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+		{
+			"name": "pod-name"
+		}
+    )
+}
+
+test_with_empty_owner_reference {
+    count(k8srejectpodwithoutcontroller.violation) == 1 with input as generate_pod(
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+		{
+			"name": "pod-name",
+			"ownerReferences": []
+		}
+    )
+}
+
+test_with_annotation {
+    count(k8srejectpodwithoutcontroller.violation) == 0 with input as generate_pod(
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+		{
+			"name": "pod-name",
+			"annotations": {
+				"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
+			}
+		}
+    )
+}
+
+test_with_wrong_annotation_key {
+    count(k8srejectpodwithoutcontroller.violation) == 1 with input as generate_pod(
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+		{
+			"name": "pod-name",
+			"annotations": {
+				"wrong-annotation": "true"
+			}
+		}
+    )
+}
+
+test_with_wrong_annotation_value {
+    count(k8srejectpodwithoutcontroller.violation) == 1 with input as generate_pod(
+        "cluster-autoscaler.kubernetes.io/safe-to-evict",
+		{
+			"name": "pod-name",
+			"annotations": {
+				"cluster-autoscaler.kubernetes.io/safe-to-evict": "wrong"
+			}
+		}
+    )
+}

--- a/helmfile.d/charts/gatekeeper/templates/templates/reject-pod-without-controller/template.yaml
+++ b/helmfile.d/charts/gatekeeper/templates/templates/reject-pod-without-controller/template.yaml
@@ -1,0 +1,21 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8srejectpodwithoutcontroller
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sRejectPodWithoutController
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+            type: object
+            properties:
+              annotation:
+                description: This annotation allows to suppress the warning of the constraint if the annotation value is "true".
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ .Files.Get "policies/reject-pod-without-controller.rego"  | indent 8 }}

--- a/helmfile.d/values/gatekeeper/constraints.yaml.gotmpl
+++ b/helmfile.d/values/gatekeeper/constraints.yaml.gotmpl
@@ -19,6 +19,9 @@ preventAccidentalDeletion:
 rejectLocalStorageEmptyDir:
     enable: {{ .Values.opa.rejectLocalStorageEmptyDir.enabled }}
     enforcementAction: {{ .Values.opa.rejectLocalStorageEmptyDir.enforcement }}
+rejectPodWithoutController:
+    enable: {{ .Values.opa.rejectPodWithoutController.enabled }}
+    enforcementAction: {{ .Values.opa.rejectPodWithoutController.enforcement }}
 {{- if eq .Environment.Name "workload_cluster" }}
 allowUserCRDs:
     enable: {{ .Values.gatekeeper.allowUserCRDs.enabled }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [x] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->


### Application Developer notice

A new guardrail is added that is enabled by default on ClusterAPI environments. It will by default warn but not deny usage of Pods without backing controllers, since this can stop cluster autoscaler from scaling down nodes. Read more on [this page](https://elastisys.io/welkin/user-guide/safeguards/enforce-no-pod-without-controller).

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Adds a policy that can reject the use of pods without any controller/ownerReference (i.e. pods that does not belong to a deployment/daemonset/job/...). This is primarily to avoid situations where the cluster autoscaler cannot scale down a node because it [will not evict pods with local storage](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node).

Part of #2318 

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [x] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](https://github.com/elastisys/welkin/pull/1050)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
