### PR TITLE
Add Cluster Autoscaler alerts

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -108,6 +108,7 @@ alerts:
     blackbox: {}
     certManager: {}
     clusterApi: {}
+    clusterAutoscaler: {}
     clusterCapacityManagement: {}
     configReloaders: {}
     coreDns: {}

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -4207,6 +4207,8 @@ properties:
             $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
           clusterApi:
             $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
+          clusterAutoscaler:
+            $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
           clusterCapacityManagement:
             $ref: '#/properties/alerts/properties/runbookUrls/$defs/upstreamRunbook'
           configReloaders:

--- a/helmfile.d/charts/autoscaling-monitoring/templates/servicemonitor.yaml
+++ b/helmfile.d/charts/autoscaling-monitoring/templates/servicemonitor.yaml
@@ -9,6 +9,10 @@ spec:
   endpoints:
   - interval: 30s
     port: http
+    relabelings:
+      - targetLabel: cluster
+        replacement: {{ .Values.clusterName }}
+        action: replace
   namespaceSelector:
     matchNames:
     - capi-cluster

--- a/helmfile.d/charts/prometheus-alerts/files/cluster-autoscaler.yaml
+++ b/helmfile.d/charts/prometheus-alerts/files/cluster-autoscaler.yaml
@@ -1,0 +1,142 @@
+- name: cluster-autoscaler
+  rules:
+    - alert: ClusterAutoscalerClusterNotSafeToAutoscale
+      expr: cluster_autoscaler_cluster_safe_to_autoscale != 1
+      for: 15m
+      labels:
+        severity: critical
+      annotations:
+        summary: "Autoscaling is not safe"
+        description: "Cluster Autoscaler for cluster {{"`{{ $labels.cluster }}`"}} has deemed it unsafe to autoscale for 15 minutes. This is primarily triggered when the number of unready nodes pass a configured threshold. It can also be triggered when the cluster is empty and scaling from zero nodes is not allowed."
+        runbook_url: {{ .Values.runbookUrls.clusterAutoscaler.ClusterAutoscalerClusterNotSafeToAutoscale }}
+
+    - alert: ClusterAutoscalerInactive
+      expr: time() - cluster_autoscaler_last_activity{activity="main"} > 300
+      for: 1m
+      labels:
+        severity: high
+      annotations:
+        summary: "No Cluster Autoscaler main loop activity"
+        description: "The main loop of the Cluster Autoscaler for cluster {{"`{{ $labels.cluster }}`"}} has not updated its last activity in over 5 minutes which means it might be stuck or not running."
+        runbook_url: {{ .Values.runbookUrls.clusterAutoscaler.ClusterAutoscalerInactive }}
+
+    - alert: ClusterAutoscalerUnschedulablePodsHigh
+      expr: cluster_autoscaler_unschedulable_pods_count{type="unschedulable"} > 0
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Pods are currently unschedulable"
+        description: "There are unschedulable pods in the cluster {{"`{{ $labels.cluster }}`"}}. The Cluster Autoscaler should address this by scaling up, if possible."
+        runbook_url: {{ .Values.runbookUrls.clusterAutoscaler.ClusterAutoscalerUnschedulablePodsHigh }}
+
+    - alert: ClusterAutoscalerFailedScaleUp
+      expr: sum(rate(cluster_autoscaler_failed_scale_ups_total[5m])) by (cluster, reason) > 0
+      for: 1m
+      labels:
+        severity: high
+      annotations:
+        summary: "Cluster Autoscaler failed to scale up"
+        description: "The Cluster Autoscaler for cluster {{"`{{ $labels.cluster }}`"}} encountered an error while attempting to scale up new nodes. Reason: {{"{{ $labels.reason }}"}}"
+        runbook_url: {{ .Values.runbookUrls.clusterAutoscaler.ClusterAutoscalerFailedScaleUp }}
+
+    - alert: ClusterAutoscalerFailedGPUScaleUp
+      expr: sum(rate(cluster_autoscaler_failed_gpu_scale_ups_total[5m])) by (cluster, reason, gpu_resource_name, gpu_name) > 0
+      for: 1m
+      labels:
+        severity: high
+      annotations:
+        summary: "Cluster Autoscaler failed to scale up GPU nodes"
+        description: "The Cluster Autoscaler for cluster {{"`{{ $labels.cluster }}`"}} encountered an error while attempting to scale up GPU nodes. Reason: {{"{{ $labels.reason }}"}}, GPU Resource: {{"{{ $labels.gpu_resource_name }}"}}, GPU Name: {{"{{ $labels.gpu_name }}"}}"
+        runbook_url: {{ .Values.runbookUrls.clusterAutoscaler.ClusterAutoscalerFailedGPUScaleUp }}
+
+    - alert: ClusterAutoscalerNodeGroupUnhealthy
+      expr: cluster_autoscaler_node_group_healthiness == 0
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Unhealthy node group"
+        description: "The node group {{"{{ $labels.node_group }}"}} in cluster {{"`{{ $labels.cluster }}`"}} is reporting as unhealthy which might prevent autoscaling operations for this group."
+        runbook_url: {{ .Values.runbookUrls.clusterAutoscaler.ClusterAutoscalerNodeGroupUnhealthy }}
+
+    - alert: ClusterAutoscalerNodeGroupBackoff
+      expr: cluster_autoscaler_node_group_backoff_status == 1
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "A node group is in backoff state"
+        description: "The node group {{"{{ $labels.node_group }}"}} in cluster {{"`{{ $labels.cluster }}`"}} is currently in a backoff state due to reason: {{"{{ $labels.reason }}"}}. This means that the Cluster Autoscaler will not try to scale it up."
+        runbook_url: {{ .Values.runbookUrls.clusterAutoscaler.ClusterAutoscalerNodeGroupBackoff }}
+
+    - alert: ClusterAutoscalerUnneededNodesNotScaledDown
+      expr: cluster_autoscaler_unneeded_nodes_count > 0
+      for: 24h
+      labels:
+        severity: warning
+      annotations:
+        summary: "Cluster Autoscaler reports unneeded nodes that are not being scaled down"
+        description: "There are {{"{{ $value }}"}} nodes in cluster {{"`{{ $labels.cluster }}`"}} identified as unneeded by the Cluster Autoscaler, but they have not been scaled down for 24 hours."
+
+    # TODO: The reason label is just the reason constant integer, needs to be fixed upstream. Perhaps a new label like "reason_str" or propose to change it to the name of the constant.
+    # TODO: Doesn't tell you which node it is. Needs to be fixed upstream.
+    # - alert: ClusterAutoscalerUnremovableNodesStuck
+    #   expr: cluster_autoscaler_unremovable_nodes_count > 0
+    #   for: 15m
+    #   labels:
+    #     severity: warning
+    #   annotations:
+    #     summary: "Cluster Autoscaler reports unremovable nodes"
+    #     description: "There are {{"{{ $value }}"}} node(s) that the Cluster Autoscaler cannot remove due to reason: {{"{{ $labels.reason }}"}}."
+    #     runbook_url: {{ .Values.runbookUrls.clusterAutoscaler.ClusterAutoscalerUnremovableNodesStuck }}
+
+    - alert: ClusterAutoscalerClusterAutoscalerErrors
+      expr: sum(rate(cluster_autoscaler_errors_total[5m])) by (cluster, type) > 0
+      for: 1m
+      labels:
+        severity: high
+      annotations:
+        summary: "Cluster Autoscaler is reporting errors"
+        description: "The Cluster Autoscaler for cluster {{"`{{ $labels.cluster }}`"}} is experiencing errors of type {{"{{ $labels.type }}"}}."
+        runbook_url: {{ .Values.runbookUrls.clusterAutoscaler.ClusterAutoscalerClusterAutoscalerErrors }}
+
+    - alert: ClusterAutoscalerPendingNodeDeletionsHigh
+      expr: cluster_autoscaler_pending_node_deletions > 0
+      for: 30m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Nodes are stuck in pending deletion state"
+        description: "There are {{"{{ $value }}"}} nodes in cluster {{"`{{ $labels.cluster }}`"}} that have completed scale-down but are still pending deletion."
+        runbook_url: {{ .Values.runbookUrls.clusterAutoscaler.ClusterAutoscalerPendingNodeDeletionsHigh }}
+
+    - alert: ClusterAutoscalerScaleUpTooLong
+      expr: histogram_quantile(0.99, sum by (le, cluster) (rate(cluster_autoscaler_function_duration_seconds_bucket{function="scaleUp"}[5m]))) > 60
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Cluster Autoscaler scale up function is taking too long"
+        description: "The 99th percentile of the {{"`{{ $labels.cluster }}`"}} Cluster Autoscaler's scaleUp function duration has exceeded 60 seconds."
+        runbook_url: {{ .Values.runbookUrls.clusterAutoscaler.ClusterAutoscalerScaleUpTooLong }}
+
+    - alert: ClusterAutoscalerScaleDownTooLong
+      expr: histogram_quantile(0.99, sum by (le, cluster) (rate(cluster_autoscaler_function_duration_seconds_bucket{function="scaleDown"}[5m]))) > 60
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Cluster Autoscaler scale down function is taking too long"
+        description: "The 99th percentile of the {{"`{{ $labels.cluster }}`"}} Cluster Autoscaler's scaleDown function duration has exceeded 60 seconds."
+        runbook_url: {{ .Values.runbookUrls.clusterAutoscaler.ClusterAutoscalerScaleDownTooLong }}
+
+    - alert: ClusterAutoscalerMainLoopTooLong
+      expr: histogram_quantile(0.99, sum by (le, cluster) (rate(cluster_autoscaler_function_duration_seconds_bucket{function="main"}[5m]))) > 120
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: "Cluster Autoscaler main loop is taking too long"
+        description: "The 99th percentile of the {{"`{{ $labels.cluster }}`"}} Cluster Autoscaler's main loop duration has exceeded 120 seconds."
+        runbook_url: {{ .Values.runbookUrls.clusterAutoscaler.ClusterAutoscalerMainLoopTooLong }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/cluster-autoscaler.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/cluster-autoscaler.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.defaultRules.create .Values.defaultRules.rules.clusterApi }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-alerts.fullname" .) "cluster-autoscaler" | trunc 63 | trimSuffix "-" }}
+  labels:
+    app: {{ template "prometheus-alerts.name" . }}
+    {{- include "prometheus-alerts.labels" . | nindent 4 }}
+    {{- with .Values.defaultRules.alertLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.defaultRules.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  groups:
+    {{- tpl (.Files.Get "files/cluster-autoscaler.yaml") . | nindent 4 }}
+{{- end }}

--- a/helmfile.d/charts/prometheus-alerts/values.yaml
+++ b/helmfile.d/charts/prometheus-alerts/values.yaml
@@ -172,6 +172,7 @@ runbookUrls:
   blackbox: {}
   certManager: {}
   clusterApi: {}
+  clusterAutoscaler: {}
   clusterCapacityManagement: {}
   configReloaders: {}
   coreDns: {}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Fixes https://github.com/elastisys/ck8s-issue-tracker/issues/186

This adds alerts to monitor the Cluster Autoscalers.

#### Information to reviewers

* Some alerts are using metrics that are not yet available because we are running an older version of Cluster Autoscaler. I thought it would be good to add them anyway so that we can take advantage of them when the Cluster Autoscaler is upgraded.
* I'm not sure about the severity settings on all the alerts. Please advice!

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
