### PR TITLE
cilium: include internal cilium IPs in the update-ips flow

### DIFF
--- a/bin/update-ips.bash
+++ b/bin/update-ips.bash
@@ -139,6 +139,8 @@ get_tunnel_ips() {
   local -a ips6_calico_ipip
   local -a ips6_calico_vxlan
   local -a ips_wireguard
+  local -a ips_cilium_internal
+
   mapfile -t ips_calico_vxlan < <("${here}/ops.bash" kubectl "${cluster}" get node "${label_argument}" -o jsonpath='{.items[*].metadata.annotations.projectcalico\.org/IPv4VXLANTunnelAddr}')
   mapfile -t ips_calico_ipip < <("${here}/ops.bash" kubectl "${cluster}" get node "${label_argument}" -o jsonpath='{.items[*].metadata.annotations.projectcalico\.org/IPv4IPIPTunnelAddr}')
   mapfile -t ips_wireguard < <("${here}/ops.bash" kubectl "${cluster}" get node "${label_argument}" -o jsonpath='{.items[*].metadata.annotations.projectcalico\.org/IPv4WireguardInterfaceAddr}')
@@ -148,10 +150,7 @@ get_tunnel_ips() {
     mapfile -t ips6_calico_ipip < <("${here}/ops.bash" kubectl "${cluster}" get node "${label_argument}" -o jsonpath='{.items[*].metadata.annotations.projectcalico\.org/IPv6IPIPTunnelAddr}')
   fi
 
-  local -a ips_cilium_internal
-  if "${here}/ops.bash" kubectl "${cluster}" get crd ciliumnodes.cilium.io >/dev/null 2>&1; then
-    mapfile -t ips_cilium_internal < <("${here}/ops.bash" kubectl "${cluster}" get ciliumnodes.cilium.io "${label_argument}" -o jsonpath='{.items[*].spec.addresses[?(@.type=="CiliumInternalIP")].ip}')
-  fi
+  mapfile -t ips_cilium_internal < <("${here}/ops.bash" kubectl "${cluster}" get node "${label_argument}" -o jsonpath='{.items[*].metadata.annotations.network\.cilium\.io/ipv4-cilium-host}')
 
   local -a ips
   read -r -a ips <<<"${ips_calico_vxlan[*]} ${ips_calico_ipip[*]} ${ips6_calico_vxlan[*]} ${ips6_calico_ipip[*]} ${ips_wireguard[*]} ${ips_cilium_internal[*]}"

--- a/tests/common/bats/update-ips.bash
+++ b/tests/common/bats/update-ips.bash
@@ -49,20 +49,20 @@ update_ips.mock_minimal() {
   mock_set_output "${mock_kubectl}" "127.0.1.8 127.0.2.8 127.0.3.8" 8        # .networkPolicies.global.scNodes.ips calico ipip
   mock_set_output "${mock_kubectl}" "127.0.1.81 127.0.2.81 127.0.3.81" 9     # .networkPolicies.global.scNodes.ips calico vxlan
   mock_set_output "${mock_kubectl}" "127.0.1.9 127.0.2.9 127.0.3.9" 10       # .networkPolicies.global.scNodes.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "" 11                                    # .networkPolicies.global.scApiserver.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 12                                    # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 11                                    # .networkPolicies.global.scNodes.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 12                                    # .networkPolicies.global.scNodes.ips cilium internal
   mock_set_output "${mock_kubectl}" "127.0.1.4 127.0.2.4 127.0.3.4" 13       # .networkPolicies.global.wcApiserver.ips node internal
   mock_set_output "${mock_kubectl}" "127.0.1.5 127.0.2.5 127.0.3.5" 14       # .networkPolicies.global.wcApiserver.ips calico ipip
   mock_set_output "${mock_kubectl}" "127.0.1.51 127.0.2.51 127.0.3.51" 15    # .networkPolicies.global.wcApiserver.ips calico vxlan
   mock_set_output "${mock_kubectl}" "127.0.1.6 127.0.2.6 127.0.3.6" 16       # .networkPolicies.global.wcApiserver.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "" 17                                    # .networkPolicies.global.scApiserver.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 18                                    # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 17                                    # .networkPolicies.global.wcApiserver.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 18                                    # .networkPolicies.global.wcApiserver.ips cilium internal
   mock_set_output "${mock_kubectl}" "127.0.1.10 127.0.2.10 127.0.3.10" 19    # .networkPolicies.global.wcNodes.ips node internal
   mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11" 20    # .networkPolicies.global.wcNodes.ips calico ipip
   mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111" 21 # .networkPolicies.global.wcNodes.ips calico vxlan
   mock_set_output "${mock_kubectl}" "127.0.1.12 127.0.2.12 127.0.3.12" 22    # .networkPolicies.global.wcNodes.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "" 23                                    # .networkPolicies.global.scApiserver.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 24                                    # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 23                                    # .networkPolicies.global.wcNodes.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 24                                    # .networkPolicies.global.wcNodes.ips cilium internal
 
 }
 
@@ -81,18 +81,18 @@ update_ips.mock_minimal_v6() {
   mock_set_output "${mock_kubectl}" "127.0.1.7 127.0.2.7 127.0.3.7 fd3e:fab4:5eda:b233::61 fd3e:fab4:5eda:b233::71 fd3e:fab4:5eda:b233::81" 9        # .networkPolicies.global.scNodes.ips node internal
   mock_set_output "${mock_kubectl}" "127.0.1.8 127.0.2.8 127.0.3.8 fd3e:fab4:5eda:b233::12 fd3e:fab4:5eda:b233::13 fd3e:fab4:5eda:b233::14" 12       # .networkPolicies.global.scNodes.ips calico ipip
   mock_set_output "${mock_kubectl}" "127.0.1.81 127.0.2.81 127.0.3.81 fd3e:fab4:5eda:b233::15 fd3e:fab4:5eda:b233::16 fd3e:fab4:5eda:b233::17" 13    # .networkPolicies.global.scNodes.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "" 14                                                                                                            # .networkPolicies.global.scApiserver.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 15                                                                                                            # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 14                                                                                                            # .networkPolicies.global.scNodes.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 15                                                                                                            # .networkPolicies.global.scNodes.ips cilium internal
   mock_set_output "${mock_kubectl}" "127.0.1.4 127.0.2.4 127.0.3.4 fd3e:fab4:5eda:b233::62 fd3e:fab4:5eda:b233::72 fd3e:fab4:5eda:b233::82" 17       # .networkPolicies.global.wcApiserver.ips node internal
   mock_set_output "${mock_kubectl}" "127.0.1.5 127.0.2.5 127.0.3.5 fd3e:fab4:5eda:b233::18 fd3e:fab4:5eda:b233::19 fd3e:fab4:5eda:b233::20" 20       # .networkPolicies.global.wcApiserver.ips calico ipip
   mock_set_output "${mock_kubectl}" "127.0.1.51 127.0.2.51 127.0.3.51 fd3e:fab4:5eda:b233::21 fd3e:fab4:5eda:b233::22 fd3e:fab4:5eda:b233::23" 21    # .networkPolicies.global.wcApiserver.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "" 22                                                                                                            # .networkPolicies.global.scApiserver.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 23                                                                                                            # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 22                                                                                                            # .networkPolicies.global.wcApiserver.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 23                                                                                                            # .networkPolicies.global.wcApiserver.ips cilium internal
   mock_set_output "${mock_kubectl}" "127.0.1.10 127.0.2.10 127.0.3.10 fd3e:fab4:5eda:b233::63 fd3e:fab4:5eda:b233::73 fd3e:fab4:5eda:b233::83" 25    # .networkPolicies.global.wcNodes.ips node internal
   mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11 fd3e:fab4:5eda:b233::24 fd3e:fab4:5eda:b233::25 fd3e:fab4:5eda:b233::26" 26    # .networkPolicies.global.wcNodes.ips calico ipip
   mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111 fd3e:fab4:5eda:b233::27 fd3e:fab4:5eda:b233::28 fd3e:fab4:5eda:b233::29" 27 # .networkPolicies.global.wcNodes.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "" 28                                                                                                            # .networkPolicies.global.scApiserver.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 29                                                                                                            # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 28                                                                                                            # .networkPolicies.global.wcNodes.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 29                                                                                                            # .networkPolicies.global.wcNodes.ips cilium internal
 }
 
 update_ips.mock_maximal() {

--- a/tests/common/bats/update-ips.bash
+++ b/tests/common/bats/update-ips.bash
@@ -43,26 +43,22 @@ update_ips.mock_minimal() {
   mock_set_output "${mock_kubectl}" "127.0.1.2 127.0.2.2 127.0.3.2" 2        # .networkPolicies.global.scApiserver.ips calico ipip
   mock_set_output "${mock_kubectl}" "127.0.1.21 127.0.2.21 127.0.3.21" 3     # .networkPolicies.global.scApiserver.ips calico vxlan
   mock_set_output "${mock_kubectl}" "127.0.1.3 127.0.2.3 127.0.3.3" 4        # .networkPolicies.global.scApiserver.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "" 5                                     # .networkPolicies.global.scApiserver.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 6                                     # .networkPolicies.global.scApiserver.ips cilium internal
-  mock_set_output "${mock_kubectl}" "127.0.1.7 127.0.2.7 127.0.3.7" 7        # .networkPolicies.global.scNodes.ips node internal
-  mock_set_output "${mock_kubectl}" "127.0.1.8 127.0.2.8 127.0.3.8" 8        # .networkPolicies.global.scNodes.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.81 127.0.2.81 127.0.3.81" 9     # .networkPolicies.global.scNodes.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "127.0.1.9 127.0.2.9 127.0.3.9" 10       # .networkPolicies.global.scNodes.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "" 11                                    # .networkPolicies.global.scNodes.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 12                                    # .networkPolicies.global.scNodes.ips cilium internal
-  mock_set_output "${mock_kubectl}" "127.0.1.4 127.0.2.4 127.0.3.4" 13       # .networkPolicies.global.wcApiserver.ips node internal
-  mock_set_output "${mock_kubectl}" "127.0.1.5 127.0.2.5 127.0.3.5" 14       # .networkPolicies.global.wcApiserver.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.51 127.0.2.51 127.0.3.51" 15    # .networkPolicies.global.wcApiserver.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "127.0.1.6 127.0.2.6 127.0.3.6" 16       # .networkPolicies.global.wcApiserver.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "" 17                                    # .networkPolicies.global.wcApiserver.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 18                                    # .networkPolicies.global.wcApiserver.ips cilium internal
-  mock_set_output "${mock_kubectl}" "127.0.1.10 127.0.2.10 127.0.3.10" 19    # .networkPolicies.global.wcNodes.ips node internal
-  mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11" 20    # .networkPolicies.global.wcNodes.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111" 21 # .networkPolicies.global.wcNodes.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "127.0.1.12 127.0.2.12 127.0.3.12" 22    # .networkPolicies.global.wcNodes.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "" 23                                    # .networkPolicies.global.wcNodes.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 24                                    # .networkPolicies.global.wcNodes.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 5                                     # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "127.0.1.7 127.0.2.7 127.0.3.7" 6        # .networkPolicies.global.scNodes.ips node internal
+  mock_set_output "${mock_kubectl}" "127.0.1.8 127.0.2.8 127.0.3.8" 7        # .networkPolicies.global.scNodes.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.81 127.0.2.81 127.0.3.81" 8     # .networkPolicies.global.scNodes.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.9 127.0.2.9 127.0.3.9" 9        # .networkPolicies.global.scNodes.ips calico wireguard
+  mock_set_output "${mock_kubectl}" "" 10                                    # .networkPolicies.global.scNodes.ips cilium internal
+  mock_set_output "${mock_kubectl}" "127.0.1.4 127.0.2.4 127.0.3.4" 11       # .networkPolicies.global.wcApiserver.ips node internal
+  mock_set_output "${mock_kubectl}" "127.0.1.5 127.0.2.5 127.0.3.5" 12       # .networkPolicies.global.wcApiserver.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.51 127.0.2.51 127.0.3.51" 13    # .networkPolicies.global.wcApiserver.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.6 127.0.2.6 127.0.3.6" 14       # .networkPolicies.global.wcApiserver.ips calico wireguard
+  mock_set_output "${mock_kubectl}" "" 15                                    # .networkPolicies.global.wcApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "127.0.1.10 127.0.2.10 127.0.3.10" 16    # .networkPolicies.global.wcNodes.ips node internal
+  mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11" 17    # .networkPolicies.global.wcNodes.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111" 18 # .networkPolicies.global.wcNodes.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.12 127.0.2.12 127.0.3.12" 19    # .networkPolicies.global.wcNodes.ips calico wireguard
+  mock_set_output "${mock_kubectl}" "" 20                                    # .networkPolicies.global.wcNodes.ips cilium internal
 
 }
 
@@ -76,23 +72,19 @@ update_ips.mock_minimal_v6() {
   mock_set_output "${mock_kubectl}" "127.0.1.1 127.0.2.1 127.0.3.1 fd3e:fab4:5eda:b233::3 fd3e:fab4:5eda:b233::4 fd3e:fab4:5eda:b233::5" 1           # .networkPolicies.global.scApiserver.ips node internal
   mock_set_output "${mock_kubectl}" "127.0.1.2 127.0.2.2 127.0.3.2 fd3e:fab4:5eda:b233::6 fd3e:fab4:5eda:b233::7 fd3e:fab4:5eda:b233::8" 4           # .networkPolicies.global.scApiserver.ips calico ipip
   mock_set_output "${mock_kubectl}" "127.0.1.21 127.0.2.21 127.0.3.21 fd3e:fab4:5eda:b233::9 fd3e:fab4:5eda:b233::10 fd3e:fab4:5eda:b233::11" 5      # .networkPolicies.global.scApiserver.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "" 6                                                                                                             # .networkPolicies.global.scApiserver.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 7                                                                                                             # .networkPolicies.global.scApiserver.ips cilium internal
-  mock_set_output "${mock_kubectl}" "127.0.1.7 127.0.2.7 127.0.3.7 fd3e:fab4:5eda:b233::61 fd3e:fab4:5eda:b233::71 fd3e:fab4:5eda:b233::81" 9        # .networkPolicies.global.scNodes.ips node internal
-  mock_set_output "${mock_kubectl}" "127.0.1.8 127.0.2.8 127.0.3.8 fd3e:fab4:5eda:b233::12 fd3e:fab4:5eda:b233::13 fd3e:fab4:5eda:b233::14" 12       # .networkPolicies.global.scNodes.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.81 127.0.2.81 127.0.3.81 fd3e:fab4:5eda:b233::15 fd3e:fab4:5eda:b233::16 fd3e:fab4:5eda:b233::17" 13    # .networkPolicies.global.scNodes.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "" 14                                                                                                            # .networkPolicies.global.scNodes.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 15                                                                                                            # .networkPolicies.global.scNodes.ips cilium internal
-  mock_set_output "${mock_kubectl}" "127.0.1.4 127.0.2.4 127.0.3.4 fd3e:fab4:5eda:b233::62 fd3e:fab4:5eda:b233::72 fd3e:fab4:5eda:b233::82" 17       # .networkPolicies.global.wcApiserver.ips node internal
-  mock_set_output "${mock_kubectl}" "127.0.1.5 127.0.2.5 127.0.3.5 fd3e:fab4:5eda:b233::18 fd3e:fab4:5eda:b233::19 fd3e:fab4:5eda:b233::20" 20       # .networkPolicies.global.wcApiserver.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.51 127.0.2.51 127.0.3.51 fd3e:fab4:5eda:b233::21 fd3e:fab4:5eda:b233::22 fd3e:fab4:5eda:b233::23" 21    # .networkPolicies.global.wcApiserver.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "" 22                                                                                                            # .networkPolicies.global.wcApiserver.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 23                                                                                                            # .networkPolicies.global.wcApiserver.ips cilium internal
-  mock_set_output "${mock_kubectl}" "127.0.1.10 127.0.2.10 127.0.3.10 fd3e:fab4:5eda:b233::63 fd3e:fab4:5eda:b233::73 fd3e:fab4:5eda:b233::83" 25    # .networkPolicies.global.wcNodes.ips node internal
-  mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11 fd3e:fab4:5eda:b233::24 fd3e:fab4:5eda:b233::25 fd3e:fab4:5eda:b233::26" 26    # .networkPolicies.global.wcNodes.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111 fd3e:fab4:5eda:b233::27 fd3e:fab4:5eda:b233::28 fd3e:fab4:5eda:b233::29" 27 # .networkPolicies.global.wcNodes.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "" 28                                                                                                            # .networkPolicies.global.wcNodes.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 29                                                                                                            # .networkPolicies.global.wcNodes.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 6                                                                                                             # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "127.0.1.7 127.0.2.7 127.0.3.7 fd3e:fab4:5eda:b233::61 fd3e:fab4:5eda:b233::71 fd3e:fab4:5eda:b233::81" 8        # .networkPolicies.global.scNodes.ips node internal
+  mock_set_output "${mock_kubectl}" "127.0.1.8 127.0.2.8 127.0.3.8 fd3e:fab4:5eda:b233::12 fd3e:fab4:5eda:b233::13 fd3e:fab4:5eda:b233::14" 11       # .networkPolicies.global.scNodes.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.81 127.0.2.81 127.0.3.81 fd3e:fab4:5eda:b233::15 fd3e:fab4:5eda:b233::16 fd3e:fab4:5eda:b233::17" 12    # .networkPolicies.global.scNodes.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "" 13                                                                                                            # .networkPolicies.global.scNodes.ips cilium internal
+  mock_set_output "${mock_kubectl}" "127.0.1.4 127.0.2.4 127.0.3.4 fd3e:fab4:5eda:b233::62 fd3e:fab4:5eda:b233::72 fd3e:fab4:5eda:b233::82" 15       # .networkPolicies.global.wcApiserver.ips node internal
+  mock_set_output "${mock_kubectl}" "127.0.1.5 127.0.2.5 127.0.3.5 fd3e:fab4:5eda:b233::18 fd3e:fab4:5eda:b233::19 fd3e:fab4:5eda:b233::20" 18       # .networkPolicies.global.wcApiserver.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.51 127.0.2.51 127.0.3.51 fd3e:fab4:5eda:b233::21 fd3e:fab4:5eda:b233::22 fd3e:fab4:5eda:b233::23" 19    # .networkPolicies.global.wcApiserver.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "" 20                                                                                                            # .networkPolicies.global.wcApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "127.0.1.10 127.0.2.10 127.0.3.10 fd3e:fab4:5eda:b233::63 fd3e:fab4:5eda:b233::73 fd3e:fab4:5eda:b233::83" 22    # .networkPolicies.global.wcNodes.ips node internal
+  mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11 fd3e:fab4:5eda:b233::24 fd3e:fab4:5eda:b233::25 fd3e:fab4:5eda:b233::26" 23    # .networkPolicies.global.wcNodes.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111 fd3e:fab4:5eda:b233::27 fd3e:fab4:5eda:b233::28 fd3e:fab4:5eda:b233::29" 24 # .networkPolicies.global.wcNodes.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "" 25                                                                                                            # .networkPolicies.global.wcNodes.ips cilium internal
 }
 
 update_ips.mock_maximal() {
@@ -265,7 +257,7 @@ update_ips.assert_minimal() {
 
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
   assert_equal "$(mock_get_call_num "${mock_dig}")" 3
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 24
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 20
 }
 
 update_ips.assert_minimal_v6() {
@@ -283,7 +275,7 @@ update_ips.assert_minimal_v6() {
 
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
   assert_equal "$(mock_get_call_num "${mock_dig}")" 6
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 32
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 28
 }
 
 update_ips.assert_swift() {
@@ -292,7 +284,7 @@ update_ips.assert_swift() {
 
   assert_equal "$(mock_get_call_num "${mock_curl}")" 2
   assert_equal "$(mock_get_call_num "${mock_dig}")" 5
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 24
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 20
 }
 
 update_ips.assert_rclone_s3() {
@@ -302,7 +294,7 @@ update_ips.assert_rclone_s3() {
   assert_equal "$(yq '.networkPolicies.rclone.sync.objectStorageSwift' "${CK8S_CONFIG_PATH}/sc-config.yaml")" "null"
 
   assert_equal "$(mock_get_call_num "${mock_dig}")" 4
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 24
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 20
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
 }
 
@@ -314,7 +306,7 @@ update_ips.assert_rclone_s3_and_swift() {
   assert_equal "$(yq '.networkPolicies.rclone.sync.objectStorageSwift | .ports style="flow" | .ports' "${CK8S_CONFIG_PATH}/sc-config.yaml")" "[443, 5678]"
 
   assert_equal "$(mock_get_call_num "${mock_dig}")" 6
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 24
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 20
   assert_equal "$(mock_get_call_num "${mock_curl}")" 2
 }
 

--- a/tests/common/bats/update-ips.bash
+++ b/tests/common/bats/update-ips.bash
@@ -43,18 +43,26 @@ update_ips.mock_minimal() {
   mock_set_output "${mock_kubectl}" "127.0.1.2 127.0.2.2 127.0.3.2" 2        # .networkPolicies.global.scApiserver.ips calico ipip
   mock_set_output "${mock_kubectl}" "127.0.1.21 127.0.2.21 127.0.3.21" 3     # .networkPolicies.global.scApiserver.ips calico vxlan
   mock_set_output "${mock_kubectl}" "127.0.1.3 127.0.2.3 127.0.3.3" 4        # .networkPolicies.global.scApiserver.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "127.0.1.7 127.0.2.7 127.0.3.7" 5        # .networkPolicies.global.scNodes.ips node internal
-  mock_set_output "${mock_kubectl}" "127.0.1.8 127.0.2.8 127.0.3.8" 6        # .networkPolicies.global.scNodes.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.81 127.0.2.81 127.0.3.81" 7     # .networkPolicies.global.scNodes.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "127.0.1.9 127.0.2.9 127.0.3.9" 8        # .networkPolicies.global.scNodes.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "127.0.1.4 127.0.2.4 127.0.3.4" 9        # .networkPolicies.global.wcApiserver.ips node internal
-  mock_set_output "${mock_kubectl}" "127.0.1.5 127.0.2.5 127.0.3.5" 10       # .networkPolicies.global.wcApiserver.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.51 127.0.2.51 127.0.3.51" 11    # .networkPolicies.global.wcApiserver.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "127.0.1.6 127.0.2.6 127.0.3.6" 12       # .networkPolicies.global.wcApiserver.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "127.0.1.10 127.0.2.10 127.0.3.10" 13    # .networkPolicies.global.wcNodes.ips node internal
-  mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11" 14    # .networkPolicies.global.wcNodes.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111" 15 # .networkPolicies.global.wcNodes.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "127.0.1.12 127.0.2.12 127.0.3.12" 16    # .networkPolicies.global.wcNodes.ips calico wireguard
+  mock_set_output "${mock_kubectl}" "" 5                                     # .networkPolicies.global.scApiserver.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 6                                     # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "127.0.1.7 127.0.2.7 127.0.3.7" 7        # .networkPolicies.global.scNodes.ips node internal
+  mock_set_output "${mock_kubectl}" "127.0.1.8 127.0.2.8 127.0.3.8" 8        # .networkPolicies.global.scNodes.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.81 127.0.2.81 127.0.3.81" 9     # .networkPolicies.global.scNodes.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.9 127.0.2.9 127.0.3.9" 10       # .networkPolicies.global.scNodes.ips calico wireguard
+  mock_set_output "${mock_kubectl}" "" 11                                    # .networkPolicies.global.scApiserver.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 12                                    # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "127.0.1.4 127.0.2.4 127.0.3.4" 13       # .networkPolicies.global.wcApiserver.ips node internal
+  mock_set_output "${mock_kubectl}" "127.0.1.5 127.0.2.5 127.0.3.5" 14       # .networkPolicies.global.wcApiserver.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.51 127.0.2.51 127.0.3.51" 15    # .networkPolicies.global.wcApiserver.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.6 127.0.2.6 127.0.3.6" 16       # .networkPolicies.global.wcApiserver.ips calico wireguard
+  mock_set_output "${mock_kubectl}" "" 17                                    # .networkPolicies.global.scApiserver.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 18                                    # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "127.0.1.10 127.0.2.10 127.0.3.10" 19    # .networkPolicies.global.wcNodes.ips node internal
+  mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11" 20    # .networkPolicies.global.wcNodes.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111" 21 # .networkPolicies.global.wcNodes.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.12 127.0.2.12 127.0.3.12" 22    # .networkPolicies.global.wcNodes.ips calico wireguard
+  mock_set_output "${mock_kubectl}" "" 23                                    # .networkPolicies.global.scApiserver.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 24                                    # .networkPolicies.global.scApiserver.ips cilium internal
 
 }
 
@@ -68,15 +76,23 @@ update_ips.mock_minimal_v6() {
   mock_set_output "${mock_kubectl}" "127.0.1.1 127.0.2.1 127.0.3.1 fd3e:fab4:5eda:b233::3 fd3e:fab4:5eda:b233::4 fd3e:fab4:5eda:b233::5" 1           # .networkPolicies.global.scApiserver.ips node internal
   mock_set_output "${mock_kubectl}" "127.0.1.2 127.0.2.2 127.0.3.2 fd3e:fab4:5eda:b233::6 fd3e:fab4:5eda:b233::7 fd3e:fab4:5eda:b233::8" 4           # .networkPolicies.global.scApiserver.ips calico ipip
   mock_set_output "${mock_kubectl}" "127.0.1.21 127.0.2.21 127.0.3.21 fd3e:fab4:5eda:b233::9 fd3e:fab4:5eda:b233::10 fd3e:fab4:5eda:b233::11" 5      # .networkPolicies.global.scApiserver.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "127.0.1.7 127.0.2.7 127.0.3.7 fd3e:fab4:5eda:b233::61 fd3e:fab4:5eda:b233::71 fd3e:fab4:5eda:b233::81" 7        # .networkPolicies.global.scNodes.ips node internal
-  mock_set_output "${mock_kubectl}" "127.0.1.8 127.0.2.8 127.0.3.8 fd3e:fab4:5eda:b233::12 fd3e:fab4:5eda:b233::13 fd3e:fab4:5eda:b233::14" 10       # .networkPolicies.global.scNodes.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.81 127.0.2.81 127.0.3.81 fd3e:fab4:5eda:b233::15 fd3e:fab4:5eda:b233::16 fd3e:fab4:5eda:b233::17" 11    # .networkPolicies.global.scNodes.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "127.0.1.4 127.0.2.4 127.0.3.4 fd3e:fab4:5eda:b233::62 fd3e:fab4:5eda:b233::72 fd3e:fab4:5eda:b233::82" 13       # .networkPolicies.global.wcApiserver.ips node internal
-  mock_set_output "${mock_kubectl}" "127.0.1.5 127.0.2.5 127.0.3.5 fd3e:fab4:5eda:b233::18 fd3e:fab4:5eda:b233::19 fd3e:fab4:5eda:b233::20" 16       # .networkPolicies.global.wcApiserver.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.51 127.0.2.51 127.0.3.51 fd3e:fab4:5eda:b233::21 fd3e:fab4:5eda:b233::22 fd3e:fab4:5eda:b233::23" 17    # .networkPolicies.global.wcApiserver.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "127.0.1.10 127.0.2.10 127.0.3.10 fd3e:fab4:5eda:b233::63 fd3e:fab4:5eda:b233::73 fd3e:fab4:5eda:b233::83" 19    # .networkPolicies.global.wcNodes.ips node internal
-  mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11 fd3e:fab4:5eda:b233::24 fd3e:fab4:5eda:b233::25 fd3e:fab4:5eda:b233::26" 20    # .networkPolicies.global.wcNodes.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111 fd3e:fab4:5eda:b233::27 fd3e:fab4:5eda:b233::28 fd3e:fab4:5eda:b233::29" 21 # .networkPolicies.global.wcNodes.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "" 6                                                                                                             # .networkPolicies.global.scApiserver.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 7                                                                                                             # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "127.0.1.7 127.0.2.7 127.0.3.7 fd3e:fab4:5eda:b233::61 fd3e:fab4:5eda:b233::71 fd3e:fab4:5eda:b233::81" 9        # .networkPolicies.global.scNodes.ips node internal
+  mock_set_output "${mock_kubectl}" "127.0.1.8 127.0.2.8 127.0.3.8 fd3e:fab4:5eda:b233::12 fd3e:fab4:5eda:b233::13 fd3e:fab4:5eda:b233::14" 12       # .networkPolicies.global.scNodes.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.81 127.0.2.81 127.0.3.81 fd3e:fab4:5eda:b233::15 fd3e:fab4:5eda:b233::16 fd3e:fab4:5eda:b233::17" 13    # .networkPolicies.global.scNodes.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "" 14                                                                                                            # .networkPolicies.global.scApiserver.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 15                                                                                                            # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "127.0.1.4 127.0.2.4 127.0.3.4 fd3e:fab4:5eda:b233::62 fd3e:fab4:5eda:b233::72 fd3e:fab4:5eda:b233::82" 17       # .networkPolicies.global.wcApiserver.ips node internal
+  mock_set_output "${mock_kubectl}" "127.0.1.5 127.0.2.5 127.0.3.5 fd3e:fab4:5eda:b233::18 fd3e:fab4:5eda:b233::19 fd3e:fab4:5eda:b233::20" 20       # .networkPolicies.global.wcApiserver.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.51 127.0.2.51 127.0.3.51 fd3e:fab4:5eda:b233::21 fd3e:fab4:5eda:b233::22 fd3e:fab4:5eda:b233::23" 21    # .networkPolicies.global.wcApiserver.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "" 22                                                                                                            # .networkPolicies.global.scApiserver.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 23                                                                                                            # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "127.0.1.10 127.0.2.10 127.0.3.10 fd3e:fab4:5eda:b233::63 fd3e:fab4:5eda:b233::73 fd3e:fab4:5eda:b233::83" 25    # .networkPolicies.global.wcNodes.ips node internal
+  mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11 fd3e:fab4:5eda:b233::24 fd3e:fab4:5eda:b233::25 fd3e:fab4:5eda:b233::26" 26    # .networkPolicies.global.wcNodes.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111 fd3e:fab4:5eda:b233::27 fd3e:fab4:5eda:b233::28 fd3e:fab4:5eda:b233::29" 27 # .networkPolicies.global.wcNodes.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "" 28                                                                                                            # .networkPolicies.global.scApiserver.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 29                                                                                                            # .networkPolicies.global.scApiserver.ips cilium internal
 }
 
 update_ips.mock_maximal() {
@@ -249,7 +265,7 @@ update_ips.assert_minimal() {
 
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
   assert_equal "$(mock_get_call_num "${mock_dig}")" 3
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 16
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 24
 }
 
 update_ips.assert_minimal_v6() {
@@ -267,7 +283,7 @@ update_ips.assert_minimal_v6() {
 
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
   assert_equal "$(mock_get_call_num "${mock_dig}")" 6
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 24
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 32
 }
 
 update_ips.assert_swift() {
@@ -276,7 +292,7 @@ update_ips.assert_swift() {
 
   assert_equal "$(mock_get_call_num "${mock_curl}")" 2
   assert_equal "$(mock_get_call_num "${mock_dig}")" 5
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 16
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 24
 }
 
 update_ips.assert_rclone_s3() {
@@ -286,7 +302,7 @@ update_ips.assert_rclone_s3() {
   assert_equal "$(yq '.networkPolicies.rclone.sync.objectStorageSwift' "${CK8S_CONFIG_PATH}/sc-config.yaml")" "null"
 
   assert_equal "$(mock_get_call_num "${mock_dig}")" 4
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 16
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 24
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
 }
 
@@ -298,7 +314,7 @@ update_ips.assert_rclone_s3_and_swift() {
   assert_equal "$(yq '.networkPolicies.rclone.sync.objectStorageSwift | .ports style="flow" | .ports' "${CK8S_CONFIG_PATH}/sc-config.yaml")" "[443, 5678]"
 
   assert_equal "$(mock_get_call_num "${mock_dig}")" 6
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 16
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 24
   assert_equal "$(mock_get_call_num "${mock_curl}")" 2
 }
 

--- a/tests/unit/general/bin-update-ips-rclone.bats
+++ b/tests/unit/general/bin-update-ips-rclone.bats
@@ -368,7 +368,7 @@ _test_apply_rclone_sync_s3_and_swift() {
   assert_equal "$(yq.dig sc '.networkPolicies.rclone.sync.secondaryUrl.ports | . style="flow"')" "[1234]"
 
   assert_equal "$(mock_get_call_num "${mock_dig}")" 4
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 16
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 24
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
 }
 
@@ -382,7 +382,7 @@ _test_apply_rclone_sync_s3_and_swift() {
   assert_equal "$(yq '.networkPolicies.rclone.sync.secondaryUrl' "${CK8S_CONFIG_PATH}/sc-config.yaml")" "null"
 
   assert_equal "$(mock_get_call_num "${mock_dig}")" 3
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 16
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 24
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
 }
 

--- a/tests/unit/general/bin-update-ips-rclone.bats
+++ b/tests/unit/general/bin-update-ips-rclone.bats
@@ -368,7 +368,7 @@ _test_apply_rclone_sync_s3_and_swift() {
   assert_equal "$(yq.dig sc '.networkPolicies.rclone.sync.secondaryUrl.ports | . style="flow"')" "[1234]"
 
   assert_equal "$(mock_get_call_num "${mock_dig}")" 4
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 24
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 20
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
 }
 
@@ -382,7 +382,7 @@ _test_apply_rclone_sync_s3_and_swift() {
   assert_equal "$(yq '.networkPolicies.rclone.sync.secondaryUrl' "${CK8S_CONFIG_PATH}/sc-config.yaml")" "null"
 
   assert_equal "$(mock_get_call_num "${mock_dig}")" 3
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 24
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 20
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
 }
 

--- a/tests/unit/general/bin-update-ips-subnet.bats
+++ b/tests/unit/general/bin-update-ips-subnet.bats
@@ -59,24 +59,24 @@ update_ips.mock_minimal_with_subnet() {
   mock_set_output "${mock_kubectl}" "127.0.1.8 127.0.2.8 127.0.3.8" 14       # .networkPolicies.global.scNodes.ips calico ipip
   mock_set_output "${mock_kubectl}" "127.0.1.81 127.0.2.81 127.0.3.81" 15    # .networkPolicies.global.scNodes.ips calico vxlan
   mock_set_output "${mock_kubectl}" "127.0.1.9 127.0.2.9 127.0.3.9" 16       # .networkPolicies.global.scNodes.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "" 17                                    # .networkPolicies.global.scApiserver.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 18                                    # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 17                                    # .networkPolicies.global.scNodes.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 18                                    # .networkPolicies.global.scNodes.ips cilium internal
   mock_set_output "${mock_kubectl}" "" 19                                    # check if cluster with name <environment>-<cluster> exists
   mock_set_output "${mock_kubectl}" "[1]" 20                                 # check number of subnets in cluster
   mock_set_output "${mock_kubectl}" "10.0.1.0/24" 21                         # .networkPolicies.global.wcApiserver.ips cluster subnet
   mock_set_output "${mock_kubectl}" "127.0.1.5 127.0.2.5 127.0.3.5" 22       # .networkPolicies.global.wcApiserver.ips calico ipip
   mock_set_output "${mock_kubectl}" "127.0.1.51 127.0.2.51 127.0.3.51" 23    # .networkPolicies.global.wcApiserver.ips calico vxlan
   mock_set_output "${mock_kubectl}" "127.0.1.6 127.0.2.6 127.0.3.6" 24       # .networkPolicies.global.wcApiserver.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "" 25                                    # .networkPolicies.global.scApiserver.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 26                                    # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 25                                    # .networkPolicies.global.wcApiserver.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 26                                    # .networkPolicies.global.wcApiserver.ips cilium internal
   mock_set_output "${mock_kubectl}" "" 27                                    # check if cluster with name <environment>-<cluster> exists
   mock_set_output "${mock_kubectl}" "[1]" 28                                 # check number of subnets in cluster
   mock_set_output "${mock_kubectl}" "10.0.1.0/24" 29                         # .networkPolicies.global.wcNodes.ips cluster subnet
   mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11" 30    # .networkPolicies.global.wcNodes.ips calico ipip
   mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111" 31 # .networkPolicies.global.wcNodes.ips calico vxlan
   mock_set_output "${mock_kubectl}" "127.0.1.12 127.0.2.12 127.0.3.12" 32    # .networkPolicies.global.wcNodes.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "" 33                                    # .networkPolicies.global.scApiserver.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 34                                    # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 33                                    # .networkPolicies.global.wcNodes.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 34                                    # .networkPolicies.global.wcNodes.ips cilium internal
 }
 
 @test "ck8s update-ips can allow subnet" {

--- a/tests/unit/general/bin-update-ips-subnet.bats
+++ b/tests/unit/general/bin-update-ips-subnet.bats
@@ -50,25 +50,33 @@ update_ips.mock_minimal_with_subnet() {
   mock_set_output "${mock_kubectl}" "127.0.1.2 127.0.2.2 127.0.3.2" 5        # .networkPolicies.global.scApiserver.ips calico ipip
   mock_set_output "${mock_kubectl}" "127.0.1.21 127.0.2.21 127.0.3.21" 6     # .networkPolicies.global.scApiserver.ips calico vxlan
   mock_set_output "${mock_kubectl}" "127.0.1.3 127.0.2.3 127.0.3.3" 7        # .networkPolicies.global.scApiserver.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "" 8                                     # check if cluster with name <environment>-sc exists
-  mock_set_output "${mock_kubectl}" "" 9                                     # check if cluster with name <environment>-<cluster> exists
-  mock_set_output "${mock_kubectl}" "[1]" 10                                 # check number of subnets in cluster
-  mock_set_output "${mock_kubectl}" "10.0.0.0/24" 11                         # .networkPolicies.global.scNodes.ips cluster subnet
-  mock_set_output "${mock_kubectl}" "127.0.1.8 127.0.2.8 127.0.3.8" 12       # .networkPolicies.global.scNodes.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.81 127.0.2.81 127.0.3.81" 13    # .networkPolicies.global.scNodes.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "127.0.1.9 127.0.2.9 127.0.3.9" 14       # .networkPolicies.global.scNodes.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "" 15                                    # check if cluster with name <environment>-<cluster> exists
-  mock_set_output "${mock_kubectl}" "[1]" 16                                 # check number of subnets in cluster
-  mock_set_output "${mock_kubectl}" "10.0.1.0/24" 17                         # .networkPolicies.global.wcApiserver.ips cluster subnet
-  mock_set_output "${mock_kubectl}" "127.0.1.5 127.0.2.5 127.0.3.5" 18       # .networkPolicies.global.wcApiserver.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.51 127.0.2.51 127.0.3.51" 19    # .networkPolicies.global.wcApiserver.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "127.0.1.6 127.0.2.6 127.0.3.6" 20       # .networkPolicies.global.wcApiserver.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "" 21                                    # check if cluster with name <environment>-<cluster> exists
-  mock_set_output "${mock_kubectl}" "[1]" 22                                 # check number of subnets in cluster
-  mock_set_output "${mock_kubectl}" "10.0.1.0/24" 23                         # .networkPolicies.global.wcNodes.ips cluster subnet
-  mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11" 24    # .networkPolicies.global.wcNodes.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111" 25 # .networkPolicies.global.wcNodes.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "127.0.1.12 127.0.2.12 127.0.3.12" 26    # .networkPolicies.global.wcNodes.ips calico wireguard
+  mock_set_output "${mock_kubectl}" "" 8                                     # .networkPolicies.global.scApiserver.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 9                                     # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 10                                    # check if cluster with name <environment>-sc exists
+  mock_set_output "${mock_kubectl}" "" 11                                    # check if cluster with name <environment>-<cluster> exists
+  mock_set_output "${mock_kubectl}" "[1]" 12                                 # check number of subnets in cluster
+  mock_set_output "${mock_kubectl}" "10.0.0.0/24" 13                         # .networkPolicies.global.scNodes.ips cluster subnet
+  mock_set_output "${mock_kubectl}" "127.0.1.8 127.0.2.8 127.0.3.8" 14       # .networkPolicies.global.scNodes.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.81 127.0.2.81 127.0.3.81" 15    # .networkPolicies.global.scNodes.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.9 127.0.2.9 127.0.3.9" 16       # .networkPolicies.global.scNodes.ips calico wireguard
+  mock_set_output "${mock_kubectl}" "" 17                                    # .networkPolicies.global.scApiserver.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 18                                    # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 19                                    # check if cluster with name <environment>-<cluster> exists
+  mock_set_output "${mock_kubectl}" "[1]" 20                                 # check number of subnets in cluster
+  mock_set_output "${mock_kubectl}" "10.0.1.0/24" 21                         # .networkPolicies.global.wcApiserver.ips cluster subnet
+  mock_set_output "${mock_kubectl}" "127.0.1.5 127.0.2.5 127.0.3.5" 22       # .networkPolicies.global.wcApiserver.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.51 127.0.2.51 127.0.3.51" 23    # .networkPolicies.global.wcApiserver.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.6 127.0.2.6 127.0.3.6" 24       # .networkPolicies.global.wcApiserver.ips calico wireguard
+  mock_set_output "${mock_kubectl}" "" 25                                    # .networkPolicies.global.scApiserver.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 26                                    # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 27                                    # check if cluster with name <environment>-<cluster> exists
+  mock_set_output "${mock_kubectl}" "[1]" 28                                 # check number of subnets in cluster
+  mock_set_output "${mock_kubectl}" "10.0.1.0/24" 29                         # .networkPolicies.global.wcNodes.ips cluster subnet
+  mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11" 30    # .networkPolicies.global.wcNodes.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111" 31 # .networkPolicies.global.wcNodes.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.12 127.0.2.12 127.0.3.12" 32    # .networkPolicies.global.wcNodes.ips calico wireguard
+  mock_set_output "${mock_kubectl}" "" 33                                    # .networkPolicies.global.scApiserver.ips cilium crds
+  mock_set_output "${mock_kubectl}" "" 34                                    # .networkPolicies.global.scApiserver.ips cilium internal
 }
 
 @test "ck8s update-ips can allow subnet" {
@@ -84,7 +92,7 @@ update_ips.mock_minimal_with_subnet() {
 
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
   assert_equal "$(mock_get_call_num "${mock_dig}")" 3
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 26
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 34
 }
 
 @test "ck8s update-ips swallows existing internal ips into cluster subnet" {
@@ -101,18 +109,18 @@ update_ips.mock_minimal_with_subnet() {
 
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
   assert_equal "$(mock_get_call_num "${mock_dig}")" 3
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 26
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 34
 }
 
 @test "ck8s update-ips falls back on individual node IPs if CAPI cluster is not found" {
   update_ips.mock_minimal_with_subnet
   update_ips.populate_minimal
 
-  mock_set_status "${mock_kubectl}" 1 21
-  mock_set_output "${mock_kubectl}" "10.0.1.2 10.0.1.3 10.0.1.4" 22          # .networkPolicies.global.wcNodes.ips node internal
-  mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11" 23    # .networkPolicies.global.wcNodes.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111" 24 # .networkPolicies.global.wcNodes.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "127.0.1.12 127.0.2.12 127.0.3.12" 25    # .networkPolicies.global.wcNodes.ips calico wireguard
+  mock_set_status "${mock_kubectl}" 1 27
+  mock_set_output "${mock_kubectl}" "10.0.1.2 10.0.1.3 10.0.1.4" 28          # .networkPolicies.global.wcNodes.ips node internal
+  mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11" 29    # .networkPolicies.global.wcNodes.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111" 30 # .networkPolicies.global.wcNodes.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.12 127.0.2.12 127.0.3.12" 31    # .networkPolicies.global.wcNodes.ips calico wireguard
 
   run ck8s update-ips both apply
 
@@ -121,5 +129,5 @@ update_ips.mock_minimal_with_subnet() {
 
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
   assert_equal "$(mock_get_call_num "${mock_dig}")" 3
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 25
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 33
 }

--- a/tests/unit/general/bin-update-ips-subnet.bats
+++ b/tests/unit/general/bin-update-ips-subnet.bats
@@ -50,33 +50,29 @@ update_ips.mock_minimal_with_subnet() {
   mock_set_output "${mock_kubectl}" "127.0.1.2 127.0.2.2 127.0.3.2" 5        # .networkPolicies.global.scApiserver.ips calico ipip
   mock_set_output "${mock_kubectl}" "127.0.1.21 127.0.2.21 127.0.3.21" 6     # .networkPolicies.global.scApiserver.ips calico vxlan
   mock_set_output "${mock_kubectl}" "127.0.1.3 127.0.2.3 127.0.3.3" 7        # .networkPolicies.global.scApiserver.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "" 8                                     # .networkPolicies.global.scApiserver.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 9                                     # .networkPolicies.global.scApiserver.ips cilium internal
-  mock_set_output "${mock_kubectl}" "" 10                                    # check if cluster with name <environment>-sc exists
-  mock_set_output "${mock_kubectl}" "" 11                                    # check if cluster with name <environment>-<cluster> exists
-  mock_set_output "${mock_kubectl}" "[1]" 12                                 # check number of subnets in cluster
-  mock_set_output "${mock_kubectl}" "10.0.0.0/24" 13                         # .networkPolicies.global.scNodes.ips cluster subnet
-  mock_set_output "${mock_kubectl}" "127.0.1.8 127.0.2.8 127.0.3.8" 14       # .networkPolicies.global.scNodes.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.81 127.0.2.81 127.0.3.81" 15    # .networkPolicies.global.scNodes.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "127.0.1.9 127.0.2.9 127.0.3.9" 16       # .networkPolicies.global.scNodes.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "" 17                                    # .networkPolicies.global.scNodes.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 18                                    # .networkPolicies.global.scNodes.ips cilium internal
-  mock_set_output "${mock_kubectl}" "" 19                                    # check if cluster with name <environment>-<cluster> exists
-  mock_set_output "${mock_kubectl}" "[1]" 20                                 # check number of subnets in cluster
-  mock_set_output "${mock_kubectl}" "10.0.1.0/24" 21                         # .networkPolicies.global.wcApiserver.ips cluster subnet
-  mock_set_output "${mock_kubectl}" "127.0.1.5 127.0.2.5 127.0.3.5" 22       # .networkPolicies.global.wcApiserver.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.51 127.0.2.51 127.0.3.51" 23    # .networkPolicies.global.wcApiserver.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "127.0.1.6 127.0.2.6 127.0.3.6" 24       # .networkPolicies.global.wcApiserver.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "" 25                                    # .networkPolicies.global.wcApiserver.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 26                                    # .networkPolicies.global.wcApiserver.ips cilium internal
-  mock_set_output "${mock_kubectl}" "" 27                                    # check if cluster with name <environment>-<cluster> exists
-  mock_set_output "${mock_kubectl}" "[1]" 28                                 # check number of subnets in cluster
-  mock_set_output "${mock_kubectl}" "10.0.1.0/24" 29                         # .networkPolicies.global.wcNodes.ips cluster subnet
-  mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11" 30    # .networkPolicies.global.wcNodes.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111" 31 # .networkPolicies.global.wcNodes.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "127.0.1.12 127.0.2.12 127.0.3.12" 32    # .networkPolicies.global.wcNodes.ips calico wireguard
-  mock_set_output "${mock_kubectl}" "" 33                                    # .networkPolicies.global.wcNodes.ips cilium crds
-  mock_set_output "${mock_kubectl}" "" 34                                    # .networkPolicies.global.wcNodes.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 8                                     # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 9                                     # check if cluster with name <environment>-sc exists
+  mock_set_output "${mock_kubectl}" "" 10                                    # check if cluster with name <environment>-<cluster> exists
+  mock_set_output "${mock_kubectl}" "[1]" 11                                 # check number of subnets in cluster
+  mock_set_output "${mock_kubectl}" "10.0.0.0/24" 12                         # .networkPolicies.global.scNodes.ips cluster subnet
+  mock_set_output "${mock_kubectl}" "127.0.1.8 127.0.2.8 127.0.3.8" 13       # .networkPolicies.global.scNodes.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.81 127.0.2.81 127.0.3.81" 14    # .networkPolicies.global.scNodes.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.9 127.0.2.9 127.0.3.9" 15       # .networkPolicies.global.scNodes.ips calico wireguard
+  mock_set_output "${mock_kubectl}" "" 16                                    # .networkPolicies.global.scNodes.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 17                                    # check if cluster with name <environment>-<cluster> exists
+  mock_set_output "${mock_kubectl}" "[1]" 18                                 # check number of subnets in cluster
+  mock_set_output "${mock_kubectl}" "10.0.1.0/24" 19                         # .networkPolicies.global.wcApiserver.ips cluster subnet
+  mock_set_output "${mock_kubectl}" "127.0.1.5 127.0.2.5 127.0.3.5" 20       # .networkPolicies.global.wcApiserver.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.51 127.0.2.51 127.0.3.51" 21    # .networkPolicies.global.wcApiserver.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.6 127.0.2.6 127.0.3.6" 22       # .networkPolicies.global.wcApiserver.ips calico wireguard
+  mock_set_output "${mock_kubectl}" "" 23                                    # .networkPolicies.global.wcApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "" 24                                    # check if cluster with name <environment>-<cluster> exists
+  mock_set_output "${mock_kubectl}" "[1]" 25                                 # check number of subnets in cluster
+  mock_set_output "${mock_kubectl}" "10.0.1.0/24" 26                         # .networkPolicies.global.wcNodes.ips cluster subnet
+  mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11" 27    # .networkPolicies.global.wcNodes.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111" 28 # .networkPolicies.global.wcNodes.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.12 127.0.2.12 127.0.3.12" 29    # .networkPolicies.global.wcNodes.ips calico wireguard
+  mock_set_output "${mock_kubectl}" "" 30                                    # .networkPolicies.global.wcNodes.ips cilium internal
 }
 
 @test "ck8s update-ips can allow subnet" {
@@ -92,7 +88,7 @@ update_ips.mock_minimal_with_subnet() {
 
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
   assert_equal "$(mock_get_call_num "${mock_dig}")" 3
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 34
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 30
 }
 
 @test "ck8s update-ips swallows existing internal ips into cluster subnet" {
@@ -109,18 +105,18 @@ update_ips.mock_minimal_with_subnet() {
 
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
   assert_equal "$(mock_get_call_num "${mock_dig}")" 3
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 34
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 30
 }
 
 @test "ck8s update-ips falls back on individual node IPs if CAPI cluster is not found" {
   update_ips.mock_minimal_with_subnet
   update_ips.populate_minimal
 
-  mock_set_status "${mock_kubectl}" 1 27
-  mock_set_output "${mock_kubectl}" "10.0.1.2 10.0.1.3 10.0.1.4" 28          # .networkPolicies.global.wcNodes.ips node internal
-  mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11" 29    # .networkPolicies.global.wcNodes.ips calico ipip
-  mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111" 30 # .networkPolicies.global.wcNodes.ips calico vxlan
-  mock_set_output "${mock_kubectl}" "127.0.1.12 127.0.2.12 127.0.3.12" 31    # .networkPolicies.global.wcNodes.ips calico wireguard
+  mock_set_status "${mock_kubectl}" 1 24
+  mock_set_output "${mock_kubectl}" "10.0.1.2 10.0.1.3 10.0.1.4" 25          # .networkPolicies.global.wcNodes.ips node internal
+  mock_set_output "${mock_kubectl}" "127.0.1.11 127.0.2.11 127.0.3.11" 26    # .networkPolicies.global.wcNodes.ips calico ipip
+  mock_set_output "${mock_kubectl}" "127.0.1.111 127.0.2.111 127.0.3.111" 27 # .networkPolicies.global.wcNodes.ips calico vxlan
+  mock_set_output "${mock_kubectl}" "127.0.1.12 127.0.2.12 127.0.3.12" 28    # .networkPolicies.global.wcNodes.ips calico wireguard
 
   run ck8s update-ips both apply
 
@@ -129,5 +125,5 @@ update_ips.mock_minimal_with_subnet() {
 
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
   assert_equal "$(mock_get_call_num "${mock_dig}")" 3
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 33
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 29
 }

--- a/tests/unit/general/bin-update-ips.bats
+++ b/tests/unit/general/bin-update-ips.bats
@@ -132,7 +132,7 @@ _apply_normalise() {
 
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
   assert_equal "$(mock_get_call_num "${mock_dig}")" 3
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 16
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 24
 }
 
 @test "ck8s update-ips skips ips in existing cidrs" {
@@ -149,7 +149,7 @@ _apply_normalise() {
 
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
   assert_equal "$(mock_get_call_num "${mock_dig}")" 3
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 16
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 24
 }
 
 @test "ck8s update-ips allows s3 region endpoint to be an ip" {
@@ -177,7 +177,7 @@ _apply_normalise() {
   assert_equal "$(yq.dig common '.networkPolicies.global.objectStorage.ips | . style="flow"')" "[10.244.0.0/16]"
 
   assert_equal "$(mock_get_call_num "${mock_dig}")" 2
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 17
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 25
 }
 
 @test "ck8s update-ips allows s3 region endpoint to be cluster local without kubeadm config" {
@@ -192,7 +192,7 @@ _apply_normalise() {
   assert_equal "$(yq.dig common '.networkPolicies.global.objectStorage.ips | . style="flow"')" "[0.0.0.0/0]"
 
   assert_equal "$(mock_get_call_num "${mock_dig}")" 2
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 17
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 25
 }
 
 # --- maximal ----------------------------------------------------------------------------------------------------------

--- a/tests/unit/general/bin-update-ips.bats
+++ b/tests/unit/general/bin-update-ips.bats
@@ -104,10 +104,10 @@ _apply_normalise() {
 @test "ck8s update-ips includes cilium internal IPs" {
   update_ips.mock_minimal
 
-  mock_set_output "${mock_kubectl}" "107.0.1.21 107.0.2.21 107.0.3.21" 6  # .networkPolicies.global.scApiserver.ips cilium internal
-  mock_set_output "${mock_kubectl}" "107.1.1.21 107.1.2.21 107.1.3.21" 12 # .networkPolicies.global.scNodes.ips cilium internal
-  mock_set_output "${mock_kubectl}" "107.2.1.21 107.2.2.21 107.2.3.21" 18 # .networkPolicies.global.wcApiserver.ips cilium internal
-  mock_set_output "${mock_kubectl}" "107.3.1.21 107.3.2.21 107.3.3.21" 24 # .networkPolicies.global.wcNodes.ips cilium internal
+  mock_set_output "${mock_kubectl}" "107.0.1.21 107.0.2.21 107.0.3.21" 5  # .networkPolicies.global.scApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "107.1.1.21 107.1.2.21 107.1.3.21" 10 # .networkPolicies.global.scNodes.ips cilium internal
+  mock_set_output "${mock_kubectl}" "107.2.1.21 107.2.2.21 107.2.3.21" 15 # .networkPolicies.global.wcApiserver.ips cilium internal
+  mock_set_output "${mock_kubectl}" "107.3.1.21 107.3.2.21 107.3.3.21" 20 # .networkPolicies.global.wcNodes.ips cilium internal
 
   run ck8s update-ips both apply
 
@@ -155,7 +155,7 @@ _apply_normalise() {
 
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
   assert_equal "$(mock_get_call_num "${mock_dig}")" 3
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 24
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 20
 }
 
 @test "ck8s update-ips skips ips in existing cidrs" {
@@ -172,7 +172,7 @@ _apply_normalise() {
 
   assert_equal "$(mock_get_call_num "${mock_curl}")" 0
   assert_equal "$(mock_get_call_num "${mock_dig}")" 3
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 24
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 20
 }
 
 @test "ck8s update-ips allows s3 region endpoint to be an ip" {
@@ -200,7 +200,7 @@ _apply_normalise() {
   assert_equal "$(yq.dig common '.networkPolicies.global.objectStorage.ips | . style="flow"')" "[10.244.0.0/16]"
 
   assert_equal "$(mock_get_call_num "${mock_dig}")" 2
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 25
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 21
 }
 
 @test "ck8s update-ips allows s3 region endpoint to be cluster local without kubeadm config" {
@@ -215,7 +215,7 @@ _apply_normalise() {
   assert_equal "$(yq.dig common '.networkPolicies.global.objectStorage.ips | . style="flow"')" "[0.0.0.0/0]"
 
   assert_equal "$(mock_get_call_num "${mock_dig}")" 2
-  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 25
+  assert_equal "$(mock_get_call_num "${mock_kubectl}")" 21
 }
 
 # --- maximal ----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

The `get_tunnel_ips` function will abort the `update-ips` script when the cluster uses Cilium as its network plugin as it won't be able to find any calico tunneling IPs. 

This PR addresses the issue by first checking if we have the `CiliumNode` CRD installed (which is a very good indicator that the cluster uses the Cilium CNI) and then extracting the Cilium internal IPs of the nodes.

- Part of https://github.com/elastisys/ck8s-issue-tracker/issues/534
- Part of https://github.com/elastisys/ck8s-issue-tracker/issues/535

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
