### PR TITLE
Add Prometheus Node Exporter ServiceMonitor scrapeTimeout override

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -375,6 +375,7 @@ prometheusOperator:
         memory: 50Mi
 
 prometheusNodeExporter:
+  scrapeTimeout: ""
   resources:
     requests:
       cpu: 25m

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -4996,6 +4996,13 @@ properties:
     properties:
       resources:
         $ref: '#/$defs/kubernetesResourceRequirements'
+      scrapeTimeout:
+        title: Prometheus Node Exporter ServiceMonitor scrape timeout
+        description: |
+          Configure Prometheus Node Exporter ServiceMonitor scrape timeout.
+          If not set, the upstream default of 10s is used
+        type: string
+        default: ""
   s3Exporter:
     title: S3 Exporter
     description: Configure S3 exporter, used to collect metrics about S3 usage.

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -920,6 +920,9 @@ $defs:
   cronSchedule:
     type: string
     pattern: ^(((\*\/)?([0-5]?[0-9])((\,|\-|\/)([0-5]?[0-9]))*|\*)[^\S\r\n]+((\*\/)?((2[0-3]|1[0-9]|[0-9]|00))((\,|\-|\/)(2[0-3]|1[0-9]|[0-9]|00))*|\*)[^\S\r\n]+((\*\/)?([1-9]|[12][0-9]|3[01])((\,|\-|\/)([1-9]|[12][0-9]|3[01]))*|\*)[^\S\r\n]+((\*\/)?([1-9]|1[0-2])((\,|\-|\/)([1-9]|1[0-2]))*|\*|(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec))[^\S\r\n]+((\*\/)?[0-6]((\,|\-|\/)[0-6])*|\*|00|(sun|mon|tue|wed|thu|fri|sat)))$|^@(annually|yearly|monthly|weekly|daily|hourly|reboot)$
+  scrapeTimeout:
+    type: string
+    pattern: ^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$
 type: object
 required:
   - global
@@ -5001,8 +5004,8 @@ properties:
         description: |
           Configure Prometheus Node Exporter ServiceMonitor scrape timeout.
           If not set, the upstream default of 10s is used
-        type: string
         default: ""
+        $ref: '#/$defs/scrapeTimeout'
   s3Exporter:
     title: S3 Exporter
     description: Configure S3 exporter, used to collect metrics about S3 usage.
@@ -5019,8 +5022,8 @@ properties:
         default: 60m
       scrapeTimeout:
         title: S3 Exporter Scrape Timeout
-        type: string
         default: 10m
+        $ref: '#/$defs/scrapeTimeout'
       resources:
         $ref: '#/$defs/kubernetesResourceRequirements'
       tolerations:
@@ -6258,8 +6261,8 @@ properties:
                 default: 30s
               scrapeTimeout:
                 title: Scrape timeout for the service monitor.
-                type: string
                 default: 30s
+                $ref: '#/$defs/scrapeTimeout'
           resources:
             $ref: '#/$defs/kubernetesResourceRequirements'
           tolerations:

--- a/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -257,6 +257,7 @@ prometheus-node-exporter:
   resources: {{- toYaml .Values.prometheusNodeExporter.resources | nindent 4 }}
   prometheus:
     monitor:
+      scrapeTimeout: {{ .Values.prometheusNodeExporter.scrapeTimeout }}
       relabelings:
         - action: replace
           sourceLabels:

--- a/helmfile.d/values/kube-prometheus-stack-wc.yaml.gotmpl
+++ b/helmfile.d/values/kube-prometheus-stack-wc.yaml.gotmpl
@@ -37,6 +37,7 @@ prometheus-node-exporter:
   resources: {{- toYaml .Values.prometheusNodeExporter.resources | nindent 4 }}
   prometheus:
     monitor:
+      scrapeTimeout: {{ .Values.prometheusNodeExporter.scrapeTimeout }}
       relabelings:
         - action: replace
           sourceLabels:


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Had an issue when upgrading Prometheus in an environment which was solved by increasing the scrapeTimeout for the Prometheus Node Exporter ServiceMonitor.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
