### PR TITLE
tests: Update for sc and wc local clusters

### DIFF
--- a/scripts/local-cluster.sh
+++ b/scripts/local-cluster.sh
@@ -450,8 +450,8 @@ setup_node_local_dns() {
   if ! test -z "$wc_node_ip"; then
     log.info "got WC node IP: $wc_node_ip"
   else
-    log.error "could not get WC node IP"
-    exit 1
+    log.warn "could not get WC node IP, defaulting to 10.96.0.20"
+    wc_node_ip="10.96.0.20"
   fi
 
   sc_node_ip=$(container.ip sc-worker)
@@ -459,8 +459,8 @@ setup_node_local_dns() {
   if ! test -z "$sc_node_ip"; then
     log.info "got SC node IP: $sc_node_ip"
   else
-    log.error "could not get SC node IP"
-    exit 1
+    log.warn "could not get SC node IP, defaulting to 10.96.0.20"
+    sc_node_ip="10.96.0.20"
   fi
 
   # need domain
@@ -485,8 +485,12 @@ setup_node_local_dns() {
     envsubst >"$CK8S_CONFIG_PATH/wc-config.yaml.new"
   mv -f "$CK8S_CONFIG_PATH/wc-config.yaml.new" "$CK8S_CONFIG_PATH/wc-config.yaml"
 
-  "$ROOT/bin/ck8s" ops helmfile sc -lapp=node-local-dns apply --include-transitive-needs
-  "$ROOT/bin/ck8s" ops helmfile wc -lapp=node-local-dns apply --include-transitive-needs
+  if [[ -f "${CK8S_CONFIG_PATH}/.state/kube_config_sc.yaml" ]]; then
+    "$ROOT/bin/ck8s" ops helmfile sc -lapp=node-local-dns apply --include-transitive-needs
+  fi
+  if [[ -f "${CK8S_CONFIG_PATH}/.state/kube_config_wc.yaml" ]]; then
+    "$ROOT/bin/ck8s" ops helmfile wc -lapp=node-local-dns apply --include-transitive-needs
+  fi
 }
 
 delete() {

--- a/tests/bats.lib.bash
+++ b/tests/bats.lib.bash
@@ -180,20 +180,24 @@ auto_setup() {
 
   log.trace "setup local cluster"
   local_cluster.setup dev test.dev-ck8s.com
-  local_cluster.create single-node-cache
+  local_cluster.create "${cluster}" single-node-cache
 
   local_cluster.configure_selfsigned
+  local_cluster.configure_node_local_dns
 
   log.trace "setup apply ${cluster} ${*}"
   ck8s ops helmfile "${cluster}" apply --include-transitive-needs --output simple "${@/#''/-l}"
 }
 
 auto_teardown() {
+  local cluster="${1}"
+  shift
+
   load_common "local-cluster.bash"
 
   log.trace "teardown local cluster"
 
-  local_cluster.delete
+  local_cluster.delete "${cluster}"
   local_cluster.teardown
 }
 

--- a/tests/common/bats/local-cluster.bash
+++ b/tests/common/bats/local-cluster.bash
@@ -24,22 +24,20 @@ local_cluster.setup() {
   gpg.setup
 
   mkdir -p "${CK8S_CONFIG_PATH}/.state"
-  export KUBECONFIG="${CK8S_CONFIG_PATH}/.state/kube_config.yaml"
 
   "${scripts}/local-cluster.sh" config apps-tests "${@}"
 }
 
-# Usage: local_cluster.create <local-cluster-profile>
+# Usage: local_cluster.create <sc|wc> <local-cluster-profile>
 local_cluster.create() {
   declares
-  "${scripts}/local-cluster.sh" create apps-tests "${@}"
-  cp "${CK8S_CONFIG_PATH}/.state/kube_config.yaml" "${CK8S_CONFIG_PATH}/.state/kube_config_sc.yaml"
-  cp "${CK8S_CONFIG_PATH}/.state/kube_config.yaml" "${CK8S_CONFIG_PATH}/.state/kube_config_wc.yaml"
+  "${scripts}/local-cluster.sh" create "apps-tests-${1}" "${@:2}"
 }
 
+# Usage: local_cluster.delete <sc|wc>
 local_cluster.delete() {
   declares
-  CK8S_AUTO_APPROVE=true "${scripts}/local-cluster.sh" delete apps-tests
+  CK8S_AUTO_APPROVE=true "${scripts}/local-cluster.sh" delete "apps-tests-${1}"
 }
 
 local_cluster.teardown() {
@@ -56,4 +54,9 @@ local_cluster.configure_selfsigned() {
 
   yq.set 'common' '.issuers.letsencrypt.prod.email' '"admin@example.com"'
   yq.set 'common' '.issuers.letsencrypt.staging.email' '"admin@example.com"'
+}
+
+local_cluster.configure_node_local_dns() {
+  declares
+  "${scripts}/local-cluster.sh" setup node-local-dns
 }

--- a/tests/common/exec.bash
+++ b/tests/common/exec.bash
@@ -39,8 +39,12 @@ check_resolve() {
     echo "error: dns does not resolve with local-resolve" >&2
     return 1
   fi
-  if [[ "$(resolvectl query dot.test.dev-ck8s.com | awk '/dot.test.dev-ck8s.com:/{ print $2 }')" != "127.0.64.43" ]]; then
-    echo "error: dns does not resolve to local-cluster" >&2
+  if [[ "$(resolvectl query dot.ops.test.dev-ck8s.com | awk '/dot.ops.test.dev-ck8s.com:/{ print $2 }')" != "127.0.64.43" ]]; then
+    echo "error: dns does not resolve to local-cluster sc" >&2
+    return 1
+  fi
+  if [[ "$(resolvectl query dot.test.dev-ck8s.com | awk '/dot.test.dev-ck8s.com:/{ print $2 }')" != "127.0.64.143" ]]; then
+    echo "error: dns does not resolve to local-cluster wc" >&2
     return 1
   fi
 }

--- a/tests/integration/general/local-clusters.bats
+++ b/tests/integration/general/local-clusters.bats
@@ -9,7 +9,7 @@ setup_file() {
   export CK8S_AUTO_APPROVE="true"
 
   local_cluster.setup dev test.dev-ck8s.com
-  local_cluster.create single-node-cache
+  local_cluster.create sc single-node-cache
 }
 
 setup() {
@@ -19,7 +19,7 @@ setup() {
 }
 
 teardown_file() {
-  local_cluster.delete
+  local_cluster.delete sc
   local_cluster.teardown
 }
 
@@ -27,15 +27,14 @@ helm_status() {
   helm -n "${1}" status "${2}" -oyaml | yq4 '.info.status'
 }
 
-@test "local cluster has created kubeconfigs" {
+@test "local cluster has created kubeconfig" {
   assert [ -f "${CK8S_CONFIG_PATH}/.state/kube_config_sc.yaml" ]
-  assert [ -f "${CK8S_CONFIG_PATH}/.state/kube_config_wc.yaml" ]
 }
 
 @test "local cluster has ready nodes" {
-  run kubectl get no apps-tests-control-plane '-ojsonpath={.status.conditions[?(@.type=="Ready")].status}'
+  run "${ROOT}/bin/ck8s" ops kubectl sc get no apps-tests-sc-control-plane '-ojsonpath={.status.conditions[?(@.type=="Ready")].status}'
   assert_output "True"
-  run kubectl get no apps-tests-worker '-ojsonpath={.status.conditions[?(@.type=="Ready")].status}'
+  run "${ROOT}/bin/ck8s" ops kubectl sc get no apps-tests-sc-worker '-ojsonpath={.status.conditions[?(@.type=="Ready")].status}'
   assert_output "True"
 }
 

--- a/tests/integration/harbor/setup_suite.bash
+++ b/tests/integration/harbor/setup_suite.bash
@@ -11,7 +11,7 @@ setup_suite() {
 teardown_suite() {
   load "../../bats.lib.bash"
 
-  auto_teardown
+  auto_teardown sc
 }
 
 setup_harbor() {


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Makes the test harness work with the new additions to local clusters.

#### Information to reviewers

Had to change some of the logic in setup node-local-dns, as else it was required to have both clusters even if you only need to test on SC.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
