### PR TITLE
config: Flatten ingress-nginx schema

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -615,11 +615,11 @@ ingressNginx:
 
       ## Type of service.
       ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
-      type: set-me-if-(.ingressNginx.controller.service.enabled)
+      # type: set-me
 
       ## Annotations to add to service
       ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-      annotations: set-me-if-(.ingressNginx.controller.service.enabled)
+      annotations: {}
 
       ## Enable node port allocation
       ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -6388,6 +6388,185 @@ properties:
     title: Ingress-NGINX Controller Config
     description: |-
       Configure Ingress-NGINX, the ingress controller.
+    $defs:
+      service:
+        title: Ingress-NGINX Service
+        description: Definition of Ingress-NGINX Service
+        type: object
+        properties:
+          enabled:
+            title: Ingress-NGINX Service Enabled
+            type: boolean
+
+          annotations:
+            title: Service Annotations
+            type: object
+            additionalProperties:
+              title: Annotation
+              type: string
+              description: Kubernetes annotations should be strings, but other scalars may be coerced during templating.
+            default: {}
+
+          type:
+            title: Service Type
+            description: Configure the type of the Service.
+            type: string
+            enum:
+              - ClusterIP
+              - LoadBalancer
+              - NodePort
+
+          clusterIP:
+            title: Service ClusterIP
+            type: string
+            oneOf:
+              - const: ""
+              - format: ipv4
+
+          ipFamilyPolicy:
+            title: Service IP Family Policy
+            description: |-
+              Represents the dual-stack-ness requested or required by this Service. When
+              utilizing an internal loadbalancer service (ie MetalLB), set this field to
+              "RequireDualStack" if you want both IPv4 and IPv6 connectivity. The
+              ipFamilies and clusterIPs fields depend on the value of this field.
+
+              See [reference](https://kubernetes.io/docs/concepts/services-networking/dual-stack/)
+            type: string
+            enum:
+              - ""
+              - SingleStack
+              - PreferDualStack
+              - RequireDualStack
+            default: SingleStack
+
+          ipFamilies:
+            title: Service IP Families
+            description: |-
+              List of IP families (e.g. IPv4, IPv6) assigned to the service. Default is IPv4 only. When utilizing an internal loadbalancer service (ie MetalLB),
+              IPv6 would also need to be included in order for the ingress service to allocate an address in that family.
+            type: array
+            uniqueItems: true
+            items:
+              title: Service IP Family
+              type: string
+              enum:
+                - IPv4
+                - IPv6
+            default:
+              - IPv4
+
+          allocateLoadBalancerNodePorts:
+            title: Load Balancer Node Ports
+            description: |-
+              When enabled node ports will be allocated for the Load Balancer Service.
+
+              This should be enabled when the cluster is fronted by a proxy load balancer regardless if it is external or internal, and disabled if the cluster uses direct routing of ingress traffic.
+
+              See [reference](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation)
+            type: boolean
+            default: false
+
+          loadBalancerIP:
+            title: Load Balancer IP
+            description: |-
+              Configure the Load Balancer IP to use an existing IP if supported by the infrastructure provider.
+
+              > [!important]
+              > With OpenStack Octavia the floating IP can be created via the CLI beforehand, and one should set the annotation `loadbalancer.openstack.org/keep-floatingip: "true"` to prevent the floating IP to be deleted.
+            type: string
+            default: ""
+
+          loadBalancerSourceRanges:
+            title: Load Balancer Source Ranges
+            description: |-
+              Configure the source ranges to allow via the Load Balancer Service.
+            type: array
+            items:
+              type: string
+            default: []
+
+          nodePorts:
+            title: Node Ports
+            description: Configure the node ports to allocate for the Service.
+            type: object
+            additionalProperties: false
+            properties:
+              http:
+                default: 30080
+                $ref: '#/$defs/port'
+              https:
+                default: 30443
+                $ref: '#/$defs/port'
+
+          disabledCondition:
+            title: Ingress-NGINX Service Disabled
+            description: Condition for when the Service is disabled.
+            type: object
+            properties:
+              enabled:
+                const: false
+                type: boolean
+
+          enabledCondition:
+            title: Ingress-NGINX Service Enabled
+            description: Condition for when the Service is enabled.
+            type: object
+            properties:
+              enabled:
+                const: true
+                type: boolean
+            required:
+              - annotations
+              - type
+            allOf:
+              - $ref: "#/properties/ingressNginx/$defs/service/properties/clusterIpCondition"
+              - $ref: "#/properties/ingressNginx/$defs/service/properties/loadBalancerCondition"
+              - $ref: "#/properties/ingressNginx/$defs/service/properties/nodePortCondition"
+
+          clusterIpCondition:
+            title: Ingress-NGINX Service ClusterIP Enabled
+            description: Condition for when the Service is using ClusterIP type.
+            if:
+              properties:
+                type:
+                  const: ClusterIP
+              required:
+                - type
+            then:
+              required:
+                - annotations
+                - type
+
+          loadBalancerCondition:
+            title: Ingress-NGINX Service LoadBalancer Enabled
+            description: Condition for when the Service is using LoadBalancer type.
+            if:
+              properties:
+                type:
+                  const: LoadBalancer
+              required:
+                - type
+            then:
+              required:
+                - type
+                - allocateLoadBalancerNodePorts
+
+          nodePortCondition:
+            title: Ingress-NGINX Service NodePort Enabled
+            description: Condition for when the Service is using NodePort type.
+            if:
+              properties:
+                type:
+                  const: NodePort
+              required:
+                - type
+            then:
+              required:
+                - annotations
+                - type
+                - nodePorts
+
     type: object
     additionalProperties: false
     properties:
@@ -6490,229 +6669,54 @@ properties:
             type: object
             properties:
               enabled:
-                title: Ingress-NGINX Service Enabled
-                type: boolean
-            if:
-              properties:
-                enabled:
-                  title: Ingress-NGINX Service Enabled
-                  type: boolean
-                  const: true
-            then:
-              additionalProperties: false
-              properties:
-                enabled:
-                  title: Ingress-NGINX Service Enabled
-                  type: boolean
-                  const: true
-                annotations:
-                  title: Service Annotations
-                  type: object
-                  additionalProperties:
-                    title: Annotation
-                    type: string
-                    description: Kubernetes annotations should be strings, but other scalars may be coereced during templating.
-                type:
-                  title: Service Type
-                  description: Configure the type of the Service.
-                  type: string
-                  enum:
-                    - ClusterIP
-                    - LoadBalancer
-                    - NodePort
-                clusterIP:
-                  title: Service ClusterIP
-                  type: string
-                  oneOf:
-                    - format: ipv4
-                    - const: ""
-                ipFamilyPolicy:
-                  title: Service IP Family Policy
-                  description: |-
-                    Represents the dual-stack-ness requested or required by this Service. When
-                    utilizing an internal loadbalancer service (ie MetalLB), set this field to
-                    "RequireDualStack" if you want both IPv4 and IPv6 connectivity. The
-                    ipFamilies and clusterIPs fields depend on the value of this field.
-
-                    See [reference](https://kubernetes.io/docs/concepts/services-networking/dual-stack/)
-                  type: string
-                  enum:
-                    - ""
-                    - SingleStack
-                    - PreferDualStack
-                    - RequireDualStack
-                  default: SingleStack
-                ipFamilies:
-                  title: Service IP Families
-                  description: |-
-                    List of IP families (e.g. IPv4, IPv6) assigned to the service. Default is IPv4 only. When utilizing an internal loadbalancer service (ie MetalLB),
-                    IPv6 would also need to be included in order for the ingress service to allocate an address in that family.
-                  type: array
-                  uniqueItems: true
-                  items:
-                    title: Service IP Family
-                    type: string
-                    enum:
-                      - IPv4
-                      - IPv6
-                  default:
-                    - IPv4
-                allocateLoadBalancerNodePorts:
-                  title: Load Balancer Node Ports
-                  type: boolean
-                  default: false
-                  description: |-
-                    When enabled node ports will be allocated for the Load Balancer Service.
-
-                    This should be enabled when the cluster is fronted by a proxy load balancer regardless if it is external or internal, and disabled if the cluster uses direct routing of ingress traffic.
-
-                    See [reference](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation)
-                loadBalancerSourceRanges:
-                  title: Load Balancer Source Ranges
-                  description: |-
-                    Configure the source ranges to allow via the Load Balancer Service.
-                  type: array
-                  items:
-                    type: string
-                  default: []
-                loadBalancerIP:
-                  title: Load Balancer IP
-                  description: |-
-                    Configure the Load Balancer IP to use an existing IP if supported by the infrastructure provider.
-
-                    > [!important]
-                    > With OpenStack Octavia the floating IP can be created via the CLI beforehand, and one should set the annotation `loadbalancer.openstack.org/keep-floatingip: "true"` to prevent the floating IP to be deleted.
-                  type: string
-                  default: ""
-                nodePorts:
-                  title: Node Ports
-                  description: Configure the node ports to allocate for the Service.
-                  type: object
-                  additionalProperties: false
-                  properties:
-                    http:
-                      default: 30080
-                      $ref: '#/$defs/port'
-                    https:
-                      default: 30443
-                      $ref: '#/$defs/port'
-                internal:
-                  title: Ingress-NGINX Internal Service
-                  description: Configure the Internal Service for traffic to Ingress-NGINX.
-                  type: object
-                  properties:
-                    service:
-                      title: Ingress-NGINX Service
-                      description: Configure the Internal Service for traffic to Ingress-NGINX.
-                      type: object
-                      properties:
-                        enabled:
-                          title: Ingress-NGINX Service Enabled
-                          type: boolean
-                      if:
-                        properties:
-                          enabled:
-                            title: Ingress-NGINX Service Enabled
-                            type: boolean
-                            const: true
-                      then:
-                        additionalProperties: false
-                        properties:
-                          enabled:
-                            title: Ingress-NGINX Service Enabled
-                            type: boolean
-                            const: true
-                          annotations:
-                            title: Service Annotations
-                            type: object
-                            additionalProperties:
-                              title: Annotation
-                              type: string
-                              description: Kubernetes annotations should be strings, but other scalars may be coereced during templating.
-                          type:
-                            title: Service Type
-                            description: Configure the type of the Service.
-                            type: string
-                            enum:
-                              - ClusterIP
-                              - LoadBalancer
-                              - NodePort
-                          clusterIP:
-                            title: Service ClusterIP
-                            type: string
-                            oneOf:
-                              - format: ipv4
-                              - const: ""
-                          ipFamilyPolicy:
-                            title: Service IP Family Policy
-                            description: |-
-                              Represents the dual-stack-ness requested or required by this Service. When
-                              utilizing an internal loadbalancer service (ie MetalLB), set this field to
-                              "RequireDualStack" if you want both IPv4 and IPv6 connectivity. The
-                              ipFamilies and clusterIPs fields depend on the value of this field.
-
-                              See [reference](https://kubernetes.io/docs/concepts/services-networking/dual-stack/)
-                            type: string
-                            enum:
-                              - ""
-                              - SingleStack
-                              - PreferDualStack
-                              - RequireDualStack
-                            default: SingleStack
-                          ipFamilies:
-                            title: Service IP Families
-                            description: |-
-                              List of IP families (e.g. IPv4, IPv6) assigned to the service. Default is IPv4 only. When utilizing an internal loadbalancer service (ie MetalLB),
-                              IPv6 would also need to be included in order for the ingress service to allocate an address in that family.
-                            type: array
-                            uniqueItems: true
-                            items:
-                              title: Service IP Family
-                              type: string
-                              enum:
-                                - IPv4
-                                - IPv6
-                            default:
-                              - IPv4
-                          allocateLoadBalancerNodePorts:
-                            title: Load Balancer Node Ports
-                            type: boolean
-                            default: false
-                            description: |-
-                              When enabled node ports will be allocated for the Load Balancer Service.
-
-                              This should be enabled when the cluster is fronted by a proxy load balancer regardless if it is external or internal, and disabled if the cluster uses direct routing of ingress traffic.
-
-                              See [reference](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation)
-                          loadBalancerSourceRanges:
-                            title: Load Balancer Source Ranges
-                            description: |-
-                              Configure the source ranges to allow via the Load Balancer Service.
-                            type: array
-                            items:
-                              type: string
-                            default: []
-                          loadBalancerIP:
-                            title: Load Balancer IP
-                            description: |-
-                              Configure the Load Balancer IP to use an existing IP if supported by the infrastructure provider.
-
-                              > [!important]
-                              > With OpenStack Octavia the floating IP can be created via the CLI beforehand, and one should set the annotation `loadbalancer.openstack.org/keep-floatingip: "true"` to prevent the floating IP to be deleted.
-                            type: string
-                            default: ""
-                          nodePorts:
-                            title: Node Ports
-                            description: Configure the node ports to allocate for the Service.
-                            type: object
-                            additionalProperties: false
-                            properties:
-                              http:
-                                default: 30080
-                                $ref: '#/$defs/port'
-                              https:
-                                default: 30443
-                                $ref: '#/$defs/port'
+                $ref: "#/properties/ingressNginx/$defs/service/properties/enabled"
+              annotations:
+                $ref: "#/properties/ingressNginx/$defs/service/properties/annotations"
+              type:
+                $ref: "#/properties/ingressNginx/$defs/service/properties/type"
+              clusterIP:
+                $ref: "#/properties/ingressNginx/$defs/service/properties/clusterIP"
+              ipFamilyPolicy:
+                $ref: "#/properties/ingressNginx/$defs/service/properties/ipFamilyPolicy"
+              ipFamilies:
+                $ref: "#/properties/ingressNginx/$defs/service/properties/ipFamilies"
+              allocateLoadBalancerNodePorts:
+                $ref: "#/properties/ingressNginx/$defs/service/properties/allocateLoadBalancerNodePorts"
+              loadBalancerIP:
+                $ref: "#/properties/ingressNginx/$defs/service/properties/loadBalancerIP"
+              loadBalancerSourceRanges:
+                $ref: "#/properties/ingressNginx/$defs/service/properties/loadBalancerSourceRanges"
+              nodePorts:
+                $ref: "#/properties/ingressNginx/$defs/service/properties/nodePorts"
+              internal:
+                title: Ingress-NGINX Internal Service
+                description: Configure the Internal Service for traffic to Ingress-NGINX.
+                type: object
+                properties:
+                  enabled:
+                    $ref: "#/properties/ingressNginx/$defs/service/properties/enabled"
+                  annotations:
+                    $ref: "#/properties/ingressNginx/$defs/service/properties/annotations"
+                  type:
+                    $ref: "#/properties/ingressNginx/$defs/service/properties/type"
+                  clusterIP:
+                    $ref: "#/properties/ingressNginx/$defs/service/properties/clusterIP"
+                  ipFamilyPolicy:
+                    $ref: "#/properties/ingressNginx/$defs/service/properties/ipFamilyPolicy"
+                  allocateLoadBalancerNodePorts:
+                    $ref: "#/properties/ingressNginx/$defs/service/properties/allocateLoadBalancerNodePorts"
+                  loadBalancerIP:
+                    $ref: "#/properties/ingressNginx/$defs/service/properties/loadBalancerIP"
+                  loadBalancerSourceRanges:
+                    $ref: "#/properties/ingressNginx/$defs/service/properties/loadBalancerSourceRanges"
+                  nodePorts:
+                    $ref: "#/properties/ingressNginx/$defs/service/properties/nodePorts"
+                anyOf:
+                  - $ref: "#/properties/ingressNginx/$defs/service/properties/disabledCondition"
+                  - $ref: "#/properties/ingressNginx/$defs/service/properties/enabledCondition"
+            anyOf:
+              - $ref: "#/properties/ingressNginx/$defs/service/properties/disabledCondition"
+              - $ref: "#/properties/ingressNginx/$defs/service/properties/enabledCondition"
           useHostPort:
             title: Ingress-NGINX Host Port
             description: |-

--- a/config/wc-config.yaml
+++ b/config/wc-config.yaml
@@ -302,18 +302,17 @@ ingressNginx:
     ## Kubernetes service configuration.
     service:
       internal:
-
         ## Type of service.
         ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
-        type: set-me-if-(.ingressNginx.controller.service.internal.enabled)
+        # type: set-me
 
         ## Annotations to add to service
         ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
         ## Set the additional internal loadbalancer annotation if `type` is "LoadBalancer"
         ## ref: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/README.md#additional-internal-load-balancer
+        ## For Azure use `service.beta.kubernetes.io/azure-load-balancer-internal: "true"`
         ## For Openstack use `service.beta.kubernetes.io/openstack-internal-load-balancer: "true"`
-        ## For Azure use `loadbalancer.openstack.org/proxy-protocol: "true"`
-        annotations: set-me-if-(.ingressNginx.controller.service.internal.enabled)
+        annotations: {}
 
         ## Enable node port allocation
         ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation

--- a/helmfile.d/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile.d/values/ingress-nginx.yaml.gotmpl
@@ -1,7 +1,3 @@
-## nginx configuration
-## Ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/index.md
-##
-
 controller:
   ingressClassResource:
     default: true
@@ -10,159 +6,148 @@ controller:
   extraArgs: {{- toYaml .Values.ingressNginx.controller.extraArgs | nindent 4 }}
   extraEnvs: {{- toYaml .Values.ingressNginx.controller.extraEnvs | nindent 4 }}
 
-  # Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
+  # NGINX configuration, ref: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
   config:
+    annotations-risk-level: {{ .Values.ingressNginx.controller.config.annotationsRiskLevel | quote }}
     disable-ipv6-dns: "true"
-    proxy-body-size: "200m"
     client-body-buffer-size: "256k"
+    proxy-body-size: "200m"
     proxy-buffer-size: "8k"
-    {{ if and .Values.externalTrafficPolicy.local .Values.externalTrafficPolicy.whitelistRange.global }}
-    whitelist-source-range: {{ .Values.externalTrafficPolicy.whitelistRange.global }}
-    {{ end }}
     use-proxy-protocol: {{ .Values.ingressNginx.controller.config.useProxyProtocol | quote }}
+    {{- if and .Values.externalTrafficPolicy.local .Values.externalTrafficPolicy.whitelistRange.global }}
+    whitelist-source-range: {{ .Values.externalTrafficPolicy.whitelistRange.global }}
+    {{- end }}
     {{- with .Values.ingressNginx.controller.additionalConfig }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    annotations-risk-level: {{ .Values.ingressNginx.controller.config.annotationsRiskLevel | quote }}
 
-  # Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
-  # By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller
-  # to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
-  {{ if .Values.ingressNginx.controller.useHostPort }}
-  dnsPolicy: ClusterFirstWithHostNet
-  {{ end }}
-
-  # Set allow-snippet-annotations to false in order to mitigate CVE-2021-25742
   allowSnippetAnnotations: {{ .Values.ingressNginx.controller.allowSnippetAnnotations }}
 
   enableAnnotationValidations: {{ .Values.ingressNginx.controller.enableAnnotationValidations }}
 
-  # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
-  # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
-  # is merged
-  {{ if .Values.ingressNginx.controller.useHostPort }}
+  {{ if .Values | get "ingressNginx.controller.useHostPort" false }}
+  # Ensure we can resolve names in cluster with host network enabled.
+  dnsPolicy: ClusterFirstWithHostNet
+  # TODO: Can be deprecated since https://github.com/kubernetes/kubernetes/issues/23920 is merged.
   hostNetwork: true
   {{ end }}
 
   ## Use host ports 80 and 443
-  ## Disabled by default
-  ##
   hostPort:
-    enabled: {{ .Values.ingressNginx.controller.useHostPort }}
+    enabled: {{ .Values | get "ingressNginx.controller.useHostPort" false }}
 
-  ## Allows customization of the source of the IP address or FQDN to report
-  ## in the ingress status field. By default, it reads the information provided
-  ## by the service. If disable, the status field reports the IP address of the
-  ## node or nodes where an ingress controller pod is running.
+  # When true, report the address or name of the service in ingress status.
+  # When false, report the addresses of the nodes the ingress controller runs on in ingress status.
   publishService:
     enabled:  {{ .Values.ingressNginx.controller.enablepublishService }}
 
-  ## DaemonSet or Deployment
-  ##
   kind: DaemonSet
 
-  # The update strategy to apply to the Deployment or DaemonSet
-  ##
   updateStrategy:
     type: RollingUpdate
 
-  # minReadySeconds to avoid killing pods before we are ready
-  ##
+  # Avoid killing Pods before they are ready
   minReadySeconds: 10
-
-
-  ## Node tolerations for server scheduling to nodes with taints
-  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-  ##
-  tolerations: {{- toYaml .Values.ingressNginx.controller.tolerations | nindent 4 }}
-
-  ## Affinity and anti-affinity
-  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-  ##
-  affinity: {{- toYaml .Values.ingressNginx.controller.affinity | nindent 4 }}
-
-  ## terminationGracePeriodSeconds
-  ## wait up to 1 minutes for the drain of connections
-  ##
+  # Avoid killing Pods immediately to drain connections
   terminationGracePeriodSeconds: 60
 
-  ## Node labels for controller pod assignment
-  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
-  ##
   nodeSelector: {{- toYaml .Values.ingressNginx.controller.nodeSelector | nindent 4 }}
 
-  # Define requests resources to avoid probe issues due to CPU utilization in busy nodes
-  # ref: https://github.com/kubernetes/ingress-nginx/issues/4735#issuecomment-551204903
-  # Ideally, there should be no limits.
-  # https://engineering.indeedblog.com/blog/2019/12/cpu-throttling-regression-fix/
+  tolerations: {{- toYaml .Values.ingressNginx.controller.tolerations | nindent 4 }}
+
+  affinity: {{- toYaml .Values.ingressNginx.controller.affinity | nindent 4 }}
+
   resources: {{- toYaml .Values.ingressNginx.controller.resources | nindent 4 }}
 
   service:
-    {{- if .Values | get "ingressNginx.controller.service.type" "" | eq "LoadBalancer" }}
-    allocateLoadBalancerNodePorts: {{ .Values.ingressNginx.controller.service.allocateLoadBalancerNodePorts }}
-    {{- end }}
-    {{ if .Values.externalTrafficPolicy.local }}
-    ## Set external traffic policy to: "Local" to preserve source IP on
-    ## providers supporting it
-    ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
-    ## Required for IP whitelisting
-    externalTrafficPolicy: "Local"
-    {{ end }}
-    {{ if .Values.ingressNginx.controller.service.enabled }}
+    {{- if .Values | get "ingressNginx.controller.service.enabled" false }}
     enabled: true
-    type: {{ .Values.ingressNginx.controller.service.type }}
+
     annotations: {{- toYaml .Values.ingressNginx.controller.service.annotations | nindent 6 }}
-    loadBalancerSourceRanges: {{- toYaml .Values.ingressNginx.controller.service.loadBalancerSourceRanges | nindent 6 }}
-    {{ else }}
-    enabled: false
-    {{ end }}
-    {{ if .Values.ingressNginx.controller.service.ipFamilyPolicy }}
-    ipFamilyPolicy: {{ .Values.ingressNginx.controller.service.ipFamilyPolicy }}
-    {{ end }}
-    {{ if .Values.ingressNginx.controller.service.ipFamilies }}
-    ipFamilies: {{- toYaml .Values.ingressNginx.controller.service.ipFamilies | nindent 6 }}
-    {{ end }}
-    {{ if eq .Values.ingressNginx.controller.service.type "NodePort" }}
-    nodePorts: {{- toYaml .Values.ingressNginx.controller.service.nodePorts | nindent 6 }}
-    {{ end }}
+
+    type: {{ .Values.ingressNginx.controller.service.type }}
+
     {{- with .Values | get "ingressNginx.controller.service.clusterIP" "" }}
     clusterIP: {{ . }}
+    {{- end }}
+
+    {{- if .Values.externalTrafficPolicy.local }}
+    # Cause external traffic to only go to Pods local to the receiving Node.
+    # Required to preserve source IP for allowlisting with direct routed and proxy loadbalancers without PROXY protocol.
+    externalTrafficPolicy: Local
+    {{- end }}
+
+    {{- with .Values.ingressNginx.controller.service.ipFamilyPolicy }}
+    ipFamilyPolicy: {{ . }}
+    {{- end }}
+    {{- with .Values.ingressNginx.controller.service.ipFamilies }}
+    ipFamilies: {{- toYaml . | nindent 6 }}
+    {{- end }}
+
+    {{- if .Values | get "ingressNginx.controller.service.type" "" | eq "LoadBalancer" }}
+
+    allocateLoadBalancerNodePorts: {{ .Values.ingressNginx.controller.service.allocateLoadBalancerNodePorts }}
+    {{- with .Values | get "ingressNginx.controller.service.loadBalancerSourceRanges" list }}
+    loadBalancerSourceRanges: {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values | get "ingressNginx.controller.service.loadBalancerIP" "" }}
     loadBalancerIP: {{ . }}
     {{- end }}
-    {{ if .Values.ingressNginx.controller.service.internal.enabled }}
+
+    {{- else if .Values | get "ingressNginx.controller.service.type" "" | eq "NodePort" }}
+
+    nodePorts: {{- toYaml .Values.ingressNginx.controller.service.nodePorts | nindent 6 }}
+
+    {{- end }}
+
+    {{- else }}
+    enabled: false
+    {{- end }}
+
     internal:
-      {{- if .Values | get "ingressNginx.controller.service.internal.type" "" | eq "LoadBalancer" }}
-      allocateLoadBalancerNodePorts: {{ .Values.ingressNginx.controller.service.internal.allocateLoadBalancerNodePorts }}
-      {{- end }}
-      enabled: {{ .Values.ingressNginx.controller.service.internal.enabled }}
-      type: {{ .Values.ingressNginx.controller.service.internal.type }}
+      {{- if .Values | get "ingressNginx.controller.service.internal.enabled" false }}
+      enabled: true
+
       annotations: {{- toYaml .Values.ingressNginx.controller.service.internal.annotations | nindent 8 }}
-      loadBalancerSourceRanges: {{- toYaml .Values.ingressNginx.controller.service.internal.loadBalancerSourceRanges | nindent 8 }}
-      {{ if .Values.externalTrafficPolicy.local }}
-      ## Set external traffic policy to: "Local" to preserve source IP on
-      ## providers supporting it
-      ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
-      ## Required for IP whitelisting
-      externalTrafficPolicy: "Local"
-      {{ end }}
-      {{ if .Values.ingressNginx.controller.service.internal.ipFamilyPolicy }}
-      ipFamilyPolicy: {{ .Values.ingressNginx.controller.service.internal.ipFamilyPolicy }}
-      {{ end }}
-      {{ if .Values.ingressNginx.controller.service.internal.ipFamilies }}
-      ipFamilies: {{- toYaml .Values.ingressNginx.controller.service.internal.ipFamilies | nindent 8 }}
-      {{ end }}
-      {{ if eq .Values.ingressNginx.controller.service.internal.type "NodePort" }}
-      nodePorts: {{- toYaml .Values.ingressNginx.controller.service.internal.nodePorts | nindent 8 }}
-      {{ end }}
+
+      type: {{ .Values.ingressNginx.controller.service.internal.type }}
+
       {{- with .Values | get "ingressNginx.controller.service.internal.clusterIP" "" }}
       clusterIP: {{ . }}
+      {{- end }}
+
+      {{- if .Values.externalTrafficPolicy.local }}
+      # Cause external traffic to only go to Pods local to the receiving Node.
+      # Required to preserve source IP for allowlisting with direct routed and proxy loadbalancers without PROXY protocol.
+      externalTrafficPolicy: Local
+      {{- end }}
+
+      {{- with .Values.ingressNginx.controller.service.internal.ipFamilyPolicy }}
+      ipFamilyPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.ingressNginx.controller.service.internal.ipFamilies }}
+      ipFamilies: {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- if .Values | get "ingressNginx.controller.service.internal.type" "" | eq "LoadBalancer" }}
+
+      allocateLoadBalancerNodePorts: {{ .Values.ingressNginx.controller.service.internal.allocateLoadBalancerNodePorts }}
+      {{- with .Values | get "ingressNginx.controller.service.internal.loadBalancerSourceRanges" list }}
+      loadBalancerSourceRanges: {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values | get "ingressNginx.controller.service.internal.loadBalancerIP" "" }}
       loadBalancerIP: {{ . }}
       {{- end }}
-    {{ end }}
+
+      {{- else if .Values | get "ingressNginx.controller.service.internal.type" "" | eq "NodePort" }}
+
+      nodePorts: {{- toYaml .Values.ingressNginx.controller.service.internal.nodePorts | nindent 8 }}
+
+      {{- end }}
+
+      {{- else }}
+      enabled: false
+      {{- end }}
 
   metrics:
     enabled: true
@@ -174,6 +159,8 @@ controller:
   image:
     chroot: true
   containerSecurityContext:
+    allowPrivilegeEscalation: true
+    runAsUser: 101
     seccompProfile:
       type: Localhost
       localhostProfile: profiles/ingress-nginx-chroot.json
@@ -183,30 +170,19 @@ controller:
       add:
       - NET_BIND_SERVICE
       - SYS_CHROOT
-    runAsUser: 101
-    allowPrivilegeEscalation: true
   {{- end }}
 
-## Default 404 backend
-##
 defaultBackend:
-  ##
   enabled: true
 
   name: default-backend
 
-  ## Node tolerations for server scheduling to nodes with taints
-  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-  ##
+  nodeSelector: {{- toYaml .Values.ingressNginx.defaultBackend.nodeSelector | nindent 4 }}
+
   tolerations: {{- toYaml .Values.ingressNginx.defaultBackend.tolerations | nindent 4 }}
 
   affinity: {{- toYaml .Values.ingressNginx.defaultBackend.affinity | nindent 4 }}
 
-  ## Node labels for default backend pod assignment
-  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
-  ##
-  nodeSelector: {{- toYaml .Values.ingressNginx.defaultBackend.nodeSelector | nindent 4 }}
+  topologySpreadConstraints: {{- toYaml .Values.ingressNginx.defaultBackend.topologySpreadConstraints | nindent 4 }}
 
   resources: {{- toYaml .Values.ingressNginx.defaultBackend.resources | nindent 4 }}
-
-  topologySpreadConstraints: {{- toYaml .Values.ingressNginx.defaultBackend.topologySpreadConstraints | nindent 4 }}

--- a/tests/unit/general/bin-conditional-set-me.bats
+++ b/tests/unit/general/bin-conditional-set-me.bats
@@ -46,26 +46,6 @@ _refute_condition_and_warn() {
   refute_output --partial "WARN: ${1} is not set in config"
 }
 
-# bats test_tags=conditional_set_me_ingress_nginx
-@test "conditional-set-me - singular conditions: ingressNginx" {
-
-  yq.set common .ingressNginx.controller.service.enabled 'true'
-  run _apply_normalise_sc
-  _assert_condition_and_warn .\"ingressNginx\".\"controller\".\"service\".\"type\"
-  _assert_condition_and_warn .\"ingressNginx\".\"controller\".\"service\".\"annotations\"
-  run _apply_normalise_wc
-  _assert_condition_and_warn .\"ingressNginx\".\"controller\".\"service\".\"type\"
-  _assert_condition_and_warn .\"ingressNginx\".\"controller\".\"service\".\"annotations\"
-
-  yq.set common .ingressNginx.controller.service.enabled 'false'
-  run _apply_normalise_sc
-  _refute_condition_and_warn .\"ingressNginx\".\"controller\".\"service\".\"type\"
-  _refute_condition_and_warn .\"ingressNginx\".\"controller\".\"service\".\"annotations\"
-  run _apply_normalise_wc
-  _refute_condition_and_warn .\"ingressNginx\".\"controller\".\"service\".\"type\"
-  _refute_condition_and_warn .\"ingressNginx\".\"controller\".\"service\".\"annotations\"
-}
-
 # bats test_tags=conditional_set_me_letsencrypt
 @test "conditional-set-me - singular conditions: letsencrypt" {
 


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice

The conditional configuration validation for Ingress-NGINX is now within the schema rather than done through conditional set-me's.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This flattens the ingress-nginx service schema so that the generated documentation [works](https://github.com/elastisys/welkin/actions/runs/14874764129/job/41769903945).

#### Information to reviewers

Also changed the conditional structure, as jsonschema2md does not support if then else so there were essentially nothing available in the docs before this.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
