### PR TITLE
Allow subnet in update-ips

### DIFF
--- a/bin/update-ips.bash
+++ b/bin/update-ips.bash
@@ -117,13 +117,13 @@ rclone_enabled() {
   return 1
 }
 
-# Fetch the InternalIP, Calico tunnel IP and Wireguard IP of Kubernetes
+# Fetch the Calico tunnel IP and Wireguard IP of Kubernetes
 # nodes using a label selector.
 #
 # If the label selector isn't specified, all nodes will be returned.
 #
-# Usage: get_kubectl_ips <cluster> <label>
-get_kubectl_ips() {
+# Usage: get_tunnel_ips <cluster> <label>
+get_tunnel_ips() {
   local cluster="${1}"
   local label="${2}"
 
@@ -132,17 +132,40 @@ get_kubectl_ips() {
     label_argument="-l ${label}"
   fi
 
-  local -a ips_internal
   local -a ips_calico_ipip
   local -a ips_calico_vxlan
   local -a ips_wireguard
-  mapfile -t ips_internal < <("${here}/ops.bash" kubectl "${cluster}" get node "${label_argument}" -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
   mapfile -t ips_calico_vxlan < <("${here}/ops.bash" kubectl "${cluster}" get node "${label_argument}" -o jsonpath='{.items[*].metadata.annotations.projectcalico\.org/IPv4VXLANTunnelAddr}')
   mapfile -t ips_calico_ipip < <("${here}/ops.bash" kubectl "${cluster}" get node "${label_argument}" -o jsonpath='{.items[*].metadata.annotations.projectcalico\.org/IPv4IPIPTunnelAddr}')
   mapfile -t ips_wireguard < <("${here}/ops.bash" kubectl "${cluster}" get node "${label_argument}" -o jsonpath='{.items[*].metadata.annotations.projectcalico\.org/IPv4WireguardInterfaceAddr}')
 
   local -a ips
-  read -r -a ips <<<"${ips_internal[*]} ${ips_calico_vxlan[*]} ${ips_calico_ipip[*]} ${ips_wireguard[*]}"
+  read -r -a ips <<<"${ips_calico_vxlan[*]} ${ips_calico_ipip[*]} ${ips_wireguard[*]}"
+
+  if [ ${#ips[@]} -eq 0 ]; then
+    log_error "No IPs for ${cluster} nodes with label ${label} was found"
+    exit 1
+  fi
+
+  echo "${ips[@]}"
+}
+
+# Fetch the InternalIP of Kubernetes nodes using a label selector.
+#
+# If the label selector isn't specified, all nodes will be returned.
+#
+# Usage: get_internal_ips <cluster> <label>
+get_internal_ips() {
+  local cluster="${1}"
+  local label="${2}"
+
+  local label_argument="--ignore-not-found"
+  if [[ "${label}" != "" ]]; then
+    label_argument="-l ${label}"
+  fi
+
+  local -a ips
+  mapfile -t ips < <("${here}/ops.bash" kubectl "${cluster}" get node "${label_argument}" -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
 
   if [ ${#ips[@]} -eq 0 ]; then
     log_error "No IPs for ${cluster} nodes with label ${label} was found"
@@ -238,9 +261,9 @@ get_swift_url() {
 
 # Sort IP addresses.
 #
-# For example, [1.0.0.10, 1.0.0.2] would be reordered to [1.0.0.2, 1.0.0.10].
-sort_ips() {
-  python3 -c "import ipaddress; import sys; ips = [ipaddress.ip_address(ip) for ip in sys.argv[1:]]; ips.sort(); [print(ip) for ip in ips]" "${@}"
+# For example, [1.0.0.10/32, 1.0.0.2/32] would be reordered to [1.0.0.2/32, 1.0.0.10/32].
+sort_cidrs() {
+  python3 -c "import ipaddress; import sys; cidrs = [ipaddress.ip_network(cidr) for cidr in sys.argv[1:]]; cidrs.sort(); [print(cidr) for cidr in cidrs]" "${@}"
 }
 
 # Check if an IP address is part of a CIDR address block.
@@ -304,6 +327,23 @@ parse_url_port() {
   esac
 }
 
+# Updates the configuration to allow CIDRs.
+#
+# Usage: allow_cidrs <config_file> <config_options> <cidr> [<cidr> ...]
+allow_cidrs() {
+  local config_file="${1}"
+  local config_option="${2}"
+  shift 2
+
+  local -a cidrs
+  readarray -t cidrs <<<"$(sort_cidrs "${@}")"
+
+  local list
+  list=$(echo "[$(for v in "${cidrs[@]}"; do echo "${v},"; done)]" | yq4 -oj)
+
+  yq_eval "${config_file}" "${config_option}" "${config_option} = ${list}"
+}
+
 # Updates the configuration to allow IPs.
 #
 # Usage: allow_ips <config_file> <config_option> <ip> [<ip> ...]
@@ -312,16 +352,10 @@ allow_ips() {
   local config_option="${2}"
   shift 2
 
-  local -a ips
-  readarray -t ips <<<"$(sort_ips "${@}")"
-
   local -a cidrs
-  readarray -t cidrs <<<"$(process_ips_to_cidrs "${config_file}" "${config_option}" "${ips[@]}")"
+  readarray -t cidrs <<<"$(process_ips_to_cidrs "${config_file}" "${config_option}" "${@}")"
 
-  local list
-  list=$(echo "[$(for v in "${cidrs[@]}"; do echo "${v},"; done)]" | yq4 -oj)
-
-  yq_eval "${config_file}" "${config_option}" "${config_option} = ${list}"
+  allow_cidrs "${config_file}" "${config_option}" "${cidrs[@]}"
 }
 
 # Updates the configuration to allow ports.
@@ -402,11 +436,54 @@ allow_nodes() {
 
   local config_file="${config["override_${cluster}"]}"
 
-  local -a ips kubectl_ips
-  kubectl_ips=$(get_kubectl_ips "${cluster}" "${label}")
-  readarray -t ips <<<"$(echo "${kubectl_ips}" | tr ' ' '\n')"
+  local -a ips internal_ips tunnel_ips
+  internal_ips=$(get_internal_ips "${cluster}" "${label}")
+  tunnel_ips=$(get_tunnel_ips "${cluster}" "${label}")
+  readarray -t ips <<<"$(echo "${internal_ips}" "${tunnel_ips}" | tr ' ' '\n')"
 
   allow_ips "${config_file}" "${config_option}" "${ips[@]}"
+}
+
+# Updates the configuration to allow the subnet.
+#
+# Usage: allow_subnet <cluster> <config_option>
+allow_subnet() {
+  local cluster="${1}"
+  local config_option="${2}"
+
+  # Allowing the subnet is currently only supported for clusters setup with
+  # CAPI on OpenStack. Fallback on allowing individual nodes otherwise.
+  if [ "$(yq_read "${cluster}" '.global.ck8sK8sInstaller' "")" != "capi" ] || [ "$(yq_read "${cluster}" '.global.ck8sCloudProvider' "")" != "openstack" ]; then
+    allow_nodes "${cluster}" "${config_option}" ""
+    return
+  fi
+
+  local config_file="${config["override_${cluster}"]}"
+
+  local environment_name
+  environment_name="$(yq_read "${cluster}" '.global.ck8sEnvironmentName' "")"
+
+  # TODO: We should not have to do this in the future...
+  capi_cluster_name="${environment_name}-${cluster}"
+  if [ "${cluster}" = "sc" ]; then
+    # If no cluster named <environment>-sc is found, try <environment>-mc
+    if ! "${here}/ops.bash" kubectl sc -n capi-cluster get openstackcluster "${capi_cluster_name}" >/dev/null 2>&1; then
+      capi_cluster_name="${environment_name}-mc"
+    fi
+  fi
+
+  local subnet_cidr
+  subnet_cidr=$("${here}/ops.bash" kubectl sc -n capi-cluster get openstackcluster "${capi_cluster_name}" -o jsonpath='{.status.network.subnets[0].cidr}')
+
+  local -a tunnel_ips
+  readarray -t tunnel_ips <<<"$(get_tunnel_ips "${cluster}" "" | tr ' ' '\n')"
+
+  local -a cidrs
+  readarray -t cidrs <<<"$(process_ips_to_cidrs "${config_file}" "${config_option}" "${tunnel_ips[@]}")"
+
+  cidrs+=("${subnet_cidr}")
+
+  allow_cidrs "${config_file}" "${config_option}" "${cidrs[@]}"
 }
 
 # Allow object storage in the common network policy configuration.
@@ -610,7 +687,7 @@ allow_ingress
 
 if [[ "${check_cluster}" =~ ^(sc|both)$ ]]; then
   allow_nodes "sc" '.networkPolicies.global.scApiserver.ips' "node-role.kubernetes.io/control-plane="
-  allow_nodes "sc" '.networkPolicies.global.scNodes.ips' ""
+  allow_subnet "sc" '.networkPolicies.global.scNodes.ips'
 
   if swift_enabled; then
     sync_swift '.objectStorage.swift' '.networkPolicies.global.objectStorageSwift'
@@ -619,7 +696,7 @@ fi
 
 if [[ "${check_cluster}" =~ ^(wc|both)$ ]]; then
   allow_nodes "wc" '.networkPolicies.global.wcApiserver.ips' "node-role.kubernetes.io/control-plane="
-  allow_nodes "wc" '.networkPolicies.global.wcNodes.ips' ""
+  allow_subnet "wc" '.networkPolicies.global.wcNodes.ips'
 fi
 
 if rclone_enabled; then

--- a/tests/unit/general/bin-update-ips-subnet.bats
+++ b/tests/unit/general/bin-update-ips-subnet.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+
+# bats file_tags=static,general,bin:update_ips
+
+setup_file() {
+  load "../../bats.lib.bash"
+  load_common "env.bash"
+  load_common "gpg.bash"
+  load_common "yq.bash"
+
+  gpg.setup
+  env.setup
+
+  env.init openstack capi dev
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_common "env.bash"
+  load_common "update-ips.bash"
+  load_common "yq.bash"
+  load_assert
+  load_mock
+
+  env.private
+
+  update_ips.setup_mocks
+
+  export mock_curl
+  export mock_dig
+  export mock_kubectl
+}
+
+teardown() {
+  env.teardown
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+update_ips.mock_minimal_with_subnet() {
+  update_ips.mock_minimal
+
+  mock_set_output "${mock_kubectl}" "127.0.1.1 127.0.2.1 127.0.3.1" 1        # .networkPolicies.global.scApiserver.ips node internal
+  mock_set_output "${mock_kubectl}" "127.0.1.2 127.0.2.2 127.0.3.2" 2        # .networkPolicies.global.scApiserver.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.21 127.0.2.21 127.0.3.21" 3     # .networkPolicies.global.scApiserver.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.3 127.0.2.3 127.0.3.3" 4        # .networkPolicies.global.scApiserver.ips calico wireguard
+  mock_set_output "${mock_kubectl}" "127.0.1.3 127.0.2.3 127.0.3.3" 5        # check if cluster with name <environment>-sc exists
+  mock_set_output "${mock_kubectl}" "10.0.0.0/24" 6                          # .networkPolicies.global.scNodes.ips cluster subnet
+  mock_set_output "${mock_kubectl}" "127.0.1.8 127.0.2.8 127.0.3.8" 7        # .networkPolicies.global.scNodes.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.81 127.0.2.81 127.0.3.81" 8     # .networkPolicies.global.scNodes.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.9 127.0.2.9 127.0.3.9" 9        # .networkPolicies.global.scNodes.ips calico wireguard
+  mock_set_output "${mock_kubectl}" "127.0.1.4 127.0.2.4 127.0.3.4" 10       # .networkPolicies.global.wcApiserver.ips node internal
+  mock_set_output "${mock_kubectl}" "127.0.1.5 127.0.2.5 127.0.3.5" 11       # .networkPolicies.global.wcApiserver.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.51 127.0.2.51 127.0.3.51" 12    # .networkPolicies.global.wcApiserver.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.6 127.0.2.6 127.0.3.6" 13       # .networkPolicies.global.wcApiserver.ips calico wireguard
+  mock_set_output "${mock_kubectl}" "10.0.1.0/24" 14                         # .networkPolicies.global.wcNodes.ips cluster subnet
+  mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11" 15    # .networkPolicies.global.wcNodes.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111" 16 # .networkPolicies.global.wcNodes.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.12 127.0.2.12 127.0.3.12" 17    # .networkPolicies.global.wcNodes.ips calico wireguard
+}
+
+@test "ck8s update-ips can allow subnet" {
+  update_ips.mock_minimal_with_subnet
+  update_ips.populate_minimal
+
+  run ck8s update-ips both apply
+
+  assert_equal "$(yq.dig sc '.networkPolicies.global.scNodes.ips | . style="flow"')" "[10.0.0.0/24, 127.0.1.8/32, 127.0.1.9/32, 127.0.1.81/32, 127.0.2.8/32, 127.0.2.9/32, 127.0.2.81/32, 127.0.3.8/32, 127.0.3.9/32, 127.0.3.81/32]"
+  assert_equal "$(yq.dig wc '.networkPolicies.global.wcNodes.ips | . style="flow"')" "[10.0.1.0/24, 127.0.1.11/32, 127.0.1.12/32, 127.0.1.111/32, 127.0.2.11/32, 127.0.2.12/32, 127.0.2.111/32, 127.0.3.11/32, 127.0.3.12/32, 127.0.3.111/32]"
+
+  assert_equal "$(mock_get_call_num "${mock_curl}")" 0
+  assert_equal "$(mock_get_call_num "${mock_dig}")" 3
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 17
+}
+
+@test "ck8s update-ips swallows existing internal ips into cluster subnet" {
+  update_ips.mock_minimal_with_subnet
+  update_ips.populate_minimal
+
+  yq.set sc .networkPolicies.global.scNodes.ips '["10.0.0.1/32", "10.0.0.2/32", "10.0.0.3/32"]'
+  yq.set wc .networkPolicies.global.wcNodes.ips '["10.0.1.1/32", "10.0.1.2/32", "10.0.1.3/32"]'
+
+  run ck8s update-ips both apply
+
+  assert_equal "$(yq.dig sc '.networkPolicies.global.scNodes.ips | . style="flow"')" "[10.0.0.0/24, 127.0.1.8/32, 127.0.1.9/32, 127.0.1.81/32, 127.0.2.8/32, 127.0.2.9/32, 127.0.2.81/32, 127.0.3.8/32, 127.0.3.9/32, 127.0.3.81/32]"
+  assert_equal "$(yq.dig wc '.networkPolicies.global.wcNodes.ips | . style="flow"')" "[10.0.1.0/24, 127.0.1.11/32, 127.0.1.12/32, 127.0.1.111/32, 127.0.2.11/32, 127.0.2.12/32, 127.0.2.111/32, 127.0.3.11/32, 127.0.3.12/32, 127.0.3.111/32]"
+
+  assert_equal "$(mock_get_call_num "${mock_curl}")" 0
+  assert_equal "$(mock_get_call_num "${mock_dig}")" 3
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 17
+}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice

Running `ck8s update-ips` on existing OpenStack CAPI clusters will now allow the entire subnet instead of individual node IPs.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

For OpenStack CAPI clusters allow the entire subnet instead of individual node IPs.

This should help with autoscaling where nodes are added on demand. Without doing this the administrator would have to run `update-ips` to make sure the new nodes are allowed.

It also has the benefit of allowing non-node addresses in the subnet such as loadbalancers.

#### Information to reviewers

It looks like it's already common practice to set the entire subnet rather than allowing individual IPs, it just has been done manually. However, if anyone has a good reason why we should **not** allow the entire subnet please speak up!

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
