### PR TITLE
apps sc: update harbor storage alerts

### DIFF
--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -421,8 +421,8 @@ harbor:
     schedule: "0 0 0 * * SUN"
   alerts:
     # Alert if values are above the below threshold
-    maxTotalStorageUsedGB: 500
-    maxTotalArtifacts: 1000
+    maxTotalStorageUsedGB: 1500
+    maxTotalArtifacts: 3000
 
 grafanaLabelEnforcer:
   resources:

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -1859,13 +1859,13 @@ properties:
             title: Alert For Max Total Artifacts
             description: |-
               Alert when the total number of artifacts is above the set number.
-            default: 1000
+            default: 3000
             type: number
           maxTotalStorageUsedGB:
             title: Alert For Max Total Storage Used (GB)
             description: |-
               Alert when the total storage usage is above the set number.
-            default: 500
+            default: 1500
             type: number
         type: object
       backup:

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/harbor.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/harbor.yaml
@@ -75,15 +75,15 @@ spec:
       annotations:
         description: Harbor JobService Is Down
         runbook_url: {{ .Values.runbookUrls.harbor.HarborJobServiceDown }}
-    - alert: HarborStorageUsageAboveLimit
+    - alert: HarborStorageUsageAboveThreshold
       expr: |
         sum(harbor_project_quota_usage_byte) / (1024^3) > {{ .Values.harbor.alerts.maxTotalStorageUsedGB }}
       for: 5m
       labels:
         severity: medium
       annotations:
-        description: Total used storage for Harbor is above the limit of {{ .Values.harbor.alerts.maxTotalStorageUsedGB }}GB
-        runbook_url: {{ .Values.runbookUrls.harbor.HarborStorageUsageAboveLimit }}
+        description: Total used storage for Harbor is high (above the threshold of {{ .Values.harbor.alerts.maxTotalStorageUsedGB }}GB). This indicates that users have not set up artifact retention. If the total size of artifacts continues to grow, then Harbor will likely consume more resources and slow down. This might also cause issues with object storage quota at the infrastructure provider.
+        runbook_url: {{ .Values.runbookUrls.harbor.HarborStorageUsageAboveThreshold }}
     - alert: HarborP99LatencyHigherThan10Seconds
       expr: |
         histogram_quantile(0.99,  sum  (rate(registry_http_request_duration_seconds_bucket[30m]) ) by (le)) > 10
@@ -102,13 +102,13 @@ spec:
       annotations:
         description: Harbor Error Rate is High
         runbook_url: {{ .Values.runbookUrls.harbor.HarborErrorRateHigh }}
-    - alert: HarborTotalNumberOfArtifactsAboveLimit
+    - alert: HarborTotalNumberOfArtifactsAboveThreshold
       expr: |
         sum(harbor_project_artifact_total) > {{ .Values.harbor.alerts.maxTotalArtifacts }}
       for: 5m
       labels:
         severity: low
       annotations:
-        description: Total number of artifacts is above the limit of {{ .Values.harbor.alerts.maxTotalArtifacts }}
-        runbook_url: {{ .Values.runbookUrls.harbor.HarborTotalNumberOfArtifactsAboveLimit }}
+        description: Total number of artifacts is high (above alert threshold of {{ .Values.harbor.alerts.maxTotalArtifacts }}). This indicates that users have not set up artifact retention. If the number of artifacts continues to grow, then Harbor will likely consume more resources and slow down.
+        runbook_url: {{ .Values.runbookUrls.harbor.HarborTotalNumberOfArtifactsAboveThreshold }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/values.yaml
+++ b/helmfile.d/charts/prometheus-alerts/values.yaml
@@ -163,8 +163,8 @@ harbor:
   redis:
     type: internal
   alerts:
-    maxTotalStorageUsedGB: 500
-    maxTotalArtifacts: 1000
+    maxTotalStorageUsedGB: 1500
+    maxTotalArtifacts: 3000
 
 runbookUrls:
   alertmanager: {}

--- a/helmfile.d/values/prometheus-alerts-runbook-urls.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-alerts-runbook-urls.yaml.gotmpl
@@ -100,10 +100,10 @@ runbookUrls:
     {{- dict "name" "HarborRedisDown" "config" .harbor | include "tpl.missing-runbook" }}
     {{- dict "name" "HarborTrivyDown" "config" .harbor | include "tpl.missing-runbook" }}
     {{- dict "name" "HarborJobServiceDown" "config" .harbor | include "tpl.missing-runbook" }}
-    {{- dict "name" "HarborStorageUsageAboveLimit" "config" .harbor | include "tpl.missing-runbook" }}
+    {{- dict "name" "HarborStorageUsageAboveThreshold" "config" .harbor | include "tpl.missing-runbook" }}
     {{- dict "name" "HarborP99LatencyHigherThan10Seconds" "config" .harbor | include "tpl.missing-runbook" }}
     {{- dict "name" "HarborErrorRateHigh" "config" .harbor | include "tpl.missing-runbook" }}
-    {{- dict "name" "HarborTotalNumberOfArtifactsAboveLimit" "config" .harbor | include "tpl.missing-runbook" }}
+    {{- dict "name" "HarborTotalNumberOfArtifactsAboveThreshold" "config" .harbor | include "tpl.missing-runbook" }}
   hnc:
     {{- dict "name" "HierarchicalNamespaceControllerNamespaceCondition" "config" .hnc | include "tpl.missing-runbook" }}
   kubeStateMetrics:

--- a/migration/v0.46/README.md
+++ b/migration/v0.46/README.md
@@ -112,6 +112,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     export CK8S_CLUSTER=<wc|sc|both>
     ```
 
+1. The harbor size alerts have changed default values. This will remove overrides to those values if the configured values are lower than the new defaults:
+
+    ```bash
+    ./migration/v0.46/prepare/10-harbor-alerts.sh
+    ```
+
 1. Preserve current Opensearch setup
 
     > [!WARNING]

--- a/migration/v0.46/prepare/10-harbor-alerts.sh
+++ b/migration/v0.46/prepare/10-harbor-alerts.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+  log_info "operation on service cluster"
+  if [[ $(yq_dig sc .harbor.alerts.maxTotalStorageUsedGB) -lt 1500 ]]; then
+    yq_remove sc .harbor.alerts.maxTotalStorageUsedGB
+  fi
+  if [[ $(yq_dig sc .harbor.alerts.maxTotalArtifacts) -lt 3000 ]]; then
+    yq_remove sc .harbor.alerts.maxTotalArtifacts
+  fi
+  if yq_check sc .harbor.alerts "{}"; then
+    yq_remove sc .harbor.alerts
+  fi
+fi


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

As part of some recent discussions we have concluded that the harbor alerts for number of artifacts and total size of artifacts have been to strict. This PR both increases the thresholds and updates the wording of the alert to make it clear that this is not a strict limit.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
