### PR TITLE
tests: add end-to-end wrappers for ck8s test components

### DIFF
--- a/tests/end-to-end/apps/status.bats
+++ b/tests/end-to-end/apps/status.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+# bats file_tags=apps
+
+setup_file() {
+  # for dynamically registering tests using `bats_test_function`
+  bats_require_minimum_version 1.11.1
+
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+  export CK8S_AUTO_APPROVE="true"
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+}
+
+declare -a _clusters=("sc" "wc")
+
+for _cluster in "${_clusters[@]}"; do
+  bats_test_function \
+    --description "${_cluster^^} apps checks should pass" \
+    -- apps_checks "${_cluster}"
+done
+
+apps_checks() {
+  local -r cluster="${1}"
+  run ck8s test "${cluster}" apps
+  assert_success
+}

--- a/tests/end-to-end/apps/status.bats
+++ b/tests/end-to-end/apps/status.bats
@@ -15,12 +15,12 @@ setup() {
   load_assert
 }
 
-declare -a _clusters=("sc" "wc")
+declare -a clusters=("sc" "wc")
 
-for _cluster in "${_clusters[@]}"; do
+for cluster in "${clusters[@]}"; do
   bats_test_function \
-    --description "${_cluster^^} apps checks should pass" \
-    -- apps_checks "${_cluster}"
+    --description "${cluster^^} apps checks should pass" \
+    -- apps_checks "${cluster}"
 done
 
 apps_checks() {

--- a/tests/end-to-end/cert-manager/status.bats
+++ b/tests/end-to-end/cert-manager/status.bats
@@ -15,12 +15,12 @@ setup() {
   load_assert
 }
 
-declare -a _clusters=("sc" "wc")
+declare -a clusters=("sc" "wc")
 
-for _cluster in "${_clusters[@]}"; do
+for cluster in "${clusters[@]}"; do
   bats_test_function \
-    --description "${_cluster^^} cert-manager status should be OK" \
-    -- cert_manager_should_be_ok "${_cluster}"
+    --description "${cluster^^} cert-manager status should be OK" \
+    -- cert_manager_should_be_ok "${cluster}"
 done
 
 cert_manager_should_be_ok() {

--- a/tests/end-to-end/cert-manager/status.bats
+++ b/tests/end-to-end/cert-manager/status.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+# bats file_tags=cert-manager
+
+setup_file() {
+  # for dynamically registering tests using `bats_test_function`
+  bats_require_minimum_version 1.11.1
+
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+  export CK8S_AUTO_APPROVE="true"
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+}
+
+declare -a _clusters=("sc" "wc")
+
+for _cluster in "${_clusters[@]}"; do
+  bats_test_function \
+    --description "${_cluster^^} cert-manager status should be OK" \
+    -- cert_manager_should_be_ok "${_cluster}"
+done
+
+cert_manager_should_be_ok() {
+  local -r cluster="${1}"
+  run ck8s test "${cluster}" cert-manager
+  assert_success
+}

--- a/tests/end-to-end/hnc/status.bats
+++ b/tests/end-to-end/hnc/status.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+# bats file_tags=hnc
+
+setup_file() {
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+  export CK8S_AUTO_APPROVE="true"
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+}
+
+@test "WC hnc status should be OK" {
+  run ck8s test wc hnc
+  assert_success
+}

--- a/tests/end-to-end/ingress/status.bats
+++ b/tests/end-to-end/ingress/status.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+# bats file_tags=ingress
+
+setup_file() {
+  # for dynamically registering tests using `bats_test_function`
+  bats_require_minimum_version 1.11.1
+
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+  export CK8S_AUTO_APPROVE="true"
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+}
+
+declare -a _clusters=("sc" "wc")
+
+for _cluster in "${_clusters[@]}"; do
+  bats_test_function \
+    --description "${_cluster^^} ingress status should be OK" \
+    -- ingress_should_be_ok "${_cluster}"
+done
+
+ingress_should_be_ok() {
+  local -r cluster="${1}"
+  run ck8s test "${cluster}" ingress
+  assert_success
+}

--- a/tests/end-to-end/ingress/status.bats
+++ b/tests/end-to-end/ingress/status.bats
@@ -15,12 +15,12 @@ setup() {
   load_assert
 }
 
-declare -a _clusters=("sc" "wc")
+declare -a clusters=("sc" "wc")
 
-for _cluster in "${_clusters[@]}"; do
+for cluster in "${clusters[@]}"; do
   bats_test_function \
-    --description "${_cluster^^} ingress status should be OK" \
-    -- ingress_should_be_ok "${_cluster}"
+    --description "${cluster^^} ingress status should be OK" \
+    -- ingress_should_be_ok "${cluster}"
 done
 
 ingress_should_be_ok() {

--- a/tests/end-to-end/opensearch/status.bats
+++ b/tests/end-to-end/opensearch/status.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+# bats file_tags=opensearch
+
+setup_file() {
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+  export CK8S_AUTO_APPROVE="true"
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+}
+
+@test "SC opensearch status should be OK" {
+  run ck8s test sc opensearch
+  assert_success
+}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Expands the end-to-end test suit with wrappers that run the status checks through `./bin/ck8s test`.

Components are wrapped individually.

- Fixes https://github.com/elastisys/ck8s-issue-tracker/issues/446

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
