### PR TITLE
Only uninstall with local environment if local cluster exist

### DIFF
--- a/scripts/clean-sc.sh
+++ b/scripts/clean-sc.sh
@@ -61,8 +61,10 @@ else
   log_info "Cluster API provisioned cluster, skipping deletion of cert-manager Helm release"
 fi
 
-# Destroy local-cluster minio release, otherwise pvc cleanup will get stuck
-helmfile -e local_cluster -f "${here}/../helmfile.d" -l app=minio destroy
+if [[ -f "${CK8S_CONFIG_PATH}/cluster-index.yaml" ]]; then
+  # Destroy local-cluster minio release, otherwise pvc cleanup will get stuck
+  helmfile -e local_cluster -f "${here}/../helmfile.d" -l app=minio destroy
+fi
 
 # Remove any lingering persistent volume claims
 "${here}/.././bin/ck8s" ops kubectl sc delete pvc -A --all

--- a/scripts/clean-wc.sh
+++ b/scripts/clean-wc.sh
@@ -73,8 +73,10 @@ else
   log_info "Cluster API provisioned cluster, skipping deletion of cert-manager Helm release"
 fi
 
-# Destroy local-cluster minio release, otherwise pvc cleanup will get stuck
-helmfile -e local_cluster -f "${here}/../helmfile.d" -l app=minio destroy
+if [[ -f "${CK8S_CONFIG_PATH}/cluster-index.yaml" ]]; then
+  # Destroy local-cluster minio release, otherwise pvc cleanup will get stuck
+  helmfile -e local_cluster -f "${here}/../helmfile.d" -l app=minio destroy
+fi
 
 # Remove any lingering persistent volume claims
 "${here}/.././bin/ck8s" ops kubectl wc delete pvc -A --all


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [x] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Without this you would get this output when running `ck8s clean` on a non-local cluster:

```
Listing releases matching ^minio$
in /home/simon/git/elastisys/compliantkubernetes-apps/helmfile.d/state.yaml: command "/home/simon/bin/helm" exited with non-zero status:

PATH:
  /home/simon/bin/helm

ARGS:
  0: helm (4 bytes)
  1: list (4 bytes)
  2: --filter (8 bytes)
  3: ^minio$ (7 bytes)
  4: --namespace (11 bytes)
  5: minio-system (12 bytes)
  6: --uninstalling (14 bytes)
  7: --deployed (10 bytes)
  8: --failed (8 bytes)
  9: --pending (9 bytes)

ERROR:
  exit status 1

EXIT STATUS
  1

STDERR:
  Error: Kubernetes cluster unreachable: Get "http://localhost:8080/version": dial tcp 127.0.0.1:8080: connect: connection refused

COMBINED OUTPUT:
  Error: Kubernetes cluster unreachable: Get "http://localhost:8080/version": dial tcp 127.0.0.1:8080: connect: connection refused
```

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
