### PR TITLE
harbor-restore command added

### DIFF
--- a/bin/ck8s
+++ b/bin/ck8s
@@ -38,6 +38,7 @@ usage() {
   echo "  upgrade <wc|sc|both> unlock                     reset an upgrade to allow trying again" 1>&2
   echo "  validate <wc|sc>                                validates config files" 1>&2
   echo "  check-requirements                              check the locally installed tool versions" 1>&2
+  echo "  harbor-restore [--backup-id <value>] [--azure-rclone-fixup]   restores Harbor using detected storage type" 1>&2
   echo "  version <all|both|config|sc|wc>                 shows apps version" 1>&2
   exit 1
 }
@@ -162,6 +163,11 @@ diagnostics)
   [[ "${2}" =~ ^(wc|sc)$ ]] || usage
   shift
   "${here}/diagnostics.bash" "${@}"
+  ;;
+harbor-restore)
+  check_tools
+  shift
+  "${here}/harbor-restore.sh" "${@}"
   ;;
 version) # all|both|sc|wc
   shift

--- a/bin/harbor-restore.sh
+++ b/bin/harbor-restore.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+here="$(readlink -f "$(dirname "${0}")")"
+
+# shellcheck source=bin/common.bash
+source "${here}/common.bash"
+
+usage() {
+  echo "Usage: $(basename "$0") [--backup-id <backup_id_value>] [--azure-rclone-fixup]" >&2
+  echo "" >&2
+  echo "Restores Harbor from a backup using the detected storage type." >&2
+  echo "" >&2
+  echo "Options:" >&2
+  echo "  --backup-id <value>      Restore from a specific backup ID" >&2
+  echo "  --azure-rclone-fixup     Run Azure rclone fixup job for Azure storage" >&2
+  exit 1
+}
+
+declare SPECIFIC_BACKUP_ARG=""
+declare AZURE_RCLONE_FIXUP_FLAG=false # Default: do not run the Azure rclone fixup job
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --backup-id)
+    if [ -n "${2:-}" ]; then
+      SPECIFIC_BACKUP_ARG="$2"
+      shift 2
+    else
+      log_fatal "--backup-id requires a value"
+    fi
+    ;;
+  --azure-rclone-fixup)
+    AZURE_RCLONE_FIXUP_FLAG=true
+    shift 1
+    ;;
+  --help)
+    usage
+    ;;
+  *)
+    log_fatal "Unknown argument: $1"
+    ;;
+  esac
+done
+
+# Create temporary files
+TMP_JOB_FILE=$(mktemp)
+TMP_RCLONE_JOB_FILE=$(mktemp)
+
+# Cleanup function using common.bash append_trap
+append_trap "rm -f ${TMP_JOB_FILE}" EXIT
+append_trap "rm -f ${TMP_RCLONE_JOB_FILE}" EXIT
+
+# Display warning and require confirmation
+log_warning "This script will restore Harbor from a backup, which will overwrite all current Harbor data."
+log_warning "This includes all images, charts, users, projects, and configurations."
+ask_abort
+
+check_tools "$@"
+
+log_info "Loading configuration..."
+config_load "sc"
+
+# Auto-detect STORAGE_TYPE
+if ! STORAGE_TYPE=$(yq --exit-status '.objectStorage.type' "${config[config_file_sc]}"); then
+  log_fatal "Missing or empty '.objectStorage.type' in merged configuration. This script requires '.objectStorage.type' to be set to either 's3' or 'azure'."
+fi
+
+# Check if STORAGE_TYPE is not 's3' or 'azure'
+if ! [[ "${STORAGE_TYPE}" =~ ^(s3|azure)$ ]]; then
+  log_fatal "Unsupported '.objectStorage.type' ('${STORAGE_TYPE}') found in merged configuration. This script currently only supports 's3' or 'azure' for Harbor restore."
+fi
+
+# Check if Harbor is using an internal database
+if ! HARBOR_DB_TYPE=$(yq --exit-status '.harbor.database.type' "${config[config_file_sc]}"); then
+  log_fatal "Missing or empty '.harbor.database.type' in merged configuration."
+fi
+
+if [ "${HARBOR_DB_TYPE}" != "internal" ]; then
+  log_fatal "This script only supports restoring Harbor with an internal database. Current database type is '${HARBOR_DB_TYPE}'."
+fi
+
+log_info "Starting Harbor restore from ${STORAGE_TYPE}..."
+
+# Determine the SPECIFIC_BACKUP key for the restore job
+# Optional: 1747441979 or 1747441979.tgz or backups/1747441979.tgz
+if [ -n "${SPECIFIC_BACKUP_ARG:-}" ]; then
+  if [[ "${SPECIFIC_BACKUP_ARG}" =~ ^[0-9]+$ ]]; then
+    # Purely numeric ID provided, construct the full path with .tgz extension
+    export SPECIFIC_BACKUP="backups/${SPECIFIC_BACKUP_ARG}.tgz"
+    log_info "Interpreted numeric ID to backup path: ${SPECIFIC_BACKUP}"
+  elif [[ "${SPECIFIC_BACKUP_ARG}" == backups/* && "${SPECIFIC_BACKUP_ARG}" == *.tgz ]]; then
+    # Full path like backups/ID.tgz provided
+    export SPECIFIC_BACKUP="${SPECIFIC_BACKUP_ARG}"
+    log_info "Using provided full backup path: ${SPECIFIC_BACKUP}"
+  elif [[ "${SPECIFIC_BACKUP_ARG}" != */* && "${SPECIFIC_BACKUP_ARG}" == *.tgz ]]; then
+    # Filename like ID.tgz provided, prepend backups/
+    export SPECIFIC_BACKUP="backups/${SPECIFIC_BACKUP_ARG}"
+    log_info "Interpreted filename to backup path: ${SPECIFIC_BACKUP}"
+  else
+    log_fatal "Invalid format for specific backup argument: '${SPECIFIC_BACKUP_ARG}'. Please provide a numeric backup ID (e.g., 1747441979), a filename with .tgz extension (e.g., 1747441979.tgz), or a full path (e.g., backups/1747441979.tgz)."
+  fi
+  log_info "Using specific backup key for restore job: ${SPECIFIC_BACKUP}"
+else
+  export SPECIFIC_BACKUP="" # This will trigger the latest backup logic in the underlying restore script
+  log_info "No specific backup argument provided; the latest backup will be restored."
+fi
+
+# Common pre-restore: Scale down Harbor deployments
+log_info "Scaling down Harbor deployments..."
+"${root_path}/bin/ck8s" ops kubectl sc scale deployment --replicas 0 -n harbor --all
+
+# Storage-specific setup
+if [ "${STORAGE_TYPE}" == "s3" ]; then
+  log_info "Setting up for S3 restore..."
+  S3_BUCKET=$(yq '.objectStorage.buckets.harbor' "${config[config_file_sc]}")
+  S3_REGION_ENDPOINT=$(yq '.objectStorage.s3.regionEndpoint' "${config[config_file_sc]}")
+  export S3_BUCKET
+  export S3_REGION_ENDPOINT
+  envsubst >"${TMP_JOB_FILE}" <"${root_path}/restore/harbor/restore-harbor-job.yaml"
+  "${root_path}/bin/ck8s" ops kubectl sc create configmap -n harbor restore-harbor --from-file="${root_path}/restore/harbor/restore-harbor.sh" --dry-run=client -o yaml | "${root_path}/bin/ck8s" ops kubectl sc apply -f -
+elif [ "${STORAGE_TYPE}" == "azure" ]; then
+  log_info "Setting up for Azure restore..."
+  if [ "${AZURE_RCLONE_FIXUP_FLAG}" = true ]; then
+    log_info "Running Azure rclone fixup job..."
+    S3_BUCKET=$(yq '.objectStorage.buckets.harbor' "${config[config_file_sc]}")
+    AZURE_ACCOUNT=$(yq '.objectStorage.azure.storageAccountName' "${config[config_file_sc]}")
+
+    # Use SOPS to extract the Azure storage account key
+    AZURE_KEY=$(sops -d --extract '["objectStorage"]["azure"]["storageAccountKey"]' "${secrets[secrets_file]}")
+    export S3_BUCKET
+    export AZURE_ACCOUNT
+    export AZURE_KEY
+    envsubst >"${TMP_RCLONE_JOB_FILE}" <"${root_path}/restore/harbor/harbor-rclone-azure.yaml"
+    "${root_path}/bin/ck8s" ops kubectl sc apply -f "${TMP_RCLONE_JOB_FILE}"
+    log_info "Waiting for Rclone data move job to complete..."
+    "${root_path}/bin/ck8s" ops kubectl sc wait --for=condition=complete job -n harbor harbor-restore-rclone-move --timeout=-1s
+    log_info "Cleaning up Rclone data move job artifacts..."
+    "${root_path}/bin/ck8s" ops kubectl sc delete -f "${TMP_RCLONE_JOB_FILE}"
+  else
+    log_info "Skipping Azure Rclone data move. Use --azure-rclone-fixup if this step is needed for your backup."
+  fi
+  log_info "Preparing Harbor database restore for Azure..."
+  envsubst >"${TMP_JOB_FILE}" <"${root_path}/restore/harbor/restore-harbor-job-azure.yaml"
+  "${root_path}/bin/ck8s" ops kubectl sc create configmap -n harbor restore-harbor --from-file="${root_path}/restore/harbor/restore-harbor.sh" --dry-run=client -o yaml | "${root_path}/bin/ck8s" ops kubectl sc apply -f -
+else
+  log_fatal "Invalid storage type '${STORAGE_TYPE}'. Must be 's3' or 'azure'."
+fi
+
+# Common restore steps
+log_info "Applying network policies and restore job..."
+"${root_path}/bin/ck8s" ops kubectl sc apply -n harbor -f "${root_path}/restore/harbor/network-policies-harbor.yaml"
+"${root_path}/bin/ck8s" ops kubectl sc apply -n harbor -f "${TMP_JOB_FILE}"
+
+log_info "Waiting for Harbor restore job to complete..."
+"${root_path}/bin/ck8s" ops kubectl sc wait --for=condition=complete job -n harbor restore-harbor-job --timeout=-1s
+
+# Common post-restore: Scale up Harbor deployments
+log_info "Scaling up Harbor deployments..."
+"${root_path}/bin/ck8s" ops kubectl sc scale deployment --replicas 1 -n harbor --all
+
+# Common cleanup
+log_info "Cleaning up restore artifacts..."
+"${root_path}/bin/ck8s" ops kubectl sc delete -n harbor -f "${root_path}/restore/harbor/network-policies-harbor.yaml"
+"${root_path}/bin/ck8s" ops kubectl sc delete -n harbor -f "${TMP_JOB_FILE}"
+"${root_path}/bin/ck8s" ops kubectl sc delete configmap -n harbor restore-harbor
+
+log_info "Harbor restore from ${STORAGE_TYPE} completed successfully."
+log_info "Post-restore steps from documentation (manual intervention may be required):"
+log_info "- If restoring to a different domain, re-run the init job (see docs)."
+log_info "- If restoring between Swift and S3/Azure, manual object storage modifications may be needed (see docs)."

--- a/restore/harbor/README.md
+++ b/restore/harbor/README.md
@@ -1,13 +1,152 @@
 # Restore Harbor
 
-With the k8s job you can restore the database in Harbor from a backup in S3 or Azure blob storage.
-_Note this restore is only designed for internal harbor database and not for an external database_
-The steps should be performed from the `compliantkubernetes-apps` root directory.
+This document describes how to restore Harbor from a backup in S3 or Azure blob storage using the `./bin/ck8s harbor-restore` command.
+_Note this restore is only designed for internal harbor database and not for an external database._
+The script should be performed from the `compliantkubernetes-apps` root directory.
 
 Before restoring the database, make sure that Harbor is installed.
 It can be installed normally.
 
-## Specific backup
+## Prerequisites
+
+- Ensure `yq`, `sops`, `envsubst`and `kubectl` are installed and configured.
+- Ensure `CK8S_CONFIG_PATH` is set correctly.
+
+## Usage
+
+The script automates the steps previously outlined in this document.
+It automatically detects your `objectStorage.type` (s3 or azure) from `${CK8S_CONFIG_PATH}/defaults/common-config.yaml`.
+
+```bash
+./bin/ck8s harbor-restore [--backup-id <specific_backup_id>] [--azure-rclone-fixup]
+```
+
+- **`--backup-id <specific_backup_id>`**: (Optional) Specify the backup to restore. This can be:
+    - A numeric ID (e.g., `1747441979`). The script will form the path as `backups/ID.tgz`.
+    - A filename (e.g., `1747441979.tgz`). The script will form the path as `backups/filename`.
+    - A full path (e.g., `backups/1747441979.tgz`).
+        If omitted, the latest backup will be used.
+- **`--azure-rclone-fixup`**: (Optional, Azure Storage Type Only) If your `objectStorage.type` is `azure` and this flag is specified, the script runs an Rclone job to correct potential path issues for Harbor image data. This is typically needed if you are restoring in Azure from a backup that was an rclone destination from a non-Azure source (e.g., S3). See the "Azure Rclone Data Move" section below for more details.
+
+### Listing Available Backups
+
+To find a specific backup ID or filename, you can use the following commands. The backups are typically named with a Unix timestamp and have a `.tgz` extension (e.g., `1747441979.tgz`).
+
+<details>
+    <summary>S3</summary>
+
+```bash
+s3cmd --config <(sops -d ${CK8S_CONFIG_PATH}/.state/s3cfg.ini) ls s3://$(yq '.objectStorage.buckets.harbor' "${CK8S_CONFIG_PATH}/defaults/sc-config.yaml")/backups/
+```
+
+</details>
+
+<details>
+    <summary>Azure</summary>
+
+```bash
+export AZURE_LOCATION=$(yq '.objectStorage.azure.region' "${CK8S_CONFIG_PATH}/common-config.yaml" ) # Or your specific Azure location
+./scripts/azure/storage-manager.sh list-harbor-backups
+```
+
+_(Note: `storage-manager.sh` might need `AZURE_ACCOUNT_NAME` and `AZURE_CONTAINER_NAME` to be set or derived correctly within the script or environment for listing backups. The restore script handles these for the restore process itself based on `CK8S_CONFIG_PATH` values.)_
+
+</details>
+
+### Example
+
+To restore the latest backup (storage type will be auto-detected):
+
+```bash
+./bin/ck8s harbor-restore
+```
+
+To restore a specific backup using its numeric ID (storage type will be auto-detected):
+
+```bash
+./bin/ck8s harbor-restore --backup-id 1747614779
+```
+
+To restore a specific backup using its filename (storage type will be auto-detected):
+
+```bash
+./bin/ck8s harbor-restore --backup-id 1747528228.tgz
+```
+
+To restore an Azure backup and run the rclone path fixup job:
+
+```bash
+./bin/ck8s harbor-restore --backup-id <your_backup_id> --azure-rclone-fixup
+```
+
+## Manual Steps (If Required Post-Restore)
+
+The script will provide reminders for these, but refer to the sections below if you encounter issues or have specific scenarios.
+
+<details>
+    <summary>Restore to a different domain</summary>
+
+If you are restoring harbor to a new environment with a different domain, you need to re-run the init job. First, make sure the harbor admin password is the same as in the old environment:
+
+```bash
+# Edit harbor.password
+sops ${CK8S_CONFIG_PATH}/secrets.yaml
+```
+
+Then, re-run the init job:
+
+```bash
+./bin/ck8s ops kubectl sc delete job -n harbor init-harbor-job
+./bin/ck8s ops helmfile sc -l app=harbor sync
+```
+
+If the new harbor is using a dex instance with a different domain compared to the dex the old harbor was using, then when users login via dex harbor will not recognize them as the same user. Harbor will have the old OIDC users in the database, but when the new ones are created at first login they will conflict with the old ones and you will get a error like `failed to create user record: user <user> or email <email> already exists`.
+
+To fix this you need to login as an admin user (you can login with the default, non-oidc admin at the URL `/account/sign-in`) and then delete the old users in the list of users. Users can then create new users again by logging. Then you need to set their permissions again.
+
+</details>
+
+<details>
+    <summary>Restore between swift and s3/azure</summary>
+
+If you are restoring Harbor from an environment that is using swift to an environment that is using s3 (or vice versa), then you need to modify some files in the object storage.
+
+In swift Harbor stores most of the image data under `files/docker/` while in s3 it is stored under just `docker/`. This means that if you simply copy the data from swift to s3, then you need to rename all files under `files/docker/<filename>` to `docker/<filename>` or vice versa.
+
+If you do not do this, then if you try to pull an old image you will get errors like: `Error response from daemon: manifest for <image> not found: manifest unknown: manifest unknown`
+
+_(Note: The `./bin/ck8s harbor-restore` command currently supports S3 and Azure. Swift specific interactions are not built into the script.)_
+
+</details>
+
+<details>
+    <summary>Azure Rclone Data Move (Handled by script)</summary>
+
+If you are restoring Harbor in an Azure environment (i.e., `objectStorage.type` is `azure`) from a bucket that was previously a rclone destination where the source was not Azure (e.g. S3), the path for the Harbor image data might be incorrect. This is due to Harbor storing image data with an extra `/` at the start of the path when the storage is Azure.
+The `./bin/ck8s harbor-restore` command attempts to handle this by running an rclone job to move the data **if your `objectStorage.type` is `azure` and you provide the `--azure-rclone-fixup` flag**.
+If you use this flag in the appropriate Azure scenario, you do not need to perform these manual steps.
+
+The original manual steps were:
+
+```bash
+# export S3_BUCKET=$(yq \'.objectStorage.buckets.harbor\' \"${CK8S_CONFIG_PATH}/defaults/sc-config.yaml\" )
+# export AZURE_ACCOUNT=$(yq \'.objectStorage.azure.storageAccountName\' \"${CK8S_CONFIG_PATH}/common-config.yaml\" )
+# export AZURE_KEY=$(sops -d --extract \'[\"objectStorage\"][\"azure\"][\"storageAccountKey\"]\' \"${CK8S_CONFIG_PATH}/secrets.yaml\" )
+# envsubst > tmp-rclone-job.yaml < restore/harbor/harbor-rclone-azure.yaml
+# ./bin/ck8s ops kubectl sc apply -f tmp-rclone-job.yaml
+# ./bin/ck8s ops kubectl sc wait --for=condition=complete job -n rclone harbor-restore-rclone-move --timeout=-1s # Note: script uses -n harbor
+# ./bin/ck8s ops kubectl sc delete -f tmp-rclone-job.yaml
+# rm -v tmp-rclone-job.yaml
+```
+
+</details>
+
+## Deprecated: Old Manual Restore Steps
+
+The following sections detail the original manual commands. These are kept for reference but the `./bin/ck8s harbor-restore` command should be used.
+
+<details>
+    <summary>Old: Specific backup</summary>
 
 By default the job will restore the latest backup.
 The environment variable `SPECIFIC_BACKUP` can be used to specify which backup to use.
@@ -36,109 +175,67 @@ export AZURE_LOCATION=swedencentral
 Then set:
 
 ```bash
-export SPECIFIC_BACKUP=<backups/xxxxxxxxxx.sql.gz> # Optional
+export SPECIFIC_BACKUP=<backups/xxxxxxxxxx.tgz> # Optional, e.g. backups/1747441979.tgz
 ```
 
-## Restore job S3
+</details>
+
+<details>
+    <summary>Old: Restore job S3</summary>
 
 Setup the necessary job.yaml and configmap:
 
 ```bash
-export S3_BUCKET=$(yq '.objectStorage.buckets.harbor' "${CK8S_CONFIG_PATH}/defaults/sc-config.yaml" )
-export S3_REGION_ENDPOINT=$(yq '.objectStorage.s3.regionEndpoint' "${CK8S_CONFIG_PATH}/common-config.yaml")
-envsubst > tmp-job.yaml < restore/harbor/restore-harbor-job.yaml
-./bin/ck8s ops kubectl sc create configmap -n harbor restore-harbor --from-file=restore/harbor/restore-harbor.sh
+# export S3_BUCKET=$(yq \'.objectStorage.buckets.harbor\' \"${CK8S_CONFIG_PATH}/defaults/sc-config.yaml\" )
+# export S3_REGION_ENDPOINT=$(yq \'.objectStorage.s3.regionEndpoint\' \"${CK8S_CONFIG_PATH}/common-config.yaml\")
+# envsubst > tmp-job.yaml < restore/harbor/restore-harbor-job.yaml
+# ./bin/ck8s ops kubectl sc create configmap -n harbor restore-harbor --from-file=restore/harbor/restore-harbor.sh
 ```
 
-## Restore job Azure
+</details>
 
-### Rclone move data
-
-If you are restoring Harbor in Azure from a bucket that was previously a rclone destination where the source was not Azure, then the path for the Harbor image data is likely wrong.
-Due to an [issue with Harbor](https://github.com/distribution/distribution/issues/1247) it is storing image data with an extra `/` at the start of the path for Azure.
-But it is not the same for other object storage types, so if the data was copied from e.g. S3 then it will likely be wrong now.
-The following steps will create a rclone job that will move all of the harbor image data to the correct path with an extra `/`.
-
-```bash
-export S3_BUCKET=$(yq '.objectStorage.buckets.harbor' "${CK8S_CONFIG_PATH}/defaults/sc-config.yaml" )
-export AZURE_ACCOUNT=$(yq '.objectStorage.azure.storageAccountName' "${CK8S_CONFIG_PATH}/common-config.yaml" )
-export AZURE_KEY=$(sops -d --extract '["objectStorage"]["azure"]["storageAccountKey"]' "${CK8S_CONFIG_PATH}/secrets.yaml" )
-envsubst > tmp-rclone-job.yaml < restore/harbor/harbor-rclone-azure.yaml
-./bin/ck8s ops kubectl sc apply -f tmp-rclone-job.yaml
-./bin/ck8s ops kubectl sc wait --for=condition=complete job -n rclone harbor-restore-rclone-move --timeout=-1s
-```
-
-Clean up:
-
-```bash
-./bin/ck8s ops kubectl sc delete -f tmp-rclone-job.yaml
-rm -v tmp-rclone-job.yaml
-```
-
-### Prepare for Harbor database restore
+<details>
+    <summary>Old: Restore job Azure - Prepare for Harbor database restore</summary>
 
 Setup the necessary job.yaml and configmap:
 
 ```bash
-envsubst > tmp-job.yaml < restore/harbor/restore-harbor-job-azure.yaml
-./bin/ck8s ops kubectl sc create configmap -n harbor restore-harbor --from-file=restore/harbor/restore-harbor.sh
+# envsubst > tmp-job.yaml < restore/harbor/restore-harbor-job-azure.yaml
+# ./bin/ck8s ops kubectl sc create configmap -n harbor restore-harbor --from-file=restore/harbor/restore-harbor.sh
 ```
 
-## Restore common
+</details>
+
+<details>
+    <summary>Old: Restore common</summary>
 
 While restoring we need to stop all harbor pods except for the database.
 
 ```bash
-./bin/ck8s ops kubectl sc scale deployment --replicas 0 -n harbor --all
+# ./bin/ck8s ops kubectl sc scale deployment --replicas 0 -n harbor --all
 ```
 
 Create the job and wait until it has completed:
 
 ```bash
-./bin/ck8s ops kubectl sc apply -n harbor -f restore/harbor/network-policies-harbor.yaml
-./bin/ck8s ops kubectl sc apply -n harbor -f tmp-job.yaml
-./bin/ck8s ops kubectl sc wait --for=condition=complete job -n harbor restore-harbor-job --timeout=-1s
+# ./bin/ck8s ops kubectl sc apply -n harbor -f restore/harbor/network-policies-harbor.yaml
+# ./bin/ck8s ops kubectl sc apply -n harbor -f tmp-job.yaml
+# ./bin/ck8s ops kubectl sc wait --for=condition=complete job -n harbor restore-harbor-job --timeout=-1s
 ```
 
 Restore the pods:
 
 ```bash
-./bin/ck8s ops kubectl sc scale deployment --replicas 1 -n harbor --all
+# ./bin/ck8s ops kubectl sc scale deployment --replicas 1 -n harbor --all
 ```
 
 Clean up:
 
 ```bash
-./bin/ck8s ops kubectl sc delete -n harbor -f restore/harbor/network-policies-harbor.yaml
-./bin/ck8s ops kubectl sc delete -n harbor -f tmp-job.yaml
-./bin/ck8s ops kubectl sc delete configmap -n harbor restore-harbor
-rm -v tmp-job.yaml
+# ./bin/ck8s ops kubectl sc delete -n harbor -f restore/harbor/network-policies-harbor.yaml
+# ./bin/ck8s ops kubectl sc delete -n harbor -f tmp-job.yaml
+# ./bin/ck8s ops kubectl sc delete configmap -n harbor restore-harbor
+# rm -v tmp-job.yaml
 ```
 
-### Restore to a different domain
-
-If you are restoring harbor to a new environment with a different domain, you need to re-run the init job. First, make sure the harbor admin password is the same as in the old environment:
-
-```bash
-# Edit harbor.password
-sops ${CK8S_CONFIG_PATH}/secrets.yaml
-```
-
-Then, re-run the init job:
-
-```bash
-./bin/ck8s ops kubectl sc delete job -n harbor init-harbor-job
-./bin/ck8s ops helmfile sc -l app=harbor sync
-```
-
-If the new harbor is using a dex instance with a different domain compared to the dex the old harbor was using, then when users login via dex harbor will not recognize them as the same user. Harbor will have the old OIDC users in the database, but when the new ones are created at first login they will conflict with the old ones and you will get a error like `failed to create user record: user <user> or email <email> already exists`.
-
-To fix this you need to login as an admin user (you can login with the default, non-oidc admin at the URL `/account/sign-in`) and then delete the old users in the list of users. Users can then create new users again by logging. Then you need to set their permissions again.
-
-### Restore between swift and s3
-
-If you are restoring Harbor from an environment that is using swift to an environment that is using s3 (or vice versa), then you need to modify some files in the object storage.
-
-In swift Harbor stores most of the image data under `files/docker/` while in s3 it is stored under just `docker/`. This means that if you simply copy the data from swift to s3, then you need to rename all files under `files/docker/<filename>` to `docker/<filename>` or vice versa.
-
-If you do not do this, then if you try to pull an old image you will get errors like: `Error response from daemon: manifest for <image> not found: manifest unknown: manifest unknown`
+</details>

--- a/restore/rclone/README.md
+++ b/restore/rclone/README.md
@@ -72,9 +72,6 @@ objectStorage:
 
 Specify destinations and sources you want to use, follows the same structure as `.objectStorage.type` does ([config schema](https://elastisys.io/welkin/operator-manual/schema/config-properties-object-storage-config-properties-rclone-restore-config)) ([secrets schema](https://elastisys.io/welkin/operator-manual/schema/secrets-properties-object-storage-secrets-properties-rclone-restore-secrets/)):
 
-> [!warning]
-> [Known issue](https://github.com/elastisys/compliantkubernetes-apps/issues/2303): Restoring Harbor from S3 to Azure does not currently work.
-
 ```yaml
 # file: sc-config.yaml
 objectStorage:


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This PR introduces a new script and CLI command for restoring Harbor from backups.

Key features include:
- **New Script**: `bin/harbor-restore.sh` is added to manage the Harbor restore process.
- **CLI Integration**: The `bin/ck8s` script now includes a `harbor-restore` command, which invokes the new restore script. Users can run `./bin/ck8s harbor-restore [--backup-id <value>] [--azure-rclone-fixup]`.
- **Automatic Storage Detection**: The script automatically detects the object storage type (S3 or Azure) from `CK8S_CONFIG_PATH/defaults/common-config.yaml`.
- **Flexible Backup Selection**:
    - Users can restore the latest backup by default.
    - Specific backups can be restored using the `--backup-id` argument. The ID can be a numeric timestamp, a filename like `1747441979.tgz`, or a full path like `backups/1747441979.tgz`.
- **Azure Rclone Fixup**: An optional `--azure-rclone-fixup` flag is available for Azure restores. This addresses potential path issues when restoring data originally backed up from a non-Azure rclone destination (e.g., S3) to Azure. The fixup job moves data within the Azure bucket to the correct paths expected by Harbor.
- **Restore Workflow**:
    1. Scales down Harbor deployments.
    2. Performs storage-specific setup (e.g., configuring S3 bucket/region or Azure account/key).
    3. If `--azure-rclone-fixup` is specified for Azure, runs a Kubernetes job to move data within the Azure storage container.
    4. Applies network policies and the Harbor restore Kubernetes job.
    5. Waits for the restore job to complete.
    6. Scales Harbor deployments back up.
    7. Cleans up temporary files and Kubernetes resources (jobs, configmaps, network policies).
- **Error Handling**: The script includes checks for `CK8S_CONFIG_PATH`, valid storage types, and correct argument usage, providing informative error messages.
- **Prerequisites**: The script must be run from the `compliantkubernetes-apps` root directory.

This functionality provides a standardized and automated way to restore Harbor instances, enhancing operational manageability.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

To test this PR:
1. Ensure `CK8S_CONFIG_PATH` is set and points to a valid configuration directory.
2. Ensure `yq` and `sops` are installed if testing Azure with secrets.
3. Have a Harbor backup available in the configured S3 or Azure storage.
4. Run the script from the `compliantkubernetes-apps` root directory:
   - For S3: `./bin/ck8s harbor-restore` (latest backup) or `./bin/ck8s harbor-restore --backup-id <your-backup-id>`
   - For Azure: `./bin/ck8s harbor-restore` (latest backup) or `./bin/ck8s harbor-restore --backup-id <your-backup-id>`
   - For Azure with rclone fixup: `./bin/ck8s harbor-restore --azure-rclone-fixup` or `./bin/ck8s harbor-restore --backup-id <your-backup-id> --azure-rclone-fixup`
5. Monitor the Kubernetes jobs and Harbor pods.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive (introduces a new command, involves scaling deployments)
    - [x] The change requires no migration steps (it's a new, standalone feature)
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [x] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\) (A new command should be documented)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change (No direct impact on existing metrics expected)
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change (Verify during testing)
- PodSecurityPolicy checks:
    - [x] Any changed Pod is covered by Kubernetes Pod Security Standards (The restore job should adhere to existing standards)
    - [x] Any changed Pod is covered by Gatekeeper Pod Security Policies (The restore job should adhere to existing policies)
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies (Verify during testing)
- NetworkPolicy checks:
    - [x] Any changed Pod is covered by Network Policies (Network policies are applied as part of the script)
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard (Verify during testing)
- Audit checks:
    - [x] The change does not cause any unnecessary Kubernetes audit events (Standard job/pod/configmap operations)
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco (Verify during testing)
- Bug checks:
    - [ ] The bug fix is covered by regression tests (N/A - new feature)
