### PR TITLE
Port patch changelogs v0.42.2, v0.43.1, v0.44.1

### DIFF
--- a/changelog/0.42.md
+++ b/changelog/0.42.md
@@ -86,3 +86,18 @@ Released 2025-01-02
 ### Improvement(s)
 
 - [#2382](https://github.com/elastisys/compliantkubernetes-apps/pull/2382) - apps: Mirror Bitnami images [@aarnq](https://github.com/aarnq)
+
+## v0.42.2
+
+Released 2025-03-11
+<!-- -->
+> [!NOTE]
+> **Application Developer Notice(s)**
+>
+> - RBAC to modify the configmaps `fluentd-extra-config` and `fluentd-extra-plugins`, and to delete any fluentd pod in the `fluentd` namespace has been removed.<br>Reach out to a platform administrator if any additional config or plugins are needed!
+
+## Changes by kind
+
+### Deprecation(s)
+
+- [#2457](https://github.com/elastisys/compliantkubernetes-apps/pull/2457) - Remove rbac for additional fluentd config and plugins configmaps [@OlleLarsson](https://github.com/OlleLarsson)

--- a/changelog/0.43.md
+++ b/changelog/0.43.md
@@ -79,3 +79,17 @@ Released 2025-01-20
 - [#2392](https://github.com/elastisys/compliantkubernetes-apps/pull/2392) - bug: Replace ck8s with Welkin in tests @anders-elastisys
 - [#2393](https://github.com/elastisys/compliantkubernetes-apps/pull/2393) - bug: Fix config schema @cristiklein
 - [#2395](https://github.com/elastisys/compliantkubernetes-apps/pull/2395) - clean-up: apps: Update prometheus-label-enforcer to v0.11.0 @Zash
+
+## v0.43.1
+
+Released 2025-03-11
+<!-- -->
+> [!NOTE]
+> **Application Developer Notice(s)**
+> - RBAC to modify the configmaps `fluentd-extra-config` and `fluentd-extra-plugins`, and to delete any fluentd pod in the `fluentd` namespace has been removed.<br>Reach out to a platform administrator if any additional config or plugins are needed!
+
+## Changes by kind
+
+### Deprecation(s)
+
+- [#2457](https://github.com/elastisys/compliantkubernetes-apps/pull/2457) - Remove rbac for additional fluentd config and plugins configmaps [@OlleLarsson](https://github.com/OlleLarsson)

--- a/changelog/0.44.md
+++ b/changelog/0.44.md
@@ -68,3 +68,17 @@ Released 2025-02-12
 - [#2431](https://github.com/elastisys/compliantkubernetes-apps/pull/2431) - bug: Fix KubeContainerOOMKilled alert for newly created pods [@lunkan93](https://github.com/lunkan93)
 - [#2432](https://github.com/elastisys/compliantkubernetes-apps/pull/2432) - other: all: update codeowners for psp values [@OlleLarsson](https://github.com/OlleLarsson)
 - [#2433](https://github.com/elastisys/compliantkubernetes-apps/pull/2433) - documentation: docs: Update QA checklist [@aarnq](https://github.com/aarnq)
+
+## v0.44.1
+
+Released 2025-03-11
+<!-- -->
+> [!NOTE]
+> **Application Developer Notice(s)**
+> - RBAC to modify the configmaps `fluentd-extra-config` and `fluentd-extra-plugins`, and to delete any fluentd pod in the `fluentd` namespace has been removed.<br>Reach out to a platform administrator if any additional config or plugins are needed!
+
+## Changes by kind
+
+### Deprecation(s)
+
+- [#2457](https://github.com/elastisys/compliantkubernetes-apps/pull/2457) - Remove rbac for additional fluentd config and plugins configmaps [@OlleLarsson](https://github.com/OlleLarsson)


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [x] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
