### PR TITLE
apps sc: made alert runbooks configurable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: check-toml
         exclude: ^helmfile\.d/upstream/
       - id: check-yaml
-        exclude: ^helmfile\.d/.*/templates/|^helmfile\.d/upstream/|^helmfile\.d/state.yaml$
+        exclude: ^helmfile\.d/.*/templates/|^helmfile\.d/upstream/|^helmfile\.d/state.yaml$|^helmfile\.d/charts/prometheus-alerts/files/
         args:
           - --allow-multiple-documents
       - id: detect-private-key

--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -106,6 +106,46 @@ user:
     ingress:
       enabled: false
 
+alerts:
+  # Configure runbook URLs for alerts, can be configured on an alert group level or
+  # per individual alert
+  runbookUrls:
+    alertmanager: {}
+    ## Example:
+    # group: https://runbooks.prometheus-operator.dev/runbooks/alertmanager/
+    # AlertmanagerFailedReload: https://runbooks.prometheus-operator.dev/runbooks/alertmanager/alertmanagerfailedreload/
+    # AlertName: link-to-specific-alert-runbook
+    backupStatus: {}
+    blackbox: {}
+    certManager: {}
+    clusterApi: {}
+    clusterCapacityManagement: {}
+    configReloaders: {}
+    coreDns: {}
+    dailyChecks: {}
+    diskPerf: {}
+    falco: {}
+    fluentd: {}
+    general: {}
+    harbor: {}
+    hnc: {}
+    kubeStateMetrics: {}
+    kubernetesApps: {}
+    kubernetesResources: {}
+    kubernetesStorage: {}
+    kubernetesSystem: {}
+    kured: {}
+    missingMetrics: {}
+    nodeExporter: {}
+    nodeNetwork: {}
+    opensearch: {}
+    openstack: {}
+    packetsDropped: {}
+    prometheusOperator: {}
+    prometheus: {}
+    thanos: {}
+    webhook: {}
+
 ## Falco configuration.
 falco:
   ## Falco alerting configuration.

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -4061,6 +4061,131 @@ properties:
           customTemplate:
             title: Slack Custom Template
             type: string
+      runbookUrls:
+        title: Alert runbooks
+        description: |-
+          Configure runbooks for alerts
+
+          Runbooks can be configured on an alert group level or per individual alert
+        type: object
+        additionalProperties: false
+        $defs:
+          upstreamRunbook:
+            title: Runbooks for alerts
+            description: |-
+              Example:
+
+              group: link-to-alert-group-runbook
+              AlertName: link-to-specific-alert-runbook
+
+              Uses upstream runbooks by default
+
+              https://runbooks.prometheus-operator.dev/runbooks/
+            type: object
+            additionalProperties:
+              type: string
+              description: Alert runbook URL
+            properties:
+              group:
+                title: Alert group runbook URL
+                type: string
+          noUpstreamRunbook:
+            title: Runbooks for alerts
+            description: |-
+              Example:
+
+              group: link-to-alert-group-runbook
+              AlertName: link-to-specific-alert-runbook
+
+              Uses no upstream runbook by default
+            type: object
+            additionalProperties:
+              type: string
+              description: Alert runbook URL
+            properties:
+              group:
+                title: Alert group runbook URL
+                type: string
+        properties:
+          alertmanager:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/upstreamRunbook'
+          backupStatus:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
+          blackbox:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
+          certManager:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
+          clusterApi:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
+          clusterCapacityManagement:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/upstreamRunbook'
+          configReloaders:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/upstreamRunbook'
+          coreDns:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
+          dailyChecks:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
+          diskPerf:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
+          falco:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
+          fluentd:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
+          general:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/upstreamRunbook'
+          harbor:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
+          hnc:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
+          kubeStateMetrics:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/upstreamRunbook'
+          kubernetesApps:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/upstreamRunbook'
+          kubernetesResources:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/upstreamRunbook'
+          kubernetesStorage:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/upstreamRunbook'
+          kubernetesSystem:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/upstreamRunbook'
+          kured:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
+          missingMetrics:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
+          nodeExporter:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/upstreamRunbook'
+          nodeNetwork:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/upstreamRunbook'
+          opensearch:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
+          openstack:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
+          packetsDropped:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
+          prometheusOperator:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/upstreamRunbook'
+          prometheus:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/upstreamRunbook'
+          thanos:
+            title: Runbooks for thanos alerts
+            description: |-
+              Example:
+
+              group: link-to-alert-group-runbook
+              AlertName: link-to-specific-alert-runbook
+
+              Uses upstream runbooks by default
+
+              https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md
+            type: object
+            additionalProperties:
+              type: string
+              description: Alert runbook URL
+            properties:
+              group:
+                title: Alert group runbook URL
+                type: string
+          webhook:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
   grafana:
     title: Grafana Config
     description: |-

--- a/helmfile.d/charts/prometheus-alerts/files/cluster-api.yaml
+++ b/helmfile.d/charts/prometheus-alerts/files/cluster-api.yaml
@@ -3,9 +3,10 @@
     - alert: ClusterApiClusterIsPaused
       annotations:
         description: |
-          The cluster `{{ $labels.name }}` has been paused for 15 minutes
+          The cluster {{"`{{ $labels.name }}`"}} has been paused for 15 minutes
         summary: |
-          The cluster `{{ $labels.name }}` has been paused for 15 minutes
+          The cluster {{"`{{ $labels.name }}`"}} has been paused for 15 minutes
+        runbook_url: {{ .Values.runbookUrls.clusterApi.ClusterApiClusterIsPaused }}
       labels:
         rulesgroup: cluster-api
         severity: warning
@@ -15,9 +16,10 @@
     - alert: ClusterApiClusterControlPlaneNotInitialized
       annotations:
         description: |
-          The cluster `{{ $labels.name }}` has an uninitialized control plane
+          The cluster {{"`{{ $labels.name }}`"}} has an uninitialized control plane
         summary: |
-          The cluster `{{ $labels.name }}` has an uninitialized control plane
+          The cluster {{"`{{ $labels.name }}`"}} has an uninitialized control plane
+        runbook_url: {{ .Values.runbookUrls.clusterApi.ClusterApiClusterControlPlaneNotInitialized }}
       labels:
         rulesgroup: cluster-api
         severity: warning
@@ -27,9 +29,10 @@
     - alert: ClusterApiClusterNotReady
       annotations:
         description: |
-          The cluster `{{ $labels.name }}` is not ready
+          The cluster {{"`{{ $labels.name }}`"}} is not ready
         summary: |
-          The cluster `{{ $labels.name }}` is not ready
+          The cluster {{"`{{ $labels.name }}`"}} is not ready
+        runbook_url: {{ .Values.runbookUrls.clusterApi.ClusterApiClusterNotReady }}
       labels:
         rulesgroup: cluster-api
         severity: high
@@ -39,9 +42,10 @@
     - alert: ClusterApiClusterInfrastructureNotReady
       annotations:
         description: |
-          The cluster `{{ $labels.name }}` infrastructur is not ready
+          The cluster {{"`{{ $labels.name }}`"}} infrastructur is not ready
         summary: |
-          The cluster `{{ $labels.name }}` infrastructur is not ready
+          The cluster {{"`{{ $labels.name }}`"}} infrastructur is not ready
+        runbook_url: {{ .Values.runbookUrls.clusterApi.ClusterApiClusterInfrastructureNotReady }}
       labels:
         rulesgroup: cluster-api
         severity: high
@@ -51,9 +55,10 @@
     - alert: ClusterApiClusterNotProvisionedState
       annotations:
         description: |
-          The cluster `{{ $labels.name }}` is not in a Provisioned state for more than 15 minutes, this can happen if the cluster is currently provisioning new nodes or replacing nodes.
+          The cluster {{"`{{ $labels.name }}`"}} is not in a Provisioned state for more than 15 minutes, this can happen if the cluster is currently provisioning new nodes or replacing nodes.
         summary: |
-          The cluster `{{ $labels.name }}` is not in a Provisioned state for more than 15 minutes
+          The cluster {{"`{{ $labels.name }}`"}} is not in a Provisioned state for more than 15 minutes
+        runbook_url: {{ .Values.runbookUrls.clusterApi.ClusterApiClusterNotProvisionedState }}
       labels:
         rulesgroup: cluster-api
         severity: warning
@@ -63,9 +68,10 @@
     - alert: ClusterApiClusterNotProvisionedState
       annotations:
         description: |
-          The cluster `{{ $labels.name }}` is not in a Provisioned state for more than 1 hour, this can happen if the cluster is currently provisioning new nodes or replacing nodes.
+          The cluster {{"`{{ $labels.name }}`"}} is not in a Provisioned state for more than 1 hour, this can happen if the cluster is currently provisioning new nodes or replacing nodes.
         summary: |
-          The cluster `{{ $labels.name }}` is not in a Provisioned state for more than 1 hour
+          The cluster {{"`{{ $labels.name }}`"}} is not in a Provisioned state for more than 1 hour
+        runbook_url: {{ .Values.runbookUrls.clusterApi.ClusterApiClusterNotProvisionedState }}
       labels:
         rulesgroup: cluster-api
         severity: high
@@ -77,9 +83,10 @@
     - alert: ClusterApiKubeadmControlPlaneNotFullyReady
       annotations:
         description: |
-          The cluster `{{ $labels.cluster_name }}` has a control plane `{{ $labels.name }}` that has some not ready nodes.
+          The cluster {{"`{{ $labels.cluster_name }}`"}} has a control plane {{"`{{ $labels.name }}`"}} that has some not ready nodes.
         summary: |
-          The cluster `{{ $labels.cluster_name }}` has a control plane `{{ $labels.name }}` that has some not ready nodes.
+          The cluster {{"`{{ $labels.cluster_name }}`"}} has a control plane {{"`{{ $labels.name }}`"}} that has some not ready nodes.
+        runbook_url: {{ .Values.runbookUrls.clusterApi.ClusterApiKubeadmControlPlaneNotFullyReady }}
       labels:
         rulesgroup: cluster-api
         severity: warning
@@ -89,9 +96,10 @@
     - alert: ClusterApiKubeadmControlPlaneCloseToMajorityNotReady
       annotations:
         description: |
-          The cluster `{{ $labels.cluster_name }}` has a control plane `{{ $labels.name }}` with one node from having majority of its nodes not ready.
+          The cluster {{"`{{ $labels.cluster_name }}`"}} has a control plane {{"`{{ $labels.name }}`"}} with one node from having majority of its nodes not ready.
         summary: |
-          The cluster `{{ $labels.cluster_name }}` has a control plane `{{ $labels.name }}` with one node from having majority of its nodes not ready.
+          The cluster {{"`{{ $labels.cluster_name }}`"}} has a control plane {{"`{{ $labels.name }}`"}} with one node from having majority of its nodes not ready.
+        runbook_url: {{ .Values.runbookUrls.clusterApi.ClusterApiKubeadmControlPlaneCloseToMajorityNotReady }}
       labels:
         rulesgroup: cluster-api
         severity: warning
@@ -101,9 +109,10 @@
     - alert: ClusterApiKubeadmControlPlaneMajorityNotReady
       annotations:
         description: |
-          The cluster `{{ $labels.cluster_name }}` has a control plane `{{ $labels.name }}` that have majority of its nodes not ready.
+          The cluster {{"`{{ $labels.cluster_name }}`"}} has a control plane {{"`{{ $labels.name }}`"}} that have majority of its nodes not ready.
         summary: |
-          The cluster `{{ $labels.cluster_name }}` has a control plane `{{ $labels.name }}` that have majority of its nodes not ready.
+          The cluster {{"`{{ $labels.cluster_name }}`"}} has a control plane {{"`{{ $labels.name }}`"}} that have majority of its nodes not ready.
+        runbook_url: {{ .Values.runbookUrls.clusterApi.ClusterApiKubeadmControlPlaneMajorityNotReady }}
       labels:
         rulesgroup: cluster-api
         severity: high
@@ -115,9 +124,10 @@
     - alert: ClusterApiMachineDeploymentNotFullyReady
       annotations:
         description: |
-          The cluster `{{ $labels.cluster_name }}` has a machine deployment `{{ $labels.name }}` that has some not ready nodes.
+          The cluster {{"`{{ $labels.cluster_name }}`"}} has a machine deployment {{"`{{ $labels.name }}`"}} that has some not ready nodes.
         summary: |
-          The cluster `{{ $labels.cluster_name }}` has a machine deployment `{{ $labels.name }}` that has some not ready nodes.
+          The cluster {{"`{{ $labels.cluster_name }}`"}} has a machine deployment {{"`{{ $labels.name }}`"}} that has some not ready nodes.
+        runbook_url: {{ .Values.runbookUrls.clusterApi.ClusterApiMachineDeploymentNotFullyReady }}
       labels:
         rulesgroup: cluster-api
         severity: warning
@@ -127,9 +137,10 @@
     - alert: ClusterApiMachineDeploymentMajorityNotReady
       annotations:
         description: |
-          The cluster `{{ $labels.cluster_name }}` has a machine deployment `{{ $labels.name }}` that have majority of its nodes not ready.
+          The cluster {{"`{{ $labels.cluster_name }}`"}} has a machine deployment {{"`{{ $labels.name }}`"}} that have majority of its nodes not ready.
         summary: |
-          The cluster `{{ $labels.cluster_name }}` has a machine deployment `{{ $labels.name }}` that have majority of its nodes not ready.
+          The cluster {{"`{{ $labels.cluster_name }}`"}} has a machine deployment {{"`{{ $labels.name }}`"}} that have majority of its nodes not ready.
+        runbook_url: {{ .Values.runbookUrls.clusterApi.ClusterApiMachineDeploymentMajorityNotReady }}
       labels:
         rulesgroup: cluster-api
         severity: high
@@ -141,9 +152,10 @@
     - alert: ClusterApiMachineConditionNotTrue
       annotations:
         description: |
-          The cluster `{{ $labels.cluster_name }}` has a machine `{{ $labels.node_name }}` that has the condition `{{ $labels.type }}` set to `{{ $labels.status }}`
+          The cluster {{"`{{ $labels.cluster_name }}`"}} has a machine {{"`{{ $labels.node_name }}`"}} that has the condition {{"`{{ $labels.type }}`"}} set to {{"`{{ $labels.status }}`"}}
         summary: |
-          The cluster `{{ $labels.cluster_name }}` has a machine `{{ $labels.node_name }}` that has the condition `{{ $labels.type }}` set to `{{ $labels.status }}`
+          The cluster {{"`{{ $labels.cluster_name }}`"}} has a machine {{"`{{ $labels.node_name }}`"}} that has the condition {{"`{{ $labels.type }}`"}} set to {{"`{{ $labels.status }}`"}}
+        runbook_url: {{ .Values.runbookUrls.clusterApi.ClusterApiMachineConditionNotTrue }}
       labels:
         rulesgroup: cluster-api
         severity: warning

--- a/helmfile.d/charts/prometheus-alerts/files/hnc.yaml
+++ b/helmfile.d/charts/prometheus-alerts/files/hnc.yaml
@@ -3,9 +3,10 @@
     - alert: HierarchicalNamespaceControllerNamespaceCondition
       annotations:
         description: |
-          The Hierarchical Namespace Controller is reporting `{{ $value }}` Namespace condition(s) `{{ $labels.Condition }}` due to `{{ $labels.Reason }}` for longer than one minute.
+          The Hierarchical Namespace Controller is reporting {{"`{{ $value }}`"}} Namespace condition(s) {{"`{{ $labels.Condition }}`"}} due to {{"`{{ $labels.Reason }}`"}} for longer than one minute.
         summary: |
-          The Hierarchical Namespace Controller is reporting `{{ $value }}` Namespace condition(s) `{{ $labels.Condition }}` due to `{{ $labels.Reason }}` for longer than one minute.
+          The Hierarchical Namespace Controller is reporting {{"`{{ $value }}`"}} Namespace condition(s) {{"`{{ $labels.Condition }}`"}} due to {{"`{{ $labels.Reason }}`"}} for longer than one minute.
+        runbook_url: {{ .Values.runbookUrls.hnc.HierarchicalNamespaceControllerNamespaceCondition }}
       labels:
         rulesgroup: hnc
         severity: warning

--- a/helmfile.d/charts/prometheus-alerts/files/missing-metrics-alerts.yaml
+++ b/helmfile.d/charts/prometheus-alerts/files/missing-metrics-alerts.yaml
@@ -4,6 +4,7 @@
     annotations:
       description: Metrics from the worker cluster is missing
       summary: Metrics from the worker cluster is not being received.
+      runbook_url: {{ .Values.runbookUrls.missingMetrics.MetricsFromWcClusterIsMissing }}
     expr: |
       absent(prometheus_tsdb_head_series{job="kube-prometheus-stack-prometheus",tenant_id!~".*-sc"}) > 0 or prometheus_tsdb_head_series{job="kube-prometheus-stack-prometheus",tenant_id!~".*-sc"} == 0
     for: 5m
@@ -13,6 +14,7 @@
     annotations:
       description: Metrics from the service cluster is missing
       summary: Metrics from the service cluster is not being received.
+      runbook_url: {{ .Values.runbookUrls.missingMetrics.MetricsFromScClusterIsMissing }}
     expr: |
       absent(prometheus_tsdb_head_series{job="kube-prometheus-stack-prometheus",tenant_id!~".*-wc"}) > 0 or prometheus_tsdb_head_series{job="kube-prometheus-stack-prometheus",tenant_id!~".*-wc"} == 0
     for: 15m

--- a/helmfile.d/charts/prometheus-alerts/files/thanos-ruler.yaml
+++ b/helmfile.d/charts/prometheus-alerts/files/thanos-ruler.yaml
@@ -7,7 +7,7 @@ groups:
     annotations:
       description: ThanosRule has disappeared. Prometheus target for the component
         cannot be discovered.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosruleisdown
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosRuleIsDown }}
       summary: Thanos component has disappeared.
     expr: |
       absent(up{job=~".*thanos-receiver-ruler.*"} == 1)
@@ -16,8 +16,8 @@ groups:
       severity: critical
   - alert: ThanosRuleQueueIsDroppingAlerts
     annotations:
-      description: Thanos Rule {{$labels.instance}} is failing to queue alerts.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulequeueisdroppingalerts
+      description: Thanos Rule {{`{{$labels.instance}}`}} is failing to queue alerts.
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosRuleQueueIsDroppingAlerts }}
       summary: Thanos Rule is failing to queue alerts.
     expr: |
       sum by (cluster, job, instance) (rate(thanos_alert_queue_alerts_dropped_total{job=~".*thanos-receiver-ruler.*"}[5m])) > 0
@@ -26,8 +26,8 @@ groups:
       severity: critical
   - alert: ThanosRuleSenderIsFailingAlerts
     annotations:
-      description: Thanos Rule {{$labels.instance}} is failing to send alerts to alertmanager.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulesenderisfailingalerts
+      description: Thanos Rule {{`{{$labels.instance}}`}} is failing to send alerts to alertmanager.
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosRuleSenderIsFailingAlerts }}
       summary: Thanos Rule is failing to send alerts to alertmanager.
     expr: |
       sum by (cluster, job, instance) (rate(thanos_alert_sender_alerts_dropped_total{job=~".*thanos-receiver-ruler.*"}[5m])) > 0
@@ -36,8 +36,8 @@ groups:
       severity: critical
   - alert: ThanosRuleHighRuleEvaluationFailures
     annotations:
-      description: Thanos Rule {{$labels.instance}} is failing to evaluate rules.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulehighruleevaluationfailures
+      description: Thanos Rule {{`{{$labels.instance}}`}} is failing to evaluate rules.
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosRuleHighRuleEvaluationFailures }}
       summary: Thanos Rule is failing to evaluate rules.
     expr: |
       (
@@ -51,9 +51,9 @@ groups:
       severity: critical
   - alert: ThanosRuleHighRuleEvaluationWarnings
     annotations:
-      description: Thanos Rule {{$labels.instance}} has high number of evaluation
+      description: Thanos Rule {{`{{$labels.instance}}`}} has high number of evaluation
         warnings.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulehighruleevaluationwarnings
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosRuleHighRuleEvaluationWarnings }}
       summary: Thanos Rule has high number of evaluation warnings.
     expr: |
       sum by (cluster, job, instance) (rate(thanos_rule_evaluation_with_warnings_total{job=~".*thanos-receiver-ruler.*"}[5m])) > 0
@@ -62,9 +62,9 @@ groups:
       severity: info
   - alert: ThanosRuleRuleEvaluationLatencyHigh
     annotations:
-      description: Thanos Rule {{$labels.instance}} has higher evaluation latency
-        than interval for {{$labels.rule_group}}.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosruleruleevaluationlatencyhigh
+      description: Thanos Rule {{`{{$labels.instance}}`}} has higher evaluation latency
+        than interval for {{`{{$labels.rule_group}}`}}.
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosRuleRuleEvaluationLatencyHigh }}
       summary: Thanos Rule has high rule evaluation latency.
     expr: |
       (
@@ -77,9 +77,9 @@ groups:
       severity: warning
   - alert: ThanosRuleGrpcErrorRate
     annotations:
-      description: Thanos Rule {{$labels.job}} is failing to handle {{$value | humanize}}%
+      description: Thanos Rule {{`{{$labels.job}}`}} is failing to handle {{`{{$value | humanize}}`}}%
         of requests.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulegrpcerrorrate
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosRuleGrpcErrorRate }}
       summary: Thanos Rule is failing to handle grpc requests.
     expr: |
       (
@@ -93,8 +93,8 @@ groups:
       severity: warning
   - alert: ThanosRuleConfigReloadFailure
     annotations:
-      description: Thanos Rule {{$labels.job}} has not been able to reload its configuration.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosruleconfigreloadfailure
+      description: Thanos Rule {{`{{$labels.job}}`}} has not been able to reload its configuration.
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosRuleConfigReloadFailure }}
       summary: Thanos Rule has not been able to reload configuration.
     expr: avg by (cluster, job, instance) (thanos_rule_config_last_reload_successful{job=~".*thanos-receiver-ruler.*"})
       != 1
@@ -103,9 +103,9 @@ groups:
       severity: info
   - alert: ThanosRuleQueryHighDNSFailures
     annotations:
-      description: Thanos Rule {{$labels.job}} has {{$value | humanize}}% of failing
+      description: Thanos Rule {{`{{$labels.job}}`}} has {{`{{$value | humanize}}`}}% of failing
         DNS queries for query endpoints.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulequeryhighdnsfailures
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosRuleQueryHighDNSFailures }}
       summary: Thanos Rule is having high number of DNS failures.
     expr: |
       (
@@ -119,9 +119,9 @@ groups:
       severity: warning
   - alert: ThanosRuleAlertmanagerHighDNSFailures
     annotations:
-      description: Thanos Rule {{$labels.instance}} has {{$value | humanize}}% of
+      description: Thanos Rule {{`{{$labels.instance}}`}} has {{`{{$value | humanize}}`}}% of
         failing DNS queries for Alertmanager endpoints.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulealertmanagerhighdnsfailures
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosRuleAlertmanagerHighDNSFailures }}
       summary: Thanos Rule is having high number of DNS failures.
     expr: |
       (
@@ -135,9 +135,9 @@ groups:
       severity: warning
   - alert: ThanosRuleNoEvaluationFor10Intervals
     annotations:
-      description: Thanos Rule {{$labels.job}} has {{$value | humanize}}% rule groups
+      description: Thanos Rule {{`{{$labels.job}}`}} has {{`{{$value | humanize}}`}}% rule groups
         that did not evaluate for at least 10x of their expected interval.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulenoevaluationfor10intervals
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosRuleNoEvaluationFor10Intervals }}
       summary: Thanos Rule has rule groups that did not evaluate for 10 intervals.
     expr: |
       time() -  max by (cluster, job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~".*thanos-receiver-ruler.*"})
@@ -148,9 +148,9 @@ groups:
       severity: info
   - alert: ThanosNoRuleEvaluations
     annotations:
-      description: Thanos Rule {{$labels.instance}} did not perform any rule evaluations
+      description: Thanos Rule {{`{{$labels.instance}}`}} did not perform any rule evaluations
         in the past 10 minutes.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosnoruleevaluations
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosNoRuleEvaluations }}
       summary: Thanos Rule did not perform any rule evaluations.
     expr: |
       sum by (cluster, job, instance) (rate(prometheus_rule_evaluations_total{job=~".*thanos-receiver-ruler.*"}[5m])) <= 0

--- a/helmfile.d/charts/prometheus-alerts/files/thanos.yaml
+++ b/helmfile.d/charts/prometheus-alerts/files/thanos.yaml
@@ -6,8 +6,8 @@ groups:
   - alert: ThanosCompactMultipleRunning
     annotations:
       description: No more than one Thanos Compact instance should be running at once.
-        There are {{$value}} instances running.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompactmultiplerunning
+        There are {{`{{$value}}`}} instances running.
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosCompactMultipleRunning }}
       summary: Thanos Compact has multiple instances running.
     expr: sum by (cluster, job) (up{job=~".*thanos-receiver-compact.*"}) > 1
     for: 5m
@@ -15,8 +15,8 @@ groups:
       severity: warning
   - alert: ThanosCompactHalted
     annotations:
-      description: Thanos Compact {{$labels.job}} has failed to run and now is halted.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompacthalted
+      description: Thanos Compact {{`{{$labels.job}}`}} has failed to run and now is halted.
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosCompactHalted }}
       summary: Thanos Compact has failed to run and is now halted.
     expr: thanos_compact_halted{job=~".*thanos-receiver-compact.*"} == 1
     for: 5m
@@ -24,9 +24,8 @@ groups:
       severity: warning
   - alert: ThanosCompactHighCompactionFailures
     annotations:
-      description: Thanos Compact {{$labels.job}} is failing to execute {{$value |
-        humanize}}% of compactions.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompacthighcompactionfailures
+      description: Thanos Compact {{`{{$labels.job}}`}} is failing to execute {{`{{$value | humanize}}`}}% of compactions.
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosCompactHighCompactionFailures }}
       summary: Thanos Compact is failing to execute compactions.
     expr: |
       (
@@ -40,9 +39,8 @@ groups:
       severity: warning
   - alert: ThanosCompactBucketHighOperationFailures
     annotations:
-      description: Thanos Compact {{$labels.job}} Bucket is failing to execute {{$value
-        | humanize}}% of operations.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompactbuckethighoperationfailures
+      description: Thanos Compact {{`{{$labels.job}}`}} Bucket is failing to execute {{`{{$value | humanize}}`}}% of operations.
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosCompactBucketHighOperationFailures }}
       summary: Thanos Compact Bucket is having a high number of operation failures.
     expr: |
       (
@@ -56,9 +54,9 @@ groups:
       severity: warning
   - alert: ThanosCompactHasNotRun
     annotations:
-      description: Thanos Compact {{$labels.job}} has not uploaded anything for 24
+      description: Thanos Compact {{`{{$labels.job}}`}} has not uploaded anything for 24
         hours.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompacthasnotrun
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosCompactHasNotRun }}
       summary: Thanos Compact has not uploaded anything for last 24 hours.
     expr: (time() - max by (cluster, job) (max_over_time(thanos_objstore_bucket_last_successful_upload_time{job=~".*thanos-receiver-compact.*"}[24h])))
       / 60 / 60 > 24
@@ -68,9 +66,9 @@ groups:
   rules:
   - alert: ThanosQueryHttpRequestQueryErrorRateHigh
     annotations:
-      description: Thanos Query {{$labels.job}} is failing to handle {{$value | humanize}}%
+      description: Thanos Query {{`{{$labels.job}}`}} is failing to handle {{`{{$value | humanize}}`}}%
         of "query" requests.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosqueryhttprequestqueryerrorratehigh
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosQueryHttpRequestQueryErrorRateHigh }}
       summary: Thanos Query is failing to handle requests.
     expr: |
       (
@@ -83,9 +81,9 @@ groups:
       severity: critical
   - alert: ThanosQueryHttpRequestQueryRangeErrorRateHigh
     annotations:
-      description: Thanos Query {{$labels.job}} is failing to handle {{$value | humanize}}%
+      description: Thanos Query {{`{{$labels.job}}`}} is failing to handle {{`{{$value | humanize}}`}}%
         of "query_range" requests.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosqueryhttprequestqueryrangeerrorratehigh
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosQueryHttpRequestQueryRangeErrorRateHigh }}
       summary: Thanos Query is failing to handle requests.
     expr: |
       (
@@ -98,9 +96,9 @@ groups:
       severity: critical
   - alert: ThanosQueryGrpcServerErrorRate
     annotations:
-      description: Thanos Query {{$labels.job}} is failing to handle {{$value | humanize}}%
+      description: Thanos Query {{`{{$labels.job}}`}} is failing to handle {{`{{$value | humanize}}`}}%
         of requests.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosquerygrpcservererrorrate
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosQueryGrpcServerErrorRate }}
       summary: Thanos Query is failing to handle requests.
     expr: |
       (
@@ -114,9 +112,9 @@ groups:
       severity: warning
   - alert: ThanosQueryGrpcClientErrorRate
     annotations:
-      description: Thanos Query {{$labels.job}} is failing to send {{$value | humanize}}%
+      description: Thanos Query {{`{{$labels.job}}`}} is failing to send {{`{{$value | humanize}}`}}%
         of requests.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosquerygrpcclienterrorrate
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosQueryGrpcClientErrorRate }}
       summary: Thanos Query is failing to send requests.
     expr: |
       (
@@ -129,9 +127,9 @@ groups:
       severity: warning
   - alert: ThanosQueryHighDNSFailures
     annotations:
-      description: Thanos Query {{$labels.job}} have {{$value | humanize}}% of failing
+      description: Thanos Query {{`{{$labels.job}}`}} have {{`{{$value | humanize}}`}}% of failing
         DNS queries for store endpoints.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosqueryhighdnsfailures
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosQueryHighDNSFailures }}
       summary: Thanos Query is having high number of DNS failures.
     expr: |
       (
@@ -144,9 +142,9 @@ groups:
       severity: warning
   - alert: ThanosQueryInstantLatencyHigh
     annotations:
-      description: Thanos Query {{$labels.job}} has a 99th percentile latency of {{$value}}
+      description: Thanos Query {{`{{$labels.job}}`}} has a 99th percentile latency of {{`{{$value}}`}}
         seconds for instant queries.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosqueryinstantlatencyhigh
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosQueryInstantLatencyHigh }}
       summary: Thanos Query has high latency for queries.
     expr: |
       (
@@ -159,9 +157,9 @@ groups:
       severity: critical
   - alert: ThanosQueryRangeLatencyHigh
     annotations:
-      description: Thanos Query {{$labels.job}} has a 99th percentile latency of {{$value}}
+      description: Thanos Query {{`{{$labels.job}}`}} has a 99th percentile latency of {{`{{$value}}`}}
         seconds for range queries.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosqueryrangelatencyhigh
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosQueryRangeLatencyHigh }}
       summary: Thanos Query has high latency for queries.
     expr: |
       (
@@ -176,9 +174,8 @@ groups:
   rules:
   - alert: ThanosReceiveHttpRequestErrorRateHigh
     annotations:
-      description: Thanos Receive {{$labels.job}} is failing to handle {{$value |
-        humanize}}% of requests.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosreceivehttprequesterrorratehigh
+      description: Thanos Receive {{`{{$labels.job}}`}} is failing to handle {{`{{$value | humanize}}`}}% of requests.
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosReceiveHttpRequestErrorRateHigh }}
       summary: Thanos Receive is failing to handle requests.
     expr: |
       (
@@ -191,9 +188,9 @@ groups:
       severity: critical
   - alert: ThanosReceiveHttpRequestLatencyHigh
     annotations:
-      description: Thanos Receive {{$labels.job}} has a 99th percentile latency of
-        {{ $value }} seconds for requests.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosreceivehttprequestlatencyhigh
+      description: Thanos Receive {{`{{$labels.job}}`}} has a 99th percentile latency of
+        {{`{{ $value }}`}} seconds for requests.
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosReceiveHttpRequestLatencyHigh }}
       summary: Thanos Receive has high HTTP requests latency.
     expr: |
       (
@@ -206,9 +203,8 @@ groups:
       severity: critical
   - alert: ThanosReceiveHighReplicationFailures
     annotations:
-      description: Thanos Receive {{$labels.job}} is failing to replicate {{$value
-        | humanize}}% of requests.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosreceivehighreplicationfailures
+      description: Thanos Receive {{`{{$labels.job}}`}} is failing to replicate {{`{{$value | humanize}}`}}% of requests.
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosReceiveHighReplicationFailures }}
       summary: Thanos Receive is having high number of replication failures.
     expr: |
       thanos_receive_replication_factor > 1
@@ -231,9 +227,8 @@ groups:
       severity: warning
   - alert: ThanosReceiveHighForwardRequestFailures
     annotations:
-      description: Thanos Receive {{$labels.job}} is failing to forward {{$value |
-        humanize}}% of requests.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosreceivehighforwardrequestfailures
+      description: Thanos Receive {{`{{$labels.job}}`}} is failing to forward {{`{{$value | humanize}}`}}% of requests.
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosReceiveHighForwardRequestFailures }}
       summary: Thanos Receive is failing to forward requests.
     expr: |
       (
@@ -246,9 +241,9 @@ groups:
       severity: info
   - alert: ThanosReceiveHighHashringFileRefreshFailures
     annotations:
-      description: Thanos Receive {{$labels.job}} is failing to refresh hashring file,
-        {{$value | humanize}} of attempts failed.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosreceivehighhashringfilerefreshfailures
+      description: Thanos Receive {{`{{$labels.job}}`}} is failing to refresh hashring file,
+        {{`{{$value | humanize}}`}} of attempts failed.
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosReceiveHighHashringFileRefreshFailures }}
       summary: Thanos Receive is failing to refresh hasring file.
     expr: |
       (
@@ -262,9 +257,9 @@ groups:
       severity: warning
   - alert: ThanosReceiveConfigReloadFailure
     annotations:
-      description: Thanos Receive {{$labels.job}} has not been able to reload hashring
+      description: Thanos Receive {{`{{$labels.job}}`}} has not been able to reload hashring
         configurations.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosreceiveconfigreloadfailure
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosReceiveConfigReloadFailure }}
       summary: Thanos Receive has not been able to reload configuration.
     expr: avg by (cluster, job) (thanos_receive_config_last_reload_successful{job=~".*thanos-receiver-receive.*"})
       != 1
@@ -273,9 +268,9 @@ groups:
       severity: warning
   - alert: ThanosReceiveNoUpload
     annotations:
-      description: Thanos Receive {{$labels.instance}} has not uploaded latest data
+      description: Thanos Receive {{`{{$labels.instance}}`}} has not uploaded latest data
         to object storage.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosreceivenoupload
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosReceiveNoUpload }}
       summary: Thanos Receive has not uploaded latest data to object storage.
     expr: |
       (up{job=~".*thanos-receiver-receive.*"} - 1)
@@ -286,10 +281,10 @@ groups:
       severity: critical
   - alert: ThanosReceiveTrafficBelowThreshold
     annotations:
-      description: At Thanos Receive {{$labels.job}} in {{$labels.namespace}} , the
-        average 1-hr avg. metrics ingestion rate  is {{$value | humanize}}% of 12-hr
+      description: At Thanos Receive {{`{{$labels.job}}`}} in {{`{{$labels.namespace}}`}} , the
+        average 1-hr avg. metrics ingestion rate  is {{`{{$value | humanize}}`}}% of 12-hr
         avg. ingestion rate.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosreceivetrafficbelowthreshold
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosReceiveTrafficBelowThreshold }}
       summary: Thanos Receive is experiencing low avg. 1-hr ingestion rate relative
         to avg. 12-hr ingestion rate.
     expr: |
@@ -305,9 +300,9 @@ groups:
   rules:
   - alert: ThanosStoreGrpcErrorRate
     annotations:
-      description: Thanos Store {{$labels.job}} is failing to handle {{$value | humanize}}%
+      description: Thanos Store {{`{{$labels.job}}`}} is failing to handle {{`{{$value | humanize}}`}}%
         of requests.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosstoregrpcerrorrate
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosStoreGrpcErrorRate }}
       summary: Thanos Store is failing to handle qrpcd requests.
     expr: |
       (
@@ -321,9 +316,9 @@ groups:
       severity: warning
   - alert: ThanosStoreSeriesGateLatencyHigh
     annotations:
-      description: Thanos Store {{$labels.job}} has a 99th percentile latency of {{$value}}
+      description: Thanos Store {{`{{$labels.job}}`}} has a 99th percentile latency of {{`{{$value}}`}}
         seconds for store series gate requests.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosstoreseriesgatelatencyhigh
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosStoreSeriesGateLatencyHigh }}
       summary: Thanos Store has high latency for store series gate requests.
     expr: |
       (
@@ -336,9 +331,8 @@ groups:
       severity: warning
   - alert: ThanosStoreBucketHighOperationFailures
     annotations:
-      description: Thanos Store {{$labels.job}} Bucket is failing to execute {{$value
-        | humanize}}% of operations.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosstorebuckethighoperationfailures
+      description: Thanos Store {{`{{$labels.job}}`}} Bucket is failing to execute {{`{{$value | humanize}}`}}% of operations.
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosStoreBucketHighOperationFailures }}
       summary: Thanos Store Bucket is failing to execute operations.
     expr: |
       (
@@ -352,9 +346,9 @@ groups:
       severity: warning
   - alert: ThanosStoreObjstoreOperationLatencyHigh
     annotations:
-      description: Thanos Store {{$labels.job}} Bucket has a 99th percentile latency
-        of {{$value}} seconds for the bucket operations.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosstoreobjstoreoperationlatencyhigh
+      description: Thanos Store {{`{{$labels.job}}`}} Bucket has a 99th percentile latency
+        of {{`{{$value}}`}} seconds for the bucket operations.
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosStoreObjstoreOperationLatencyHigh }}
       summary: Thanos Store is having high latency for bucket operations.
     expr: |
       (
@@ -369,9 +363,9 @@ groups:
   rules:
   - alert: ThanosBucketReplicateErrorRate
     annotations:
-      description: Thanos Replicate is failing to run, {{$value | humanize}}% of attempts
+      description: Thanos Replicate is failing to run, {{`{{$value | humanize}}`}}% of attempts
         failed.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosbucketreplicateerrorrate
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosBucketReplicateErrorRate }}
       summary: Thanos Replicate is failing to run.
     expr: |
       (
@@ -384,9 +378,9 @@ groups:
       severity: critical
   - alert: ThanosBucketReplicateRunLatency
     annotations:
-      description: Thanos Replicate {{$labels.job}} has a 99th percentile latency
-        of {{$value}} seconds for the replicate operations.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosbucketreplicaterunlatency
+      description: Thanos Replicate {{`{{$labels.job}}`}} has a 99th percentile latency
+        of {{`{{$value}}`}} seconds for the replicate operations.
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosBucketReplicateRunLatency }}
       summary: Thanos Replicate has a high latency for replicate operations.
     expr: |
       (
@@ -403,7 +397,7 @@ groups:
     annotations:
       description: ThanosCompact has disappeared. Prometheus target for the component
         cannot be discovered.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompactisdown
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosCompactIsDown }}
       summary: Thanos component has disappeared.
     expr: |
       absent(up{job=~".*thanos-receiver-compact.*"} == 1)
@@ -414,7 +408,7 @@ groups:
     annotations:
       description: ThanosQuery has disappeared. Prometheus target for the component
         cannot be discovered.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosqueryisdown
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosQueryIsDown }}
       summary: Thanos component has disappeared.
     expr: |
       absent(up{job=~".*thanos-query-query"} == 1)
@@ -425,7 +419,7 @@ groups:
     annotations:
       description: ThanosReceive has disappeared. Prometheus target for the component
         cannot be discovered.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosreceiveisdown
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosReceiveIsDown }}
       summary: Thanos component has disappeared.
     expr: |
       absent(up{job=~".*thanos-receiver-receive.*"} == 1)
@@ -436,7 +430,7 @@ groups:
     annotations:
       description: ThanosStore has disappeared. Prometheus target for the component
         cannot be discovered.
-      runbook_url: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosstoreisdown
+      runbook_url: {{ .Values.runbookUrls.thanos.ThanosStoreIsDown }}
       summary: Thanos component has disappeared.
     expr: |
       absent(up{job=~".*thanos-receiver-store.*"} == 1)

--- a/helmfile.d/charts/prometheus-alerts/files/webhooks.yaml
+++ b/helmfile.d/charts/prometheus-alerts/files/webhooks.yaml
@@ -4,6 +4,7 @@
     annotations:
       description: Webhooks have been failing during the last 10m
       summary: Webhooks requests are failing
+      runbook_url: {{ .Values.runbookUrls.webhook.WebhookFailing }}
     expr: rate(apiserver_admission_webhook_rejection_count{error_type!="no_error"}[5m]) > 0
     for: 10m
     labels:

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/alertmanager.rules.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/alertmanager.rules.yaml
@@ -28,7 +28,7 @@ spec:
     - alert: AlertmanagerConfigInconsistent
       annotations:
         description: Alertmanager instances within the {{`{{`}}$labels.job{{`}}`}} cluster have different configurations.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}/alertmanager/alertmanagerconfiginconsistent
+        runbook_url: {{ .Values.runbookUrls.alertmanager.AlertmanagerConfigInconsistent }}
         summary: Alertmanager instances within the same cluster have different configurations.
       expr: |-
         count by (cluster,service) (
@@ -41,7 +41,7 @@ spec:
     - alert: AlertmanagerFailedReload
       annotations:
         description: Configuration has failed to load for {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod{{`}}`}}.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}/alertmanager/alertmanagerfailedreload
+        runbook_url: {{ .Values.runbookUrls.alertmanager.AlertmanagerFailedReload }}
         summary: Reloading an Alertmanager configuration has failed.
       expr: |-
         # Without max_over_time, failed scrapes could create false negatives, see
@@ -53,7 +53,7 @@ spec:
     - alert: AlertmanagerMembersInconsistent
       annotations:
         description: Alertmanager {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod{{`}}`}} has only found {{`{{`}} $value {{`}}`}} members of the {{`{{`}}$labels.job{{`}}`}} cluster.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}/alertmanager/alertmanagermembersinconsistent
+        runbook_url: {{ .Values.runbookUrls.alertmanager.AlertmanagerMembersInconsistent }}
         summary: A member of an Alertmanager cluster has not found all other cluster members.
       expr: |-
         # Without max_over_time, failed scrapes could create false negatives, see

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/backup-status.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/backup-status.yaml
@@ -20,7 +20,7 @@ spec:
     - alert: HarborBackupHaveFailed24Hours
       annotations:
         description: The job daily backup job harbor-backup have failed over 24 hours.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-harborbackup
+        runbook_url: {{ .Values.runbookUrls.backupStatus.HarborBackupHaveFailed24Hours }}
         summary: The daily backup job harbor-backup have failed over 24 hours.
       expr: |-
         (
@@ -32,7 +32,7 @@ spec:
     - alert: HarborBackupHaveFailed48Hours
       annotations:
         description: The job daily backup job harbor-backup have failed over 48 hours.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-harborbackup
+        runbook_url: {{ .Values.runbookUrls.backupStatus.HarborBackupHaveFailed48Hours }}
         summary: The daily backup job harbor-backup have failed over 48 hours.
       expr: |-
         (
@@ -44,7 +44,7 @@ spec:
     - alert: VeleroBackupHaveFailed24Hours
       annotations:
         description: The job daily backup job velero-backup have failed over 24 hours.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-velerobackup
+        runbook_url: {{ .Values.runbookUrls.backupStatus.VeleroBackupHaveFailed24Hours }}
         summary: The daily backup job velero-backup have failed over 24 hours.
       expr: |-
         (
@@ -56,7 +56,7 @@ spec:
     - alert: VeleroBackupHaveFailed48Hours
       annotations:
         description: The job daily backup job velero-backup have failed over 48 hours.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-velerobackup
+        runbook_url: {{ .Values.runbookUrls.backupStatus.VeleroBackupHaveFailed48Hours }}
         summary: The daily backup job velero-backup have failed over 48 hours.
       expr: |-
         (
@@ -68,7 +68,7 @@ spec:
     - alert: OpenSearchSnapshotHaveFailed24Hours
       annotations:
         description: There have been no successful OpenSearch snapshots for over 24 hours.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-elasticsearchsnap
+        runbook_url: {{ .Values.runbookUrls.backupStatus.OpenSearchSnapshotHaveFailed24Hours }}
         summary: OpenSearch snapshots have failed for over 24 hours.
       expr: |-
         (
@@ -82,7 +82,7 @@ spec:
     - alert: OpenSearchSnapshotHaveFailed48Hours
       annotations:
         description: There have been no successful OpenSearch snapshots for over 48 hours.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}alert-name-elasticsearchsnap
+        runbook_url: {{ .Values.runbookUrls.backupStatus.OpenSearchSnapshotHaveFailed48Hours }}
         summary: OpenSearch snapshots have failed for over 48 hours.
       expr: |-
         (

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/blackbox.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/blackbox.yaml
@@ -24,4 +24,5 @@ spec:
             severity: "critical"
           annotations:
             summary: "Endpoint {{`{{ $labels.target }}`}} at {{`{{ $labels.instance }}`}} down"
+            runbook_url: {{ .Values.runbookUrls.blackbox.EndpointDown }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/cert-manager-alerts.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/cert-manager-alerts.yaml
@@ -21,6 +21,7 @@ spec:
     - alert: CertificateExpiringSoon
       annotations:
         message: The Certificate {{`{{$labels.name}}`}} is expiring within 20 days.
+        runbook_url: {{ .Values.runbookUrls.certManager.CertificateExpiringSoon }}
       # Fire the alert when there are less than 20 days = 60*60*24*20 seconds left
       expr: certmanager_certificate_expiration_timestamp_seconds - time() < 60*60*24*20
       for: 10m
@@ -29,6 +30,7 @@ spec:
     - alert: CertificateNotReady
       annotations:
         message: The Certificate {{`{{$labels.name}}`}} is not ready!
+        runbook_url: {{ .Values.runbookUrls.certManager.CertificateNotReady }}
       # Fire the alert when the Certificaet is not ready
       expr: certmanager_certificate_ready_status{condition="False"} > 0
       for: 10m

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/cluster-api.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/cluster-api.yaml
@@ -15,5 +15,5 @@ metadata:
   {{- end }}
 spec:
   groups:
-    {{- .Files.Get "files/cluster-api.yaml" | nindent 4 }}
+    {{- tpl (.Files.Get "files/cluster-api.yaml") . | nindent 4 }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/cluster-capacity-management-alerts.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/cluster-capacity-management-alerts.yaml
@@ -20,7 +20,7 @@ spec:
     - alert: NodeFilesystemSpaceFillingUp
       annotations:
         description: Filesystem on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available space left and is filling up.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}node/nodefilesystemspacefillingup
+        runbook_url: {{ .Values.runbookUrls.clusterCapacityManagement.NodeFilesystemSpaceFillingUp }}
         summary: Filesystem is predicted to run out of space within the next 3 days.
       expr: |-
         (
@@ -37,6 +37,7 @@ spec:
     - alert: PersistentVolume{{.Values.capacityManagementAlertsPersistentVolumeLimit}}PercentInThreeDays
       annotations:
         message: The PersistentVolume claimed by {{`{{ $labels.persistentvolumeclaim }}`}} in Namespace {{`{{ $labels.namespace }}`}} will go over {{.Values.capacityManagementAlertsPersistentVolumeLimit}} in three days.
+        runbook_url: {{ .Values.runbookUrls.clusterCapacityManagement.PersistentVolumeXPercentInThreeDays }}
       expr: predict_linear(kubelet_volume_stats_available_bytes[24h], 3*24*60*60) <= (kubelet_volume_stats_capacity_bytes*(1-{{ .Values.capacityManagementAlertsPersistentVolumeLimit }}/100))
       for: 5m
       labels:
@@ -46,6 +47,7 @@ spec:
     - alert: Memory{{.Values.capacityManagementAlertsUsageLimit}}PercentInThreeDays
       annotations:
         message: Memory usage in Cluster {{`{{ $labels.cluster }}`}} Instance {{`{{ $labels.instance }}`}} is predicted to go over {{.Values.capacityManagementAlertsUsageLimit}}% within the next 3 days at current use rate.
+        runbook_url: {{ .Values.runbookUrls.clusterCapacityManagement.MemoryXPercentInThreeDays }}
       expr: predict_linear(node_memory_MemAvailable_bytes[24h], 3*24*60*60) <= (node_memory_MemTotal_bytes*(1-{{ .Values.capacityManagementAlertsUsageLimit }}/100))
       for: 5m
       labels:
@@ -54,6 +56,7 @@ spec:
     - alert: NodeGroupCPU{{.Values.capacityManagementAlertsNodeGroupCpuLimit24h}}PercentOver24h
       annotations:
         message: CPU usage has been over {{.Values.capacityManagementAlertsNodeGroupCpuLimit24h}}% on average over the span of 24h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
+        runbook_url: {{ .Values.runbookUrls.clusterCapacityManagement.NodeGroupCPUXPercentOver24h }}
       expr: avg by (label_elastisys_io_node_group,cluster) (sum by (instance) (rate(node_cpu_seconds_total{mode!='idle',cluster=~".*"}[24h])) / on (instance) instance:node_num_cpu:sum * on (instance) group_left (label_elastisys_io_node_group,cluster) label_replace(kube_node_labels{label_elastisys_io_node_group!=""}, "instance", "$1", "node", "(.*)")) > {{.Values.capacityManagementAlertsNodeGroupCpuLimit24h}}/100
       for: 5m
       labels:
@@ -61,6 +64,7 @@ spec:
     - alert: NodeGroupCPU{{.Values.capacityManagementAlertsNodeGroupCpuLimit1h}}PercentOver1h
       annotations:
         message: CPU usage has been over {{.Values.capacityManagementAlertsNodeGroupCpuLimit1h}}% on average over the span of 1h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
+        runbook_url: {{ .Values.runbookUrls.clusterCapacityManagement.NodeGroupCPUXPercentOver1h }}
       expr: avg by (label_elastisys_io_node_group,cluster) (sum by (instance) (rate(node_cpu_seconds_total{mode!='idle',cluster=~".*"}[1h])) / on (instance) instance:node_num_cpu:sum * on (instance) group_left (label_elastisys_io_node_group,cluster) label_replace(kube_node_labels{label_elastisys_io_node_group!=""}, "instance", "$1", "node", "(.*)")) > {{.Values.capacityManagementAlertsNodeGroupCpuLimit1h}}/100
       for: 5m
       labels:
@@ -68,6 +72,7 @@ spec:
     - alert: NodeGroupMemory{{.Values.capacityManagementAlertsNodeGroupMemoryLimit24h}}PercentOver24h
       annotations:
         message: Memory usage has been over {{.Values.capacityManagementAlertsNodeGroupMemoryLimit24h}}% on average over the span of 24h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
+        runbook_url: {{ .Values.runbookUrls.clusterCapacityManagement.NodeGroupMemoryXPercentOver24h }}
       expr: avg by (label_elastisys_io_node_group,cluster) ((avg_over_time (instance:node_memory_utilisation:ratio{cluster=~".*"}[24h])) * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group!=""}, "instance", "$1", "node", "(.*)")) > {{.Values.capacityManagementAlertsNodeGroupMemoryLimit24h}}/100
       for: 5m
       labels:
@@ -75,6 +80,7 @@ spec:
     - alert: NodeGroupMemory{{.Values.capacityManagementAlertsNodeGroupMemoryLimit1h}}PercentOver1h
       annotations:
         message: Memory usage has been over {{.Values.capacityManagementAlertsNodeGroupMemoryLimit1h}}% on average over the span of 1h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
+        runbook_url: {{ .Values.runbookUrls.clusterCapacityManagement.NodeGroupMemoryXPercentOver1h }}
       expr: avg by (label_elastisys_io_node_group,cluster) ((avg_over_time (instance:node_memory_utilisation:ratio{cluster=~".*"}[1h])) * on (instance) group_left (label_elastisys_io_node_group) label_replace(kube_node_labels{label_elastisys_io_node_group!=""}, "instance", "$1", "node", "(.*)")) > {{.Values.capacityManagementAlertsNodeGroupMemoryLimit1h}}/100
       for: 5m
       labels:
@@ -82,6 +88,7 @@ spec:
     - alert: NodeCPU{{.Values.capacityManagementAlertsNodeCpuLimit1h}}PercentOver1h
       annotations:
         message: CPU usage has been over {{.Values.capacityManagementAlertsNodeCpuLimit1h}}% on average over the span of 1h for the node {{`{{ $labels.instance }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
+        runbook_url: {{ .Values.runbookUrls.clusterCapacityManagement.NodeCPUXPercentOver1h }}
       expr: sum by (instance) (rate(node_cpu_seconds_total{mode!='idle',cluster=~".*"}[1h])) / on (instance) instance:node_num_cpu:sum * on (instance) group_left (label_elastisys_io_node_group,cluster) label_replace(kube_node_labels{label_elastisys_io_node_group!=""}, "instance", "$1", "node", "(.*)") > {{.Values.capacityManagementAlertsNodeCpuLimit1h}}/100
       for: 5m
       labels:
@@ -89,6 +96,7 @@ spec:
     - alert: NodeMemory{{.Values.capacityManagementAlertsNodeMemoryLimit1h}}PercentOver1h
       annotations:
         message: Memory usage has been over {{.Values.capacityManagementAlertsNodeMemoryLimit1h}}% on average over the span of 1h for the Node {{`{{ $labels.instance }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
+        runbook_url: {{ .Values.runbookUrls.clusterCapacityManagement.NodeMemoryXPercentOver1h }}
       expr: |-
         (
           avg_over_time (instance:node_memory_utilisation:ratio{cluster=~".*"}[1h]) * on (instance) group_left (label_elastisys_io_node_group)
@@ -100,6 +108,7 @@ spec:
     - alert: NodeGroupCpuRequest{{ .Values.capacityManagementAlertsCpuRequestLimit }}Percent
       annotations:
         message: Average CPU requests is over {{ .Values.capacityManagementAlertsCpuRequestLimit }}% in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
+        runbook_url: {{ .Values.runbookUrls.clusterCapacityManagement.NodeGroupCpuRequestXPercent }}
       expr: |-
         (
           avg by (label_elastisys_io_node_group,cluster) (sum by (node,cluster) (kube_pod_container_resource_requests{cluster=~".*",namespace=~".*",resource="cpu"}
@@ -115,6 +124,7 @@ spec:
     - alert: NodeGroupMemoryRequest{{ .Values.capacityManagementAlertsMemoryRequestLimit }}Percent
       annotations:
         message: Average memory requests is over {{ .Values.capacityManagementAlertsMemoryRequestLimit }}% in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
+        runbook_url: {{ .Values.runbookUrls.clusterCapacityManagement.NodeGroupMemoryRequestXPercent }}
       expr: |-
         (
           avg by (label_elastisys_io_node_group,cluster) (sum by (node,cluster) (kube_pod_container_resource_requests{cluster=~".*",namespace=~".*",resource="memory"}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/config-reloaders.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/config-reloaders.yaml
@@ -21,7 +21,7 @@ spec:
       annotations:
         description: 'Errors encountered while the {{`{{`}}$labels.pod{{`}}`}} config-reloader sidecar attempts to sync config in {{`{{`}}$labels.namespace{{`}}`}} namespace.
           As a result, configuration for service running in {{`{{`}}$labels.pod{{`}}`}} may be stale and cannot be updated anymore.'
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/prometheus-operator/configreloadersidecarerrors
+        runbook_url: {{ .Values.runbookUrls.configReloaders.ConfigReloaderSidecarErrors }}
         summary: config-reloader sidecar has not had a successful reload for 10m
       expr: max_over_time(reloader_last_reload_successful{namespace=~".+"}[5m]) == 0
       for: 10m

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/coredns.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/coredns.yaml
@@ -21,7 +21,7 @@ spec:
     - alert: {{ . | title }}Down
       annotations:
         description: {{ . | title }} has disappeared from Prometheus target discovery.
-        runbook_url: https://github.com/povilasv/coredns-mixin/tree/master/runbook.md#alert-name-corednsdown
+        runbook_url: {{ $.Values.runbookUrls.coreDns.CorednsDown }}
         summary: {{ . | title }} has disappeared from Prometheus target discovery.
       expr: absent(up{job="{{ . }}"} == 1)
       for: 15m
@@ -30,7 +30,7 @@ spec:
     - alert: {{ . | title }}LatencyHigh
       annotations:
         description: {{ . | title }} has 99th percentile latency of {{`{{`}} $value {{`}}`}} seconds for server  {{`{{`}} $labels.server {{`}}`}} zone  {{`{{`}} $labels.zone {{`}}`}}.
-        runbook_url: https://github.com/povilasv/coredns-mixin/tree/master/runbook.md#alert-name-corednslatencyhigh
+        runbook_url: {{ $.Values.runbookUrls.coreDns.CorednsLatencyHigh }}
         summary: {{ . | title }} is experiencing high 99th percentile latency.
       expr: |
         histogram_quantile(0.99, sum(rate(coredns_dns_request_duration_seconds_bucket{job="{{ . }}"}[5m])) without (instance,pod)) > 4
@@ -40,7 +40,7 @@ spec:
     - alert: {{ . | title }}ErrorsHigh
       annotations:
         description: {{ . | title }} is returning SERVFAIL for {{`{{`}} $value | humanizePercentage {{`}}`}} of requests.
-        runbook_url: https://github.com/povilasv/coredns-mixin/tree/master/runbook.md#alert-name-corednserrorshigh
+        runbook_url: {{ $.Values.runbookUrls.coreDns.CorednsErrorsHigh }}
         summary: {{ . | title }} is returning SERVFAIL.
       expr: |
         sum without (pod, instance, server, zone, view, rcode, plugin) (rate(coredns_dns_responses_total{job="{{ . }}",rcode="SERVFAIL"}[5m]))
@@ -52,7 +52,7 @@ spec:
     - alert: {{ . | title }}ErrorsHigh
       annotations:
         description: {{ . | title }} is returning SERVFAIL for {{`{{`}} $value | humanizePercentage {{`}}`}} of requests.
-        runbook_url: https://github.com/povilasv/coredns-mixin/tree/master/runbook.md#alert-name-corednserrorshigh
+        runbook_url: {{ $.Values.runbookUrls.coreDns.CorednsErrorsHigh }}
         summary: {{ . | title }} is returning SERVFAIL.
       expr: |
         sum without (pod, instance, server, zone, view, rcode, plugin) (rate(coredns_dns_responses_total{job="{{ . }}",rcode="SERVFAIL"}[5m]))
@@ -64,7 +64,7 @@ spec:
     - alert: {{ . | title }}ForwardLatencyHigh
       annotations:
         description: {{ . | title }} has 99th percentile latency of {{`{{`}} $value {{`}}`}} seconds forwarding requests to  {{`{{`}} $labels.to {{`}}`}}.
-        runbook_url: https://github.com/povilasv/coredns-mixin/tree/master/runbook.md#alert-name-corednsforwardlatencyhigh
+        runbook_url: {{ $.Values.runbookUrls.coreDns.CorednsForwardLatencyHigh }}
         summary: {{ . | title }} is experiencing high latency forwarding requests.
       expr: |
         histogram_quantile(0.99, sum(rate(coredns_forward_request_duration_seconds_bucket{job="{{ . }}"}[5m])) without (pod, instance, rcode)) > 4
@@ -74,7 +74,7 @@ spec:
     - alert: {{ . | title }}ForwardErrorsHigh
       annotations:
         description: {{ . | title }} is returning SERVFAIL for {{`{{`}} $value | humanizePercentage {{`}}`}} of forward requests to  {{`{{`}} $labels.to {{`}}`}}.
-        runbook_url: https://github.com/povilasv/coredns-mixin/tree/master/runbook.md#alert-name-corednsforwarderrorshigh
+        runbook_url: {{ $.Values.runbookUrls.coreDns.CorednsForwardErrorsHigh }}
         summary: {{ . | title }} is returning SERVFAIL for forward requests.
       expr: |
         sum without (pod, instance, rcode) (rate(coredns_forward_responses_total{job="{{ . }}",rcode="SERVFAIL"}[5m]))
@@ -86,7 +86,7 @@ spec:
     - alert: {{ . | title }}ForwardErrorsHigh
       annotations:
         description: {{ . | title }} is returning SERVFAIL for {{`{{`}} $value | humanizePercentage {{`}}`}} of forward requests to  {{`{{`}} $labels.to {{`}}`}}.
-        runbook_url: https://github.com/povilasv/coredns-mixin/tree/master/runbook.md#alert-name-corednsforwarderrorshigh
+        runbook_url: {{ $.Values.runbookUrls.coreDns.CorednsForwardErrorsHigh }}
         summary: {{ . | title }} is returning SERVFAIL for forward requests.
       expr: |
         sum without (pod, instance, rcode) (rate(coredns_forward_responses_total{job="{{ . }}",rcode="SERVFAIL"}[5m]))
@@ -98,7 +98,7 @@ spec:
     - alert: {{ . | title }}ForwardHealthcheckFailureCount
       annotations:
         description: {{ . | title }} health checks have failed to upstream server  {{`{{`}} $labels.to {{`}}`}}.
-        runbook_url: https://github.com/povilasv/coredns-mixin/tree/master/runbook.md#alert-name-corednsforwardhealthcheckfailurecount
+        runbook_url: {{ $.Values.runbookUrls.coreDns.CorednsForwardHealthcheckFailureCount }}
         summary: {{ . | title }} health checks have failed to upstream server.
       expr: |
         sum without (pod, instance) (rate(coredns_forward_healthcheck_failures_total{job="{{ . }}"}[5m])) > 0
@@ -108,7 +108,7 @@ spec:
     - alert: {{ . | title }}ForwardHealthcheckBrokenCount
       annotations:
         description: {{ . | title }} health checks have failed for all upstream servers.
-        runbook_url: https://github.com/povilasv/coredns-mixin/tree/master/runbook.md#alert-name-corednsforwardhealthcheckbrokencount
+        runbook_url: {{ $.Values.runbookUrls.coreDns.CorednsForwardHealthcheckBrokenCount }}
         summary: {{ . | title }} health checks have failed for all upstream servers.
       expr: |
         sum without (pod, instance) (rate(coredns_forward_healthcheck_broken_total{job="{{ . }}"}[5m])) > 0
@@ -118,6 +118,7 @@ spec:
     - alert: {{ . | title }}PanicCount
       annotations:
         description: "Number of {{ . | title }} panics encountered VALUE = {{`{{`}} $value {{`}}`}}  LABELS = {{`{{`}} $labels {{`}}`}}"
+        runbook_url: {{ $.Values.runbookUrls.coreDns.CorednsPanicCount }}
         summary: {{ . | title }} Panic Count (instance {{`{{`}} $labels.pod {{`}}`}})
       expr: increase(coredns_panics_total{job="{{ . }}"}[1m]) > 0
       for: 1m

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/daily-checks.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/daily-checks.yaml
@@ -21,6 +21,7 @@ spec:
     - alert: S3BucketSizeOver{{.Values.s3BucketAlerts.size.percent}}Percent
       annotations:
         message: Over {{.Values.s3BucketAlerts.size.percent}} percent of the total s3bucket size limit is used in bucket {{`{{ $labels.bucket }}`}}.
+        runbook_url: {{ .Values.runbookUrls.dailyChecks.S3BucketSizeOverXPercent }}
       expr: |-
         (
           sum(s3_objects_size_sum_bytes{bucket!~"{{ join "|" .Values.s3BucketAlerts.exclude }}"}) by (bucket) >= ({{ .Values.s3BucketAlerts.size.sizeQuotaGB }} * (1024^3)) * ({{ .Values.s3BucketAlerts.size.percent }} / 100)
@@ -33,6 +34,7 @@ spec:
     - alert: S3BucketsTotalSizeOver{{.Values.s3BucketAlerts.totalSize.percent}}Percent
       annotations:
         message: Over {{.Values.s3BucketAlerts.totalSize.percent}} percent for the total size of all s3 buckets.
+        runbook_url: {{ .Values.runbookUrls.dailyChecks.S3BucketsTotalSizeOverXPercent }}
       expr: |-
         (
           sum(max_over_time(s3_objects_size_sum_bytes[1h])) >= ({{ .Values.s3BucketAlerts.totalSize.sizeQuotaGB }} * (1024^3)) * ({{ .Values.s3BucketAlerts.totalSize.percent }} / 100)
@@ -45,6 +47,7 @@ spec:
     - alert: S3BucketObjectsOver{{.Values.s3BucketAlerts.objects.percent}}Percent
       annotations:
         message: Over {{.Values.s3BucketAlerts.objects.percent}} percent of the total s3bucket object limit is used in bucket {{`{{ $labels.bucket }}`}}.
+        runbook_url: {{ .Values.runbookUrls.dailyChecks.S3BucketObjectsOverXPercent }}
       expr: |-
         (
           sum(s3_objects{bucket!~"{{ join "|" .Values.s3BucketAlerts.exclude }}"}) by (bucket) > {{ .Values.s3BucketAlerts.objects.count }} * ({{ .Values.s3BucketAlerts.objects.percent }} / 100)
@@ -56,6 +59,7 @@ spec:
     - alert: Bucket36hActivityCheck
       annotations:
         message: The bucket {{`{{ $labels.bucket }}`}} haven't had any activity in 36h hours.
+        runbook_url: {{ .Values.runbookUrls.dailyChecks.Bucket36hActivityCheck }}
       expr: |-
         (
           sum(time() - s3_last_modified_object_date{bucket!~"{{- join "|" .Values.s3BucketAlerts.exclude }}"}) by (bucket) / 3600 > 36

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/disk-perf.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/disk-perf.yaml
@@ -26,6 +26,7 @@ spec:
           annotations:
             description: Disk {{`{{`}} $labels.device {{`}}`}} Wait Time on {{`{{`}} $labels.instance {{`}}`}} is {{`{{`}} $value {{`}}`}}, check the workload
             summary: Disk {{`{{`}} $labels.device {{`}}`}} Wait Time is high on {{`{{`}} $labels.instance {{`}}`}}
+            runbook_url: {{ .Values.runbookUrls.diskPerf.DiskReadWaitTimeHigh }}
             severity_level: warning
             storage_type: local
           expr: |
@@ -41,6 +42,7 @@ spec:
           annotations:
             description: Disk {{`{{`}} $labels.device {{`}}`}} Wait Time on {{`{{`}} $labels.instance {{`}}`}} is {{`{{`}} $value {{`}}`}}, check the workload
             summary: Disk {{`{{`}} $labels.device {{`}}`}} Wait Time is high on {{`{{`}} $labels.instance {{`}}`}}
+            runbook_url: {{ .Values.runbookUrls.diskPerf.DiskWriteWaitTimeHigh }}
             severity_level: warning
             storage_type: local
           expr: |
@@ -56,6 +58,7 @@ spec:
           annotations:
             description: Disk {{`{{`}} $labels.device {{`}}`}} Queue Size on {{`{{`}} $labels.instance {{`}}`}} is {{`{{`}} $value {{`}}`}}, check the workload
             summary: Disk {{`{{`}} $labels.device {{`}}`}} has very large Queue Size on {{`{{`}} $labels.instance {{`}}`}}
+            runbook_url: {{ .Values.runbookUrls.diskPerf.DiskQueueSizeHigh }}
             severity_level: warning
             storage_type: local
           expr: |

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/falco-alerts.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/falco-alerts.yaml
@@ -20,6 +20,7 @@ spec:
     - alert: FalcoAlert
       annotations:
         message: 'Pod: {{`{{ $labels.pod }}`}}, Rule: {{`{{ $labels.rule }}`}}'
+        runbook_url: {{ .Values.runbookUrls.falco.FalcoAlert }}
       expr: |-
         falcosecurity_falcosidekick_falco_events_total != 0
       labels:

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/fluentd.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/fluentd.yaml
@@ -26,6 +26,7 @@ spec:
       annotations:
         summary: fluentd cannot be scraped
         description: Prometheus could not scrape {{ "{{ $labels.job }}" }} for more than 10 minutes
+        runbook_url: {{ .Values.runbookUrls.fluentd.FluentdNodeDown }}
     - alert: FluentdNodeDown
       expr: up{job=~"fluentd.*"} == 0
       for: 30m
@@ -35,6 +36,7 @@ spec:
       annotations:
         summary: fluentd cannot be scraped
         description: Prometheus could not scrape {{ "{{ $labels.job }}" }} for more than 30 minutes
+        runbook_url: {{ .Values.runbookUrls.fluentd.FluentdNodeDown }}
     - alert: FluentdQueueLength
       expr: rate(fluentd_status_buffer_queue_length[15m]) > 0.3
       for: 5m
@@ -44,6 +46,7 @@ spec:
       annotations:
         summary: fluentd node are failing
         description: In the last 15 minutes, fluentd queues increased 30%. Current value is {{ "{{ $value }}" }}
+        runbook_url: {{ .Values.runbookUrls.fluentd.FluentdQueueLength }}
     - alert: FluentdQueueLength
       expr: rate(fluentd_status_buffer_queue_length[5m]) > 0.5
       for: 1m
@@ -53,6 +56,7 @@ spec:
       annotations:
         summary: fluentd node are critical
         description: In the last 5 minutes, fluentd queues increased 50%. Current value is {{ "{{ $value }}" }}
+        runbook_url: {{ .Values.runbookUrls.fluentd.FluentdQueueLength }}
     - alert: FluentdAvailableSpaceBuffer
       expr: sum(fluentd_output_status_buffer_available_space_ratio) by (pod, cluster, plugin_id) < 50
       for: 5m
@@ -62,6 +66,7 @@ spec:
       annotations:
         summary: fluentd available space in buffer is less than 50%
         description: For the last 5 minutes, the available buffer space for pod {{ "{{ $labels.pod }}" }}, plugin-id {{  "{{ $labels.plugin_id }}" }} in cluster {{ "{{ $labels.cluster }}" }} is below 50%. Current value is {{ "{{ $value }}" }}
+        runbook_url: {{ .Values.runbookUrls.fluentd.FluentdAvailableSpaceBuffer }}
     - alert: FluentdAvailableSpaceBuffer
       expr: sum(fluentd_output_status_buffer_available_space_ratio) by (pod, cluster, plugin_id) < 10
       for: 5m
@@ -71,6 +76,7 @@ spec:
       annotations:
         summary: fluentd available space in buffer is less than 90%
         description: For the last 5 minutes, the available buffer space for pod {{ "{{ $labels.pod }}" }}, plugin-id {{  "{{ $labels.plugin_id }}" }} in cluster {{ "{{ $labels.cluster }}" }} is below 10%. Current value is {{ "{{ $value }}" }}
+        runbook_url: {{ .Values.runbookUrls.fluentd.FluentdAvailableSpaceBuffer }}
     - alert: FluentdRecordsCountsHigh
       expr: >
         sum(rate(fluentd_output_status_emit_records{job="fluentd-metrics"}[5m]))
@@ -83,6 +89,7 @@ spec:
       annotations:
         summary: fluentd records count are critical
         description: In the last 5m, records counts increased 3 times, comparing to the latest 15 min.
+        runbook_url: {{ .Values.runbookUrls.fluentd.FluentdRecordsCountsHigh }}
     - alert: FluentdRetry
       expr: sum(increase(fluentd_status_retry_count[10m])) by (pod, cluster, service) > 0
       for: 30m
@@ -92,6 +99,7 @@ spec:
       annotations:
         description: Fluentd retry count has been  {{ "{{ $value }}" }} for the last 10 minutes
         summary: Fluentd retry count has been  {{ "{{ $value }}" }} for the last 10 minutes
+        runbook_url: {{ .Values.runbookUrls.fluentd.FluentdRetry }}
     - alert: FluentdOutputError
       expr: sum(increase(fluentd_output_status_num_errors[10m])) by (pod, cluster, service) > 0
       for: 30m
@@ -101,4 +109,5 @@ spec:
       annotations:
         description: Fluentd output error count is {{ "{{ $value }}" }} for the last 10 minutes
         summary: There have been Fluentd output error(s) for the last 10 minutes
+        runbook_url: {{ .Values.runbookUrls.fluentd.FluentdOutputError }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/general.rules.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/general.rules.yaml
@@ -20,7 +20,7 @@ spec:
     - alert: TargetDown
       annotations:
         description: '{{`{{`}} printf "%.4g" $value {{`}}`}}% of the {{`{{`}} $labels.job {{`}}`}}/{{`{{`}} $labels.service {{`}}`}} targets in {{`{{`}} $labels.namespace {{`}}`}} namespace are down.'
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}general/targetdown
+        runbook_url: {{ .Values.runbookUrls.general.TargetDown }}
         summary: One or more targets are unreachable.
       expr: 100 * (count(up == 0) by (cluster, namespace, service, job) / count(up) by (cluster, namespace, service, job)) > 10
       for: 10m
@@ -42,7 +42,7 @@ spec:
           "DeadMansSnitch" integration in PagerDuty.
 
           '
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}general/watchdog
+        runbook_url: {{ .Values.runbookUrls.general.Watchdog }}
         summary: An alert that should always be firing to certify that Alertmanager is working properly.
       expr: vector(1)
       labels:

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/harbor.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/harbor.yaml
@@ -17,7 +17,7 @@ spec:
   groups:
   - name: harbor
     rules:
-    - alert: 'Harbor Core Is Down'
+    - alert: HarborCoreDown
       expr: |
         harbor_up{component="core"} == 0
       for: 5m
@@ -25,8 +25,9 @@ spec:
         severity: critical
       annotations:
         description: Harbor Core Is Down
+        runbook_url: {{ .Values.runbookUrls.harbor.HarborCoreDown }}
     {{- if eq .Values.harbor.database.type "internal" }}
-    - alert: 'Harbor Database Is Down'
+    - alert: HarborDatabaseDown
       expr: |
         harbor_up{component="database"} == 0
       for: 5m
@@ -34,8 +35,9 @@ spec:
         severity: critical
       annotations:
         description: Harbor Database Is Down
+        runbook_url: {{ .Values.runbookUrls.harbor.HarborDatabaseDown }}
     {{- end }}
-    - alert: 'Harbor Registry Is Down'
+    - alert: HarborRegistryDown
       expr: |
         harbor_up{component="registry"} == 0
       for: 5m
@@ -43,8 +45,9 @@ spec:
         severity: critical
       annotations:
         description: Harbor Registry Is Down
+        runbook_url: {{ .Values.runbookUrls.harbor.HarborRegistryDown }}
     {{- if eq .Values.harbor.redis.type "internal" }}
-    - alert: 'Harbor Redis Is Down'
+    - alert: HarborRedisDown
       expr: |
         harbor_up{component="redis"} == 0
       for: 5m
@@ -52,8 +55,9 @@ spec:
         severity: critical
       annotations:
         description: Harbor Redis Is Down
+        runbook_url: {{ .Values.runbookUrls.harbor.HarborRedisDown }}
     {{- end }}
-    - alert: 'Harbor Trivy Is Down'
+    - alert: HarborTrivyDown
       expr: |
         harbor_up{component="trivy"} == 0
       for: 5m
@@ -61,7 +65,8 @@ spec:
         severity: critical
       annotations:
         description: Harbor Trivy Is Down
-    - alert: 'Harbor JobService Is Down'
+        runbook_url: {{ .Values.runbookUrls.harbor.HarborTrivyDown }}
+    - alert: HarborJobServiceDown
       expr: |
         harbor_up{component="jobservice"} == 0
       for: 5m
@@ -69,7 +74,8 @@ spec:
         severity: critical
       annotations:
         description: Harbor JobService Is Down
-    - alert: 'Harbor storage Usage Is Above the Limit'
+        runbook_url: {{ .Values.runbookUrls.harbor.HarborJobServiceDown }}
+    - alert: HarborStorageUsageAboveLimit
       expr: |
         sum(harbor_project_quota_usage_byte) / (1024^3) > {{ .Values.harbor.alerts.maxTotalStorageUsedGB }}
       for: 5m
@@ -77,7 +83,8 @@ spec:
         severity: medium
       annotations:
         description: Total used storage for Harbor is above the limit of {{ .Values.harbor.alerts.maxTotalStorageUsedGB }}GB
-    - alert: 'Harbor p99 latency is higher than 10 seconds'
+        runbook_url: {{ .Values.runbookUrls.harbor.HarborStorageUsageAboveLimit }}
+    - alert: HarborP99LatencyHigherThan10Seconds
       expr: |
         histogram_quantile(0.99,  sum  (rate(registry_http_request_duration_seconds_bucket[30m]) ) by (le)) > 10
       for: 5m
@@ -85,7 +92,8 @@ spec:
         severity: low
       annotations:
         description: Harbor p99 latency is higher than 10 seconds
-    - alert: 'Harbor Error Rate is High'
+        runbook_url: {{ .Values.runbookUrls.harbor.HarborP99LatencyHigherThan10Seconds }}
+    - alert: HarborErrorRateHigh
       expr: |
         sum(rate(registry_http_requests_total{code=~"4..|5.."}[5m]))/sum(rate(registry_http_requests_total[5m])) > 0.15
       for: 5m
@@ -93,7 +101,8 @@ spec:
         severity: low
       annotations:
         description: Harbor Error Rate is High
-    - alert: 'Harbor Total Number of Artifacts is above the limit'
+        runbook_url: {{ .Values.runbookUrls.harbor.HarborErrorRateHigh }}
+    - alert: HarborTotalNumberOfArtifactsAboveLimit
       expr: |
         sum(harbor_project_artifact_total) > {{ .Values.harbor.alerts.maxTotalArtifacts }}
       for: 5m
@@ -101,4 +110,5 @@ spec:
         severity: low
       annotations:
         description: Total number of artifacts is above the limit of {{ .Values.harbor.alerts.maxTotalArtifacts }}
+        runbook_url: {{ .Values.runbookUrls.harbor.HarborTotalNumberOfArtifactsAboveLimit }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/hnc.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/hnc.yaml
@@ -15,5 +15,5 @@ metadata:
   {{- end }}
 spec:
   groups:
-    {{- .Files.Get "files/hnc.yaml" | nindent 4 }}
+    {{- tpl (.Files.Get "files/hnc.yaml") . | nindent 4 }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kube-state-metrics.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kube-state-metrics.yaml
@@ -20,7 +20,7 @@ spec:
     - alert: KubeStateMetricsListErrors
       annotations:
         description: kube-state-metrics is experiencing errors at an elevated rate in list operations. This is likely causing it to not be able to expose metrics about Kubernetes objects correctly or at all.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kube-state-metrics/kubestatemetricslisterrors
+        runbook_url: {{ .Values.runbookUrls.kubeStateMetrics.KubeStateMetricsListErrors }}
         summary: kube-state-metrics is experiencing errors in list operations.
       expr: |-
         (sum(rate(kube_state_metrics_list_total{job="kube-state-metrics",result="error"}[5m])) by (cluster)
@@ -36,7 +36,7 @@ spec:
     - alert: KubeStateMetricsWatchErrors
       annotations:
         description: kube-state-metrics is experiencing errors at an elevated rate in watch operations. This is likely causing it to not be able to expose metrics about Kubernetes objects correctly or at all.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kube-state-metrics/kubestatemetricswatcherrors
+        runbook_url: {{ .Values.runbookUrls.kubeStateMetrics.KubeStateMetricsWatchErrors }}
         summary: kube-state-metrics is experiencing errors in watch operations.
       expr: |-
         (sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics",result="error"}[5m])) by (cluster)
@@ -52,7 +52,7 @@ spec:
     - alert: KubeStateMetricsShardingMismatch
       annotations:
         description: kube-state-metrics pods are running with different --total-shards configuration, some Kubernetes objects may be exposed multiple times or not exposed at all.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kube-state-metrics/kubestatemetricsshardingmismatch
+        runbook_url: {{ .Values.runbookUrls.kubeStateMetrics.KubeStateMetricsShardingMismatch }}
         summary: kube-state-metrics sharding is misconfigured.
       expr: stdvar (kube_state_metrics_total_shards{job="kube-state-metrics"}) by (cluster) != 0
       for: 15m
@@ -64,7 +64,7 @@ spec:
     - alert: KubeStateMetricsShardsMissing
       annotations:
         description: kube-state-metrics shards are missing, some Kubernetes objects are not being exposed.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kube-state-metrics/kubestatemetricsshardsmissing
+        runbook_url: {{ .Values.runbookUrls.kubeStateMetrics.KubeStateMetricsShardsMissing }}
         summary: kube-state-metrics shards are missing.
       expr: |-
         2^max(kube_state_metrics_total_shards{job="kube-state-metrics"}) by (cluster) - 1

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-apps.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-apps.yaml
@@ -21,7 +21,7 @@ spec:
     - alert: KubePodCrashLooping
       annotations:
         description: 'Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} ({{`{{`}} $labels.container {{`}}`}}) is in waiting state (reason: "CrashLoopBackOff").'
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubepodcrashlooping
+        runbook_url: {{ .Values.runbookUrls.kubernetesApps.KubePodCrashLooping }}
         summary: Pod is crash looping.
       expr: max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}[5m]) >= 1
       for: 15m
@@ -33,7 +33,7 @@ spec:
     - alert: KubePodNotReady
       annotations:
         description: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} has been in a non-ready state for longer than 15 minutes.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubepodnotready
+        runbook_url: {{ .Values.runbookUrls.kubernetesApps.KubePodNotReady }}
         summary: Pod has been in a non-ready state for more than 15 minutes.
       expr: |-
         sum by (cluster, namespace, pod) (
@@ -52,6 +52,7 @@ spec:
     - alert: KubeContainerOOMKilled
       annotations:
         description: Container {{`{{`}} $labels.container {{`}}`}} in pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} from {{`{{`}} $labels.cluster {{`}}`}} has been OOMKilled {{`{{`}} $value {{`}}`}} times in the last 30 minutes.
+        runbook_url: {{ .Values.runbookUrls.kubernetesApps.KubeContainerOOMKilled }}
         summary: Kubernetes container OOMKilled.
       expr: increase(kube_pod_container_status_restarts_total[30m]) >= 2 and ignoring (reason) min_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}[30m]) == 1
       for: 0m
@@ -63,7 +64,7 @@ spec:
     - alert: KubeDeploymentGenerationMismatch
       annotations:
         description: Deployment generation for {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.deployment {{`}}`}} does not match, this indicates that the Deployment has failed but has not been rolled back.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubedeploymentgenerationmismatch
+        runbook_url: {{ .Values.runbookUrls.kubernetesApps.KubeDeploymentGenerationMismatch }}
         summary: Deployment generation mismatch due to possible roll-back
       expr: |-
         kube_deployment_status_observed_generation{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
@@ -78,7 +79,7 @@ spec:
     - alert: KubeDeploymentReplicasMismatch
       annotations:
         description: Deployment {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.deployment {{`}}`}} has not matched the expected number of replicas for longer than 15 minutes.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubedeploymentreplicasmismatch
+        runbook_url: {{ .Values.runbookUrls.kubernetesApps.KubeDeploymentReplicasMismatch }}
         summary: Deployment has not matched the expected number of replicas.
       expr: |-
         (
@@ -99,7 +100,7 @@ spec:
     - alert: KubeStatefulSetReplicasMismatch
       annotations:
         description: StatefulSet {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.statefulset {{`}}`}} has not matched the expected number of replicas for longer than 15 minutes.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubestatefulsetreplicasmismatch
+        runbook_url: {{ .Values.runbookUrls.kubernetesApps.KubeStatefulSetReplicasMismatch }}
         summary: Deployment has not matched the expected number of replicas.
       expr: |-
         (
@@ -120,7 +121,7 @@ spec:
     - alert: KubeStatefulSetGenerationMismatch
       annotations:
         description: StatefulSet generation for {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.statefulset {{`}}`}} does not match, this indicates that the StatefulSet has failed but has not been rolled back.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubestatefulsetgenerationmismatch
+        runbook_url: {{ .Values.runbookUrls.kubernetesApps.KubeStatefulSetGenerationMismatch }}
         summary: StatefulSet generation mismatch due to possible roll-back
       expr: |-
         kube_statefulset_status_observed_generation{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
@@ -135,7 +136,7 @@ spec:
     - alert: KubeStatefulSetUpdateNotRolledOut
       annotations:
         description: StatefulSet {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.statefulset {{`}}`}} update has not been rolled out.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubestatefulsetupdatenotrolledout
+        runbook_url: {{ .Values.runbookUrls.kubernetesApps.KubeStatefulSetUpdateNotRolledOut }}
         summary: StatefulSet update has not been rolled out.
       expr: |-
         (
@@ -164,7 +165,7 @@ spec:
     - alert: KubeDaemonSetRolloutStuck
       annotations:
         description: DaemonSet {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.daemonset {{`}}`}} has not finished or progressed for at least 15 minutes.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubedaemonsetrolloutstuck
+        runbook_url: {{ .Values.runbookUrls.kubernetesApps.KubeDaemonSetRolloutStuck }}
         summary: DaemonSet rollout is stuck.
       expr: |-
         (
@@ -199,7 +200,7 @@ spec:
     - alert: KubeContainerWaiting
       annotations:
         description: Pod {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}} container {{`{{`}} $labels.container{{`}}`}} has been in waiting state for longer than 1 hour.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubecontainerwaiting
+        runbook_url: {{ .Values.runbookUrls.kubernetesApps.KubeContainerWaiting }}
         summary: Pod container waiting longer than 1 hour
       expr: sum by (cluster, namespace, pod, container) (kube_pod_container_status_waiting_reason{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}) > 0
       for: 1h
@@ -211,7 +212,7 @@ spec:
     - alert: KubeDaemonSetNotScheduled
       annotations:
         description: '{{`{{`}} $value {{`}}`}} Pods of DaemonSet {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.daemonset {{`}}`}} are not scheduled.'
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubedaemonsetnotscheduled
+        runbook_url: {{ .Values.runbookUrls.kubernetesApps.KubeDaemonSetNotScheduled }}
         summary: DaemonSet pods are not scheduled.
       expr: |-
         kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
@@ -226,7 +227,7 @@ spec:
     - alert: KubeDaemonSetMisScheduled
       annotations:
         description: '{{`{{`}} $value {{`}}`}} Pods of DaemonSet {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.daemonset {{`}}`}} are running where they are not supposed to run.'
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubedaemonsetmisscheduled
+        runbook_url: {{ .Values.runbookUrls.kubernetesApps.KubeDaemonSetMisScheduled }}
         summary: DaemonSet pods are misscheduled.
       expr: kube_daemonset_status_number_misscheduled{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"} > 0
       for: 15m
@@ -238,7 +239,7 @@ spec:
     - alert: KubeJobNotCompleted
       annotations:
         description: Job {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job_name {{`}}`}} is taking more than {{`{{`}} "43200" | humanizeDuration {{`}}`}} to complete.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubejobnotcompleted
+        runbook_url: {{ .Values.runbookUrls.kubernetesApps.KubeJobNotCompleted }}
         summary: Job did not complete in time
       expr: |-
         time() - max by(cluster, namespace, job_name) (kube_job_status_start_time{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}
@@ -252,7 +253,7 @@ spec:
     - alert: KubeJobFailed
       annotations:
         description: Job {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.job_name {{`}}`}} failed to complete. Removing failed job after investigation should clear this alert.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubejobfailed
+        runbook_url: {{ .Values.runbookUrls.kubernetesApps.KubeJobFailed }}
         summary: Job failed to complete.
       expr: kube_job_failed{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"}  > 0
       for: 15m
@@ -265,6 +266,7 @@ spec:
       annotations:
         description: '{{`{{`}} $value {{`}}`}} Failed Evicted pods in {{`{{`}} $labels.namespace {{`}}`}} namespace {{`{{`}} $labels.cluster {{`}}`}} cluster'
         summary: Kubernetes failed evicted pods
+        runbook_url: {{ .Values.runbookUrls.kubernetesApps.KubeFailedEvictedPods }}
       expr: sum by (namespace, cluster) (kube_pod_status_phase{phase="Failed"} > 0 and on(namespace, cluster) kube_pod_status_reason{reason="Evicted"} > 0) > 0
       for: 10m
       labels:

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-resources.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-resources.yaml
@@ -20,7 +20,7 @@ spec:
     - alert: KubeCPUOvercommit
       annotations:
         description: Cluster has overcommitted CPU resource requests for Pods by {{`{{`}} $value {{`}}`}} CPU shares and cannot tolerate node failure.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubecpuovercommit
+        runbook_url: {{ .Values.runbookUrls.kubernetesResources.KubeCPUOvercommit }}
         summary: Cluster has overcommitted CPU resource requests.
       expr: |-
         sum(namespace_cpu:kube_pod_container_resource_requests:sum{}) by (cluster) - (sum(kube_node_status_allocatable{resource="cpu"}) by (cluster) - max(kube_node_status_allocatable{resource="cpu"}) by (cluster)) > 0
@@ -35,7 +35,7 @@ spec:
     - alert: KubeMemoryOvercommit
       annotations:
         description: Cluster has overcommitted memory resource requests for Pods by {{`{{`}} $value | humanize {{`}}`}} bytes and cannot tolerate node failure.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubememoryovercommit
+        runbook_url: {{ .Values.runbookUrls.kubernetesResources.KubeMemoryOvercommit }}
         summary: Cluster has overcommitted memory resource requests.
       expr: |-
         sum(namespace_memory:kube_pod_container_resource_requests:sum{}) by (cluster) - (sum(kube_node_status_allocatable{resource="memory"}) by (cluster) - max(kube_node_status_allocatable{resource="memory"}) by (cluster)) > 0
@@ -50,7 +50,7 @@ spec:
     - alert: CPUThrottlingHigh
       annotations:
         description: '{{`{{`}} $value | humanizePercentage {{`}}`}} throttling of CPU in namespace {{`{{`}} $labels.namespace {{`}}`}} for container {{`{{`}} $labels.container {{`}}`}} in pod {{`{{`}} $labels.pod {{`}}`}}.'
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/cputhrottlinghigh
+        runbook_url: {{ .Values.runbookUrls.kubernetesResources.CPUThrottlingHigh }}
         summary: Processes experience elevated CPU throttling.
       expr: |-
         sum(increase(container_cpu_cfs_throttled_periods_total{container!="", }[5m])) by (cluster, container, pod, namespace)

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-storage.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-storage.yaml
@@ -21,7 +21,7 @@ spec:
     - alert: KubePersistentVolumeFillingUp
       annotations:
         description: The PersistentVolume claimed by {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in Namespace {{`{{`}} $labels.namespace {{`}}`}} is only {{`{{`}} $value | humanizePercentage {{`}}`}} free.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubepersistentvolumefillingup
+        runbook_url: {{ .Values.runbookUrls.kubernetesStorage.KubePersistentVolumeFillingUp }}
         summary: PersistentVolume is filling up.
       expr: |-
         (
@@ -40,7 +40,7 @@ spec:
     - alert: KubePersistentVolumeFillingUp
       annotations:
         description: Based on recent sampling, the PersistentVolume claimed by {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in Namespace {{`{{`}} $labels.namespace {{`}}`}} is expected to fill up within four days. Currently {{`{{`}} $value | humanizePercentage {{`}}`}} is available.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubepersistentvolumefillingup
+        runbook_url: {{ .Values.runbookUrls.kubernetesStorage.KubePersistentVolumeFillingUp }}
         summary: PersistentVolume is filling up.
       expr: |-
         (
@@ -61,7 +61,7 @@ spec:
     - alert: KubePersistentVolumeErrors
       annotations:
         description: The persistent volume {{`{{`}} $labels.persistentvolume {{`}}`}} has status {{`{{`}} $labels.phase {{`}}`}}.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubepersistentvolumeerrors
+        runbook_url: {{ .Values.runbookUrls.kubernetesStorage.KubePersistentVolumeErrors }}
         summary: PersistentVolume is having issues with provisioning.
       expr: kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} > 0
       for: 5m

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system-apiserver.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system-apiserver.yaml
@@ -20,7 +20,7 @@ spec:
     - alert: KubeClientCertificateExpiration
       annotations:
         description: A client certificate used to authenticate to the apiserver is expiring in less than 7.0 days.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeclientcertificateexpiration
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeClientCertificateExpiration }}
         summary: Client certificate is about to expire.
       expr: apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
       labels:
@@ -31,7 +31,7 @@ spec:
     - alert: KubeClientCertificateExpiration
       annotations:
         description: A client certificate used to authenticate to the apiserver is expiring in less than 24.0 hours.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeclientcertificateexpiration
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeClientCertificateExpiration }}
         summary: Client certificate is about to expire.
       expr: apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
       labels:
@@ -42,7 +42,7 @@ spec:
     - alert: KubeAggregatedAPIErrors
       annotations:
         description: An aggregated API {{`{{`}} $labels.name {{`}}`}}/{{`{{`}} $labels.namespace {{`}}`}} has reported errors. It has appeared unavailable {{`{{`}} $value | humanize {{`}}`}} times averaged over the past 10m.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeaggregatedapierrors
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeAggregatedAPIErrors }}
         summary: An aggregated API has reported errors.
       expr: sum by(cluster, name, namespace)(increase(aggregator_unavailable_apiservice_total[10m])) > 4
       labels:
@@ -53,7 +53,7 @@ spec:
     - alert: KubeAggregatedAPIDown
       annotations:
         description: An aggregated API {{`{{`}} $labels.name {{`}}`}}/{{`{{`}} $labels.namespace {{`}}`}} has been only {{`{{`}} $value | humanize {{`}}`}}% available over the last 10m.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeaggregatedapidown
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeAggregatedAPIDown }}
         summary: An aggregated API is down.
       expr: (1 - max by(cluster, name, namespace)(avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 85
       for: 5m
@@ -65,7 +65,7 @@ spec:
     - alert: KubeAPIDown
       annotations:
         description: KubeAPI has disappeared from Prometheus target discovery.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeapidown
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeAPIDown }}
         summary: Target disappeared from Prometheus target discovery.
       expr: absent(up{job="apiserver"} == 1)
       for: 15m
@@ -77,7 +77,7 @@ spec:
     - alert: KubeAPITerminatedRequests
       annotations:
         description: The apiserver has terminated {{`{{`}} $value | humanizePercentage {{`}}`}} of its incoming requests.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeapiterminatedrequests
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeAPITerminatedRequests }}
         summary: The apiserver has terminated {{`{{`}} $value | humanizePercentage {{`}}`}} of its incoming requests.
       expr: sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m])) by (cluster)  / (  sum(rate(apiserver_request_total{job="apiserver"}[10m])) by (cluster) + sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m])) by (cluster) ) > 0.20
       for: 5m

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system-kube-proxy.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system-kube-proxy.yaml
@@ -20,7 +20,7 @@ spec:
     - alert: KubeProxyDown
       annotations:
         description: KubeProxy has disappeared from Prometheus target discovery.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeproxydown
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeProxyDown }}
         summary: Target disappeared from Prometheus target discovery.
       expr: absent(up{job="kube-proxy"} == 1)
       for: 15m

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system-kubelet.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system-kubelet.yaml
@@ -20,7 +20,7 @@ spec:
     - alert: KubeNodeNotReady
       annotations:
         description: '{{`{{`}} $labels.node {{`}}`}} has been unready for more than 15 minutes.'
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubenodenotready
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeNodeNotReady }}
         summary: Node is not ready.
       expr: kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
       for: 15m
@@ -32,7 +32,7 @@ spec:
     - alert: KubeNodeUnreachable
       annotations:
         description: '{{`{{`}} $labels.node {{`}}`}} is unreachable and some workloads may be rescheduled.'
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubenodeunreachable
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeNodeUnreachable }}
         summary: Node is unreachable.
       expr: (kube_node_spec_taint{job="kube-state-metrics",key="node.kubernetes.io/unreachable",effect="NoSchedule"} unless ignoring(key,value) kube_node_spec_taint{job="kube-state-metrics",key=~"ToBeDeletedByClusterAutoscaler|cloud.google.com/impending-node-termination|aws-node-termination-handler/spot-itn"}) == 1
       for: 15m
@@ -44,7 +44,7 @@ spec:
     - alert: KubeletTooManyPods
       annotations:
         description: Kubelet '{{`{{`}} $labels.node {{`}}`}}' is running at {{`{{`}} $value | humanizePercentage {{`}}`}} of its Pod capacity.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubelettoomanypods
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeletTooManyPods }}
         summary: Kubelet is running at capacity.
       expr: |-
         count by(cluster,node) (
@@ -63,7 +63,7 @@ spec:
     - alert: KubeNodeReadinessFlapping
       annotations:
         description: The readiness status of node {{`{{`}} $labels.node {{`}}`}} has changed {{`{{`}} $value {{`}}`}} times in the last 15 minutes.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubenodereadinessflapping
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeNodeReadinessFlapping }}
         summary: Node readiness status is flapping.
       expr: sum(changes(kube_node_status_condition{status="true",condition="Ready"}[15m])) by (cluster,node) > 2
       for: 15m
@@ -75,7 +75,7 @@ spec:
     - alert: KubeletPlegDurationHigh
       annotations:
         description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile duration of {{`{{`}} $value {{`}}`}} seconds on node {{`{{`}} $labels.node {{`}}`}}.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeletplegdurationhigh
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeletPlegDurationHigh }}
         summary: Kubelet Pod Lifecycle Event Generator is taking too long to relist.
       expr: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile{quantile="0.99"} >= 10
       for: 5m
@@ -87,7 +87,7 @@ spec:
     - alert: KubeletPodStartUpLatencyHigh
       annotations:
         description: Kubelet Pod startup 99th percentile latency is {{`{{`}} $value {{`}}`}} seconds on node {{`{{`}} $labels.node {{`}}`}}.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeletpodstartuplatencyhigh
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeletPodStartUpLatencyHigh }}
         summary: Kubelet Pod startup latency is too high.
       expr: histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{job="kubelet", metrics_path="/metrics"}[5m])) by (cluster,instance,le)) * on(cluster,instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"} > 60
       for: 15m
@@ -99,7 +99,7 @@ spec:
     - alert: KubeletClientCertificateExpiration
       annotations:
         description: Client certificate for Kubelet on node {{`{{`}} $labels.node {{`}}`}} expires in {{`{{`}} $value | humanizeDuration {{`}}`}}.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeletclientcertificateexpiration
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeletClientCertificateExpiration }}
         summary: Kubelet client certificate is about to expire.
       expr: kubelet_certificate_manager_client_ttl_seconds < 604800
       labels:
@@ -110,7 +110,7 @@ spec:
     - alert: KubeletClientCertificateExpiration
       annotations:
         description: Client certificate for Kubelet on node {{`{{`}} $labels.node {{`}}`}} expires in {{`{{`}} $value | humanizeDuration {{`}}`}}.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeletclientcertificateexpiration
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeletClientCertificateExpiration }}
         summary: Kubelet client certificate is about to expire.
       expr: kubelet_certificate_manager_client_ttl_seconds < 86400
       labels:
@@ -121,7 +121,7 @@ spec:
     - alert: KubeletServerCertificateExpiration
       annotations:
         description: Server certificate for Kubelet on node {{`{{`}} $labels.node {{`}}`}} expires in {{`{{`}} $value | humanizeDuration {{`}}`}}.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeletservercertificateexpiration
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeletServerCertificateExpiration }}
         summary: Kubelet server certificate is about to expire.
       expr: kubelet_certificate_manager_server_ttl_seconds < 604800
       labels:
@@ -132,7 +132,7 @@ spec:
     - alert: KubeletServerCertificateExpiration
       annotations:
         description: Server certificate for Kubelet on node {{`{{`}} $labels.node {{`}}`}} expires in {{`{{`}} $value | humanizeDuration {{`}}`}}.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeletservercertificateexpiration
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeletServerCertificateExpiration }}
         summary: Kubelet server certificate is about to expire.
       expr: kubelet_certificate_manager_server_ttl_seconds < 86400
       labels:
@@ -143,7 +143,7 @@ spec:
     - alert: KubeletClientCertificateRenewalErrors
       annotations:
         description: Kubelet on node {{`{{`}} $labels.node {{`}}`}} has failed to renew its client certificate ({{`{{`}} $value | humanize {{`}}`}} errors in the last 5 minutes).
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeletclientcertificaterenewalerrors
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeletClientCertificateRenewalErrors }}
         summary: Kubelet has failed to renew its client certificate.
       expr: increase(kubelet_certificate_manager_client_expiration_renew_errors[5m]) > 0
       for: 15m
@@ -155,7 +155,7 @@ spec:
     - alert: KubeletServerCertificateRenewalErrors
       annotations:
         description: Kubelet on node {{`{{`}} $labels.node {{`}}`}} has failed to renew its server certificate ({{`{{`}} $value | humanize {{`}}`}} errors in the last 5 minutes).
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeletservercertificaterenewalerrors
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeletServerCertificateRenewalErrors }}
         summary: Kubelet has failed to renew its server certificate.
       expr: increase(kubelet_server_expiration_renew_errors[5m]) > 0
       for: 15m
@@ -167,7 +167,7 @@ spec:
     - alert: KubeletDown
       annotations:
         description: Kubelet has disappeared from Prometheus target discovery.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeletdown
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeletDown }}
         summary: Target disappeared from Prometheus target discovery.
       expr: absent(up{job="kubelet", metrics_path="/metrics"} == 1)
       for: 15m
@@ -180,6 +180,7 @@ spec:
     - alert: KubletDownForAutoscaledNodeFor15m
       annotations:
         description: The kubelet job of an existing autoscaled node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 15m.
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubletDownForAutoscaledNodeFor15m }}
         summary: The kubelet job of an existing autoscaled cluster {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.node }}`}} is down for the last 15m.
       expr: |-
           sum by (node, cluster) (kube_node_info and on (node) up{job="kubelet",metrics_path="/metrics"} == 0)
@@ -194,6 +195,7 @@ spec:
     - alert: KubletDownForAutoscaledNodeFor30m
       annotations:
         description: The kubelet job of an existing autoscaled node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 30m.
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubletDownForAutoscaledNodeFor30m }}
         summary: The kubelet job of an existing autoscaled node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 30m.
       expr: |-
           sum by (node, cluster) (kube_node_info and on (node) up{job="kubelet",metrics_path="/metrics"} == 0)
@@ -208,6 +210,7 @@ spec:
     - alert: KubletDownForNonAutoscaledNodeFor5m
       annotations:
         description: The kubelet job of an existing non-autoscaled node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 5m.
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubletDownForNonAutoscaledNodeFor5m }}
         summary: The kubelet job of an existing non-autoscaled node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 5m.
       expr: |-
           sum by (node, cluster) (kube_node_info and on (node) up{job="kubelet",metrics_path="/metrics"} == 0)
@@ -222,6 +225,7 @@ spec:
     - alert: KubletDownForNonAutoscaledNodeFor15m
       annotations:
         description: The kubelet job of an existing non-autoscaled node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 15m.
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubletDownForNonAutoscaledNodeFor15m }}
         summary: The kubelet job of an existing non-autoscaled node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 15m.
       expr: |-
           sum by (node, cluster) (kube_node_info and on (node) up{job="kubelet",metrics_path="/metrics"} == 0)
@@ -237,6 +241,7 @@ spec:
     - alert: KubeletDownFor5m
       annotations:
         description: The kubelet job of an existing node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 5m.
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeletDownFor5m }}
         summary: The kubelet job of an existing node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 5m.
       expr: sum by (node, cluster) (kube_node_info and on (node) up{job="kubelet",metrics_path="/metrics"} == 0)
       for: 5m
@@ -248,6 +253,7 @@ spec:
     - alert: KubeletDownFor15m
       annotations:
         description: The kubelet job of an existing node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 15m.
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeletDownFor15m }}
         summary: The kubelet job of an existing node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.cluster }}`}} is down for the last 15m.
       expr: sum by (node, cluster) (kube_node_info and on (node) up{job="kubelet",metrics_path="/metrics"} == 0)
       for: 15m

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system.yaml
@@ -20,7 +20,7 @@ spec:
     - alert: KubeVersionMismatch
       annotations:
         description: There are {{`{{`}} $value {{`}}`}} different semantic versions of Kubernetes components running.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeversionmismatch
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeVersionMismatch }}
         summary: Different semantic versions of Kubernetes components running.
       expr: count(count by (cluster, git_version) (label_replace(kubernetes_build_info{job!~"kube-dns|coredns|openstack-monitoring"},"git_version","$1","git_version","(v[0-9]*.[0-9]*).*"))) by (cluster) > 1
       for: 15m
@@ -32,7 +32,7 @@ spec:
     - alert: KubeClientErrors
       annotations:
         description: Kubernetes API server client '{{`{{`}} $labels.job {{`}}`}}/{{`{{`}} $labels.instance {{`}}`}}' is experiencing {{`{{`}} $value | humanizePercentage {{`}}`}} errors.'
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}kubernetes/kubeclienterrors
+        runbook_url: {{ .Values.runbookUrls.kubernetesSystem.KubeClientErrors }}
         summary: Kubernetes API server client is experiencing errors.
       expr: |-
         (sum(rate(rest_client_requests_total{code=~"5.."}[5m])) by (cluster, instance, job, namespace)

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kured.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kured.yaml
@@ -17,7 +17,7 @@ spec:
   groups:
   - name: kured
     rules:
-    - alert: 'Kured Failed Node Reboot'
+    - alert: KuredFailedNodeReboot
       expr: |
         min_over_time((sum(kured_reboot_required) by (node))[30d:1m]) > 0 and on (node) kube_node_info
       for: 5m
@@ -25,4 +25,5 @@ spec:
         severity: warning
       annotations:
         description: "Kured has failed with required reboot of node {{`{{ $labels.node }}`}} over 30 days."
+        runbook_url: {{ .Values.runbookUrls.kured.KuredFailedNodeReboot }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/missing-metrics-rules.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/missing-metrics-rules.yaml
@@ -17,5 +17,5 @@ metadata:
   namespace: "monitoring"
 spec:
   groups:
-    {{- .Files.Get "files/missing-metrics-alerts.yaml" | nindent 4}}
+    {{- tpl (.Files.Get "files/missing-metrics-alerts.yaml") . | nindent 4}}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/node-exporter.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/node-exporter.yaml
@@ -21,7 +21,7 @@ spec:
     - alert: NodeFilesystemAlmostOutOfSpace
       annotations:
         description: Filesystem on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available space left.
-        runbook_url: {{ $.Values.defaultRules.runbookUrl }}node/nodefilesystemalmostoutofspace
+        runbook_url: {{ $.Values.runbookUrls.nodeExporter.NodeFilesystemAlmostOutOfSpace }}
         summary: Filesystem has less than {{ .freeSpacePercentage }}% space left.
       expr: |-
         (
@@ -40,7 +40,7 @@ spec:
     - alert: NodeFilesystemSpaceFillingUp
       annotations:
         description: Filesystem on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available space left and is filling up.
-        runbook_url: {{ $.Values.defaultRules.runbookUrl }}node/nodefilesystemspacefillingup
+        runbook_url: {{ $.Values.runbookUrls.nodeExporter.NodeFilesystemSpaceFillingUp }}
         summary: Filesystem is predicted to run out of space within the next {{ .hours }} hours.
       expr: |-
         (
@@ -61,7 +61,7 @@ spec:
     - alert: NodeFilesystemAlmostOutOfSpace
       annotations:
         description: Filesystem on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available inodes left.
-        runbook_url: {{ $.Values.defaultRules.runbookUrl }}node/nodefilesystemalmostoutoffiles
+        runbook_url: {{ $.Values.runbookUrls.nodeExporter.NodeFilesystemAlmostOutOfSpace }}
         summary: Filesystem has less than {{ .freeSpacePercentage }}% inodes left.
       expr: |-
         (
@@ -80,7 +80,7 @@ spec:
     - alert: NodeFilesystemSpaceFillingUp
       annotations:
         description: Filesystem on {{`{{`}} $labels.device {{`}}`}} at {{`{{`}} $labels.instance {{`}}`}} has only {{`{{`}} printf "%.2f" $value {{`}}`}}% available inodes left and is filling up fast.
-        runbook_url: {{ $.Values.defaultRules.runbookUrl }}node/nodefilesystemfilesfillingup
+        runbook_url: {{ $.Values.runbookUrls.nodeExporter.NodeFilesystemSpaceFillingUp }}
         summary: Filesystem is predicted to run out of inodes within the next {{ .hours }} hours.
       expr: |-
         (
@@ -100,7 +100,7 @@ spec:
     - alert: NodeNetworkReceiveErrs
       annotations:
         description: '{{`{{`}} $labels.instance {{`}}`}} interface {{`{{`}} $labels.device {{`}}`}} has encountered {{`{{`}} printf "%.0f" $value {{`}}`}} receive errors in the last two minutes.'
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}node/nodenetworkreceiveerrs
+        runbook_url: {{ $.Values.runbookUrls.nodeExporter.NodeNetworkReceiveErrs }}
         summary: Network interface is reporting many receive errors.
       expr: rate(node_network_receive_errs_total[2m]) / rate(node_network_receive_packets_total[2m]) > 0.01
       for: 1h
@@ -112,7 +112,7 @@ spec:
     - alert: NodeNetworkTransmitErrs
       annotations:
         description: '{{`{{`}} $labels.instance {{`}}`}} interface {{`{{`}} $labels.device {{`}}`}} has encountered {{`{{`}} printf "%.0f" $value {{`}}`}} transmit errors in the last two minutes.'
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}node/nodenetworktransmiterrs
+        runbook_url: {{ $.Values.runbookUrls.nodeExporter.NodeNetworkTransmitErrs }}
         summary: Network interface is reporting many transmit errors.
       expr: rate(node_network_transmit_errs_total[2m]) / rate(node_network_transmit_packets_total[2m]) > 0.01
       for: 1h
@@ -124,7 +124,7 @@ spec:
     - alert: NodeHighNumberConntrackEntriesUsed
       annotations:
         description: '{{`{{`}} $value | humanizePercentage {{`}}`}} of conntrack entries are used.'
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}node/nodehighnumberconntrackentriesused
+        runbook_url: {{ $.Values.runbookUrls.nodeExporter.NodeHighNumberConntrackEntriesUsed }}
         summary: Number of conntrack are getting close to the limit.
       expr: (node_nf_conntrack_entries / node_nf_conntrack_entries_limit) > 0.75
       labels:
@@ -135,7 +135,7 @@ spec:
     - alert: NodeTextFileCollectorScrapeError
       annotations:
         description: Node Exporter text file collector failed to scrape.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}node/nodetextfilecollectorscrapeerror
+        runbook_url: {{ $.Values.runbookUrls.nodeExporter.NodeTextFileCollectorScrapeError }}
         summary: Node Exporter text file collector failed to scrape.
       expr: node_textfile_scrape_error{job="node-exporter"} == 1
       labels:
@@ -146,7 +146,7 @@ spec:
     - alert: NodeClockSkewDetected
       annotations:
         description: Clock on {{`{{`}} $labels.instance {{`}}`}} is out of sync by more than 300s. Ensure NTP is configured correctly on this host.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}node/nodeclockskewdetected
+        runbook_url: {{ $.Values.runbookUrls.nodeExporter.NodeClockSkewDetected }}
         summary: Clock skew detected.
       expr: |-
         (
@@ -169,7 +169,7 @@ spec:
     - alert: NodeClockNotSynchronising
       annotations:
         description: Clock on {{`{{`}} $labels.instance {{`}}`}} is not synchronising. Ensure NTP is configured on this host.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}node/nodeclocknotsynchronising
+        runbook_url: {{ $.Values.runbookUrls.nodeExporter.NodeClockNotSynchronising }}
         summary: Clock not synchronising.
       expr: |-
         min_over_time(node_timex_sync_status{job="node-exporter"}[5m]) == 0
@@ -184,7 +184,7 @@ spec:
     - alert: NodeFileDescriptorLimit
       annotations:
         description: File descriptors limit at {{`{{`}} $labels.instance {{`}}`}} is currently at {{`{{`}} printf "%.2f" $value {{`}}`}}%.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}node/nodefiledescriptorlimit
+        runbook_url: {{ $.Values.runbookUrls.nodeExporter.NodeFileDescriptorLimit }}
         summary: Kernel is predicted to exhaust file descriptors limit soon.
       expr: |-
         (
@@ -199,7 +199,7 @@ spec:
     - alert: NodeFileDescriptorLimit
       annotations:
         description: File descriptors limit at {{`{{`}} $labels.instance {{`}}`}} is currently at {{`{{`}} printf "%.2f" $value {{`}}`}}%.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}node/nodefiledescriptorlimit
+        runbook_url: {{ $.Values.runbookUrls.nodeExporter.NodeFileDescriptorLimit }}
         summary: Kernel is predicted to exhaust file descriptors limit soon.
       expr: |-
         (

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/node-network.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/node-network.yaml
@@ -20,7 +20,7 @@ spec:
     - alert: NodeNetworkInterfaceFlapping
       annotations:
         description: Network interface "{{`{{`}} $labels.device {{`}}`}}" changing it's up status often on node-exporter {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod {{`}}`}}
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}general/nodenetworkinterfaceflapping
+        runbook_url: {{ .Values.runbookUrls.nodeNetwork.NodeNetworkInterfaceFlapping }}
         summary: Network interface is often changing it's status
       expr: changes(node_network_up{job="node-exporter",device!~"veth.+"}[2m]) > 2
       for: 2m

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/opensearch.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/opensearch.yaml
@@ -25,15 +25,16 @@ spec:
       annotations:
         description: There are only {{`{{ $value }}`}}  OpenSearch nodes running
         summary: OpenSearch running on less than {{ .Values.osNodeCount }} nodes
+        runbook_url: {{ .Values.runbookUrls.opensearch.OpenSearchTooFewNodesRunning }}
     - alert: OpenSearchHeapTooHigh
-      expr: elasticsearch_jvm_memory_used_bytes{namespace="opensearch-system",area="heap"} / elasticsearch_jvm_memory_max_bytes{namespace="opensearch-system",area="heap"}
-        > 0.9
+      expr: elasticsearch_jvm_memory_used_bytes{namespace="opensearch-system",area="heap"} / elasticsearch_jvm_memory_max_bytes{namespace="opensearch-system",area="heap"} > 0.9
       for: 15m
       labels:
         severity: critical
       annotations:
         description: The heap usage is over 90% for 15m
         summary: OpenSearch node {{`{{ $labels.node}}`}} heap usage is high
+        runbook_url: {{ .Values.runbookUrls.opensearch.OpenSearchHeapTooHigh }}
     - alert: OpenSearchFieldLimit
       expr: (sum(max_over_time(elasticsearch_indices_mappings_stats_fields{namespace="opensearch-system"}[5m])) by (index) / sum(max_over_time(elasticsearch_indices_settings_total_fields{namespace="opensearch-system"}[5m])) by (index)) * 100 > 80
       for: 15m
@@ -42,6 +43,7 @@ spec:
       annotations:
         description: Index {{`{{ $labels.index }}`}} is using {{`{{ $value }}`}} percent of max field limit
         summary: Index {{`{{ $labels.index }}`}} is using {{`{{ $value }}`}} percent of max field limit
+        runbook_url: {{ .Values.runbookUrls.opensearch.OpenSearchFieldLimit }}
     - alert: OpenSearchFieldLimit
       expr: (sum(max_over_time(elasticsearch_indices_mappings_stats_fields{namespace="opensearch-system"}[5m])) by (index) / sum(max_over_time(elasticsearch_indices_settings_total_fields{namespace="opensearch-system"}[5m])) by (index)) * 100 > 95
       for: 15m
@@ -50,6 +52,7 @@ spec:
       annotations:
         description: Index {{`{{ $labels.index }}`}} is using {{`{{ $value }}`}} percent of max field limit
         summary: Index {{`{{ $labels.index }}`}} is using {{`{{ $value }}`}} percent of max field limit
+        runbook_url: {{ .Values.runbookUrls.opensearch.OpenSearchFieldLimit }}
     - alert: OpensearchClusterYellow
       expr: elasticsearch_cluster_health_status{namespace="opensearch-system",color="yellow"} == 1
       for: 15m
@@ -58,6 +61,7 @@ spec:
       annotations:
         summary: Opensearch Cluster Yellow (instance {{`{{ $labels.instance }}`}})
         description: Opensearch Cluster is in a Yellow status VALUE = {{`{{ $value }}`}}  LABELS = {{`{{ $labels }}`}}
+        runbook_url: {{ .Values.runbookUrls.opensearch.OpensearchClusterYellow }}
     - alert: OpensearchClusterRed
       expr: elasticsearch_cluster_health_status{namespace="opensearch-system",color="red"} == 1
       for: 15m
@@ -66,6 +70,7 @@ spec:
       annotations:
         summary: Opensearch Cluster Red (instance {{`{{ $labels.instance }}`}})
         description: Opensearch Cluster is in a Red status VALUE = {{`{{ $value }}`}}  LABELS = {{`{{ $labels }}`}}
+        runbook_url: {{ .Values.runbookUrls.opensearch.OpensearchClusterRed }}
     {{- range $prefixes := .Values.osIndexAlerts }}
     - alert: OpenSearch{{ $prefixes.prefix | trimSuffix "-" | title }}IndexSizeOverLimit
       expr: (elasticsearch_indices_store_size_bytes_primary{namespace="opensearch-system", index=~"{{ $prefixes.prefix }}.+"} / (1024 ^ 2) > {{ $prefixes.alertSizeMB }}) * clamp(rate(elasticsearch_indices_docs_primary{namespace="opensearch-system", index=~"{{ $prefixes.prefix }}.+"}[4h]) > 0, 1, 1)
@@ -75,5 +80,6 @@ spec:
       annotations:
         message: Active primary shard size for index {{`{{ $labels.index }}`}} has increased over the limit of {{ $prefixes.alertSizeMB }}MB, current size is {{`{{ $value | printf "%.0f" }}`}}MB
         description: This indicates a problem with index state management preventing the alias to roll over to a new index.
+        runbook_url: {{ $.Values.runbookUrls.opensearch.OpenSearchXIndexSizeOverLimit }}
     {{- end }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/openstack.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/openstack.yaml
@@ -20,6 +20,7 @@ spec:
     - alert: OpenStackCloudControllerDown
       annotations:
         summary: OpenStack cloud controller manager has disappeared.
+        runbook_url: {{ .Values.runbookUrls.openstack.OpenStackCloudControllerDown }}
       expr: (group(present_over_time(up{job="openstack-monitoring"}[6h])) by (cluster) unless group(up{job="openstack-monitoring"}) by (cluster)) or (absent(up{job="openstack-monitoring"} == 1))
       for: 10m
       labels:
@@ -27,6 +28,7 @@ spec:
     - alert: OpenStackApiRequestFailed
       annotations:
         summary: Failed OpenStack API call.
+        runbook_url: {{ .Values.runbookUrls.openstack.OpenStackApiRequestFailed }}
       expr: rate(openstack_api_request_errors_total[5m]) > 0.01
       for: 5m
       labels:
@@ -34,6 +36,7 @@ spec:
     - alert: OpenStackApiRequestDuration
       annotations:
         summary: OpenStack API has taken longer than 15 seconds.
+        runbook_url: {{ .Values.runbookUrls.openstack.OpenStackApiRequestDuration }}
       expr: rate(openstack_api_request_duration_seconds_sum[5m]) / rate(openstack_api_request_duration_seconds_count[5m]) > 15
       for: 5m
       labels:
@@ -41,6 +44,7 @@ spec:
     - alert: OpenStackApiRequestTotal
       annotations:
         summary: Too high amount of OpenStack API calls.
+        runbook_url: {{ .Values.runbookUrls.openstack.OpenStackApiRequestTotal }}
       expr: (delta(openstack_api_requests_total[5m]))/5 > 20
       for: 5m
       labels:
@@ -48,6 +52,7 @@ spec:
     - alert: OpenStackReconcileFailed
       annotations:
         summary: Increased reconciliation errors.
+        runbook_url: {{ .Values.runbookUrls.openstack.OpenStackReconcileFailed }}
       expr: rate(cloudprovider_openstack_reconcile_errors_total[5m]) > 0
       for: 10m
       labels:
@@ -55,6 +60,7 @@ spec:
     - alert: OpenStackReconcileDuration
       annotations:
         summary: Reconciliation has taken longer than 10 minutes.
+        runbook_url: {{ .Values.runbookUrls.openstack.OpenStackReconcileDuration }}
       expr: rate(cloudprovider_openstack_reconcile_duration_seconds_sum[5m]) / rate(cloudprovider_openstack_reconcile_duration_seconds_count[5m]) > 600
       for: 10m
       labels:

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/packets-dropped.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/packets-dropped.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         description: Number of packets dropped to workload {{ "{{ $labels.exported_pod }}" }} in namespace {{ "{{ $labels.pod_namespace }}" }}, because no policies matched them
         summary: Number of packets dropped to workload in {{ "{{ $labels.cluster }}" }} cluster
+        runbook_url: {{ .Values.runbookUrls.packetsDropped.FrequentPacketsDroppedToWorkload }}
       expr: |
         increase(no_policy_drop_counter{type="tw"}[15m]) > 0
       for: 5m
@@ -33,6 +34,7 @@ spec:
       annotations:
         description: Number of packets dropped to workload {{ "{{ $labels.exported_pod }}" }} in namespace {{ "{{ $labels.pod_namespace }}" }}, because no policies matched them
         summary: Number of packets dropped to workload in {{ "{{ $labels.cluster }}" }} cluster
+        runbook_url: {{ .Values.runbookUrls.packetsDropped.ScarcePacketsDroppedToWorkload }}
       expr: |
         increase(no_policy_drop_counter{type="tw"}[3h]) > 20
       for: 6h
@@ -45,6 +47,7 @@ spec:
       annotations:
         description: Number of packets dropped from workload {{ "{{ $labels.exported_pod }}" }} in namespace {{ "{{ $labels.pod_namespace }}" }}, because no policies matched them
         summary: Number of packets dropped from workload in {{ "{{ $labels.cluster }}" }} cluster
+        runbook_url: {{ .Values.runbookUrls.packetsDropped.FrequentPacketsDroppedFromWorkload }}
       expr: |
         increase(no_policy_drop_counter{type="fw"}[15m]) > 0
       for: 5m
@@ -57,6 +60,7 @@ spec:
       annotations:
         description: Number of packets dropped from workload {{ "{{ $labels.exported_pod }}" }} in namespace {{ "{{ $labels.pod_namespace }}" }}, because no policies matched them
         summary: Number of packets dropped from workload in {{ "{{ $labels.cluster }}" }} cluster
+        runbook_url: {{ .Values.runbookUrls.packetsDropped.ScarcePacketsDroppedFromWorkload }}
       expr: |
         increase(no_policy_drop_counter{type="fw"}[3h]) > 20
       for: 6h

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/prometheus-operator.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/prometheus-operator.yaml
@@ -22,7 +22,7 @@ spec:
     - alert: PrometheusOperatorListErrors
       annotations:
         description: Errors while performing List operations in controller {{`{{`}}$labels.controller{{`}}`}} in {{`{{`}}$labels.namespace{{`}}`}} namespace.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus-operator/prometheusoperatorlisterrors
+        runbook_url: {{ .Values.runbookUrls.prometheusOperator.PrometheusOperatorListErrors }}
         summary: Errors while performing list operations in controller.
       expr: (sum by (cluster,controller,namespace) (rate(prometheus_operator_list_operations_failed_total{job="{{ $operatorJob }}",namespace="{{ $namespace }}"}[10m])) / sum by (cluster,controller,namespace) (rate(prometheus_operator_list_operations_total{job="{{ $operatorJob }}",namespace="{{ $namespace }}"}[10m]))) > 0.4
       for: 15m
@@ -34,7 +34,7 @@ spec:
     - alert: PrometheusOperatorWatchErrors
       annotations:
         description: Errors while performing watch operations in controller {{`{{`}}$labels.controller{{`}}`}} in {{`{{`}}$labels.namespace{{`}}`}} namespace.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus-operator/prometheusoperatorwatcherrors
+        runbook_url: {{ .Values.runbookUrls.prometheusOperator.PrometheusOperatorWatchErrors }}
         summary: Errors while performing watch operations in controller.
       expr: (sum by (cluster,controller,namespace) (rate(prometheus_operator_watch_operations_failed_total{job="{{ $operatorJob }}",namespace="{{ $namespace }}"}[10m])) / sum by (cluster,controller,namespace) (rate(prometheus_operator_watch_operations_total{job="{{ $operatorJob }}",namespace="{{ $namespace }}"}[10m]))) > 0.4
       for: 15m
@@ -46,7 +46,7 @@ spec:
     - alert: PrometheusOperatorSyncFailed
       annotations:
         description: Controller {{`{{`}} $labels.controller {{`}}`}} in {{`{{`}} $labels.namespace {{`}}`}} namespace fails to reconcile {{`{{`}} $value {{`}}`}} objects.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus-operator/prometheusoperatorsyncfailed
+        runbook_url: {{ .Values.runbookUrls.prometheusOperator.PrometheusOperatorSyncFailed }}
         summary: Last controller reconciliation failed
       expr: min_over_time(prometheus_operator_syncs{status="failed",job="{{ $operatorJob }}",namespace="{{ $namespace }}"}[5m]) > 0
       for: 10m
@@ -58,7 +58,7 @@ spec:
     - alert: PrometheusOperatorReconcileErrors
       annotations:
         description: '{{`{{`}} $value | humanizePercentage {{`}}`}} of reconciling operations failed for {{`{{`}} $labels.controller {{`}}`}} controller in {{`{{`}} $labels.namespace {{`}}`}} namespace.'
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus-operator/prometheusoperatorreconcileerrors
+        runbook_url: {{ .Values.runbookUrls.prometheusOperator.PrometheusOperatorReconcileErrors }}
         summary: Errors while reconciling controller.
       expr: (sum by (cluster,controller,namespace) (rate(prometheus_operator_reconcile_errors_total{job="{{ $operatorJob }}",namespace="{{ $namespace }}"}[5m]))) / (sum by (cluster,controller,namespace) (rate(prometheus_operator_reconcile_operations_total{job="{{ $operatorJob }}",namespace="{{ $namespace }}"}[5m]))) > 0.1
       for: 10m
@@ -70,7 +70,7 @@ spec:
     - alert: PrometheusOperatorNodeLookupErrors
       annotations:
         description: Errors while reconciling Prometheus in {{`{{`}} $labels.namespace {{`}}`}} Namespace.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus-operator/prometheusoperatornodelookuperrors
+        runbook_url: {{ .Values.runbookUrls.prometheusOperator.PrometheusOperatorNodeLookupErrors }}
         summary: Errors while reconciling Prometheus.
       expr: rate(prometheus_operator_node_address_lookup_errors_total{job="{{ $operatorJob }}",namespace="{{ $namespace }}"}[5m]) > 0.1
       for: 10m
@@ -82,7 +82,7 @@ spec:
     - alert: PrometheusOperatorNotReady
       annotations:
         description: Prometheus operator in {{`{{`}} $labels.namespace {{`}}`}} namespace isn't ready to reconcile {{`{{`}} $labels.controller {{`}}`}} resources.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus-operator/prometheusoperatornotready
+        runbook_url: {{ .Values.runbookUrls.prometheusOperator.PrometheusOperatorNotReady }}
         summary: Prometheus operator not ready
       expr: min by(cluster, namespace, controller) (max_over_time(prometheus_operator_ready{job="{{ $operatorJob }}",namespace="{{ $namespace }}"}[5m]) == 0)
       for: 5m
@@ -94,7 +94,7 @@ spec:
     - alert: PrometheusOperatorRejectedResources
       annotations:
         description: Prometheus operator in {{`{{`}} $labels.namespace {{`}}`}} namespace rejected {{`{{`}} printf "%0.0f" $value {{`}}`}} {{`{{`}} $labels.controller {{`}}`}}/{{`{{`}} $labels.resource {{`}}`}} resources.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus-operator/prometheusoperatorrejectedresources
+        runbook_url: {{ .Values.runbookUrls.prometheusOperator.PrometheusOperatorRejectedResources }}
         summary: Resources rejected by Prometheus operator
       expr: min_over_time(prometheus_operator_managed_resources{state="rejected",job="{{ $operatorJob }}",namespace="{{ $namespace }}"}[5m]) > 0
       for: 5m

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/prometheus.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/prometheus.yaml
@@ -23,7 +23,7 @@ spec:
     - alert: PrometheusBadConfig
       annotations:
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has failed to reload its configuration.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheusbadconfig
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusBadConfig }}
         summary: Failed Prometheus configuration reload.
       expr: |-
         # Without max_over_time, failed scrapes could create false negatives, see
@@ -38,7 +38,7 @@ spec:
     - alert: PrometheusNotificationQueueRunningFull
       annotations:
         description: Alert notification queue of Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} is running full.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheusnotificationqueuerunningfull
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusNotificationQueueRunningFull }}
         summary: Prometheus alert notification queue predicted to run full in less than 30m.
       expr: |-
         # Without min_over_time, failed scrapes could create false negatives, see
@@ -57,7 +57,7 @@ spec:
     - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
       annotations:
         description: '{{`{{`}} printf "%.1f" $value {{`}}`}}% errors while sending alerts from Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} to Alertmanager {{`{{`}}$labels.alertmanager{{`}}`}}.'
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheuserrorsendingalertstosomealertmanagers
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusErrorSendingAlertsToSomeAlertmanagers }}
         summary: Prometheus has encountered more than 1% errors sending alerts to a specific Alertmanager.
       expr: |-
         (
@@ -76,7 +76,7 @@ spec:
     - alert: PrometheusNotConnectedToAlertmanagers
       annotations:
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} is not connected to any Alertmanagers.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheusnotconnectedtoalertmanagers
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusNotConnectedToAlertmanagers }}
         summary: Prometheus is not connected to any Alertmanagers.
       expr: |-
         # Without max_over_time, failed scrapes could create false negatives, see
@@ -91,7 +91,7 @@ spec:
     - alert: PrometheusTSDBReloadsFailing
       annotations:
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has detected {{`{{`}}$value | humanize{{`}}`}} reload failures over the last 3h.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheustsdbreloadsfailing
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusTSDBReloadsFailing }}
         summary: Prometheus has issues reloading blocks from disk.
       expr: increase(prometheus_tsdb_reloads_failures_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[3h]) > 0
       for: 4h
@@ -103,7 +103,7 @@ spec:
     - alert: PrometheusTSDBCompactionsFailing
       annotations:
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has detected {{`{{`}}$value | humanize{{`}}`}} compaction failures over the last 3h.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheustsdbcompactionsfailing
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusTSDBCompactionsFailing }}
         summary: Prometheus has issues compacting blocks.
       expr: increase(prometheus_tsdb_compactions_failed_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[3h]) > 0
       for: 4h
@@ -115,7 +115,7 @@ spec:
     - alert: PrometheusNotIngestingSamples
       annotations:
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} is not ingesting samples.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheusnotingestingsamples
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusNotIngestingSamples }}
         summary: Prometheus is not ingesting samples.
       expr: |-
         (
@@ -136,7 +136,7 @@ spec:
     - alert: PrometheusDuplicateTimestamps
       annotations:
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} is dropping {{`{{`}} printf "%.4g" $value  {{`}}`}} samples/s with different values but duplicated timestamp.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheusduplicatetimestamps
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusDuplicateTimestamps }}
         summary: Prometheus is dropping samples with duplicate timestamps.
       expr: rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m]) > 0
       for: 10m
@@ -148,7 +148,7 @@ spec:
     - alert: PrometheusOutOfOrderTimestamps
       annotations:
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} is dropping {{`{{`}} printf "%.4g" $value  {{`}}`}} samples/s with timestamps arriving out of order.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheusoutofordertimestamps
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusOutOfOrderTimestamps }}
         summary: Prometheus drops samples with out-of-order timestamps.
       expr: rate(prometheus_target_scrapes_sample_out_of_order_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m]) > 0
       for: 10m
@@ -160,7 +160,7 @@ spec:
     - alert: PrometheusRemoteStorageFailures
       annotations:
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} failed to send {{`{{`}} printf "%.1f" $value {{`}}`}}% of the samples to {{`{{`}} $labels.remote_name{{`}}`}}:{{`{{`}} $labels.url {{`}}`}}
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheusremotestoragefailures
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusRemoteStorageFailures }}
         summary: Prometheus fails to send samples to remote storage.
       expr: |-
         (
@@ -183,7 +183,7 @@ spec:
     - alert: PrometheusRemoteWriteBehind
       annotations:
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} remote write is {{`{{`}} printf "%.1f" $value {{`}}`}}s behind for {{`{{`}} $labels.remote_name{{`}}`}}:{{`{{`}} $labels.url {{`}}`}}.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheusremotewritebehind
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusRemoteWriteBehind }}
         summary: Prometheus remote write is behind.
       expr: |-
         # Without max_over_time, failed scrapes could create false negatives, see
@@ -203,7 +203,7 @@ spec:
     - alert: PrometheusRemoteWriteDesiredShards
       annotations:
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} remote write desired shards calculation wants to run {{`{{`}} $value {{`}}`}} shards for queue {{`{{`}} $labels.remote_name{{`}}`}}:{{`{{`}} $labels.url {{`}}`}}, which is more than the max of {{`{{`}} printf `prometheus_remote_storage_shards_max{instance="%s",job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}` $labels.instance | query | first | value {{`}}`}}.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheusremotewritedesiredshards
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusRemoteWriteDesiredShards }}
         summary: Prometheus remote write desired shards calculation wants to run more than configured max shards.
       expr: |-
         # Without max_over_time, failed scrapes could create false negatives, see
@@ -222,7 +222,7 @@ spec:
     - alert: PrometheusRuleFailures
       annotations:
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has failed to evaluate {{`{{`}} printf "%.0f" $value {{`}}`}} rules in the last 5m.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheusrulefailures
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusRuleFailures }}
         summary: Prometheus is failing rule evaluations.
       expr: increase(prometheus_rule_evaluation_failures_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m]) > 0
       for: 15m
@@ -234,7 +234,7 @@ spec:
     - alert: PrometheusMissingRuleEvaluations
       annotations:
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has missed {{`{{`}} printf "%.0f" $value {{`}}`}} rule group evaluations in the last 5m.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheusmissingruleevaluations
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusMissingRuleEvaluations }}
         summary: Prometheus is missing rule evaluations due to slow rule group evaluation.
       expr: increase(prometheus_rule_group_iterations_missed_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m]) > 0
       for: 15m
@@ -246,7 +246,7 @@ spec:
     - alert: PrometheusTargetLimitHit
       annotations:
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has dropped {{`{{`}} printf "%.0f" $value {{`}}`}} targets because the number of targets exceeded the configured target_limit.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheustargetlimithit
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusTargetLimitHit }}
         summary: Prometheus has dropped targets because some scrape configs have exceeded the targets limit.
       expr: increase(prometheus_target_scrape_pool_exceeded_target_limit_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m]) > 0
       for: 15m
@@ -258,7 +258,7 @@ spec:
     - alert: PrometheusLabelLimitHit
       annotations:
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has dropped {{`{{`}} printf "%.0f" $value {{`}}`}} targets because some samples exceeded the configured label_limit, label_name_length_limit or label_value_length_limit.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheuslabellimithit
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusLabelLimitHit }}
         summary: Prometheus has dropped targets because some scrape configs have exceeded the labels limit.
       expr: increase(prometheus_target_scrape_pool_exceeded_label_limits_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m]) > 0
       for: 15m
@@ -270,7 +270,7 @@ spec:
     - alert: PrometheusScrapeBodySizeLimitHit
       annotations:
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has failed {{`{{`}} printf "%.0f" $value {{`}}`}} scrapes in the last 5m because some targets exceeded the configured body_size_limit.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheusscrapebodysizelimithit
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusScrapeBodySizeLimitHit }}
         summary: Prometheus has dropped some targets that exceeded body size limit.
       expr: increase(prometheus_target_scrapes_exceeded_body_size_limit_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m]) > 0
       for: 15m
@@ -282,7 +282,7 @@ spec:
     - alert: PrometheusScrapeSampleLimitHit
       annotations:
         description: Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} has failed {{`{{`}} printf "%.0f" $value {{`}}`}} scrapes in the last 5m because some targets exceeded the configured sample_limit.
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheusscrapesamplelimithit
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusScrapeSampleLimitHit }}
         summary: Prometheus has failed scrapes that have exceeded the configured sample limit.
       expr: increase(prometheus_target_scrapes_exceeded_sample_limit_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[5m]) > 0
       for: 15m
@@ -294,7 +294,7 @@ spec:
     - alert: PrometheusTargetSyncFailure
       annotations:
         description: '{{`{{`}} printf "%.0f" $value {{`}}`}} targets in Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} have failed to sync because invalid configuration was supplied.'
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheustargetsyncfailure
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusTargetSyncFailure }}
         summary: Prometheus has failed to sync targets.
       expr: increase(prometheus_target_sync_failed_total{job="{{ $prometheusJob }}",namespace="{{ $namespace }}"}[30m]) > 0
       for: 5m
@@ -306,7 +306,7 @@ spec:
     - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
       annotations:
         description: '{{`{{`}} printf "%.1f" $value {{`}}`}}% minimum errors while sending alerts from Prometheus {{`{{`}}$labels.namespace{{`}}`}}/{{`{{`}}$labels.pod{{`}}`}} to any Alertmanager.'
-        runbook_url: {{ .Values.defaultRules.runbookUrl }}prometheus/prometheuserrorsendingalertstoanyalertmanager
+        runbook_url: {{ .Values.runbookUrls.prometheus.PrometheusErrorSendingAlertsToAnyAlertmanager }}
         summary: Prometheus encounters more than 3% errors sending alerts to any Alertmanager.
       expr: |-
         min without (alertmanager) (

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/thanos-ruler.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/thanos-ruler.yaml
@@ -15,5 +15,5 @@ metadata:
 {{ toYaml .Values.defaultRules.annotations | indent 4 }}
 {{- end }}
 spec:
-  {{- .Files.Get "files/thanos-ruler.yaml" | nindent 2}}
+  {{- tpl (.Files.Get "files/thanos-ruler.yaml") . | nindent 2}}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/thanos.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/thanos.yaml
@@ -15,5 +15,5 @@ metadata:
 {{ toYaml .Values.defaultRules.annotations | indent 4 }}
 {{- end }}
 spec:
-  {{- .Files.Get "files/thanos.yaml" | nindent 2}}
+  {{- tpl (.Files.Get "files/thanos.yaml") . | nindent 2}}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/webhooks.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/webhooks.yaml
@@ -15,5 +15,5 @@ metadata:
   {{- end }}
 spec:
   groups:
-    {{- .Files.Get "files/webhooks.yaml" | nindent 4 }}
+    {{- tpl (.Files.Get "files/webhooks.yaml") . | nindent 4 }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/values.yaml
+++ b/helmfile.d/charts/prometheus-alerts/values.yaml
@@ -81,7 +81,6 @@ diskAlerts:
 
 defaultRules:
   create: true
-  runbookUrl: "https://runbooks.prometheus-operator.dev/runbooks/"
   ## Any labels to add to the alert rules
   # alertLabels:
   #   key: value
@@ -166,3 +165,36 @@ harbor:
   alerts:
     maxTotalStorageUsedGB: 500
     maxTotalArtifacts: 1000
+
+runbookUrls:
+  alertmanager: {}
+  backupStatus: {}
+  blackbox: {}
+  certManager: {}
+  clusterApi: {}
+  clusterCapacityManagement: {}
+  configReloaders: {}
+  coreDns: {}
+  dailyChecks: {}
+  diskPerf: {}
+  falco: {}
+  fluentd: {}
+  general: {}
+  harbor: {}
+  hnc: {}
+  kubeStateMetrics: {}
+  kubernetesApps: {}
+  kubernetesResources: {}
+  kubernetesStorage: {}
+  kubernetesSystem: {}
+  kured: {}
+  missingMetrics: {}
+  nodeExporter: {}
+  nodeNetwork: {}
+  opensearch: {}
+  openstack: {}
+  packetsDropped: {}
+  prometheusOperator: {}
+  prometheus: {}
+  thanos: {}
+  webhook: {}

--- a/helmfile.d/stacks/monitoring-prometheus.yaml.gotmpl
+++ b/helmfile.d/stacks/monitoring-prometheus.yaml.gotmpl
@@ -63,6 +63,7 @@ templates:
       - monitoring/kube-prometheus-stack # creates prometheus-operator/prometheusrules
     values:
       - values/prometheus-alerts-sc.yaml.gotmpl
+      - values/prometheus-alerts-runbook-urls.yaml.gotmpl
 
   prometheus-wc-monitors:
     disableValidationOnInstall: true
@@ -87,6 +88,7 @@ templates:
       - monitoring/kube-prometheus-stack # creates prometheus-operator/prometheusrules
     values:
       - values/prometheus-user-alerts-wc.yaml.gotmpl
+      - values/prometheus-alerts-runbook-urls.yaml.gotmpl
 
   kube-state-metrics-extra-resources:
     inherit: [ template: prometheus ]

--- a/helmfile.d/values/prometheus-alerts-runbook-urls.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-alerts-runbook-urls.yaml.gotmpl
@@ -1,0 +1,273 @@
+{{- define "tpl.prometheus-operator" -}}
+{{- $output := . | dig "override" .name | lower | printf "https://runbooks.prometheus-operator.dev/runbooks/%s/%s" .subpath }}
+{{- $output = .config | dig "group" $output }}
+{{- $output = .config | dig .name $output }}
+    {{ .name }}: {{ $output }}
+{{- end }}
+
+{{- define "tpl.thanos" -}}
+{{- $output := printf "https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#%s" .header }}
+{{- $output = .config | dig "group" $output }}
+{{- $output = .config | dig .name $output }}
+    {{ .name }}: {{ $output }}
+{{- end }}
+
+{{- define "tpl.missing-runbook" -}}
+{{- $output := printf "Missing runbook" }}
+{{- $output = .config | dig "group" $output }}
+{{- $output = .config | dig .name $output }}
+    {{ .name }}: {{ $output }}
+{{- end }}
+
+{{- with .Values.alerts.runbookUrls }}
+runbookUrls:
+  alertmanager:
+    {{- dict "name" "AlertmanagerConfigInconsistent" "subpath" "alertmanager" "config" .alertmanager | include "tpl.prometheus-operator" }}
+    {{- dict "name" "AlertmanagerFailedReload" "subpath" "alertmanager" "config" .alertmanager | include "tpl.prometheus-operator" }}
+    {{- dict "name" "AlertmanagerMembersInconsistent" "subpath" "alertmanager" "config" .alertmanager | include "tpl.prometheus-operator" }}
+  backupStatus:
+    {{- dict "name" "HarborBackupHaveFailed24Hours" "config" .backupStatus | include "tpl.missing-runbook" }}
+    {{- dict "name" "HarborBackupHaveFailed48Hours" "config" .backupStatus | include "tpl.missing-runbook" }}
+    {{- dict "name" "VeleroBackupHaveFailed24Hours" "config" .backupStatus | include "tpl.missing-runbook" }}
+    {{- dict "name" "VeleroBackupHaveFailed48Hours" "config" .backupStatus | include "tpl.missing-runbook" }}
+    {{- dict "name" "OpenSearchSnapshotHaveFailed24Hours" "config" .backupStatus | include "tpl.missing-runbook" }}
+    {{- dict "name" "OpenSearchSnapshotHaveFailed48Hours" "config" .backupStatus | include "tpl.missing-runbook" }}
+  blackbox:
+    {{- dict "name" "EndpointDown" "config" .blackbox | include "tpl.missing-runbook" }}
+  certManager:
+    {{- dict "name" "CertificateExpiringSoon" "config" .certManager | include "tpl.missing-runbook" }}
+    {{- dict "name" "CertificateNotReady" "config" .certManager | include "tpl.missing-runbook" }}
+  clusterApi:
+    {{- dict "name" "ClusterApiClusterIsPaused" "config" .clusterApi | include "tpl.missing-runbook" }}
+    {{- dict "name" "ClusterApiClusterControlPlaneNotInitialized" "config" .clusterApi | include "tpl.missing-runbook" }}
+    {{- dict "name" "ClusterApiClusterNotReady" "config" .clusterApi | include "tpl.missing-runbook" }}
+    {{- dict "name" "ClusterApiClusterInfrastructureNotReady" "config" .clusterApi | include "tpl.missing-runbook" }}
+    {{- dict "name" "ClusterApiClusterNotProvisionedState" "config" .clusterApi | include "tpl.missing-runbook" }}
+    {{- dict "name" "ClusterApiKubeadmControlPlaneNotFullyReady" "config" .clusterApi | include "tpl.missing-runbook" }}
+    {{- dict "name" "ClusterApiKubeadmControlPlaneCloseToMajorityNotReady" "config" .clusterApi | include "tpl.missing-runbook" }}
+    {{- dict "name" "ClusterApiKubeadmControlPlaneMajorityNotReady" "config" .clusterApi | include "tpl.missing-runbook" }}
+    {{- dict "name" "ClusterApiMachineDeploymentNotFullyReady" "config" .clusterApi | include "tpl.missing-runbook" }}
+    {{- dict "name" "ClusterApiMachineDeploymentMajorityNotReady" "config" .clusterApi | include "tpl.missing-runbook" }}
+    {{- dict "name" "ClusterApiMachineConditionNotTrue" "config" .clusterApi | include "tpl.missing-runbook" }}
+  clusterCapacityManagement:
+    {{- dict "name" "NodeFilesystemSpaceFillingUp" "subpath" "node" "config" .clusterCapacityManagement | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PersistentVolumeXPercentInThreeDays" "subpath" "kubernetes" "override" "kubepersistentvolumefillingup" "config" .clusterCapacityManagement | include "tpl.prometheus-operator" }}
+    {{- dict "name" "MemoryXPercentInThreeDays" "config" .clusterCapacityManagement | include "tpl.missing-runbook" }}
+    {{- dict "name" "NodeGroupCPUXPercentOver24h" "config" .clusterCapacityManagement | include "tpl.missing-runbook" }}
+    {{- dict "name" "NodeGroupCPUXPercentOver1h" "config" .clusterCapacityManagement | include "tpl.missing-runbook" }}
+    {{- dict "name" "NodeGroupMemoryXPercentOver24h" "config" .clusterCapacityManagement | include "tpl.missing-runbook" }}
+    {{- dict "name" "NodeGroupMemoryXPercentOver1h" "config" .clusterCapacityManagement | include "tpl.missing-runbook" }}
+    {{- dict "name" "NodeCPUXPercentOver1h" "config" .clusterCapacityManagement | include "tpl.missing-runbook" }}
+    {{- dict "name" "NodeMemoryXPercentOver1h" "config" .clusterCapacityManagement | include "tpl.missing-runbook" }}
+    {{- dict "name" "NodeGroupCpuRequestXPercent" "config" .clusterCapacityManagement | include "tpl.missing-runbook" }}
+    {{- dict "name" "NodeGroupMemoryRequestXPercent" "config" .clusterCapacityManagement | include "tpl.missing-runbook" }}
+  configReloaders:
+    {{- dict "name" "ConfigReloaderSidecarErrors" "subpath" "prometheus-operator" "config" .configReloaders | include "tpl.prometheus-operator" }}
+  coreDns:
+    {{- dict "name" "CorednsDown" "config" .coreDns | include "tpl.missing-runbook" }}
+    {{- dict "name" "CorednsLatencyHigh" "config" .coreDns | include "tpl.missing-runbook" }}
+    {{- dict "name" "CorednsErrorsHigh" "config" .coreDns | include "tpl.missing-runbook" }}
+    {{- dict "name" "CorednsForwardLatencyHigh" "config" .coreDns | include "tpl.missing-runbook" }}
+    {{- dict "name" "CorednsForwardErrorsHigh" "config" .coreDns | include "tpl.missing-runbook" }}
+    {{- dict "name" "CorednsForwardHealthcheckFailureCount" "config" .coreDns | include "tpl.missing-runbook" }}
+    {{- dict "name" "CorednsForwardHealthcheckBrokenCount" "config" .coreDns | include "tpl.missing-runbook" }}
+    {{- dict "name" "CorednsPanicCount" "config" .coreDns | include "tpl.missing-runbook" }}
+  dailyChecks:
+    {{- dict "name" "S3BucketSizeOverXPercent" "config" .dailyChecks | include "tpl.missing-runbook" }}
+    {{- dict "name" "S3BucketsTotalSizeOverXPercent" "config" .dailyChecks | include "tpl.missing-runbook" }}
+    {{- dict "name" "S3BucketObjectsOverXPercent" "config" .dailyChecks | include "tpl.missing-runbook" }}
+    {{- dict "name" "Bucket36hActivityCheck" "config" .dailyChecks | include "tpl.missing-runbook" }}
+  diskPerf:
+    {{- dict "name" "DiskReadWaitTimeHigh" "config" .diskPerf | include "tpl.missing-runbook" }}
+    {{- dict "name" "DiskWriteWaitTimeHigh" "config" .diskPerf | include "tpl.missing-runbook" }}
+    {{- dict "name" "DiskQueueSizeHigh" "config" .diskPerf | include "tpl.missing-runbook" }}
+  falco:
+    {{- dict "name" "FalcoAlert" "config" .falco | include "tpl.missing-runbook" }}
+  fluentd:
+    {{- dict "name" "FluentdNodeDown" "config" .fluentd | include "tpl.missing-runbook" }}
+    {{- dict "name" "FluentdQueueLength" "config" .fluentd | include "tpl.missing-runbook" }}
+    {{- dict "name" "FluentdAvailableSpaceBuffer" "config" .fluentd | include "tpl.missing-runbook" }}
+    {{- dict "name" "FluentdRecordsCountsHigh" "config" .fluentd | include "tpl.missing-runbook" }}
+    {{- dict "name" "FluentdRetry" "config" .fluentd | include "tpl.missing-runbook" }}
+    {{- dict "name" "FluentdOutputError" "config" .fluentd | include "tpl.missing-runbook" }}
+  general:
+    {{- dict "name" "TargetDown" "subpath" "general" "config" .general | include "tpl.prometheus-operator" }}
+    {{- dict "name" "Watchdog" "subpath" "general" "config" .general | include "tpl.prometheus-operator" }}
+  harbor:
+    {{- dict "name" "HarborCoreDown" "config" .harbor | include "tpl.missing-runbook" }}
+    {{- dict "name" "HarborDatabaseDown" "config" .harbor | include "tpl.missing-runbook" }}
+    {{- dict "name" "HarborRegistryDown" "config" .harbor | include "tpl.missing-runbook" }}
+    {{- dict "name" "HarborRedisDown" "config" .harbor | include "tpl.missing-runbook" }}
+    {{- dict "name" "HarborTrivyDown" "config" .harbor | include "tpl.missing-runbook" }}
+    {{- dict "name" "HarborJobServiceDown" "config" .harbor | include "tpl.missing-runbook" }}
+    {{- dict "name" "HarborStorageUsageAboveLimit" "config" .harbor | include "tpl.missing-runbook" }}
+    {{- dict "name" "HarborP99LatencyHigherThan10Seconds" "config" .harbor | include "tpl.missing-runbook" }}
+    {{- dict "name" "HarborErrorRateHigh" "config" .harbor | include "tpl.missing-runbook" }}
+    {{- dict "name" "HarborTotalNumberOfArtifactsAboveLimit" "config" .harbor | include "tpl.missing-runbook" }}
+  hnc:
+    {{- dict "name" "HierarchicalNamespaceControllerNamespaceCondition" "config" .hnc | include "tpl.missing-runbook" }}
+  kubeStateMetrics:
+    {{- dict "name" "KubeStateMetricsListErrors" "subpath" "kube-state-metrics" "config" .kubeStateMetrics | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeStateMetricsWatchErrors" "subpath" "kube-state-metrics" "config" .kubeStateMetrics | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeStateMetricsShardingMismatch" "subpath" "kube-state-metrics" "config" .kubeStateMetrics | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeStateMetricsShardsMissing" "subpath" "kube-state-metrics" "config" .kubeStateMetrics | include "tpl.prometheus-operator" }}
+  kubernetesApps:
+    {{- dict "name" "KubePodCrashLooping" "subpath" "kubernetes" "config" .kubernetesApps | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubePodNotReady" "subpath" "kubernetes" "config" .kubernetesApps | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeContainerOOMKilled" "config" .kubernetesApps | include "tpl.missing-runbook" }}
+    {{- dict "name" "KubeDeploymentGenerationMismatch" "subpath" "kubernetes" "config" .kubernetesApps | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeDeploymentReplicasMismatch" "subpath" "kubernetes" "config" .kubernetesApps | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeStatefulSetReplicasMismatch" "subpath" "kubernetes" "config" .kubernetesApps | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeStatefulSetGenerationMismatch" "subpath" "kubernetes" "config" .kubernetesApps | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeStatefulSetUpdateNotRolledOut" "subpath" "kubernetes" "config" .kubernetesApps | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeDaemonSetRolloutStuck" "subpath" "kubernetes" "config" .kubernetesApps | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeContainerWaiting" "subpath" "kubernetes" "config" .kubernetesApps | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeDaemonSetNotScheduled" "subpath" "kubernetes" "config" .kubernetesApps | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeDaemonSetMisScheduled" "subpath" "kubernetes" "config" .kubernetesApps | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeJobNotCompleted" "subpath" "kubernetes" "config" .kubernetesApps | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeJobFailed" "subpath" "kubernetes" "config" .kubernetesApps | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeFailedEvictedPods" "config" .kubernetesApps | include "tpl.missing-runbook" }}
+  kubernetesResources:
+    {{- dict "name" "KubeCPUOvercommit" "subpath" "kubernetes" "config" .kubernetesResources | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeMemoryOvercommit" "subpath" "kubernetes" "config" .kubernetesResources | include "tpl.prometheus-operator" }}
+    {{- dict "name" "CPUThrottlingHigh" "subpath" "kubernetes" "config" .kubernetesResources | include "tpl.prometheus-operator" }}
+  kubernetesStorage:
+    {{- dict "name" "KubePersistentVolumeFillingUp" "subpath" "kubernetes" "config" .kubernetesStorage | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubePersistentVolumeErrors" "subpath" "kubernetes" "config" .kubernetesStorage | include "tpl.prometheus-operator" }}
+  kubernetesSystem:
+    {{- dict "name" "KubeClientCertificateExpiration" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeAggregatedAPIErrors" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeAggregatedAPIDown" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeAPIDown" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeAPITerminatedRequests" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeProxyDown" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeNodeNotReady" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeNodeUnreachable" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeletTooManyPods" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeNodeReadinessFlapping" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeletPlegDurationHigh" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeletPodStartUpLatencyHigh" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeletClientCertificateExpiration" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeletServerCertificateExpiration" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeletClientCertificateRenewalErrors" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeletServerCertificateRenewalErrors" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeletDown" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubletDownForAutoscaledNodeFor15m" "subpath" "kubernetes" "override" "kubeletdown" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubletDownForAutoscaledNodeFor30m" "subpath" "kubernetes" "override" "kubeletdown" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubletDownForNonAutoscaledNodeFor5m" "subpath" "kubernetes" "override" "kubeletdown" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubletDownForNonAutoscaledNodeFor15m" "subpath" "kubernetes" "override" "kubeletdown" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeletDownFor5m" "subpath" "kubernetes" "override" "kubeletdown" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeletDownFor15m" "subpath" "kubernetes" "override" "kubeletdown" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeVersionMismatch" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+    {{- dict "name" "KubeClientErrors" "subpath" "kubernetes" "config" .kubernetesSystem | include "tpl.prometheus-operator" }}
+  kured:
+    {{- dict "name" "KuredFailedNodeReboot" "config" .kured | include "tpl.missing-runbook" }}
+  missingMetrics:
+    {{- dict "name" "MetricsFromWcClusterIsMissing" "config" .missingMetrics | include "tpl.missing-runbook" }}
+    {{- dict "name" "MetricsFromScClusterIsMissing" "config" .missingMetrics | include "tpl.missing-runbook" }}
+  nodeExporter:
+    {{- dict "name" "NodeFilesystemAlmostOutOfSpace" "subpath" "node" "config" .nodeExporter | include "tpl.prometheus-operator" }}
+    {{- dict "name" "NodeFilesystemSpaceFillingUp" "subpath" "node" "config" .nodeExporter | include "tpl.prometheus-operator" }}
+    {{- dict "name" "NodeNetworkReceiveErrs" "subpath" "node" "config" .nodeExporter | include "tpl.prometheus-operator" }}
+    {{- dict "name" "NodeNetworkTransmitErrs" "subpath" "node" "config" .nodeExporter | include "tpl.prometheus-operator" }}
+    {{- dict "name" "NodeHighNumberConntrackEntriesUsed" "subpath" "node" "config" .nodeExporter | include "tpl.prometheus-operator" }}
+    {{- dict "name" "NodeTextFileCollectorScrapeError" "subpath" "node" "config" .nodeExporter | include "tpl.prometheus-operator" }}
+    {{- dict "name" "NodeClockSkewDetected" "subpath" "node" "config" .nodeExporter | include "tpl.prometheus-operator" }}
+    {{- dict "name" "NodeClockNotSynchronising" "subpath" "node" "config" .nodeExporter | include "tpl.prometheus-operator" }}
+    {{- dict "name" "NodeFileDescriptorLimit" "subpath" "node" "config" .nodeExporter | include "tpl.prometheus-operator" }}
+  nodeNetwork:
+    {{- dict "name" "NodeNetworkInterfaceFlapping" "subpath" "general" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+  opensearch:
+    {{- dict "name" "OpenSearchTooFewNodesRunning" "config" .opensearch | include "tpl.missing-runbook" }}
+    {{- dict "name" "OpenSearchHeapTooHigh" "config" .opensearch | include "tpl.missing-runbook" }}
+    {{- dict "name" "OpenSearchFieldLimit" "config" .opensearch | include "tpl.missing-runbook" }}
+    {{- dict "name" "OpensearchClusterYellow" "config" .opensearch | include "tpl.missing-runbook" }}
+    {{- dict "name" "OpensearchClusterRed" "config" .opensearch | include "tpl.missing-runbook" }}
+    {{- dict "name" "OpenSearchXIndexSizeOverLimit" "config" .opensearch | include "tpl.missing-runbook" }}
+  openstack:
+    {{- dict "name" "OpenStackCloudControllerDown" "config" .openstack | include "tpl.missing-runbook" }}
+    {{- dict "name" "OpenStackApiRequestFailed" "config" .openstack | include "tpl.missing-runbook" }}
+    {{- dict "name" "OpenStackApiRequestDuration" "config" .openstack | include "tpl.missing-runbook" }}
+    {{- dict "name" "OpenStackApiRequestTotal" "config" .openstack | include "tpl.missing-runbook" }}
+    {{- dict "name" "OpenStackReconcileFailed" "config" .openstack | include "tpl.missing-runbook" }}
+    {{- dict "name" "OpenStackReconcileDuration" "config" .openstack | include "tpl.missing-runbook" }}
+  packetsDropped:
+    {{- dict "name" "FrequentPacketsDroppedToWorkload" "config" .packetsDropped | include "tpl.missing-runbook" }}
+    {{- dict "name" "ScarcePacketsDroppedToWorkload" "config" .packetsDropped | include "tpl.missing-runbook" }}
+    {{- dict "name" "FrequentPacketsDroppedFromWorkload" "config" .packetsDropped | include "tpl.missing-runbook" }}
+    {{- dict "name" "ScarcePacketsDroppedFromWorkload" "config" .packetsDropped | include "tpl.missing-runbook" }}
+  prometheusOperator:
+    {{- dict "name" "PrometheusOperatorListErrors" "subpath" "prometheus-operator" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusOperatorWatchErrors" "subpath" "prometheus-operator" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusOperatorSyncFailed" "subpath" "prometheus-operator" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusOperatorReconcileErrors" "subpath" "prometheus-operator" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusOperatorNodeLookupErrors" "subpath" "prometheus-operator" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusOperatorNotReady" "subpath" "prometheus-operator" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusOperatorRejectedResources" "subpath" "prometheus-operator" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+  prometheus:
+    {{- dict "name" "PrometheusBadConfig" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusNotificationQueueRunningFull" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusErrorSendingAlertsToSomeAlertmanagers" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusNotConnectedToAlertmanagers" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusTSDBReloadsFailing" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusTSDBCompactionsFailing" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusNotIngestingSamples" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusDuplicateTimestamps" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusOutOfOrderTimestamps" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusRemoteStorageFailures" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusRemoteWriteBehind" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusRemoteWriteDesiredShards" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusRuleFailures" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusMissingRuleEvaluations" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusTargetLimitHit" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusLabelLimitHit" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusScrapeBodySizeLimitHit" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusScrapeSampleLimitHit" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusTargetSyncFailure" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+    {{- dict "name" "PrometheusErrorSendingAlertsToAnyAlertmanager" "subpath" "prometheus" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
+  thanos:
+    {{- dict "name" "ThanosRuleIsDown" "header" "thanos-component-absent" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosRuleQueueIsDroppingAlerts" "header" "thanos-rule" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosRuleSenderIsFailingAlerts" "header" "thanos-rule" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosRuleHighRuleEvaluationFailures" "header" "thanos-rule" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosRuleHighRuleEvaluationWarnings" "header" "thanos-rule" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosRuleRuleEvaluationLatencyHigh" "header" "thanos-rule" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosRuleGrpcErrorRate" "header" "thanos-rule" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosRuleConfigReloadFailure" "header" "thanos-rule" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosRuleQueryHighDNSFailures" "header" "thanos-rule" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosRuleAlertmanagerHighDNSFailures" "header" "thanos-rule" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosRuleNoEvaluationFor10Intervals" "header" "thanos-rule" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosNoRuleEvaluations" "header" "thanos-rule" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosCompactMultipleRunning" "header" "thanos-compact" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosCompactHalted" "header" "thanos-compact" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosCompactHighCompactionFailures" "header" "thanos-compact" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosCompactBucketHighOperationFailures" "header" "thanos-compact" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosCompactHasNotRun" "header" "thanos-compact" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosQueryHttpRequestQueryErrorRateHigh" "header" "thanos-query" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosQueryHttpRequestQueryRangeErrorRateHigh" "header" "thanos-query" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosQueryGrpcServerErrorRate" "header" "thanos-query" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosQueryGrpcClientErrorRate" "header" "thanos-query" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosQueryHighDNSFailures" "header" "thanos-query" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosQueryInstantLatencyHigh" "header" "thanos-query" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosQueryRangeLatencyHigh" "header" "thanos-query" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosReceiveHttpRequestErrorRateHigh" "header" "thanos-receive" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosReceiveHttpRequestLatencyHigh" "header" "thanos-receive" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosReceiveHighReplicationFailures" "header" "thanos-receive" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosReceiveHighForwardRequestFailures" "header" "thanos-receive" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosReceiveHighHashringFileRefreshFailures" "header" "thanos-receive" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosReceiveConfigReloadFailure" "header" "thanos-receive" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosReceiveNoUpload" "header" "thanos-receive" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosReceiveTrafficBelowThreshold" "header" "thanos-receive" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosStoreGrpcErrorRate" "header" "thanos-store" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosStoreSeriesGateLatencyHigh" "header" "thanos-store" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosStoreBucketHighOperationFailures" "header" "thanos-store" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosStoreObjstoreOperationLatencyHigh" "header" "thanos-store" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosBucketReplicateErrorRate" "header" "thanos-bucket-replicate" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosBucketReplicateRunLatency" "header" "thanos-bucket-replicate" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosCompactIsDown" "header" "thanos-component-absent" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosQueryIsDown" "header" "thanos-component-absent" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosReceiveIsDown" "header" "thanos-component-absent" "config" .thanos | include "tpl.thanos" }}
+    {{- dict "name" "ThanosStoreIsDown" "header" "thanos-component-absent" "config" .thanos | include "tpl.thanos" }}
+  webhook:
+    {{- dict "name" "WebhookFailing" "config" .webhook | include "tpl.missing-runbook" }}
+{{- end }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Makes it possible to configure runbooks, can be configured on an alert group level or per individual alert.

Current override priority:
1. Use individual alert runbook override if set
2. Use group alert runbook override if set
3. Use upstream alert runbook by default if exists
4. Runbook is set to "Missing runbook" if there's no upstream runbook and nothing is configured.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes https://github.com/elastisys/ck8s-issue-tracker/issues/423

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [x] The metrics are still exposed and present in Grafana after the change
    - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [x] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [x] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
