### PR TITLE
changed cert-manager helm validation

### DIFF
--- a/helmfile.d/stacks/cert-manager.yaml.gotmpl
+++ b/helmfile.d/stacks/cert-manager.yaml.gotmpl
@@ -20,7 +20,7 @@ templates:
       - values/networkpolicies/common/cert-manager.yaml.gotmpl
 
   cert-manager-controller:
-    disableValidationOnInstall: true
+    disableValidation: true
     inherit:
       - template: cert-manager
       - template: cert-manager-chart
@@ -35,7 +35,7 @@ templates:
       - values/cert-manager.yaml.gotmpl
 
   cert-manager-issuers:
-    disableValidationOnInstall: true
+    disableValidation: true
     inherit: [ template: cert-manager ]
     installed: {{ .Values | get "ck8sAnyCluster.enabled" false }}
     chart: charts/issuers


### PR DESCRIPTION

<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->
# fix: Allow cert-manager to be installed when ServiceMonitor CRD is missing

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me) <!-- This PR implements an ADR, add the link -->

### What does this PR do / why do we need this PR?

When running `ck8s apply` on a CAPI-provisioned cluster, the `cert-manager` Helm release upgrade could fail. This happens because `cert-manager` might already be installed, and its chart now includes `ServiceMonitor` resources.

The Helm upgrade process attempts to validate these resources against the Kubernetes API before applying them. If the `ServiceMonitor` CRD (which is part of the `kube-prometheus-stack` release) is not yet present on the cluster, this validation fails. The previous setting, `disableValidationOnInstall: true`, was not sufficient as it only applies to the initial installation, not to subsequent upgrades.

This PR changes `disableValidationOnInstall: true` to `disableValidation: true` for both the `cert-manager-controller` and `cert-manager-issuers` releases. This instructs Helm to skip CRD validation during upgrades as well. This allows Helmfile's `needs` dependency logic to correctly install `kube-prometheus-stack` first, ensuring the `ServiceMonitor` CRD is available before the `cert-manager` release is upgraded, thus resolving the failure.

- Fixes #2557

#### Information to reviewers

#### Checklist

- [x] Proper commit message prefix on all commits
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me)
- Metrics checks:
    - [x] The metrics are still exposed and present in Grafana after the change
    - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [x] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [x] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [x] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [x] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [x] Any changed Pod is covered by Network Policies
    - [x] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [x] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
