### PR TITLE
Added dual-stack support

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -54,6 +54,20 @@ global:
   ## Supported values are 'docker', 'containerd'
   containerRuntime: containerd
 
+  ## Enable to install mutation webhook that sets `ipFamilyPolicy` on all services to what is specified in `.global.ipFamilyPolicy`
+  enforceIPFamilyPolicy: false
+  ## Enable to install mutation webhook that sets `ipFamilies` on all services to what is specified in `.global.ipFamilies`
+  enforceIPFamilies: false
+  ## Global setting for configuring all services `ipFamilyPolicy`
+  ## Note that not all services exposes this setting.
+  ## If you want to enforce this for all services, set `.global.enforceIPFamilyPolicy`
+  ipFamilyPolicy: "SingleStack"
+  ## Global setting for configuring all services `ipFamilies`
+  ## Note that not all services exposes this setting.
+  ## If you want to enforce this for all services, set `.global.enforceIPFamilies`
+  ipFamilies:
+    - "IPv4"
+
 clusterApi:
   ## Set to true if kubernetes is installed with cluster-api
   enabled: set-me

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -1429,6 +1429,52 @@ properties:
         type: string
         examples:
           - "2025-04-29T08:34:21+00:00"
+      enforceIPFamilyPolicy:
+        title: Enforce ipFamilyPolicy to all services that doesn't explicitly set it.
+        description: |-
+          Enforce ipFamilyPolicy to all services that doesn't explicitly set it.
+          This is done using a mutating webhook to all services that doesn't set this.
+          The value it sets is taken from `.global.ipFamilyPolicy`
+        type: boolean
+        default: false
+      enforceIPFamilies:
+        title: Enforce ipFamilies to all services that doesn't explicitly set it.
+        description: |-
+          Enforce ipFamilyPolicy to all services that doesn't explicitly set it.
+          This is done using a mutating webhook to all services that doesn't set this.
+          The value it sets is taken from `.global.ipFamilies`
+        type: boolean
+        default: false
+      ipFamilyPolicy:
+        title: Global setting for ipFamilyPolicy for services
+        description: |-
+          Used to set the ipFamilyPolicy for all configurable services.
+        type: string
+        enum:
+          - SingleStack
+          - PreferDualStack
+          - RequireDualStack
+        meta:enum:
+          SingleStack: Single-stack service. The control plane allocates a cluster IP for the Service, using the first configured service cluster IP range.
+          PreferDualStack: Allocates both IPv4 and IPv6 cluster IPs for the Service when dual-stack is enabled. If dual-stack is not enabled or supported, it falls back to single-stack behavior.
+          RequireDualStack: Allocates Service `.spec.clusterIPs` from both IPv4 and IPv6 address ranges when dual-stack is enabled. If dual-stack is not enabled or supported, the Service API object creation fails.
+        default: "SingleStack"
+        examples:
+          - SingleStack
+          - PreferDualStack
+          - RequireDualStack
+      ipFamilies:
+        title: Global setting for ipFamilies for services
+        description: |-
+          Used to set the ipFamilyPolicy for all configurable services.
+        items:
+          type: string
+          enum:
+            - "IPv4"
+            - "IPv6"
+        type: array
+        uniqueItems: true
+        default: ["IPv4"]
     additionalProperties: false
   clusterApi:
     additionalProperties: false

--- a/helmfile.d/charts/calico-accountant/templates/service.yaml
+++ b/helmfile.d/charts/calico-accountant/templates/service.yaml
@@ -19,6 +19,12 @@ metadata:
       app: "calico-accountant"
   name: calico-accountant-metrics
 spec:
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.service.ipFamilies }}
+  ipFamilies: {{ toYaml .Values.service.ipFamilies | nindent 4 }}
+  {{- end }}
   ports:
   - port: 9009
     name: metrics

--- a/helmfile.d/charts/calico-accountant/values.yaml
+++ b/helmfile.d/charts/calico-accountant/values.yaml
@@ -15,3 +15,6 @@ tolerations:
     effect: NoSchedule
   - key: node-role.kubernetes.io/control-plane
     effect: NoSchedule
+service:
+  ipFamilyPolicy: ""
+  ipFamilies: []

--- a/helmfile.d/charts/calico-felix-metrics/templates/service.yaml
+++ b/helmfile.d/charts/calico-felix-metrics/templates/service.yaml
@@ -19,6 +19,12 @@ metadata:
       app: "calico-felix-metrics"
   name: calico-felix-metrics-svc
 spec:
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.service.ipFamilies }}
+  ipFamilies: {{ toYaml .Values.service.ipFamilies | nindent 4 }}
+  {{- end }}
   ports:
   - port: 9091
     name: metrics

--- a/helmfile.d/charts/calico-felix-metrics/values.yaml
+++ b/helmfile.d/charts/calico-felix-metrics/values.yaml
@@ -1,0 +1,3 @@
+service:
+  ipFamilyPolicy: ""
+  ipFamilies: []

--- a/helmfile.d/charts/gatekeeper/metrics/templates/gatekeeper-audit-metrics.yaml
+++ b/helmfile.d/charts/gatekeeper/metrics/templates/gatekeeper-audit-metrics.yaml
@@ -8,6 +8,12 @@ metadata:
     type: metrics
   name: {{ .Release.Name }}-audit
 spec:
+  {{- if .Values.auditMetricsService.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.auditMetricsService.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.auditMetricsService.ipFamily }}
+  ipFamilies: {{ toYaml .Values.auditMetricsService.ipFamilies | nindent 4 }}
+  {{- end }}
   ports:
   - port: 8888
     name: metrics

--- a/helmfile.d/charts/gatekeeper/metrics/templates/gatekeeper-controller-metrics.yaml
+++ b/helmfile.d/charts/gatekeeper/metrics/templates/gatekeeper-controller-metrics.yaml
@@ -8,6 +8,12 @@ metadata:
     type: metrics
   name: {{ .Release.Name }}-controller
 spec:
+  {{- if .Values.controllerMetricsService.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.controllerMetricsService.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.controllerMetricsService.ipFamily }}
+  ipFamilies: {{ toYaml .Values.controllerMetricsService.ipFamilies | nindent 4 }}
+  {{- end }}
   ports:
   - port: 8888
     name: metrics

--- a/helmfile.d/charts/gatekeeper/metrics/values.yaml
+++ b/helmfile.d/charts/gatekeeper/metrics/values.yaml
@@ -1,0 +1,6 @@
+auditMetricsService:
+  ipFamilyPolicy: ""
+  ipFamilies: []
+controllerMetricsService:
+  ipFamilyPolicy: ""
+  ipFamilies: []

--- a/helmfile.d/charts/gatekeeper/mutations/templates/service-ip-families.yaml
+++ b/helmfile.d/charts/gatekeeper/mutations/templates/service-ip-families.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceIPFamilies.enabled }}
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: service-ip-families
+spec:
+  applyTo:
+    - groups: [""]
+      kinds: ["Services"]
+      versions: ["v1"]
+  location: "spec.ipFamilies"
+  parameters:
+    assign:
+      value: {{ toYaml .Values.serviceIPFamilies.ipFamilies | nindent 8 }}
+    pathTests:
+      - subPath: "spec.ipFamilies"
+        condition: MustNotExist
+{{- end }}

--- a/helmfile.d/charts/gatekeeper/mutations/templates/service-ip-family-policy.yaml
+++ b/helmfile.d/charts/gatekeeper/mutations/templates/service-ip-family-policy.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceIPFamilyPolicy.enabled }}
+apiVersion: mutations.gatekeeper.sh/v1
+kind: Assign
+metadata:
+  name: service-ip-family-policy
+spec:
+  applyTo:
+    - groups: [""]
+      kinds: ["Service"]
+      versions: ["v1"]
+  location: "spec.ipFamilyPolicy"
+  parameters:
+    assign:
+      value: {{ .Values.serviceIPFamilyPolicy.ipFamilyPolicy }}
+    pathTests:
+      - subPath: "spec.ipFamilyPolicy"
+        condition: MustNotExist
+{{- end }}

--- a/helmfile.d/charts/gatekeeper/mutations/values.yaml
+++ b/helmfile.d/charts/gatekeeper/mutations/values.yaml
@@ -8,3 +8,12 @@ ndots:
   labelSelector:
     matchLabels:
       # labelkey: labelvalue
+
+serviceIPFamilyPolicy:
+  enabled: false
+  ipFamilyPolicy: "SingleStack"
+
+serviceIPFamilies:
+  enabled: false
+  ipFamilies:
+    - "IPv4"

--- a/helmfile.d/charts/grafana-label-enforcer/templates/service.yaml
+++ b/helmfile.d/charts/grafana-label-enforcer/templates/service.yaml
@@ -4,6 +4,12 @@ metadata:
   name: {{ include "grafana-label-enforcer.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.service.ipFamilies }}
+  ipFamilies: {{ toYaml .Values.service.ipFamilies | nindent 4 }}
+  {{- end }}
   ports:
   - name: promql
     port: 9090

--- a/helmfile.d/charts/grafana-label-enforcer/values.yaml
+++ b/helmfile.d/charts/grafana-label-enforcer/values.yaml
@@ -12,3 +12,7 @@ enforcementLabel: ""
 image:
   tag: ""
   repository: quay.io/prometheuscommunity/prom-label-proxy
+
+service:
+  ipFamilyPolicy: ""
+  ipFamilies: []

--- a/helmfile.d/charts/hnc/controller/templates/manager-service.yaml
+++ b/helmfile.d/charts/hnc/controller/templates/manager-service.yaml
@@ -11,6 +11,12 @@ metadata:
   name: {{ include "hnc.fullname" . }}-controller-manager-metrics-service
 spec:
   type: ClusterIP
+  {{- if .Values.managerService.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.managerService.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.managerService.ipFamilies }}
+  ipFamilies: {{ toYaml .Values.managerService.ipFamilies | nindent 4 }}
+  {{- end }}
   selector:
     {{- include "hnc.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: {{ .Chart.Name }}-controller-manager

--- a/helmfile.d/charts/hnc/controller/templates/webhook-service.yaml
+++ b/helmfile.d/charts/hnc/controller/templates/webhook-service.yaml
@@ -6,6 +6,12 @@ metadata:
   name: {{ include "hnc.fullname" . }}-webhook-service
 spec:
   type: ClusterIP
+  {{- if .Values.webhookService.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.webhookService.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.webhookService.ipFamilies }}
+  ipFamilies: {{ toYaml .Values.webhookService.ipFamilies | nindent 4 }}
+  {{- end }}
   selector:
     {{- include "hnc.selectorLabels" . | nindent 4 }}
     {{- if .Values.webhookDeployment.create }}

--- a/helmfile.d/charts/hnc/controller/values.yaml
+++ b/helmfile.d/charts/hnc/controller/values.yaml
@@ -73,6 +73,8 @@ managerDeployment:
 managerService:
   annotations: {}
   port: 8080
+  ipFamilyPolicy: ""
+  ipFamilies: []
 
 webhook:
   annotations: {}
@@ -99,6 +101,8 @@ webhookDeployment:
 
 webhookService:
   port: 443
+  ipFamilyPolicy: ""
+  ipFamilies: []
 
 certificate:
   create: true

--- a/helmfile.d/charts/kubeapi-metrics/templates/service.yaml
+++ b/helmfile.d/charts/kubeapi-metrics/templates/service.yaml
@@ -6,6 +6,12 @@ metadata:
     {{- include "kubeapi-metrics.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.service.ipFamilies }}
+  ipFamilies: {{ toYaml .Values.service.ipFamilies | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: 6443

--- a/helmfile.d/charts/kubeapi-metrics/values.yaml
+++ b/helmfile.d/charts/kubeapi-metrics/values.yaml
@@ -4,6 +4,8 @@ fullnameOverride: ""
 service:
   type: ClusterIP
   port: 6443
+  ipFamilyPolicy: ""
+  ipFamilies: []
 
 ingress:
   enabled: false

--- a/helmfile.d/charts/node-local-dns/templates/node-local-dns.yaml
+++ b/helmfile.d/charts/node-local-dns/templates/node-local-dns.yaml
@@ -31,6 +31,12 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "KubeDNSUpstream"
 spec:
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.service.ipFamilies }}
+  ipFamilies: {{ toYaml .Values.service.ipFamilies | nindent 4 }}
+  {{- end }}
   ports:
   - name: dns
     port: 53
@@ -205,6 +211,12 @@ metadata:
     k8s-app: node-local-dns
   name: node-local-dns
 spec:
+  {{- if .Values.metricsService.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.metricsService.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.metricsService.ipFamilies }}
+  ipFamilies: {{ toYaml .Values.metricsService.ipFamilies | nindent 4 }}
+  {{- end }}
   clusterIP: None
   ports:
     - name: metrics

--- a/helmfile.d/charts/node-local-dns/values.yaml
+++ b/helmfile.d/charts/node-local-dns/values.yaml
@@ -9,6 +9,14 @@ resources:
     cpu: 25m
     memory: 40Mi
 
+service:
+  ipFamilyPolicy: ""
+  ipFamilies:
+
+metricsService:
+  ipFamilyPolicy: ""
+  ipFamilies: []
+
 hostZone:
   extraConfig: #|
     # template ANY ANY {

--- a/helmfile.d/charts/openstack-monitoring/templates/service.yaml
+++ b/helmfile.d/charts/openstack-monitoring/templates/service.yaml
@@ -6,6 +6,12 @@ metadata:
     {{- include "openstack-monitoring.labels" . | nindent 4}}
   name: {{ include "openstack-monitoring.fullname" . }}
 spec:
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.service.ipFamilies }}
+  ipFamilies: {{ toYaml .Values.service.ipFamilies | nindent 4 }}
+  {{- end }}
   ports:
   - name: http
     port: 10258

--- a/helmfile.d/charts/openstack-monitoring/values.yaml
+++ b/helmfile.d/charts/openstack-monitoring/values.yaml
@@ -6,3 +6,6 @@ openstackMonitoring:
 serviceMonitor:
   labels: {}
   namespace: ""
+service:
+  ipFamilyPolicy: ""
+  ipFamilies: []

--- a/helmfile.d/charts/s3-exporter/templates/service.yaml
+++ b/helmfile.d/charts/s3-exporter/templates/service.yaml
@@ -6,6 +6,12 @@ metadata:
     {{- include "s3-exporter.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.service.ipFamilies }}
+  ipFamilies: {{ toYaml .Values.service.ipFamilies | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/helmfile.d/charts/s3-exporter/values.yaml
+++ b/helmfile.d/charts/s3-exporter/values.yaml
@@ -53,6 +53,8 @@ securityContext:
 service:
   type: ClusterIP
   port: 9340
+  ipFamilyPolicy: ""
+  ipFamilies: []
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/helmfile.d/charts/tekton-pipelines/templates/controller/service.yaml
+++ b/helmfile.d/charts/tekton-pipelines/templates/controller/service.yaml
@@ -14,6 +14,12 @@ metadata:
   {{- include "tekton-pipelines.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
+  {{- if .Values.controller.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.controller.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.controller.service.ipFamily }}
+  ipFamilies: {{ toYaml .Values.controller.service.ipFamilies | nindent 4 }}
+  {{- end }}
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default

--- a/helmfile.d/charts/tekton-pipelines/templates/webhook/service.yaml
+++ b/helmfile.d/charts/tekton-pipelines/templates/webhook/service.yaml
@@ -16,6 +16,12 @@ metadata:
   {{- include "tekton-pipelines.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
+  {{- if .Values.webhook.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.webhook.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.webhook.service.ipFamily }}
+  ipFamilies: {{ toYaml .Values.webhook.service.ipFamilies | nindent 4 }}
+  {{- end }}
   selector:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default

--- a/helmfile.d/charts/tekton-pipelines/values.yaml
+++ b/helmfile.d/charts/tekton-pipelines/values.yaml
@@ -13,6 +13,10 @@ controller:
     repository: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller
     tag: "v0.45.0@sha256:8a302dab54484bbb83d46ff9455b077ea51c1c189641dcda12575f8301bfb257"
 
+  service:
+    ipFamilyPolicy: ""
+    ipFamilies: []
+
 webhook:
   replicas: 1
 
@@ -27,6 +31,10 @@ webhook:
   image:
     repository: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook
     tag: "v0.45.0@sha256:07390c988b1c651c4810e9f7b15a88dfce8030845a429cf19b762a0d50e18ca7"
+
+  service:
+    ipFamilyPolicy: ""
+    ipFamilies: []
 
 remoteResolvers:
   replicas: 1

--- a/helmfile.d/stacks/calico.yaml.gotmpl
+++ b/helmfile.d/stacks/calico.yaml.gotmpl
@@ -41,3 +41,5 @@ templates:
     name: calico-felix-metrics
     needs:
       - monitoring/kube-prometheus-stack # creates servicemonitors
+    values:
+      - values/calico-felix-metrics.yaml.gotmpl

--- a/helmfile.d/values/calico-accountant.yaml.gotmpl
+++ b/helmfile.d/values/calico-accountant.yaml.gotmpl
@@ -16,3 +16,7 @@ image:
   {{- end }}
 {{- end }}
 {{- end }}
+
+service:
+  ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+  ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 6 }}

--- a/helmfile.d/values/calico-felix-metrics.yaml.gotmpl
+++ b/helmfile.d/values/calico-felix-metrics.yaml.gotmpl
@@ -1,0 +1,3 @@
+service:
+  ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+  ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 6 }}

--- a/helmfile.d/values/cert-manager.yaml.gotmpl
+++ b/helmfile.d/values/cert-manager.yaml.gotmpl
@@ -18,6 +18,7 @@ nodeSelector: {{- toYaml .Values.certmanager.nodeSelector | nindent 2 }}
 affinity:     {{- toYaml .Values.certmanager.affinity | nindent 2 }}
 tolerations:  {{- toYaml .Values.certmanager.tolerations | nindent 2 }}
 extraArgs:    {{- toYaml .Values.certmanager.extraArgs | nindent 2 }}
+serviceIPFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
 
 webhook:
   resources:    {{- toYaml .Values.certmanager.webhook.resources | nindent 4 }}
@@ -35,6 +36,8 @@ webhook:
     {{- end }}
   {{- end }}
   {{- end }}
+
+  serviceIPFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
 
 cainjector:
   resources:    {{- toYaml .Values.certmanager.cainjector.resources | nindent 4 }}

--- a/helmfile.d/values/gatekeeper/gatekeeper.yaml.gotmpl
+++ b/helmfile.d/values/gatekeeper/gatekeeper.yaml.gotmpl
@@ -97,6 +97,7 @@ mutatingWebhookCustomRules:
       - replicasets/scale
       - replicationcontrollers
       - replicationcontrollers/scale
+      - services
       - statefulsets
       - statefulsets/scale
       - services/proxy

--- a/helmfile.d/values/gatekeeper/mutations.yaml.gotmpl
+++ b/helmfile.d/values/gatekeeper/mutations.yaml.gotmpl
@@ -9,3 +9,10 @@ ndots:
     matchLabels: {{ range $key, $val := .Values.opa.mutations.ndots.labelSelector.matchLabels }}
       {{ $key }}: {{ $val }}
       {{- end }}
+
+serviceIPFamilies:
+  enabled: {{ .Values.global.enforceIPFamilies }}
+  ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 4 }}
+serviceIPFamilyPolicy:
+  enabled: {{ .Values.global.enforceIPFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}

--- a/helmfile.d/values/grafana/grafana-label-enforcer.yaml.gotmpl
+++ b/helmfile.d/values/grafana/grafana-label-enforcer.yaml.gotmpl
@@ -19,3 +19,7 @@ image:
   {{- end }}
 {{- end }}
 {{- end }}
+
+service:
+  ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+  ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 6 }}

--- a/helmfile.d/values/grafana/grafana-ops.yaml.gotmpl
+++ b/helmfile.d/values/grafana/grafana-ops.yaml.gotmpl
@@ -1,6 +1,9 @@
 # admin username is "admin"
 serviceMonitor:
   enabled: true
+service:
+  ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+  ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 4 }}
 ingress:
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/helmfile.d/values/grafana/grafana-user.yaml.gotmpl
+++ b/helmfile.d/values/grafana/grafana-user.yaml.gotmpl
@@ -1,5 +1,9 @@
 adminPassword: {{ .Values.user.grafanaPassword }}
 
+service:
+  ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+  ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 4 }}
+
 ingress:
   {{ if and .Values.externalTrafficPolicy.local .Values.externalTrafficPolicy.whitelistRange.userGrafana }}
   annotations:

--- a/helmfile.d/values/hnc/controller.yaml.gotmpl
+++ b/helmfile.d/values/hnc/controller.yaml.gotmpl
@@ -67,12 +67,20 @@ managerDeployment:
   {{- toYaml . | nindent 2 }}
   {{- end }}
 
+managerService:
+  ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+  ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 6 }}
+
 webhookDeployment:
   {{- with .Values.hnc.webhook -}}
   {{- toYaml . | nindent 2 }}
   {{- end }}
 
   create: {{ .Values.hnc.ha }}
+
+webhookService:
+  ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+  ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 6 }}
 
 serviceMonitor:
   relabelings:

--- a/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -22,6 +22,11 @@ kube-state-metrics:
   {{- end }}
   {{- end }}
 
+  service:
+    ipDualStack:
+      enabled: true
+      ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+      ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 8 }}
   selfMonitor:
     enabled: true
   resources: {{- toYaml .Values.kubeStateMetrics.resources | nindent 4 }}
@@ -90,6 +95,10 @@ kubeEtcd:
     port: 4001
     targetPort: 4001
     {{- end }}
+    ipDualStack:
+      enabled: true
+      ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+      ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 8 }}
 
 alertmanager:
   {{- with .Values.images | dig "monitoring" "kubeStateMetrics" "" }}
@@ -201,6 +210,12 @@ alertmanager:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 
+  service:
+    ipDualStack:
+      enabled: true
+      ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+      ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 8 }}
+
   alertmanagerSpec:
     replicas: {{ .Values.prometheus.alertmanagerSpec.replicas }}
     retention: {{ .Values.prometheus.retention.alertmanager }}
@@ -235,6 +250,20 @@ kubeScheduler:
 
 grafana:
   enabled: false
+
+kubeProxy:
+  service:
+    ipDualStack:
+      enabled: true
+      ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+      ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 8 }}
+
+coreDns:
+  service:
+    ipDualStack:
+      enabled: true
+      ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+      ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 8 }}
 
 prometheusOperator:
   resources: {{- toYaml .Values.prometheusOperator.resources | nindent 4 }}
@@ -286,6 +315,12 @@ prometheusOperator:
         {{- end }}
   {{- end }}
   {{- end }}
+
+  service:
+    ipDualStack:
+      enabled: true
+      ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+      ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 8 }}
 
 prometheus:
   prometheusSpec:
@@ -362,6 +397,11 @@ prometheus:
             requests:
               storage: {{ .Values.prometheus.storage.size }}
     {{- end }}
+  service:
+    ipDualStack:
+      enabled: true
+      ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+      ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 8 }}
 
 prometheus-node-exporter:
   resources: {{- toYaml .Values.prometheusNodeExporter.resources | nindent 4 }}
@@ -390,3 +430,9 @@ prometheus-node-exporter:
     {{- end }}
   {{- end }}
   {{- end }}
+
+  service:
+    ipDualStack:
+      enabled: true
+      ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+      ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 8 }}

--- a/helmfile.d/values/kube-prometheus-stack-wc.yaml.gotmpl
+++ b/helmfile.d/values/kube-prometheus-stack-wc.yaml.gotmpl
@@ -8,6 +8,11 @@ defaultRules:
 
 {{- if .Values.prometheus.devAlertmanager.enabled }}
 alertmanager:
+  service:
+    ipDualStack:
+      enabled: true
+      ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+      ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 8 }}
   namespaceOverride: {{ .Values.prometheus.devAlertmanager.namespace }}
   {{ if eq .Values.prometheus.devAlertmanager.ingressEnabled true }}
   extraSecret:
@@ -52,6 +57,20 @@ alertmanager:
 
 grafana:
   enabled: false
+
+kubeProxy:
+  service:
+    ipDualStack:
+      enabled: true
+      ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+      ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 8 }}
+
+coreDns:
+  service:
+    ipDualStack:
+      enabled: true
+      ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+      ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 8 }}
 
 kubeControllerManager:
   enabled: false
@@ -110,6 +129,11 @@ prometheusOperator:
   {{- end }}
   {{- end }}
 
+  service:
+    ipDualStack:
+      enabled: true
+      ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+      ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 8 }}
 
 kube-state-metrics:
   {{- with .Values.images | dig "monitoring" "kubeStateMetrics" "" }}
@@ -126,6 +150,12 @@ kube-state-metrics:
     {{- end }}
   {{- end }}
   {{- end }}
+
+  service:
+    ipDualStack:
+      enabled: true
+      ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+      ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 8 }}
 
   selfMonitor:
     enabled: true
@@ -167,6 +197,12 @@ prometheus-node-exporter:
   {{- end }}
   {{- end }}
 
+  service:
+    ipDualStack:
+      enabled: true
+      ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+      ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 8 }}
+
 kubeApiServer:
   serviceMonitor:
     metricRelabelings:
@@ -183,6 +219,10 @@ kubeEtcd:
     port: 4001
     targetPort: 4001
     {{ end }}
+    ipDualStack:
+      enabled: true
+      ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+      ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 8 }}
 
 prometheus:
   ingress:
@@ -320,3 +360,8 @@ prometheus:
     {{- with .Values.prometheus.additionalScrapeConfigs }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  service:
+    ipDualStack:
+      enabled: true
+      ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+      ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 8 }}

--- a/helmfile.d/values/kubeapi-metrics.yaml.gotmpl
+++ b/helmfile.d/values/kubeapi-metrics.yaml.gotmpl
@@ -8,3 +8,7 @@ ingress:
   extraAnnotations:
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.externalTrafficPolicy.whitelistRange.kubeapiMetrics }}
   {{ end }}
+
+service:
+  ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+  ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 6 }}

--- a/helmfile.d/values/node-local-dns.yaml.gotmpl
+++ b/helmfile.d/values/node-local-dns.yaml.gotmpl
@@ -31,3 +31,11 @@ image:
   {{- end }}
 {{- end }}
 {{- end }}
+
+service:
+  ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+  ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 6 }}
+
+metricsService:
+  ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+  ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 6 }}

--- a/helmfile.d/values/opensearch/common.yaml.gotmpl
+++ b/helmfile.d/values/opensearch/common.yaml.gotmpl
@@ -14,6 +14,11 @@ clusterName: {{ .Values.opensearch.clusterName }}
 
 masterService: {{ .Values.opensearch.clusterName }}-master
 
+service:
+  ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+  # TODO: Make sure upstream support this instead
+  # ipFamilies: toYaml .Values.global.ipFamilies | nindent 4
+
 config:
   opensearch.yml: |
     cluster:

--- a/helmfile.d/values/opensearch/dashboards.yaml.gotmpl
+++ b/helmfile.d/values/opensearch/dashboards.yaml.gotmpl
@@ -1,5 +1,10 @@
 opensearchHosts: https://{{ .Values.opensearch.clusterName }}-master:9200
 
+service:
+  ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+  # TODO: Make sure upstream support this instead
+  # ipFamilies: toYaml .Values.global.ipFamilies | nindent 4
+
 config:
   opensearch_dashboards.yml:
     server:

--- a/helmfile.d/values/openstack-monitoring.yaml.gotmpl
+++ b/helmfile.d/values/openstack-monitoring.yaml.gotmpl
@@ -7,3 +7,7 @@ serviceMonitor:
   {{- else }}
     k8s-app: openstack-cloud-controller-manager
   {{- end }}
+
+service:
+  ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+  ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 6 }}

--- a/helmfile.d/values/prometheus-blackbox-exporter-sc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-blackbox-exporter-sc.yaml.gotmpl
@@ -57,6 +57,11 @@ config:
     tcp_connect:
       prober: tcp
     {{- end }}
+service:
+  ipDualStack:
+    enabled: true
+    ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+    ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 6 }}
 serviceMonitor:
   enabled: true
   targets:

--- a/helmfile.d/values/prometheus-blackbox-exporter-wc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-blackbox-exporter-wc.yaml.gotmpl
@@ -52,6 +52,11 @@ config:
           insecure_skip_verify: true
     tcp_connect:
       prober: tcp
+service:
+  ipDualStack:
+    enabled: true
+    ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+    ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 6 }}
 serviceMonitor:
   enabled: true
   targets:

--- a/helmfile.d/values/s3-exporter.yaml.gotmpl
+++ b/helmfile.d/values/s3-exporter.yaml.gotmpl
@@ -31,3 +31,7 @@ image:
   {{- end }}
 {{- end }}
 {{- end }}
+
+service:
+  ipFamilyPolicy: {{ .Values.global.ipFamilyPolicy }}
+  ipFamilies: {{ toYaml .Values.global.ipFamilies | nindent 6 }}

--- a/migration/v0.48/README.md
+++ b/migration/v0.48/README.md
@@ -90,6 +90,26 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ./bin/ck8s upgrade both v0.48 apply
     ```
 
+1. Update all services if you enabled the enforcement of ipFamilyPolicy and ipFamilies
+
+    > [!WANING]
+    > This should only be done if you have enabled the enforcement of ipFamilyPolicy and ipFamilies.
+    > You can check this by looking at the values `.global.enforceIPFamilyPolicy` and `.global.enforceIPFamilies` and see if any of those is set to `true`
+    > After you've ran this you can't revert to `SingleStack` without recreating the service.
+
+    If you are updating to `PreferDualStack` you can use the following snippet to update all services that hasn't been updated by config.
+
+    ```bash
+    CLUSTER="sc" # Or wc
+
+    bin/ck8s ops kubectl "${CLUSTER}" get svc -A -o=custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,POLICY:.spec.ipFamilyPolicy' | \
+        # Filter out SingleStack services
+        grep SingleStack | \
+        # Print namespace and name of service
+        awk '{print $1 " " $2}' | \
+        xargs -L1 kubectl patch svc -p '{"spec":{"ipFamilyPolicy":"PreferDualStack","ipFamilies":["IPv4","IPv6"]}}' --type=merge -n
+    ```
+
 ## Manual method
 
 ### Prepare upgrade - _non-disruptive_
@@ -161,6 +181,26 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     ./bin/ck8s apply {sc|wc}
     # or
     ./migration/v0.48/apply/80-apply.sh execute
+    ```
+
+1. Update all services if you enabled the enforcement of ipFamilyPolicy and ipFamilies
+
+    > [!WANING]
+    > This should only be done if you have enabled the enforcement of ipFamilyPolicy and ipFamilies.
+    > You can check this by looking at the values `.global.enforceIPFamilyPolicy` and `.global.enforceIPFamilies` and see if any of those is set to `true`
+    > After you've ran this you can't revert to `SingleStack` without recreating the service.
+
+    If you are updating to `PreferDualStack` you can use the following snippet to update all services that hasn't been updated by config.
+
+    ```bash
+    CLUSTER="sc" # Or wc
+
+    bin/ck8s ops kubectl "${CLUSTER}" get svc -A -o=custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,POLICY:.spec.ipFamilyPolicy' | \
+        # Filter out SingleStack services
+        grep SingleStack | \
+        # Print namespace and name of service
+        awk '{print $1 " " $2}' | \
+        xargs -L1 kubectl patch svc -p '{"spec":{"ipFamilyPolicy":"PreferDualStack","ipFamilies":["IPv4","IPv6"]}}' --type=merge -n
     ```
 
 ## Postrequisite


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice

It's now possible to change the services to be dual-stack globally.
You can also enforce this to all services by enabling the gatekeeper mutation.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Adds support to set all services to dual-stack

- Fixes elastisys/ck8s-issue-tracker#361

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
