### PR TITLE
apps wc: expose internal ingress-nginx LB config

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -649,6 +649,9 @@ ingressNginx:
 
       clusterIP: ""
 
+      internal:
+        enabled: false
+
     ## Additional configuration options for Nginx
     ## ref: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
     additionalConfig: {}

--- a/config/providers/aws/wc-config.yaml
+++ b/config/providers/aws/wc-config.yaml
@@ -1,8 +1,5 @@
 ingressNginx:
   controller:
-    config:
-      useProxyProtocol: false
-    useHostPort: false
     service:
       internal:
         enabled: true

--- a/config/providers/aws/wc-config.yaml
+++ b/config/providers/aws/wc-config.yaml
@@ -1,0 +1,13 @@
+ingressNginx:
+  controller:
+    config:
+      useProxyProtocol: false
+    useHostPort: false
+    service:
+      internal:
+        enabled: true
+        type: LoadBalancer
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-type: nlb
+          service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+        allocateLoadBalancerNodePorts: true

--- a/config/providers/aws/wc-config.yaml
+++ b/config/providers/aws/wc-config.yaml
@@ -2,7 +2,6 @@ ingressNginx:
   controller:
     service:
       internal:
-        enabled: true
         type: LoadBalancer
         annotations:
           service.beta.kubernetes.io/aws-load-balancer-type: nlb

--- a/config/providers/azure/wc-config.yaml
+++ b/config/providers/azure/wc-config.yaml
@@ -1,0 +1,8 @@
+ingressNginx:
+  controller:
+    service:
+      internal:
+        enabled: true
+        type: LoadBalancer
+        annotations:
+          service.beta.kubernetes.io/azure-load-balancer-internal: "true"

--- a/config/providers/azure/wc-config.yaml
+++ b/config/providers/azure/wc-config.yaml
@@ -6,3 +6,4 @@ ingressNginx:
         type: LoadBalancer
         annotations:
           service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+        allocateLoadBalancerNodePorts: false

--- a/config/providers/azure/wc-config.yaml
+++ b/config/providers/azure/wc-config.yaml
@@ -2,7 +2,6 @@ ingressNginx:
   controller:
     service:
       internal:
-        enabled: true
         type: LoadBalancer
         annotations:
           service.beta.kubernetes.io/azure-load-balancer-internal: "true"

--- a/config/providers/elastx/wc-config.yaml
+++ b/config/providers/elastx/wc-config.yaml
@@ -11,7 +11,6 @@ ingressNginx:
   controller:
     service:
       internal:
-        enabled: false
         type: LoadBalancer
         annotations:
           service.beta.kubernetes.io/openstack-internal-load-balancer: "true"

--- a/config/providers/elastx/wc-config.yaml
+++ b/config/providers/elastx/wc-config.yaml
@@ -16,4 +16,4 @@ ingressNginx:
         annotations:
           service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
           loadbalancer.openstack.org/proxy-protocol: "true"
-        externalTrafficPolicy: Local
+        allocateLoadBalancerNodePorts: true

--- a/config/providers/elastx/wc-config.yaml
+++ b/config/providers/elastx/wc-config.yaml
@@ -7,3 +7,13 @@ hnc:
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
         whenUnsatisfiable: DoNotSchedule
+ingressNginx:
+  controller:
+    service:
+      internal:
+        enabled: false
+        type: LoadBalancer
+        annotations:
+          service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
+          loadbalancer.openstack.org/proxy-protocol: "true"
+        externalTrafficPolicy: Local

--- a/config/providers/openstack/wc-config.yaml
+++ b/config/providers/openstack/wc-config.yaml
@@ -6,3 +6,4 @@ ingressNginx:
         type: LoadBalancer
         annotations:
           service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
+        allocateLoadBalancerNodePorts: true

--- a/config/providers/openstack/wc-config.yaml
+++ b/config/providers/openstack/wc-config.yaml
@@ -1,0 +1,8 @@
+ingressNginx:
+  controller:
+    service:
+      internal:
+        enabled: false
+        type: LoadBalancer
+        annotations:
+          service.beta.kubernetes.io/openstack-internal-load-balancer: "true"

--- a/config/providers/openstack/wc-config.yaml
+++ b/config/providers/openstack/wc-config.yaml
@@ -2,7 +2,6 @@ ingressNginx:
   controller:
     service:
       internal:
-        enabled: false
         type: LoadBalancer
         annotations:
           service.beta.kubernetes.io/openstack-internal-load-balancer: "true"

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -6574,6 +6574,123 @@ properties:
                     https:
                       default: 30443
                       $ref: '#/$defs/port'
+                internal:
+                  title: Ingress-NGINX Internal Service
+                  description: Configure the Internal Service for traffic to Ingress-NGINX.
+                  type: object
+                  properties:
+                    service:
+                      title: Ingress-NGINX Service
+                      description: Configure the Internal Service for traffic to Ingress-NGINX.
+                      type: object
+                      properties:
+                        enabled:
+                          title: Ingress-NGINX Service Enabled
+                          type: boolean
+                      if:
+                        properties:
+                          enabled:
+                            title: Ingress-NGINX Service Enabled
+                            type: boolean
+                            const: true
+                      then:
+                        additionalProperties: false
+                        properties:
+                          enabled:
+                            title: Ingress-NGINX Service Enabled
+                            type: boolean
+                            const: true
+                          annotations:
+                            title: Service Annotations
+                            type: object
+                            additionalProperties:
+                              title: Annotation
+                              type: string
+                              description: Kubernetes annotations should be strings, but other scalars may be coereced during templating.
+                          type:
+                            title: Service Type
+                            description: Configure the type of the Service.
+                            type: string
+                            enum:
+                              - ClusterIP
+                              - LoadBalancer
+                              - NodePort
+                          clusterIP:
+                            title: Service ClusterIP
+                            type: string
+                            oneOf:
+                              - format: ipv4
+                              - const: ""
+                          ipFamilyPolicy:
+                            title: Service IP Family Policy
+                            description: |-
+                              Represents the dual-stack-ness requested or required by this Service. When
+                              utilizing an internal loadbalancer service (ie MetalLB), set this field to
+                              "RequireDualStack" if you want both IPv4 and IPv6 connectivity. The
+                              ipFamilies and clusterIPs fields depend on the value of this field.
+
+                              See [reference](https://kubernetes.io/docs/concepts/services-networking/dual-stack/)
+                            type: string
+                            enum:
+                              - ""
+                              - SingleStack
+                              - PreferDualStack
+                              - RequireDualStack
+                            default: SingleStack
+                          ipFamilies:
+                            title: Service IP Families
+                            description: |-
+                              List of IP families (e.g. IPv4, IPv6) assigned to the service. Default is IPv4 only. When utilizing an internal loadbalancer service (ie MetalLB),
+                              IPv6 would also need to be included in order for the ingress service to allocate an address in that family.
+                            type: array
+                            uniqueItems: true
+                            items:
+                              title: Service IP Family
+                              type: string
+                              enum:
+                                - IPv4
+                                - IPv6
+                            default:
+                              - IPv4
+                          allocateLoadBalancerNodePorts:
+                            title: Load Balancer Node Ports
+                            type: boolean
+                            default: false
+                            description: |-
+                              When enabled node ports will be allocated for the Load Balancer Service.
+
+                              This should be enabled when the cluster is fronted by a proxy load balancer regardless if it is external or internal, and disabled if the cluster uses direct routing of ingress traffic.
+
+                              See [reference](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation)
+                          loadBalancerSourceRanges:
+                            title: Load Balancer Source Ranges
+                            description: |-
+                              Configure the source ranges to allow via the Load Balancer Service.
+                            type: array
+                            items:
+                              type: string
+                            default: []
+                          loadBalancerIP:
+                            title: Load Balancer IP
+                            description: |-
+                              Configure the Load Balancer IP to use an existing IP if supported by the infrastructure provider.
+
+                              > [!important]
+                              > With OpenStack Octavia the floating IP can be created via the CLI beforehand, and one should set the annotation `loadbalancer.openstack.org/keep-floatingip: "true"` to prevent the floating IP to be deleted.
+                            type: string
+                            default: ""
+                          nodePorts:
+                            title: Node Ports
+                            description: Configure the node ports to allocate for the Service.
+                            type: object
+                            additionalProperties: false
+                            properties:
+                              http:
+                                default: 30080
+                                $ref: '#/$defs/port'
+                              https:
+                                default: 30443
+                                $ref: '#/$defs/port'
           useHostPort:
             title: Ingress-NGINX Host Port
             description: |-

--- a/config/wc-config.yaml
+++ b/config/wc-config.yaml
@@ -320,12 +320,6 @@ ingressNginx:
         ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
         allocateLoadBalancerNodePorts: true
 
-        ## Set external traffic policy to: "Local" to preserve source IP on
-        ## providers supporting it
-        ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
-        ## Required for IP whitelisting
-        externalTrafficPolicy: Cluster
-
         ## Whitelist IP address for octavia loadbalancer
         ## ref: https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#restrict-access-for-loadbalancer-service
         loadBalancerSourceRanges: []

--- a/config/wc-config.yaml
+++ b/config/wc-config.yaml
@@ -305,7 +305,7 @@ ingressNginx:
 
         ## Type of service.
         ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
-        type: set-me-if-(.ingressNginx.controller.service.enabled)
+        type: set-me-if-(.ingressNginx.controller.service.internal.enabled)
 
         ## Annotations to add to service
         ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
@@ -313,7 +313,7 @@ ingressNginx:
         ## ref: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/README.md#additional-internal-load-balancer
         ## For Openstack use `service.beta.kubernetes.io/openstack-internal-load-balancer: "true"`
         ## For Azure use `loadbalancer.openstack.org/proxy-protocol: "true"`
-        annotations: set-me-if-(.ingressNginx.controller.service.enabled)
+        annotations: set-me-if-(.ingressNginx.controller.service.internal.enabled)
 
         ## Enable node port allocation
         ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation

--- a/config/wc-config.yaml
+++ b/config/wc-config.yaml
@@ -302,7 +302,6 @@ ingressNginx:
     ## Kubernetes service configuration.
     service:
       internal:
-        enabled: set-me
 
         ## Type of service.
         ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types

--- a/config/wc-config.yaml
+++ b/config/wc-config.yaml
@@ -298,6 +298,58 @@ prometheusBlackboxExporter:
 
 ingressNginx:
   subDomain: ingress-nginx
+  controller:
+    ## Kubernetes service configuration.
+    service:
+      internal:
+        enabled: set-me
+
+        ## Type of service.
+        ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+        type: set-me-if-(.ingressNginx.controller.service.enabled)
+
+        ## Annotations to add to service
+        ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+        ## Set the additional internal loadbalancer annotation if `type` is "LoadBalancer"
+        ## ref: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/README.md#additional-internal-load-balancer
+        ## For Openstack use `service.beta.kubernetes.io/openstack-internal-load-balancer: "true"`
+        ## For Azure use `loadbalancer.openstack.org/proxy-protocol: "true"`
+        annotations: set-me-if-(.ingressNginx.controller.service.enabled)
+
+        ## Enable node port allocation
+        ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
+        allocateLoadBalancerNodePorts: true
+
+        ## Set external traffic policy to: "Local" to preserve source IP on
+        ## providers supporting it
+        ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
+        ## Required for IP whitelisting
+        externalTrafficPolicy: Cluster
+
+        ## Whitelist IP address for octavia loadbalancer
+        ## ref: https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#restrict-access-for-loadbalancer-service
+        loadBalancerSourceRanges: []
+
+        # Set this to use an existing floating ip
+        # If you want to change this then you need to recreate the service
+        loadBalancerIP: ""
+
+        # -- Represents the dual-stack-ness requested or required by this Service. Possible values are
+        # SingleStack (default), PreferDualStack or RequireDualStack. When utilizing an internal loadbalancer service (ie MetalLB),
+        # set this field to "RequireDualStack" if you want both IPv4 and IPv6 connectivity.
+        # The ipFamilies and clusterIPs fields depend on the value of this field.
+        ## Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+        ipFamilyPolicy: ""
+        # -- List of IP families (e.g. IPv4, IPv6) assigned to the service. Default is IPv4 only. When utilizing an internal loadbalancer service (ie MetalLB),
+        # IPv6 would also need to be included in order for the ingress service to allocate an address in that family.
+        ipFamilies: []
+
+        ## type: NodePort
+        nodePorts:
+          http: 30080
+          https: 30443
+
+        clusterIP: ""
 
 # Network policies for workload cluster
 networkPolicies:

--- a/helmfile.d/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile.d/values/ingress-nginx.yaml.gotmpl
@@ -131,11 +131,11 @@ controller:
     {{- with .Values | get "ingressNginx.controller.service.loadBalancerIP" "" }}
     loadBalancerIP: {{ . }}
     {{- end }}
+    {{ if .Values.ingressNginx.controller.service.internal.enabled }}
     internal:
       {{- if .Values | get "ingressNginx.controller.service.internal.type" "" | eq "LoadBalancer" }}
       allocateLoadBalancerNodePorts: {{ .Values.ingressNginx.controller.service.internal.allocateLoadBalancerNodePorts }}
       {{- end }}
-      {{ if .Values.ingressNginx.controller.service.internal.enabled }}
       enabled: {{ .Values.ingressNginx.controller.service.internal.enabled }}
       type: {{ .Values.ingressNginx.controller.service.internal.type }}
       annotations: {{- toYaml .Values.ingressNginx.controller.service.internal.annotations | nindent 8 }}
@@ -146,7 +146,6 @@ controller:
       ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
       ## Required for IP whitelisting
       externalTrafficPolicy: "Local"
-      {{ end }}
       {{ else }}
       enabled: false
       {{ end }}
@@ -165,6 +164,7 @@ controller:
       {{- with .Values | get "ingressNginx.controller.service.internal.loadBalancerIP" "" }}
       loadBalancerIP: {{ . }}
       {{- end }}
+    {{ end }}
 
   metrics:
     enabled: true

--- a/helmfile.d/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile.d/values/ingress-nginx.yaml.gotmpl
@@ -140,7 +140,13 @@ controller:
       type: {{ .Values.ingressNginx.controller.service.internal.type }}
       annotations: {{- toYaml .Values.ingressNginx.controller.service.internal.annotations | nindent 8 }}
       loadBalancerSourceRanges: {{- toYaml .Values.ingressNginx.controller.service.internal.loadBalancerSourceRanges | nindent 8 }}
-      externalTrafficPolicy: {{ .Values.ingressNginx.controller.service.internal.externalTrafficPolicy }}
+      {{ if .Values.externalTrafficPolicy.local }}
+      ## Set external traffic policy to: "Local" to preserve source IP on
+      ## providers supporting it
+      ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
+      ## Required for IP whitelisting
+      externalTrafficPolicy: "Local"
+      {{ end }}
       {{ else }}
       enabled: false
       {{ end }}

--- a/helmfile.d/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile.d/values/ingress-nginx.yaml.gotmpl
@@ -146,8 +146,6 @@ controller:
       ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
       ## Required for IP whitelisting
       externalTrafficPolicy: "Local"
-      {{ else }}
-      enabled: false
       {{ end }}
       {{ if .Values.ingressNginx.controller.service.internal.ipFamilyPolicy }}
       ipFamilyPolicy: {{ .Values.ingressNginx.controller.service.internal.ipFamilyPolicy }}

--- a/helmfile.d/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile.d/values/ingress-nginx.yaml.gotmpl
@@ -131,6 +131,34 @@ controller:
     {{- with .Values | get "ingressNginx.controller.service.loadBalancerIP" "" }}
     loadBalancerIP: {{ . }}
     {{- end }}
+    internal:
+      {{- if .Values | get "ingressNginx.controller.service.internal.type" "" | eq "LoadBalancer" }}
+      allocateLoadBalancerNodePorts: {{ .Values.ingressNginx.controller.service.internal.allocateLoadBalancerNodePorts }}
+      {{- end }}
+      {{ if .Values.ingressNginx.controller.service.internal.enabled }}
+      enabled: {{ .Values.ingressNginx.controller.service.internal.enabled }}
+      type: {{ .Values.ingressNginx.controller.service.internal.type }}
+      annotations: {{- toYaml .Values.ingressNginx.controller.service.internal.annotations | nindent 8 }}
+      loadBalancerSourceRanges: {{- toYaml .Values.ingressNginx.controller.service.internal.loadBalancerSourceRanges | nindent 8 }}
+      externalTrafficPolicy: {{ .Values.ingressNginx.controller.service.internal.externalTrafficPolicy }}
+      {{ else }}
+      enabled: false
+      {{ end }}
+      {{ if .Values.ingressNginx.controller.service.internal.ipFamilyPolicy }}
+      ipFamilyPolicy: {{ .Values.ingressNginx.controller.service.internal.ipFamilyPolicy }}
+      {{ end }}
+      {{ if .Values.ingressNginx.controller.service.internal.ipFamilies }}
+      ipFamilies: {{- toYaml .Values.ingressNginx.controller.service.internal.ipFamilies | nindent 8 }}
+      {{ end }}
+      {{ if eq .Values.ingressNginx.controller.service.internal.type "NodePort" }}
+      nodePorts: {{- toYaml .Values.ingressNginx.controller.service.internal.nodePorts | nindent 8 }}
+      {{ end }}
+      {{- with .Values | get "ingressNginx.controller.service.internal.clusterIP" "" }}
+      clusterIP: {{ . }}
+      {{- end }}
+      {{- with .Values | get "ingressNginx.controller.service.internal.loadBalancerIP" "" }}
+      loadBalancerIP: {{ . }}
+      {{- end }}
 
   metrics:
     enabled: true


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Exposes internal ingress-nginx load balancer config
It's possible to configure it for multiple providers

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2504

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [x] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [x] The metrics are still exposed and present in Grafana after the change
    - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [x] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [x] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [x] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [x] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [x] Any changed Pod is covered by Network Policies
    - [x] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [x] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
