### PR TITLE
Fredrikcarlssn/fixcalicoaccountant

### DIFF
--- a/helmfile.d/charts/calico-accountant/values.yaml
+++ b/helmfile.d/charts/calico-accountant/values.yaml
@@ -2,7 +2,7 @@ calicoDataStore: "kubernetes"
 backend: nftables
 image:
   repository: ghcr.io/elastisys/calico-accountant
-  tag: 0.1.6-ck8s2
+  tag: 0.1.6-ck8s3
 resources:
   limits:
     cpu: 100m

--- a/helmfile.d/lists/images.yaml
+++ b/helmfile.d/lists/images.yaml
@@ -1,7 +1,7 @@
 ---
 images:
   calico:
-    accountant: ghcr.io/elastisys/calico-accountant:0.1.6-ck8s2
+    accountant: ghcr.io/elastisys/calico-accountant:0.1.6-ck8s3
   certManager:
     controller: quay.io/jetstack/cert-manager-controller:v1.17.1
     webhook: quay.io/jetstack/cert-manager-webhook:v1.17.1


### PR DESCRIPTION
### What kind of PR is this?

- [x] kind/bug           <!-- This PR fixes a bug -->

### What does this PR do / why do we need this PR?

Bumps `calico-accountant` from `0.1.6-ck8s2` to `0.1.6-ck8s3`.
This fixes an issue where, under Kubespray-based clusters, the
exporter could emit **duplicate metric samples with identical label sets** during
the same scrape interval.

#### Information to reviewers

1. run

   ```bash
      ./bin/ck8s ops helmfile sc --selector name=calico-accountant apply
   ```

   Verify the new Pod pulls `ghcr.io/elastisys/calico-accountant:0.1.6-ck8s3`.

2. Validate that metrics are exposed in the grafana "network-policy" dashboard

#### Checklist

- [x] Proper commit message prefix on all commits
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The public documentation required no updates
- Metrics checks:
    - [x] The metrics are still exposed and present in Grafana after the change
    - [x] The metrics names didn't change
- Logs checks:
    - [x] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [x] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [x] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [x] The change does not cause any Pods to be blocked
- NetworkPolicy checks:
    - [x] Any changed Pod is covered by Network Policies
    - [x] The change does not cause any dropped packets
- Audit checks:
    - [x] The change does not cause any unnecessary Kubernetes audit events
- Falco checks:
    - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [x] The bug fix is covered by regression tests
