### PR TITLE
Revise default config

### DIFF
--- a/config/flavors/air-gapped/common-config.yaml
+++ b/config/flavors/air-gapped/common-config.yaml
@@ -30,3 +30,7 @@ trivy:
         "index.docker.io": set-me
         "quay.io": set-me
         "registry.k8s.io": set-me
+
+fluentd:
+  audit:
+    enabled: true

--- a/config/flavors/prod/common-config.yaml
+++ b/config/flavors/prod/common-config.yaml
@@ -19,3 +19,7 @@ networkPolicies:
     dns01:
       ips:
         - 0.0.0.0/0
+
+fluentd:
+  audit:
+    enabled: true

--- a/config/k8s-installers/capi/common-config.yaml
+++ b/config/k8s-installers/capi/common-config.yaml
@@ -9,3 +9,11 @@ networkPolicies:
     serviceIp:
       ips:
         - 10.233.0.10/32
+metricsServer:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node-restriction.kubernetes.io/autoscaled-node-type
+                operator: DoesNotExist

--- a/config/providers/elastx/common-config.yaml
+++ b/config/providers/elastx/common-config.yaml
@@ -7,7 +7,9 @@ networkPolicies:
     openstack:
       enabled: true
       ips:
-        - set-me
+        - 217.61.244.51/32
+        - 217.61.244.53/32
+        - 217.61.244.55/32
       ports:
         - 5000
         - 8774
@@ -22,19 +24,29 @@ networkPolicies:
 objectStorage:
   type: s3
   s3:
-    region: set-me
-    regionEndpoint: set-me
+    region: us-east-1
+    regionEndpoint: https://swift.elastx.cloud
     forcePathStyle: true
 ingressNginx:
   controller:
     config:
-      useProxyProtocol: false
+      useProxyProtocol: true
     useHostPort: false
     service:
       enabled: true
       type: LoadBalancer
-      annotations: {}
+      annotations:
+        loadbalancer.openstack.org/proxy-protocol: "true"
       allocateLoadBalancerNodePorts: true
 opa:
   rejectLoadBalancerService:
     enabled: false
+  controllerManager:
+    topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: gatekeeper
+            control-plane: controller-manager
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: DoNotSchedule

--- a/config/providers/elastx/sc-config.yaml
+++ b/config/providers/elastx/sc-config.yaml
@@ -17,3 +17,154 @@ objectStorage:
 thanos:
   objectStorage:
     type: swift
+  receiver:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - sto1
+                    - sto2
+    topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: receive
+            app.kubernetes.io/instance: thanos-receiver
+            app.kubernetes.io/name: thanos
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: DoNotSchedule
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: receive
+            app.kubernetes.io/instance: thanos-receiver
+            app.kubernetes.io/name: thanos
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+  ruler:
+    topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: thanos
+            app.kubernetes.io/instance: thanos-receiver
+            app.kubernetes.io/component: ruler
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: DoNotSchedule
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: thanos
+            app.kubernetes.io/instance: thanos-receiver
+            app.kubernetes.io/component: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+  query:
+    topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: thanos
+            app.kubernetes.io/instance: thanos-query
+            app.kubernetes.io/component: query
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: DoNotSchedule
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: thanos
+            app.kubernetes.io/instance: thanos-query
+            app.kubernetes.io/component: query
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+opensearch:
+  masterNode:
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+              - opensearch-master
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - opensearch
+          topologyKey: topology.kubernetes.io/zone
+  dataNode:
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+              - opensearch-data
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - opensearch
+          topologyKey: topology.kubernetes.io/zone
+  clientNode:
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+              - opensearch-client
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - opensearch
+          topologyKey: topology.kubernetes.io/zone
+dex:
+  topologySpreadConstraints:
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: dex
+      maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: DoNotSchedule
+    - labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: dex
+      maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+prometheus:
+  alertmanagerSpec:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values:
+                    - sto1
+                    - sto2
+    topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: alertmanager
+            app.kubernetes.io/instance: kube-prometheus-stack-alertmanager
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: DoNotSchedule
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: alertmanager
+            app.kubernetes.io/instance: kube-prometheus-stack-alertmanager
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule

--- a/config/providers/elastx/wc-config.yaml
+++ b/config/providers/elastx/wc-config.yaml
@@ -1,0 +1,9 @@
+hnc:
+  webhook:
+    topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: hnc-webhook
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: DoNotSchedule

--- a/config/providers/safespring/common-config.yaml
+++ b/config/providers/safespring/common-config.yaml
@@ -13,7 +13,7 @@ networkPolicies:
     openstack:
       enabled: true
       ips:
-        - set-me
+        - 185.189.29.233/32
       ports:
         - 5000
         - 8774
@@ -21,8 +21,8 @@ networkPolicies:
 objectStorage:
   type: s3
   s3:
-    region: set-me
-    regionEndpoint: set-me
+    region: sto1
+    regionEndpoint: https://s3.sto1.safedc.net
     forcePathStyle: true
 ingressNginx:
   controller:

--- a/config/providers/upcloud/sc-config.yaml
+++ b/config/providers/upcloud/sc-config.yaml
@@ -1,4 +1,37 @@
 harbor:
+  database:
+    internal:
+      persistentVolumeClaim:
+        size: 10Gi
+  jobservice:
+    jobLog:
+      persistentVolumeClaim:
+        size: 10Gi
+    scanDataExports:
+      persistentVolumeClaim:
+        size: 10Gi
+  registry:
+    persistentVolumeClaim:
+      size: 10Gi
+  redis:
+    internal:
+      persistentVolumeClaim:
+        size: 10Gi
+  trivy:
+    persistentVolumeClaim:
+      size: 10Gi
   persistence:
     type: objectStorage
     disableRedirect: true
+thanos:
+  storegateway:
+    persistence:
+      size: 10Gi
+prometheus:
+  alertmanagerSpec:
+    storage:
+      volumeClaimTemplate:
+        spec:
+          resources:
+            requests:
+              storage: 10Gi

--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -676,7 +676,7 @@ thanos:
     # https://thanos.io/v0.24/components/compact.md/#disk
     persistence:
       enabled: true
-      size: 8Gi
+      size: 20Gi
 
     resources:
       requests:

--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -961,7 +961,7 @@ opensearch:
     nodeSelector: {}
     tolerations: []
 
-  # Config for https://github.com/elastisys/compliantkubernetes-apps/blob/main/helmfile/charts/prometheus-alerts/templates/alerts/opensearch.yaml#L70:L77
+  # Config for https://github.com/elastisys/compliantkubernetes-apps/blob/main/helmfile.d/charts/prometheus-alerts/templates/alerts/opensearch.yaml#L75:L83
   promIndexAlerts:
     - prefix: kubernetes-default
       alertSizeMB: 5500

--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -814,19 +814,19 @@ opensearch:
     additionalPolicies: {}
 
   masterNode:
-    count: 1
+    count: 3
     ## If null, no storageclass is specified in pvc and default storageClass is used
     ## if the DefaultStorageClass admission plugin is enabled.
     ## If "-", "" will be used as storageClassName.
     storageClass: null
-    storageSize: 8Gi
-    javaOpts: -Xms512m -Xmx512m
+    storageSize: 100Gi
+    javaOpts: -Xms1536m -Xmx1536m
     resources:
       requests:
-        memory: 1024Mi
+        memory: 2Gi
         cpu: 200m
       limits:
-        memory: 1024Mi
+        memory: 3Gi
         cpu: 1
     affinity:
       ## Note: The OpenSearch chart has some restrictions on pod anti affinity:
@@ -852,8 +852,8 @@ opensearch:
 
   dataNode:
     ## Enables dedicated statefulset for data nodes, else the master nodes will assume data role.
-    dedicatedPods: true
-    count: 2
+    dedicatedPods: false
+    count: 0
     ## If null, no storageclass is specified in pvc and default storageClass is used
     ## if the DefaultStorageClass admission plugin is enabled.
     ## If "-", "" will be used as storageClassName.
@@ -889,8 +889,8 @@ opensearch:
 
   clientNode:
     ## Enables dedicated deployment for client/ingest nodes, else the master nodes will assume client/ingest roles
-    dedicatedPods: true
-    count: 1
+    dedicatedPods: false
+    count: 0
     javaOpts: -Xms512m -Xmx512m
     resources:
       requests:

--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -938,7 +938,7 @@ opensearch:
     retention:
       - pattern: other-*
         sizeGB: 1
-        ageDays: 7
+        ageDays: 30
       - pattern: kubeaudit-*
         sizeGB: 50
         ageDays: 30
@@ -1047,7 +1047,7 @@ fluentd:
       ephemeralVolumes:
         enabled: false
       schedule: 0 1/6 * * *
-      days: 10
+      days: 30
     retention:
       enabled: true
       schedule: 0 20 * * *
@@ -1060,11 +1060,11 @@ fluentd:
       ephemeralVolumes:
         enabled: false
       schedule: 0 2/6 * * *
-      days: 7
+      days: 30
     retention:
       enabled: true
       schedule: 0 21 * * *
-      days: 7
+      days: 30
 
   aggregator:
     resources:

--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -937,16 +937,19 @@ opensearch:
     enabled: true
     retention:
       - pattern: other-*
-        sizeGB: 1
+        sizeGB: 5000
         ageDays: 30
       - pattern: kubeaudit-*
-        sizeGB: 50
+        sizeGB: 5000
         ageDays: 30
       - pattern: kubernetes-*
-        sizeGB: 50
-        ageDays: 50
+        sizeGB: 5000
+        ageDays: 30
       - pattern: authlog-*
-        sizeGB: 1
+        sizeGB: 5000
+        ageDays: 30
+      - pattern: security-auditlog-*
+        sizeGB: 5000
         ageDays: 30
     startingDeadlineSeconds: 600
     activeDeadlineSeconds: 2700

--- a/helmfile.d/values/opensearch/client.yaml.gotmpl
+++ b/helmfile.d/values/opensearch/client.yaml.gotmpl
@@ -11,7 +11,7 @@ opensearchJavaOpts: {{ .Values.opensearch.clientNode.javaOpts }}
 resources: {{- toYaml .Values.opensearch.clientNode.resources | nindent 2 }}
 
 {{ if (hasKey .Values.opensearch.clientNode.affinity.podAntiAffinity "requiredDuringSchedulingIgnoredDuringExecution") -}}
-antiAffinityTopologyKey: {{ (first .Values.opensearch.clientNode.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution).podAffinityTerm.topologyKey | quote }}
+antiAffinityTopologyKey: {{ (first .Values.opensearch.clientNode.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution).topologyKey | quote }}
 antiAffinity: hard
 {{ else if (hasKey .Values.opensearch.clientNode.affinity.podAntiAffinity "preferredDuringSchedulingIgnoredDuringExecution") -}}
 antiAffinityTopologyKey: {{ (first .Values.opensearch.clientNode.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution).podAffinityTerm.topologyKey | quote }}

--- a/helmfile.d/values/opensearch/data.yaml.gotmpl
+++ b/helmfile.d/values/opensearch/data.yaml.gotmpl
@@ -14,7 +14,7 @@ persistence:
   storageClass: {{ toYaml .Values.opensearch.dataNode.storageClass }}
 
 {{ if (hasKey .Values.opensearch.dataNode.affinity.podAntiAffinity "requiredDuringSchedulingIgnoredDuringExecution") -}}
-antiAffinityTopologyKey: {{ (first .Values.opensearch.dataNode.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution).podAffinityTerm.topologyKey | quote }}
+antiAffinityTopologyKey: {{ (first .Values.opensearch.dataNode.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution).topologyKey | quote }}
 antiAffinity: hard
 {{ else if (hasKey .Values.opensearch.dataNode.affinity.podAntiAffinity "preferredDuringSchedulingIgnoredDuringExecution") -}}
 antiAffinityTopologyKey: {{ (first .Values.opensearch.dataNode.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution).podAffinityTerm.topologyKey | quote }}

--- a/helmfile.d/values/opensearch/master.yaml.gotmpl
+++ b/helmfile.d/values/opensearch/master.yaml.gotmpl
@@ -21,7 +21,7 @@ persistence:
   storageClass: {{ toYaml .Values.opensearch.masterNode.storageClass }}
 
 {{ if (hasKey .Values.opensearch.masterNode.affinity.podAntiAffinity "requiredDuringSchedulingIgnoredDuringExecution") -}}
-antiAffinityTopologyKey: {{ (first .Values.opensearch.masterNode.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution).podAffinityTerm.topologyKey | quote }}
+antiAffinityTopologyKey: {{ (first .Values.opensearch.masterNode.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution).topologyKey | quote }}
 antiAffinity: hard
 {{ else if (hasKey .Values.opensearch.masterNode.affinity.podAntiAffinity "preferredDuringSchedulingIgnoredDuringExecution") -}}
 antiAffinityTopologyKey: {{ (first .Values.opensearch.masterNode.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution).podAffinityTerm.topologyKey | quote }}

--- a/migration/v0.46/README.md
+++ b/migration/v0.46/README.md
@@ -1,0 +1,176 @@
+# Upgrade to v0.46.x
+
+> [!WARNING]
+> Upgrade only supported from v0.45.x.
+
+<!--
+Notice to developers on writing migration steps:
+
+- Migration steps:
+  - are written per minor version and placed in a subdirectory of the migration directory with the name `vX.Y/`,
+  - are written to be idempotent and usable no matter which patch version you are upgrading from and to,
+  - are documented in this document to be able to run them manually,
+  - are divided into prepare and apply steps:
+    - Prepare steps:
+      - are placed in the `prepare/` directory,
+      - may **only** modify the configuration of the environment,
+      - may **not** modify the state of the environment,
+      - steps are run in order of their names use two digit prefixes.
+    - Apply steps:
+      - are placed in the `apply/` directory,
+      - may **only** modify the state of the environment,
+      - may **not** modify the configuration of the environment,
+      - are run in order of their names use two digit prefixes,
+      - are run with the argument `execute` on upgrade and should return 1 on failure and 2 on successful internal rollback,
+      - are rerun with the argument `rollback` on execute failure and should return 1 on failure.
+
+For prepare the init step is given.
+For apply the bootstrap and the apply steps are given, it is expected that releases upgraded in custom steps are excluded from the apply step.
+
+Upgrades of components that are dependent on each other should be done within the same snippet to easily manage the upgrade to a working state and to be able to rollback to a working state.
+
+Steps should use the `scripts/migration/lib.sh` which will provide helper functions, see the file for available helper functions.
+This script expects the `ROOT` environment variable to be set pointing to the root of the repository.
+As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
+-->
+
+## Prerequisites
+
+- [ ] Read through the changelog to check if there are any changes you need to be aware of. Read through the release notes, Platform Administrator notices, Application Developer notices, and Security notice.
+- [ ] Notify the users (if any) before the upgrade starts;
+- [ ] Check if there are any pending changes to the environment;
+- [ ] Check the state of the environment, pods, nodes and backup jobs:
+
+    ```bash
+    ./bin/ck8s test sc|wc
+    ./bin/ck8s ops kubectl sc|wc get pods -A -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-false:status.containerStatuses[*].ready,REASON:status.containerStatuses[*].state.terminated.reason | grep false | grep -v Completed
+    ./bin/ck8s ops kubectl sc|wc get nodes
+    ./bin/ck8s ops kubectl sc|wc get jobs -A
+    ./bin/ck8s ops helm sc|wc list -A --all
+    ./bin/ck8s ops velero sc|wc get backup
+    ```
+
+- [ ] Silence the notifications for the alerts. e.g you can use [alertmanager silences](https://prometheus.io/docs/alerting/latest/alertmanager/#silences);
+
+## Automatic method
+
+1. Pull the latest changes and switch to the correct branch:
+
+    ```bash
+    git pull
+    git switch -d v0.46.x
+    ```
+
+1. Prepare upgrade - _non-disruptive_
+
+    > _Done before maintenance window._
+
+    > [!WARNING]
+    > Default Opensearch setup has been changed. Opensearch is now configured to use 3 master nodes, 0 data nodes and 0 client nodes by default. There's no easy migration path for the new configuration, if the old default Opensearch setup is used it should be added to the override config. This is done automatically if you run the prepare command.
+
+    ```bash
+    ./bin/ck8s upgrade both v0.46 prepare
+
+    # check if the netpol IPs need to be updated
+    ./bin/ck8s update-ips both dry-run
+    # if you agree with the changes apply
+    ./bin/ck8s update-ips both apply
+    ```
+
+    > **Note:**
+    > It is possible to upgrade `wc` and `sc` clusters separately by replacing `both` when running the `upgrade` command, e.g. the following will only upgrade the workload cluster:
+
+    ```bash
+    ./bin/ck8s upgrade wc v0.46 prepare
+    ./bin/ck8s upgrade wc v0.46 apply
+    ```
+
+1. Apply upgrade - _disruptive_
+
+    > _Done during maintenance window._
+
+    ```bash
+    ./bin/ck8s upgrade both v0.46 apply
+    ```
+
+## Manual method
+
+### Prepare upgrade - _non-disruptive_
+
+> _Done before maintenance window._
+
+1. Pull the latest changes and switch to the correct branch:
+
+    ```bash
+    git pull
+    git switch -d v0.46.x
+    ```
+
+1. Set whether or not upgrade should be prepared for `both` clusters or for one of `sc` or `wc`:
+
+    ```bash
+    export CK8S_CLUSTER=<wc|sc|both>
+    ```
+
+1. Preserve current Opensearch setup
+
+    > [!WARNING]
+    > Default Opensearch setup has been changed. Opensearch is now configured to use 3 master nodes, 0 data nodes and 0 client nodes by default. There's no easy migration path for the new configuration, if the old default Opensearch setup is used it should be added to the override config.
+
+    ```bash
+    migration/v0.46/prepare/40-preserve-current-os-setup.sh
+    ```
+
+1. Update apps configuration:
+
+    This will take a backup into `backups/` before modifying any files.
+
+    ```bash
+    ./bin/ck8s init ${CK8S_CLUSTER}
+    # or
+    ./migration/v0.46/prepare/50-init.sh
+
+    # check if the netpol IPs need to be updated
+    ./bin/ck8s update-ips ${CK8S_CLUSTER} dry-run
+    # if you agree with the changes apply
+    ./bin/ck8s update-ips ${CK8S_CLUSTER} apply
+    ```
+
+### Apply upgrade - _disruptive_
+
+> _Done during maintenance window._
+
+1. Set whether or not upgrade should be applied for `both` clusters or for one of `sc` or `wc`:
+
+    ```bash
+    export CK8S_CLUSTER=<wc|sc|both>
+    ```
+
+1. Upgrade applications:
+
+    ```bash
+    ./bin/ck8s apply {sc|wc}
+    # or
+    ./migration/v0.46/apply/80-apply.sh execute
+    ```
+
+## Postrequisite
+
+- [ ] Check the state of the environment, pods and nodes:
+
+    ```bash
+    ./bin/ck8s test sc|wc
+    ./bin/ck8s ops kubectl sc|wc get pods -A -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-false:status.containerStatuses[*].ready,REASON:status.containerStatuses[*].state.terminated.reason | grep false | grep -v Completed
+    ./bin/ck8s ops kubectl sc|wc get nodes
+    ./bin/ck8s ops helm sc|wc list -A --all
+    ```
+
+- [ ] Enable the notifications for the alerts;
+- [ ] Notify the users (if any) when the upgrade is complete;
+
+> [!NOTE]
+> Additionally it is good to check:
+>
+> - if any alerts generated by the upgrade didn't close;
+> - if you can login to Grafana, Opensearch or Harbor;
+> - you can see fresh metrics and logs.

--- a/migration/v0.46/apply/00-template.sh
+++ b/migration/v0.46/apply/00-template.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+# functions currently available in the library:
+#   - logging:
+#     - log_info(_no_newline) <message>
+#     - log_warn(_no_newline) <message>
+#     - log_error(_no_newline) <message>
+#     - log_fatal <message> # this will call "exit 1"
+#
+#   - kubectl
+#     # Use kubectl with kubeconfig set
+#     - kubectl_do <sc|wc> <kubectl args...>
+#     # Perform kubectl delete, will not cause errors if the resource is missing
+#     - kubectl_delete <sc|wc> <resource> <namespace> <name>
+#
+#   - helm
+#     # Use helm with kubeconfig set
+#     - helm_do <sc|wc> <helm args...>
+#     # Checks if a release is installed
+#     - helm_installed <sc|wc> <namespace> <release>
+#     # Uninstalls a release if it is installed
+#     - helm_uninstall <sc|wc> <namespace> <release>
+#
+#   - helmfile
+#     # Use helmfile with kubeconfig set
+#     - helmfile_do <sc|wc> <helmfile args...>
+#     # For selector args all will be prefixed with "-l"
+#     # List releases matching the selector
+#     - helmfile_list <sc|wc> <selectors...>
+#     # Apply releases matching the selector
+#     - helmfile_apply <sc|wc> <selectors...>
+#     # Check for changes on releases matching the selector
+#     - helmfile_change <sc|wc> <selectors...>
+#     # Destroy releases matching the selector
+#     - helmfile_destroy <sc|wc> <selectors...>
+#     # Replaces the releases matching the selector, performing destroy and apply on each release individually
+#     - helmfile_replace <sc|wc> <selectors...>
+#     # Upgrades the releases matching the selector, performing automatic rollback on failure set "CK8S_ROLLBACK=false" to disable
+#     - helmfile_upgrade <sc|wc> <selectors...>
+
+run() {
+  case "${1:-}" in
+  execute)
+    # Note: 00-template.sh will be skipped by the upgrade command
+    log_info "no operation: this is a template"
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      log_info "operation on service cluster"
+    fi
+    if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+      log_info "operation on workload cluster"
+    fi
+    ;;
+  rollback)
+    log_warn "rollback not implemented"
+
+    # if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+    #   log_info "rollback operation on service cluster"
+    # fi
+    # if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+    #   log_info "rollback operation on workload cluster"
+    # fi
+    ;;
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.46/apply/80-apply.sh
+++ b/migration/v0.46/apply/80-apply.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+# Add selector filters if covered by other snippets.
+# Example: "app!=something"
+declare -a skipped
+skipped=(
+)
+declare -a skipped_sc
+skipped_sc=(
+)
+declare -a skipped_wc
+skipped_wc=(
+)
+
+run() {
+  case "${1:-}" in
+  execute)
+    local -a filters
+    local selector
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      filters=("${skipped[@]}" "${skipped_sc[@]}")
+      selector="${filters[*]:-"app!=null"}"
+      helmfile_upgrade sc "${selector// /,}"
+    fi
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+      filters=("${skipped[@]}" "${skipped_wc[@]}")
+      selector="${filters[*]:-"app!=null"}"
+      helmfile_upgrade wc "${selector// /,}"
+    fi
+    ;;
+
+  rollback)
+    log_warn "rollback not implemented"
+
+    # if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+    #   log_info "rollback operation on service cluster"
+    # fi
+    # if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+    #   log_info "rollback operation on workload cluster"
+    # fi
+    ;;
+
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.46/prepare/00-template.sh
+++ b/migration/v0.46/prepare/00-template.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+# functions currently available in the library:
+#   - logging:
+#     - log_info(_no_newline) <message>
+#     - log_warn(_no_newline) <message>
+#     - log_error(_no_newline) <message>
+#     - log_fatal <message> # this will call "exit 1"
+#
+#  - yq:
+#     - yq_null <common|sc|wc> <target>
+#     - yq_copy <common|sc|wc> <source> <destination>
+#     - yq_move <common|sc|wc> <source> <destination>
+#     - yq_remove <common|sc|wc> <target>
+#     - yq_add <common|sc|wc> <destination> <value>
+
+# Note: 00-template.sh will be skipped by the upgrade command
+log_info "no operation: this is a template"
+
+if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+  log_info "operation on service cluster"
+fi
+if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+  log_info "operation on workload cluster"
+fi

--- a/migration/v0.46/prepare/40-preserve-current-os-setup.sh
+++ b/migration/v0.46/prepare/40-preserve-current-os-setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+  log_info "Moving current Opensearch configuration to override config"
+  yq_add sc .opensearch "$(yq_merge "${CK8S_CONFIG_PATH}/defaults/sc-config.yaml" "${CK8S_CONFIG_PATH}/sc-config.yaml" "${CK8S_CONFIG_PATH}/common-config.yaml" | yq4 -o json .opensearch)"
+fi

--- a/migration/v0.46/prepare/50-init.sh
+++ b/migration/v0.46/prepare/50-init.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+case "${CK8S_CLUSTER}" in
+both | sc | wc)
+  "${ROOT}/bin/ck8s" init "${CK8S_CLUSTER}"
+  ;;
+*)
+  log_fatal "usage: 50-init.sh <wc|sc|both>"
+  ;;
+esac


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

### Release notes
Default Opensearch setup has been changed. Opensearch is now configured to use 3 master nodes, 0 data nodes and 0 client nodes by default. There's no easy migration path for the new configuration, if the old default Opensearch setup is used it should be added to the override config.
Proxy protocol is now enabled by default in ingress-nginx when using ElastX as infrastructure provider.
Fluentd audit is now enabled by default.
Log retention is now 30 days by default.

### Platform Administrator notice
Default Opensearch setup has been changed. Opensearch is now configured to use 3 master nodes, 0 data nodes and 0 client nodes by default. There's no easy migration path for the new configuration, if the old default Opensearch setup is used it should be added to the override config.
Proxy protocol is now enabled by default in ingress-nginx when using ElastX as infrastructure provider.
Fluentd audit is now enabled by default when using prod or air-gapped flavor.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Changed some default configuration

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes https://github.com/elastisys/ck8s-issue-tracker/issues/352

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [x] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [x] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [x] The metrics are still exposed and present in Grafana after the change
    - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [x] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [x] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [x] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [x] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [x] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [x] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [x] The bug fix is covered by regression tests
