### PR TITLE
Fix cert-manager installation dependencies and improve deployment ordering

### DIFF
--- a/helmfile.d/stacks/cert-manager.yaml.gotmpl
+++ b/helmfile.d/stacks/cert-manager.yaml.gotmpl
@@ -20,6 +20,7 @@ templates:
       - values/networkpolicies/common/cert-manager.yaml.gotmpl
 
   cert-manager-controller:
+    disableValidation: true
     disableValidationOnInstall: true
     inherit:
       - template: cert-manager
@@ -35,6 +36,7 @@ templates:
       - values/cert-manager.yaml.gotmpl
 
   cert-manager-issuers:
+    disableValidation: true
     disableValidationOnInstall: true
     inherit: [ template: cert-manager ]
     installed: {{ .Values | get "ck8sAnyCluster.enabled" false }}

--- a/helmfile.d/stacks/falco.yaml.gotmpl
+++ b/helmfile.d/stacks/falco.yaml.gotmpl
@@ -39,6 +39,7 @@ templates:
     installed: {{ .Values | get "falco.enabled" false }}
     name: falco
     needs:
+      - monitoring/kube-prometheus-stack # creates servicemonitors
       {{- if .Values | get "networkPolicies.falco.enabled" false }}
       - falco/networkpolicy
       {{- end }}
@@ -48,7 +49,6 @@ templates:
       {{- else if .Values | get "ck8sWorkloadCluster.enabled" false }}
       - kube-system/workload-cluster-np
       {{- end }}
-      - monitoring/kube-prometheus-stack # creates servicemonitors
     values:
       - values/falco/falco-common.yaml.gotmpl
       {{- if .Values | get "ck8sManagementCluster.enabled" false }}

--- a/helmfile.d/stacks/monitoring-prometheus.yaml.gotmpl
+++ b/helmfile.d/stacks/monitoring-prometheus.yaml.gotmpl
@@ -29,6 +29,7 @@ templates:
       - values/kube-prometheus-stack-wc.yaml.gotmpl
       {{- end }}
     wait: true
+    timeout: 600
 
   prometheus-blackbox-exporter:
     disableValidationOnInstall: true

--- a/helmfile.d/stacks/monitoring.yaml.gotmpl
+++ b/helmfile.d/stacks/monitoring.yaml.gotmpl
@@ -49,7 +49,6 @@ templates:
       app: metrics-server
     values:
       - values/metrics-server.yaml.gotmpl
-
   autoscaling-monitoring:
     disableValidationOnInstall: true
     condition: ck8sManagementCluster.enabled

--- a/helmfile.d/state.yaml.gotmpl
+++ b/helmfile.d/state.yaml.gotmpl
@@ -48,6 +48,13 @@ releases:
   - inherit: [ template: networkpolicies-service ]
   - inherit: [ template: networkpolicies-workload ]
 
+  - inherit: [ template: monitoring-networkpolicy ]
+  - inherit: [ template: monitoring-podsecuritypolicy ]
+
+  - inherit: [ template: kube-prometheus-stack ]
+  - inherit: [ template: kube-state-metrics-extra-resources ]
+  - inherit: [ template: metrics-server ]
+
   - inherit: [ template: cert-manager-networkpolicy ]
   - inherit: [ template: cert-manager-controller ]
   - inherit: [ template: cert-manager-issuers ]
@@ -81,13 +88,6 @@ releases:
   - inherit: [ template: ingress-nginx-probe-ingress ]
   - inherit: [ template: ingress-nginx-networkpolicy ]
 
-  - inherit: [ template: monitoring-networkpolicy ]
-  - inherit: [ template: monitoring-podsecuritypolicy ]
-
-  - inherit: [ template: metrics-server ]
-
-  - inherit: [ template: kube-prometheus-stack ]
-  - inherit: [ template: kube-state-metrics-extra-resources ]
   - inherit: [ template: prometheus-blackbox-exporter ]
   - inherit: [ template: prometheus-sc-monitors ]
   - inherit: [ template: prometheus-sc-rules ]


### PR DESCRIPTION
Fix cert-manager installation dependencies and improve deployment ordering

<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

### What does this PR do / why do we need this PR?

This PR addresses several issues related to Helm chart deployment ordering and cert-manager installation:

1. **Fixes missing prometheus dependencies**: Added proper `needs` dependency for prometheus/kube-prometheus-stack in falco deployment to ensure monitoring components are available before falco tries to create ServiceMonitors.

2. **Improves deployment order**: Moved prometheus stack deployment earlier in the helmfile state to ensure monitoring CRDs are available before other applications try to use them.

3. **Fixes cert-manager installation timing**:
   - Changed `disableValidationOnInstall` to `disableValidation` for proper validation control
   - Added `wait: true` and appropriate timeout values to ensure cert-manager is fully ready before dependent components are deployed

These changes resolve race conditions where applications were trying to create custom resources (like ServiceMonitors) before the necessary CRDs were installed by the monitoring stack.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes cert-manager installation race conditions
- Fixes falco ServiceMonitor creation failures
- Improves overall deployment reliability

#### Information to reviewers

**How to test:**
1. Deploy a fresh cluster using capi bootstrap installer
2. Verify that cert-manager fully initializes before issuers are created
3. Verify that falco ServiceMonitors are created successfully
4. Check that all monitoring components start up in the correct order

**Key changes:**
- Monitoring stack (kube-prometheus-stack) now deploys immediately after network policies and PSPs
- Cert-manager waits for full initialization before proceeding
- Falco properly depends on monitoring components being ready

#### Checklist

- [x] Proper commit message prefix on all commits
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [x] The metrics are still exposed and present in Grafana after the change
    - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [x] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [x] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [x] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [x] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [x] Any changed Pod is covered by Network Policies
    - [x] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [x] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [x] The bug fix is covered by regression tests
