### PR TITLE
Add image signature verification Kyverno policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,6 +39,7 @@
 /helmfile.d/charts/kube-state-metrics-extra-resource-metrics/ @elastisys/goto-monitoring-stack
 /helmfile.d/charts/kubeapi-metrics @elastisys/goto-monitoring-stack
 /helmfile.d/charts/kured-secret/ @elastisys/goto-security
+/helmfile.d/charts/kyverno-policies/ @elastisys/goto-access-control
 /helmfile.d/charts/log-manager/ @elastisys/goto-logging-stack
 /helmfile.d/charts/networkpolicy/ @elastisys/goto-networking
 /helmfile.d/charts/node-local-dns/ @elastisys/goto-networking

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -7951,6 +7951,44 @@ properties:
         $ref: '#/$defs/kubernetesTopologySpreadConstraints'
       tolerations:
         $ref: '#/$defs/kubernetesTolerations'
+      policies:
+        type: object
+        properties:
+          verifyImageSignature:
+            title: Verify Image Signature Kyverno policy
+            description: A policy that requires that all images in HNC controlled namespaces are signed
+            type: object
+            properties:
+              enabled:
+                title: Enable the Verify Image Signature policy
+                default: false
+                type: boolean
+              type:
+                title: Method of signature validation
+                type: string
+                enum:
+                  - Cosign
+                  - Notary
+              publicKeys:
+                description: A set of public keys used to verify image signatures
+                type: string
+                example: |
+                  -----BEGIN PUBLIC KEY-----
+                  MFkwEwY...
+                  -----END PUBLIC KEY-----
+                  -----BEGIN PUBLIC KEY-----
+                  MFkwEwY...
+                  -----END PUBLIC KEY-----
+              certificates:
+                description: A set of certificates used to verify images
+                type: string
+                example: |
+                  -----BEGIN CERTIFICATE-----
+                  MIIDTTCCA...
+                  -----END CERTIFICATE-----
+                  -----BEGIN CERTIFICATE-----
+                  MIIDTTCCA...
+                  -----END CERTIFICATE-----
 
 additionalProperties:
   title: Additional Properties

--- a/config/wc-config.yaml
+++ b/config/wc-config.yaml
@@ -400,3 +400,11 @@ gatekeeper:
 
 gpu:
   enabled: false
+
+kyverno:
+  policies:
+    verifyImageSignature:
+      enabled: false
+      type: Cosign
+      publicKeys: ""
+      certificates: ""

--- a/helmfile.d/charts/kyverno-policies/Chart.yaml
+++ b/helmfile.d/charts/kyverno-policies/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+name: kyverno-policies
+description: Kyverno policies
+version: 0.1.0
+appVersion: 0.1.0

--- a/helmfile.d/charts/kyverno-policies/templates/verify-image-signature.yaml
+++ b/helmfile.d/charts/kyverno-policies/templates/verify-image-signature.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.verifyImageSignature.enabled -}}
+{{- if and (not .Values.verifyImageSignature.publicKeys) (not .Values.verifyImageSignature.certificates) }}
+{{- fail "publicKeys and certificates can't both be unset" }}
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: com.elastisys.policies.verify-image-signature
+  namespace: kyverno
+data:
+  {{- with .Values.verifyImageSignature.publicKeys }}
+  publicKeys: |
+    {{- . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.verifyImageSignature.certificates }}
+  certificates: |
+    {{- . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-image-signature
+spec:
+  webhookConfiguration:
+    failurePolicy: Fail
+    timeoutSeconds: 30
+  background: false
+  rules:
+    - name: verify-image-signature
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaceSelector:
+                matchLabels:
+                  hnc.x-k8s.io/included-namespace: "true"
+      context:
+        - name: entries
+          configMap:
+            name: com.elastisys.policies.verify-image-signature
+            namespace: kyverno
+      verifyImages:
+        - type: {{ .Values.verifyImageSignature.type }}
+          failureAction: Enforce
+          imageReferences: ["*"]
+          attestors:
+            - entries:
+              {{- if .Values.verifyImageSignature.publicKeys }}
+              - keys:
+                  publicKeys: {{`"{{ entries.data.publicKeys }}"`}}
+             {{- end }}
+              {{- if .Values.verifyImageSignature.certificates }}
+              - certificates:
+                  cert: {{`"{{ entries.data.certificates }}"`}}
+             {{- end }}
+{{- end }}

--- a/helmfile.d/charts/kyverno-policies/values.yaml
+++ b/helmfile.d/charts/kyverno-policies/values.yaml
@@ -1,0 +1,5 @@
+verifyImageSignature:
+  enabled: false
+  type: Cosign
+  publicKeys: ""
+  certificates: ""

--- a/helmfile.d/stacks/kyverno.yaml.gotmpl
+++ b/helmfile.d/stacks/kyverno.yaml.gotmpl
@@ -28,3 +28,16 @@ templates:
     values:
       - values/networkpolicies/common/common.yaml.gotmpl
       - values/networkpolicies/common/kyverno.yaml.gotmpl
+
+  kyverno-policies:
+    disableValidationOnInstall: true
+    inherit:
+      - template: kyverno
+    chart: charts/kyverno-policies
+    name: kyverno-policies
+    version: 0.1.0
+    installed: {{ .Values | get "kyverno.enabled" false }}
+    needs:
+      - kyverno/kyverno
+    values:
+      - values/kyverno-policies.yaml.gotmpl

--- a/helmfile.d/state.yaml.gotmpl
+++ b/helmfile.d/state.yaml.gotmpl
@@ -59,6 +59,7 @@ releases:
 
   - inherit: [ template: kyverno-admission-controller ]
   - inherit: [ template: kyverno-networkpolicy ]
+  - inherit: [ template: kyverno-policies ]
 
   - inherit: [ template: default-podsecuritypolicy ]
 

--- a/helmfile.d/values/kyverno-policies.yaml.gotmpl
+++ b/helmfile.d/values/kyverno-policies.yaml.gotmpl
@@ -1,0 +1,1 @@
+verifyImageSignature: {{- toYaml .Values.kyverno.policies.verifyImageSignature | nindent 2 }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

- Fixes https://github.com/elastisys/ck8s-issue-tracker/issues/497

This adds a Kyverno policy that ensures that all images in the HNC controlled namespaces are signed.

#### Information to reviewers

I've deliberately chosen to introduce as few configuration options as possible to don't overcomplicate things early. A few things that we might want in the future:
* Which namespaces should be included - instead of all HNC namespaces (this is a deviation from the roadmap acceptance criteria).
* Being able to configure `attestors.count` which controls how many attestors (keys or certificate entries) need to be verified. By default all entries must be verified. For example, users might want to add multiple keys but only require that one of them verifies the image.
* `imageReferences` (or `skipImageReferences`) to allow for filtering the images or repositories.

See this for the reason a ConfigMap is used: https://github.com/elastisys/roadmaps/issues/200#issuecomment-2826897143

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
