### PR TITLE
tests: Optimisations

### DIFF
--- a/bin/common.bash
+++ b/bin/common.bash
@@ -102,6 +102,9 @@ ask_abort() {
 
 # Checks that all dependencies are available and critical ones for matching minor version.
 check_tools() {
+  # Skip in tests
+  [[ "${CK8S_TESTS_HARNESS:-}" != "true" ]] || return 0
+
   local req just_check
 
   if [[ "${1:-}" == "--just-check" ]]; then

--- a/tests/bats.lib.bash
+++ b/tests/bats.lib.bash
@@ -13,6 +13,8 @@ export CHARTS="${ROOT}/helmfile.d/charts"
 export TESTS
 export ROOT
 
+export CK8S_TESTS_HARNESS="true"
+
 log.fatal() {
   if [[ -e /dev/fd/3 ]]; then
     echo "error: ${1}" >&3

--- a/tests/unit/templates/releases.bash
+++ b/tests/unit/templates/releases.bash
@@ -108,9 +108,7 @@ helmfile_template_release() {
     local -a files
     readarray -t files <<<"$(find "${release}" -type f -name '*.yaml')"
 
-    for file in "${files[@]}"; do
-      yq ".metadata.namespace = (.metadata.namespace // \"${namespace}\")" "${file}"
-    done
+    yq ".metadata.namespace = (.metadata.namespace // \"${namespace}\")" "${files[@]}"
 
   else
     echo "error: missing release ${1}/${2}" >&2
@@ -149,10 +147,10 @@ releases_have_through_needs() {
   local selector
   for selector in "${selectors[@]}"; do
     local used_resources
-    used_resources="$(helmfile_template_release "${cluster}" "${selector}" | yq -N "select(. != null) | [${used_expression}] | .[]" | sort -u)"
+    used_resources="$(helmfile_template_release "${cluster}" "${selector}" | yq -N "select(. != null) | [${used_expression}] | sort | unique | .[]")"
 
     local created_resources
-    created_resources="$(helmfile_template_release_needs "${cluster}" "${selector}" | yq -N "select(. != null) | [${created_expression}] | .[]" | sort -u)"
+    created_resources="$(helmfile_template_release_needs "${cluster}" "${selector}" | yq -N "select(. != null) | [${created_expression}] | sort | unique | .[]")"
 
     local uniques
     # print used resources once and created resources twice, then filter on totally unique identifiers


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Removes a for loop that added 100 seconds for some tests on my machine.

Removes check tools for tests that adds 0.5-1 seconds per bin script invocation.

Simplifies a sort unique that could be done in yq before it.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [x] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
