### PR TITLE
apps sc: default Limitconfig for thanos

### DIFF
--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -582,7 +582,7 @@ thanos:
         memory: 1Gi
     extraFlags:  #use extraflags when you want to add more command line flags to the component.
       - >-
-        --receive.limits-config={"write":{"global":{"max_concurrency":30}}}
+        --receive.limits-config={"write":{"global":{"max_concurrency":20}}}
   ruler:
     # Enables the ruler component
     # Evaluates alert rules through thanos, record rules and thanos alert rules are still evaluated through prometheus.

--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -580,9 +580,9 @@ thanos:
       limits:
         cpu: 1000m
         memory: 1Gi
-    extraFlags:  #use extraflags when you want to add more command line flags to the component.
-      - >-
-        --receive.limits-config={"write":{"global":{"max_concurrency":20}}}
+    receiveHashringsAlgorithm: ketama
+    receiveMaxConcurrency: 20
+    extraFlags: [] #use extraflags when you want to add more command line flags to the component.
   ruler:
     # Enables the ruler component
     # Evaluates alert rules through thanos, record rules and thanos alert rules are still evaluated through prometheus.

--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -580,8 +580,9 @@ thanos:
       limits:
         cpu: 1000m
         memory: 1Gi
-    extraFlags: [] #use extraflags when you want to add more command line flags to the component.
-
+    extraFlags:  #use extraflags when you want to add more command line flags to the component.
+      - >-
+        --receive.limits-config={"write":{"global":{"max_concurrency":30}}}
   ruler:
     # Enables the ruler component
     # Evaluates alert rules through thanos, record rules and thanos alert rules are still evaluated through prometheus.

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -5140,6 +5140,15 @@ properties:
             title: Thanos receiveDistributor Replicas
             type: integer
             default: 1
+          receiveHashringsAlgorithm:
+             title: Thanos receiveDistributor algolrithm
+             description: Algorithm used for distributing writes across Thanos receive replicas.
+             type: string
+             default: ketama
+          receiveMaxConcurrency:
+            title: thanos receiveDistributor maximum Concurrency
+            description: Maximum number of concurrent write requests allowed by Thanos receiveDistributor.
+            type: integer
           extraFlags:
             title: Thanos receiveDistributor extraFlags
             description: |-

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -5144,7 +5144,7 @@ properties:
              title: Thanos receiveDistributor algolrithm
              description: Algorithm used for distributing writes across Thanos receive replicas.
              type: string
-             enum: 
+             enum:
                - hashmod
                - ketama
              default: ketama

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -5149,7 +5149,7 @@ properties:
                - ketama
              default: ketama
           receiveMaxConcurrency:
-            title: thanos receiveDistributor maximum Concurrency
+            title: Thanos receiveDistributor maximum Concurrency
             description: Maximum number of concurrent write requests allowed by Thanos receiveDistributor.
             type: integer
           extraFlags:

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -5144,6 +5144,9 @@ properties:
              title: Thanos receiveDistributor algolrithm
              description: Algorithm used for distributing writes across Thanos receive replicas.
              type: string
+             enum: 
+               - hashmod
+               - ketama
              default: ketama
           receiveMaxConcurrency:
             title: thanos receiveDistributor maximum Concurrency

--- a/helmfile.d/values/thanos/receiver.yaml.gotmpl
+++ b/helmfile.d/values/thanos/receiver.yaml.gotmpl
@@ -125,10 +125,20 @@ receiveDistributor:
         - ALL
     seccompProfile:
       type: RuntimeDefault
-  {{- if .Values.thanos.receiveDistributor.extraFlags }}
   extraFlags:
-    {{- toYaml .Values.thanos.receiveDistributor.extraFlags | nindent 4 }}
-  {{ end }}
+    {{- if .Values.thanos.receiveDistributor.extraFlags }}
+    {{- toYaml .Values.thanos.receiveDistributor.extraFlags | nindent 2 }}
+    {{- end }}
+    {{- if .Values.thanos.receiveDistributor.receiveMaxConcurrency }}
+    - |-
+      --receive.limits-config=
+      write:
+        global:
+          max_concurrency: {{ .Values.thanos.receiveDistributor.receiveMaxConcurrency }}
+    {{- end }}
+    {{- if .Values.thanos.receiveDistributor.receiveHashringsAlgorithm }}
+    - "--receive.hashrings-algorithm={{ .Values.thanos.receiveDistributor.receiveHashringsAlgorithm }}"
+    {{- end }}
 
 ruler:
   enabled: {{ .Values.thanos.ruler.enabled }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?
This PR adds the default concurrency for the thanos receiver distributor configuration.
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #
https://github.com/elastisys/compliantkubernetes-apps/issues/2099

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [x] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [x] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
