### PR TITLE
apps sc: S3 quota alerts per bucket

### DIFF
--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -450,6 +450,18 @@ prometheus:
       percent: 80
       count: 1638400
     exclude: []
+    # Custom per-bucket alerts
+    buckets: []
+    #  - name: <cluster>-thanos # This gets excluded from regular object storage alerts
+    #    size:
+    #      enabled: false
+    #      percent: 80
+    #      sizeQuotaGB: 1000
+    #    objects:
+    #      enabled: false
+    #      percent: 80
+    #      count: 1638400
+
   # Todo remove dependency on alertmanager from service cluster
   alertmanagerSpec:
     groupBy:

--- a/config/schemas/README.md
+++ b/config/schemas/README.md
@@ -71,7 +71,7 @@ Lists, `type: array`, has schema for its items in `items`.
 
 Scalar types can have various constraints and validation hints, e.g. length and range constraints, `format: email` etc. <!-- how much of json-schema-validation to duplicate? -->
 
-The tool `bin/genschema.py` can be used to generate a schema from a YAML snippet.
+The tool `scripts/genschema.py` can be used to generate a schema from a YAML snippet.
 
 ```bash
 cat > conf-snippet.yaml <<EOF
@@ -80,7 +80,7 @@ service:
   features:
   - nice
 EOF
-./bin/genschema.py ./conf-snippet.yaml | tee ./conf-snippet.yaml
+./scripts/genschema.py ./conf-snippet.yaml | tee ./conf-snippet.yaml
 ```
 
 The output can be tweaked and inserted into `config/schemas/config.yaml` under `.properties`.

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -4687,6 +4687,56 @@ properties:
             items:
               title: S3 Bucket Name
               type: string
+          buckets:
+            title: S3 Bucket Specific Alerts
+            description: Definitions for specific S3 bucket alerts.
+            items:
+              title: S3 Bucket Specific Alert
+              description: S3 Bucket Alert configuration for specific bucket
+              additionalProperties: false
+              properties:
+                name:
+                  examples:
+                  - <cluster>-thanos
+                  type: string
+                objects:
+                  title: S3 Bucket Specific Alerts Objects
+                  description: Alert when the S3 bucket reaches the set percentage of the set number of objects.
+                  additionalProperties: false
+                  properties:
+                    enabled:
+                      title: S3 Bucket Alerts Objects Enabled
+                      type: boolean
+                      default: false
+                    percent:
+                      title: S3 Bucket Alerts Objects Percentage
+                      $ref: '#/$defs/percentage'
+                      default: 80
+                    count:
+                      title: S3 Bucket Alerts Objects Quota
+                      default: 1638400
+                      type: number
+                  type: object
+                size:
+                  title: S3 Bucket Specific Alerts Size
+                  description: Alert when the S3 bucket reaches the set percentage of the set size.
+                  additionalProperties: false
+                  properties:
+                    enabled:
+                      title: S3 Bucket Alerts Size Enabled
+                      type: boolean
+                      default: false
+                    percent:
+                      title: S3 Bucket Alerts Size Percentage
+                      $ref: '#/$defs/percentage'
+                      default: 80
+                    sizeQuotaGB:
+                      title: S3 Bucket Alerts Size Quota
+                      type: number
+                      default: 1000
+                  type: object
+              type: object
+            type: array
       autoscaledNodeGroupAlerts:
         title: Autoscaled NodeGroup Alerts
         description: Configure whether to split KubeletDownForXm alerts into autoscaled and non-autoscaled nodes groups.
@@ -4893,6 +4943,8 @@ properties:
             $ref: "#/properties/prometheus/$defs/s3BucketAlerts/properties/totalSize"
           exclude:
             $ref: "#/properties/prometheus/$defs/s3BucketAlerts/properties/exclude"
+          buckets:
+            $ref: "#/properties/prometheus/$defs/s3BucketAlerts/properties/buckets"
       webhookAlerts:
         title: Webhook Alerts
         description: Configure webhook alerts.

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/daily-checks.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/daily-checks.yaml
@@ -1,4 +1,9 @@
 {{- if and .Values.defaultRules.create .Values.defaultRules.rules.dailyChecks}}
+{{- $bucketNames := list }}
+{{- range .Values.s3BucketAlerts.buckets }}
+  {{- $bucketNames = append $bucketNames .name }}
+{{- end }}
+{{- $fullExclude := concat $bucketNames .Values.s3BucketAlerts.exclude }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -17,6 +22,37 @@ spec:
   groups:
   - name: daily-checks
     rules:
+{{- if .Values.s3BucketAlerts.buckets }}
+  {{- $root := . }}
+  {{- range .Values.s3BucketAlerts.buckets }}
+    {{- if .size.enabled }}
+    - alert: S3BucketSizeOver{{.size.percent}}Percent-{{ .name }}
+      annotations:
+        message: Over {{.size.percent}} percent of the total s3bucket size limit is used in bucket {{`{{ $labels.bucket }}`}}.
+        runbook_url: {{ $root.Values.runbookUrls.dailyChecks.S3BucketSizeOverXPercent }}
+      expr: |-
+        (
+          sum(avg_over_time(s3_objects_size_sum_bytes{bucket="{{ .name }}",prefix!~".+"}[1h])) by (bucket) >= ({{ .size.sizeQuotaGB }} * (1024^3)) * ({{ .size.percent }} / 100)
+        )
+      for: 1h
+      labels:
+        severity: warning
+    {{- end }}
+    {{- if .objects.enabled }}
+    - alert: S3BucketObjectsOver{{.objects.percent}}Percent-{{ .name }}
+      annotations:
+        message: Over {{.objects.percent}} percent of the total s3bucket object limit is used in bucket {{`{{ $labels.bucket }}`}}.
+        runbook_url: {{ $root.Values.runbookUrls.dailyChecks.S3BucketObjectsOverXPercent }}
+      expr: |-
+        (
+          sum(avg_over_time(s3_objects{bucket="{{ .name }}"}[1h])) by (bucket) > {{ .objects.count }} * ({{ .objects.percent }} / 100)
+        )
+      for: 2h
+      labels:
+        severity: warning
+    {{- end }}
+  {{- end }}
+{{- end }}
 {{- if .Values.s3BucketAlerts.size.enabled }}
     - alert: S3BucketSizeOver{{.Values.s3BucketAlerts.size.percent}}Percent
       annotations:
@@ -24,7 +60,7 @@ spec:
         runbook_url: {{ .Values.runbookUrls.dailyChecks.S3BucketSizeOverXPercent }}
       expr: |-
         (
-          sum(s3_objects_size_sum_bytes{bucket!~"{{ join "|" .Values.s3BucketAlerts.exclude }}",prefix!~".+"}) by (bucket) >= ({{ .Values.s3BucketAlerts.size.sizeQuotaGB }} * (1024^3)) * ({{ .Values.s3BucketAlerts.size.percent }} / 100)
+          sum(avg_over_time(s3_objects_size_sum_bytes{bucket!~"{{ join "|" $fullExclude }}",prefix!~".+"}[1h])) by (bucket) >= ({{ .Values.s3BucketAlerts.size.sizeQuotaGB }} * (1024^3)) * ({{ .Values.s3BucketAlerts.size.percent }} / 100)
         )
       for: 1h
       labels:
@@ -50,7 +86,7 @@ spec:
         runbook_url: {{ .Values.runbookUrls.dailyChecks.S3BucketObjectsOverXPercent }}
       expr: |-
         (
-          sum(s3_objects{bucket!~"{{ join "|" .Values.s3BucketAlerts.exclude }}"}) by (bucket) > {{ .Values.s3BucketAlerts.objects.count }} * ({{ .Values.s3BucketAlerts.objects.percent }} / 100)
+          sum(avg_over_time(s3_objects{bucket!~"{{ join "|" $fullExclude }}"}[1h])) by (bucket) > {{ .Values.s3BucketAlerts.objects.count }} * ({{ .Values.s3BucketAlerts.objects.percent }} / 100)
         )
       for: 2h
       labels:

--- a/helmfile.d/charts/prometheus-alerts/values.yaml
+++ b/helmfile.d/charts/prometheus-alerts/values.yaml
@@ -18,6 +18,16 @@ s3BucketAlerts:
     percent: 80
     count: 1638400
   exclude: []
+  buckets: []
+    #  - name: <cluster>-thanos # This gets excluded from regular object storage alerts
+    #    size:
+    #      enabled: false
+    #      percent: 80
+    #      sizeQuotaGB: 1000
+    #    objects:
+    #      enabled: false
+    #      percent: 80
+    #      count: 1638400
 
 autoscaledNodeGroupAlerts:
   enabled: true

--- a/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
@@ -82,6 +82,7 @@ s3BucketAlerts:
     percent: {{ .Values.prometheus.s3BucketAlerts.objects.percent }}
     count: {{ .Values.prometheus.s3BucketAlerts.objects.count }}
   exclude: {{ toYaml .Values.prometheus.s3BucketAlerts.exclude | nindent 4 }}
+  buckets: {{ toYaml .Values.prometheus.s3BucketAlerts.buckets | nindent 4 }}
 
 buckets:
   harbor: {{ .Values.objectStorage.buckets.harbor }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2543 

#### Information to reviewers
* Would be happy if anyone got any suggestions/improvements to the schema titles/descriptions for the new buckets section.
* I changed how the S3 Bucket Alert expression works in general because of how it was leaving "gaps" of data when you query the expression. This was due to while testing I noticed how changing the for: 1h to for: 10m would make the alert start pending but then return to Normal since there was no data (when it should have triggered). If you see any issue with it let me know. See below for example.
* New query/expression
![image](https://github.com/user-attachments/assets/4db89be6-bdcc-40c1-b547-85d8dd4e93d7)
* Old query/expression
![image](https://github.com/user-attachments/assets/1f3dcb94-2ed7-4006-bc59-5b8c8907025e)


* Example per bucket alerts (sc-config)
```
prometheus:
  s3BucketAlerts:
    objects:
      enabled: true
    size:
      enabled: true
    buckets:
      - name: marcus-v2-thanos
        size:
          enabled: true
          percent: 80
          sizeQuotaGB: 1000
        objects:
          enabled: true
          percent: 80
          count: 1638400
    exclude:
      - marcus-v2-thanos
```
![Screenshot from 2025-06-19 16-06-53](https://github.com/user-attachments/assets/5544cfdb-7907-483c-b9d2-45d5052c96ed)


<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
