### PR TITLE
add kubernetes access tests

### DIFF
--- a/config/schemas/secrets.yaml
+++ b/config/schemas/secrets.yaml
@@ -562,6 +562,32 @@ properties:
         title: Dex Static Password
         format: crypt
         type: string
+      extraStaticLogins:
+        title: Extra Static Logins
+        description: Configure additional static logins for Dex.
+        type: array
+        items:
+          title: Extra Static Login
+          description: Additional static logins for Dex.
+          type: object
+          $comment: the password field can be used to store the password in plain text, and it will not be applied to the environment.
+          properties:
+            email:
+              title: Email that the static login will use.
+              type: string
+              oneOf:
+                - format: email
+                - $ref: '#/$defs/encrypted'
+            hash:
+              title: Dex Static Password
+              format: crypt
+              type: string
+            username:
+              title: User ID
+              type: string
+            userID:
+              title: User ID
+              type: string
   issuers:
     title: Issuers Secrets
     description: Configure secrets for issuers.

--- a/config/secrets.yaml
+++ b/config/secrets.yaml
@@ -171,6 +171,12 @@ dex:
     #    name: 'Example App'
     #    redirectURIs:
     #      - 'http://192.168.42.219:31850/oauth2/callback'
+  extraStaticLogins: []
+    # - email: dev@example.com
+    #   userID: 08a8684b-db88-4b73-90a9-3cd1661f5467
+    #   username: dev
+    #   password: password
+    #   hash: $2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W
 issuers:
   secrets: {}
     # route53-credentials-secret:

--- a/helmfile.d/values/dex.yaml.gotmpl
+++ b/helmfile.d/values/dex.yaml.gotmpl
@@ -96,6 +96,11 @@ config:
       hash: {{ .Values.dex.staticPassword | default "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W" }}
       username: "admin"
       userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+  {{ if .Values.dex.extraStaticLogins }}
+    {{- range .Values.dex.extraStaticLogins }}
+    - {{ omit . "password" | toYaml | nindent 6 }}
+    {{- end }}
+  {{ end }}
 {{ end }}
 
 securityContext:

--- a/tests/cypress.config.js
+++ b/tests/cypress.config.js
@@ -4,6 +4,26 @@ module.exports = defineConfig({
   env: process.env,
   e2e: {
     setupNodeEvents(on, config) {
+      const { spawn } = require('child_process');
+
+      on('task', {
+        log(message) {
+          console.log(message)
+          return null
+        },
+        kubectlLogin(kubeconfig) {
+          return new Promise((resolve, reject) => {
+            process.env.KUBECONFIG = kubeconfig
+            var child = spawn("kubectl", ["auth", "whoami"],
+              {
+                stdio: "ignore",
+                detached: true
+              }
+            ).unref();
+            resolve(null)
+          })
+        }
+      })
       config.env = {
         ...process.env,
         ...config.env

--- a/tests/end-to-end/kubernetes/allow-root-nginx.yaml
+++ b/tests/end-to-end/kubernetes/allow-root-nginx.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-root-nginx
+spec:
+  podSelector:
+    matchLabels:
+      app: root-nginx
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: root-nginx
+  name: root-nginx
+spec:
+  restartPolicy: Never
+  containers:
+    - name: nginx
+      image: nginx:stable
+      resources:
+        requests:
+          memory: 64Mi
+          cpu: 250m
+        limits:
+          memory: 128Mi
+          cpu: 500m

--- a/tests/end-to-end/kubernetes/authentication-admin.cy.js
+++ b/tests/end-to-end/kubernetes/authentication-admin.cy.js
@@ -1,0 +1,32 @@
+describe("kubernetes authentication", function() {
+  before(function() {
+    cy.withTestKubeconfig("wc", "static-admin", "true")
+  })
+
+  after(function() {
+    cy.deleteTestKubeconfig("wc", "static-admin")
+  })
+
+  it("can login via static dex user", function() {
+
+    cy.yqDig("sc", ".dex.enableStaticLogin")
+      .then(staticLoginEnabled => {
+        if (staticLoginEnabled !== "true") {
+          this.skip("dex static login is not enabled")
+        }
+      })
+
+    cy.task('kubectlLogin', Cypress.env("KUBECONFIG"))
+    cy.visit(`http://localhost:8000`)
+
+    cy.dexStaticLogin()
+
+    cy.origin('http://localhost:8000', () => {
+      cy.contains("Authenticated")
+        .should("exist")
+
+      cy.contains("You have logged in to the cluster. You can close this window.")
+        .should("exist")
+    })
+  })
+})

--- a/tests/end-to-end/kubernetes/authentication-admin.gen.bats
+++ b/tests/end-to-end/kubernetes/authentication-admin.gen.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+setup_file() {
+  load "../../bats.lib.bash"
+
+  cypress_setup "${ROOT}/tests/end-to-end/kubernetes/authentication-admin.cy.js"
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+}
+
+teardown_file() {
+  cypress_teardown "${ROOT}/tests/end-to-end/kubernetes/authentication-admin.cy.js"
+}
+
+@test "kubernetes authentication can login via static dex user" {
+  cypress_test "kubernetes authentication can login via static dex user"
+}

--- a/tests/end-to-end/kubernetes/authentication-dev.cy.js
+++ b/tests/end-to-end/kubernetes/authentication-dev.cy.js
@@ -1,0 +1,28 @@
+describe("kubernetes authentication", function() {
+  before(function() {
+    cy.withTestKubeconfig("wc", "static-dev", "true")
+  })
+
+  it("can login via extra static dex user", function() {
+
+    cy.yqDig("sc", ".dex.enableStaticLogin")
+      .then(staticLoginEnabled => {
+        if (staticLoginEnabled !== "true") {
+          this.skip("dex static login is not enabled")
+        }
+      })
+
+    cy.task('kubectlLogin', Cypress.env("KUBECONFIG"))
+    cy.visit(`http://localhost:8000`)
+
+    cy.dexExtraStaticLogin("dev@example.com")
+
+    cy.origin('http://localhost:8000', () => {
+      cy.contains("Authenticated")
+        .should("exist")
+
+      cy.contains("You have logged in to the cluster. You can close this window.")
+        .should("exist")
+    })
+  })
+})

--- a/tests/end-to-end/kubernetes/authentication-dev.gen.bats
+++ b/tests/end-to-end/kubernetes/authentication-dev.gen.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+setup_file() {
+  load "../../bats.lib.bash"
+
+  cypress_setup "${ROOT}/tests/end-to-end/kubernetes/authentication-dev.cy.js"
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+}
+
+teardown_file() {
+  cypress_teardown "${ROOT}/tests/end-to-end/kubernetes/authentication-dev.cy.js"
+}
+
+@test "kubernetes authentication can login via extra static dex user" {
+  cypress_test "kubernetes authentication can login via extra static dex user"
+}

--- a/tests/end-to-end/kubernetes/bin-access.bats
+++ b/tests/end-to-end/kubernetes/bin-access.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+# bats file_tags=kubernetes
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+  load_file
+
+  export CK8S_AUTO_APPROVE=true
+  CK8S_PGP_FP=$(yq '.creation_rules[].pgp' "${CK8S_CONFIG_PATH}/.sops.yaml")
+  export CK8S_PGP_FP
+}
+
+teardown() {
+  delete_test_kubeconfig wc static-dev
+}
+
+@test "static user can list access" {
+  with_test_kubeconfig wc static-dev
+  echo "# If cypress auth tests were run previously, test should continue automatically. Otherwise, go to http://localhost:8000 and log in with static email user dev@example.com" >&3
+  run kubectl auth whoami
+  assert_output --partial "dev@example.com"
+  run kubectl -n staging auth can-i --list
+  assert_success
+}
+
+@test "static user can delegate admin access" {
+  with_test_kubeconfig wc static-dev
+  run kubectl auth whoami
+  assert_output --partial "dev@example.com"
+  run kubectl -n staging patch rolebinding extra-workload-admins -p '{"subjects":[{"apiGroup":"rbac.authorization.k8s.io","kind":"User","name":"jane"}]}'
+  assert_success
+}
+
+@test "static user can delegate view access" {
+  with_test_kubeconfig wc static-dev
+  run kubectl auth whoami
+  assert_output --partial "dev@example.com"
+  run kubectl patch clusterrolebinding extra-user-view -p '{"subjects":[{"apiGroup":"rbac.authorization.k8s.io","kind":"User","name":"jane"}]}'
+  assert_success
+}
+
+@test "static user cannot run pod as root" {
+  with_test_kubeconfig wc static-dev
+  run kubectl auth whoami
+  assert_output --partial "dev@example.com"
+  kubectl delete --ignore-not-found -n staging -f "${APPS_PATH}/tests/end-to-end/kubernetes/allow-root-nginx.yaml"
+  kubectl apply -n staging -f "${APPS_PATH}/tests/end-to-end/kubernetes/allow-root-nginx.yaml"
+  run kubectl wait --for=jsonpath='{.status.containerStatuses[0].state.waiting.reason}=CreateContainerConfigError' -n staging pod/root-nginx --timeout=60s
+
+  assert_output "pod/root-nginx condition met"
+  kubectl delete --ignore-not-found -n staging -f "${APPS_PATH}/tests/end-to-end/kubernetes/allow-root-nginx.yaml"
+}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [x] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Adds end-to-end tests for Kubernetes access.

There are a few things of note here:

- ~~I implemented a cypress test for doing a static e-mail login, and I tried to do the same for "cluster admin" login but I'm not sure it will be possible. Since cypress doesn't have the cookies from your main browser, it requires you to actually log in via your IdP (e.g. Google), which is challenging because:~~
  - ~~We don't know what IdP the user is using,~~
  - ~~Even if we assume Google as IdP, you need to do a real login with your real Google account, which is hard to cover in a test,~~
  - ~~Even if we _could_ cover it in a test, I'm not sure we _should_ go through an OAuth authentication in a test since it's the sort of thing that is meant to be done by a human so you know what access you are granting to the application in question.~~
  - ~~Regardless, if someone has a good idea for how it could be done, I'm open for suggestions, but it seems hard.~~
- The above point has been remedied by using a second static dex user instead of logging in via IdP.
- I tried using the `KUBECACHEDIR` environment variable to change the cache for kubelogin, but I found that kubelogin actually doesn't use that environment variable at all (it will change the cache directory for other kubectl things, but not for kubelogin). It seems that the only way to change the cache directory for kubelogin is via a flag when you run the `oidc-login` command, so I found the easiest implementation of this to be to make a copy of the kubeconfig with that flag added and use it as a "testing" kubeconfig, one for the "admin" login and one for the "static" login". See the `with_test_kubeconfig` functions below.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes elastisys/ck8s-issue-tracker#228

#### Information to reviewers

How to test:

```bash
$ export CK8S_CONFIG_PATH=...
$ make run-end-to-end/kubernetes
```

Some notes about the tests: the cypress tests are slightly flaky, they're implemented in a way that doesn't really conform with cypress best practices (starting a web server inside of the test). Unfortunately this seemed unavoidable because our "web server" in this case is started by running a kubectl command.

They usually work, but I noticed when I had a lot of programs/tabs open and my laptop would be a bit slow running the tests, it was more likely that the tests would fail (usually with an `ECONNREFUSED` error).

Also, you need to make sure that you have decrypted something with your GPG key recently so it doesn't try to prompt you for your passcode when you run the tests (but I think this issue exists for all tests that access the `secrets.yaml` file).

The following config is necessary for the tests:

- `clusterAdmin.users` has `admin@example.com`
- `user.adminUsers` has `dev@example.com`
- For the `authentication-dev` cypress test, you need to have `extraStaticLogins` set, see [this commit](https://github.com/elastisys/compliantkubernetes-apps/pull/2548/commits/753d1c6b5ac575244c931cdfb380a377ed3930dd). You need to add a `password` field to it in your `secrets.yaml` file; the default password that matches the hash is `password`.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
