### PR TITLE
config: Revert schema fixes

### DIFF
--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -656,13 +656,13 @@ $defs:
     type: object
     properties:
       configMapKeyRef:
-        $ref: '#/$defs/io.k8s.api.core.v1.ConfigMapKeySelector'
+        $ref: '#/components/schemas/io.k8s.api.core.v1.ConfigMapKeySelector'
       fieldRef:
-        $ref: '#/$defs/io.k8s.api.core.v1.ObjectFieldSelector'
+        $ref: '#/components/schemas/io.k8s.api.core.v1.ObjectFieldSelector'
       resourceFieldRef:
-        $ref: '#/$defs/io.k8s.api.core.v1.ResourceFieldSelector'
+        $ref: '#/components/schemas/io.k8s.api.core.v1.ResourceFieldSelector'
       secretKeyRef:
-        $ref: '#/$defs/io.k8s.api.core.v1.SecretKeySelector'
+        $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
     $comment: Imported from Kubernetes project
   io.k8s.api.core.v1.ConfigMapKeySelector:
     title: Config Map Key Selector
@@ -719,7 +719,7 @@ $defs:
       divisor:
         title: Divisor
         description: Specifies the output format of the exposed resources, defaults to `1`.
-        $ref: "#/$defs/kubernetesQuantity"
+        $ref: "#/$defs/KubernetesQuantity"
       resource:
         title: Resource
         description: Required, resource to select.


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [x] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This reverts fixes to the schema as it for some reason breaks jsonschema2md.

What happens is that the `$ref`s seem to hijack the origin schema object instead of generating their own pages (as all other `$ref`s do), and this causes [mkdocs to fail](https://github.com/elastisys/welkin/actions/runs/14656554913/job/41132565929) to build as pages are missing.

This is temporary, until I find out why and how to fix it properly.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
