### PR TITLE
E2E: kubectl proxy access tests for prometheus & alertmanager

### DIFF
--- a/scripts/kubeproxy-wrapper.sh
+++ b/scripts/kubeproxy-wrapper.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Starts a `kubectl proxy` process in the background
+# and continually "prods" it with curl until the port 8000 becomes open,
+# a good indication that further authentication is needed
+#
+# Then, it extracts the Dex redirect URL from visiting http://127.0.0.1:8000
+# and outputs a "ready" marked along with the extracted URL
+#
+# TODO - randomized ports
+
+set -euo pipefail
+
+cleanup() {
+  if [[ -n "$proxy_pid" ]] && kill -0 "$proxy_pid" 2>/dev/null; then
+    kill "$proxy_pid"
+  fi
+  if [[ -n "$curl_pid" ]] && kill -0 "$curl_pid" 2>/dev/null; then
+    kill -9 "$curl_pid"
+  fi
+  exit 0
+}
+
+trap cleanup EXIT INT TERM
+
+kubectl proxy 2>&1 &
+proxy_pid=$!
+
+curl -s --retry 10 --retry-all-errors http://127.0.0.1:8001/healthz 2>&1 &
+curl_pid=$!
+
+# wait until port 8000 is open
+for _ in $(seq 1 10); do
+  if nc -z 127.0.0.1 8000; then
+    redir_url="$(curl -si http://127.0.0.1:8000/ | grep -oP 'Location: \K.+')"
+    echo "%%PROXY_READY%% $redir_url"
+    break
+  fi
+  sleep 2
+done
+
+wait

--- a/scripts/kubeproxy-wrapper.sh
+++ b/scripts/kubeproxy-wrapper.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 
 # Starts a `kubectl proxy` process in the background
-# and continually "prods" it with curl until the port 8000 becomes open,
-# a good indication that further authentication is needed
+# and continually "prods" it with curl until the port 127.0.0.1:8000 becomes open,
+# a good indication that further authentication is needed.
 #
 # Then, it extracts the Dex redirect URL from visiting http://127.0.0.1:8000
-# and outputs a "ready" marked along with the extracted URL
+# and outputs a "ready" marker along with the extracted URL.
 #
 # TODO - randomized ports
 
 set -euo pipefail
+
+PROXY_READY_MARKER='%%PROXY_READY%%'
 
 cleanup() {
   if [[ -n "$proxy_pid" ]] && kill -0 "$proxy_pid" 2>/dev/null; then
@@ -33,7 +35,7 @@ curl_pid=$!
 for _ in $(seq 1 10); do
   if nc -z 127.0.0.1 8000; then
     redir_url="$(curl -si http://127.0.0.1:8000/ | grep -oP 'Location: \K.+')"
-    echo "%%PROXY_READY%% $redir_url"
+    echo "$PROXY_READY_MARKER $redir_url"
     break
   fi
   sleep 2

--- a/tests/cypress.config.js
+++ b/tests/cypress.config.js
@@ -12,12 +12,11 @@ module.exports = defineConfig({
           return null
         },
         kubectlLogin(kubeconfig) {
-          return new Promise((resolve, reject) => {
+          return new Promise((resolve) => {
             process.env.KUBECONFIG = kubeconfig
-            var child = spawn('kubectl', ['auth', 'whoami'], {
-              stdio: 'ignore',
-              detached: true,
-            }).unref()
+            const child = spawn('kubectl', ['auth', 'whoami'], { stdio: 'ignore', detached: true })
+
+            child.unref()
 
             resolve(null)
           })

--- a/tests/cypress.config.js
+++ b/tests/cypress.config.js
@@ -26,16 +26,12 @@ module.exports = defineConfig({
         wrapProxy(kubeconfig) {
           process.env.KUBECONFIG = kubeconfig
 
-          // Put apps scripts in the path of the current process
           const path = require('path')
-          const scriptPath = path.resolve(
-            path.dirname(process.env.BATS_TEST_FILENAME) + '/../../../scripts'
+          const wrapperPath = path.resolve(
+            path.dirname(process.env.BATS_TEST_FILENAME) + '/../../../scripts/kubeproxy-wrapper.sh'
           )
-          if (!process.env.PATH.includes(`:${scriptPath}`)) {
-            process.env.PATH += `:${scriptPath}`
-          }
 
-          const proxy = spawn('kubeproxy-wrapper.sh', [], {
+          const proxy = spawn(wrapperPath, [], {
             detached: true,
             stdio: ['ignore', 'pipe', 'pipe'],
           })

--- a/tests/cypress.config.js
+++ b/tests/cypress.config.js
@@ -1,5 +1,7 @@
 const { defineConfig } = require('cypress')
 
+const PROXY_READY_MARKER = '%%PROXY_READY%%'
+
 module.exports = defineConfig({
   env: process.env,
   e2e: {
@@ -23,6 +25,8 @@ module.exports = defineConfig({
         },
         wrapProxy(kubeconfig) {
           process.env.KUBECONFIG = kubeconfig
+
+          // Put apps scripts in the path of the current process
           const path = require('path')
           const scriptPath = path.resolve(
             path.dirname(process.env.BATS_TEST_FILENAME) + '/../../../scripts'
@@ -37,8 +41,9 @@ module.exports = defineConfig({
           })
           return new Promise((resolve) => {
             proxy.stdout.on('data', (data) => {
-              if (data.includes('%%PROXY_READY%%')) {
-                resolve(data.toString().split(' ')[1])
+              if (data.includes(PROXY_READY_MARKER)) {
+                const redirectUrl = data.toString().split(' ')[1]
+                resolve(redirectUrl)
               }
             })
           })

--- a/tests/cypress.support.js
+++ b/tests/cypress.support.js
@@ -166,6 +166,20 @@ Cypress.Commands.add('dexExtraStaticLogin', (email) => {
   )
 })
 
+Cypress.Commands.add('visitProxied', function (cluster, user, refresh, url) {
+  cy.withTestKubeconfig(cluster, user, refresh, url).then(() => {
+    cy.task('wrapProxy', Cypress.env('KUBECONFIG')).then((redir_url) => {
+      cy.visit(`${redir_url}`)
+      cy.dexExtraStaticLogin('dev@example.com')
+    })
+  })
+})
+
+Cypress.Commands.add('cleanupProxy', function (cluster, user) {
+  cy.task('pKill', 'kubeproxy-wrapper.sh')
+  cy.deleteTestKubeconfig(cluster, user)
+})
+
 Cypress.Commands.add('withTestKubeconfig', function (cluster, user, refresh, url = null) {
   const config_base = Cypress.env('CK8S_CONFIG_PATH') + '/.state/kube_config'
   const base_kubeconfig = `${config_base}_${cluster}.yaml`

--- a/tests/cypress.support.js
+++ b/tests/cypress.support.js
@@ -166,8 +166,8 @@ Cypress.Commands.add('dexExtraStaticLogin', (email) => {
   )
 })
 
-Cypress.Commands.add('visitProxied', function (cluster, user, refresh, url) {
-  cy.withTestKubeconfig(cluster, user, refresh, url).then(() => {
+Cypress.Commands.add('visitProxied', function ({ cluster, user, refresh, url }) {
+  cy.withTestKubeconfig({ cluster, user, refresh, url }).then(() => {
     cy.task('wrapProxy', Cypress.env('KUBECONFIG')).then((redir_url) => {
       cy.visit(`${redir_url}`)
       cy.dexExtraStaticLogin('dev@example.com')
@@ -175,12 +175,12 @@ Cypress.Commands.add('visitProxied', function (cluster, user, refresh, url) {
   })
 })
 
-Cypress.Commands.add('cleanupProxy', function (cluster, user) {
+Cypress.Commands.add('cleanupProxy', function ({ cluster, user }) {
   cy.task('pKill', 'kubeproxy-wrapper.sh')
-  cy.deleteTestKubeconfig(cluster, user)
+  cy.deleteTestKubeconfig({ cluster, user })
 })
 
-Cypress.Commands.add('withTestKubeconfig', function (cluster, user, refresh, url = null) {
+Cypress.Commands.add('withTestKubeconfig', function ({ cluster, user, refresh, url = null }) {
   const config_base = Cypress.env('CK8S_CONFIG_PATH') + '/.state/kube_config'
   const base_kubeconfig = `${config_base}_${cluster}.yaml`
   const user_kubeconfig = `${config_base}_${cluster}_${user}.yaml`
@@ -210,7 +210,7 @@ Cypress.Commands.add('withTestKubeconfig', function (cluster, user, refresh, url
   }
 })
 
-Cypress.Commands.add('deleteTestKubeconfig', function (cluster, user) {
+Cypress.Commands.add('deleteTestKubeconfig', function ({ cluster, user }) {
   const test_kubeconfig =
     Cypress.env('CK8S_CONFIG_PATH') + `/.state/kube_config_${cluster}_${user}.yaml`
   cy.exec(`rm ${test_kubeconfig}`)

--- a/tests/end-to-end/alertmanager/via-proxy.cy.js
+++ b/tests/end-to-end/alertmanager/via-proxy.cy.js
@@ -1,0 +1,28 @@
+describe("alertmanager", function() {
+  it("can be accessed via kubectl proxy", () => {
+    cy.intercept("/api/**")
+      .as("api")
+
+    cy.visitProxied(
+      "wc",
+      "static-dev",
+      "true",
+      "http://127.0.0.1:8001/api/v1/namespaces/alertmanager/services/alertmanager-operated:9093/proxy/"
+    )
+
+    cy.origin("http://127.0.0.1:8001", () => {
+      cy.contains("span", 'alertname="Watchdog"')
+        .should("exist")
+
+      cy.visit("http://127.0.0.1:8001/api/v1/namespaces/alertmanager/services/alertmanager-operated:9093/proxy/#/status")
+
+      cy.wait(['@api', '@api'], {timeout: 20000})
+
+      cy.contains("span", "ready").should("exist")
+    })
+  })
+
+  after(() => {
+    cy.cleanupProxy("wc", "static-dev")
+  })
+})

--- a/tests/end-to-end/alertmanager/via-proxy.cy.js
+++ b/tests/end-to-end/alertmanager/via-proxy.cy.js
@@ -1,28 +1,28 @@
-describe("alertmanager", function() {
-  it("can be accessed via kubectl proxy", () => {
-    cy.intercept("/api/**")
-      .as("api")
+describe('alertmanager', function () {
+  it('can be accessed via kubectl proxy', () => {
+    cy.intercept('/api/**').as('api')
 
-    cy.visitProxied(
-      "wc",
-      "static-dev",
-      "true",
-      "http://127.0.0.1:8001/api/v1/namespaces/alertmanager/services/alertmanager-operated:9093/proxy/"
-    )
+    cy.visitProxied({
+      cluster: 'wc',
+      user: 'static-dev',
+      refresh: 'true',
+      url: 'http://127.0.0.1:8001/api/v1/namespaces/alertmanager/services/alertmanager-operated:9093/proxy/',
+    })
 
-    cy.origin("http://127.0.0.1:8001", () => {
-      cy.contains("span", 'alertname="Watchdog"')
-        .should("exist")
+    cy.origin('http://127.0.0.1:8001', () => {
+      cy.contains('span', 'alertname="Watchdog"').should('exist')
 
-      cy.visit("http://127.0.0.1:8001/api/v1/namespaces/alertmanager/services/alertmanager-operated:9093/proxy/#/status")
+      cy.visit(
+        'http://127.0.0.1:8001/api/v1/namespaces/alertmanager/services/alertmanager-operated:9093/proxy/#/status'
+      )
 
-      cy.wait(['@api', '@api'], {timeout: 20000})
+      cy.wait(['@api', '@api'], { timeout: 20000 })
 
-      cy.contains("span", "ready").should("exist")
+      cy.contains('span', 'ready').should('exist')
     })
   })
 
   after(() => {
-    cy.cleanupProxy("wc", "static-dev")
+    cy.cleanupProxy({ cluster: 'wc', user: 'static-dev' })
   })
 })

--- a/tests/end-to-end/alertmanager/via-proxy.cy.js
+++ b/tests/end-to-end/alertmanager/via-proxy.cy.js
@@ -7,6 +7,7 @@ describe('alertmanager', function () {
       user: 'static-dev',
       refresh: 'true',
       url: 'http://127.0.0.1:8001/api/v1/namespaces/alertmanager/services/alertmanager-operated:9093/proxy/',
+      checkAdmin: true,
     })
 
     cy.origin('http://127.0.0.1:8001', () => {

--- a/tests/end-to-end/alertmanager/via-proxy.cy.js
+++ b/tests/end-to-end/alertmanager/via-proxy.cy.js
@@ -12,14 +12,6 @@ describe('alertmanager', function () {
 
     cy.origin('http://127.0.0.1:8001', () => {
       cy.contains('span', 'alertname="Watchdog"').should('exist')
-
-      cy.visit(
-        'http://127.0.0.1:8001/api/v1/namespaces/alertmanager/services/alertmanager-operated:9093/proxy/#/status'
-      )
-
-      cy.wait(['@api', '@api'], { timeout: 20000 })
-
-      cy.contains('span', 'ready').should('exist')
     })
   })
 

--- a/tests/end-to-end/alertmanager/via-proxy.gen.bats
+++ b/tests/end-to-end/alertmanager/via-proxy.gen.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+setup_file() {
+  load "../../bats.lib.bash"
+
+  cypress_setup "${ROOT}/tests/end-to-end/alertmanager/via-proxy.cy.js"
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+}
+
+teardown_file() {
+  cypress_teardown "${ROOT}/tests/end-to-end/alertmanager/via-proxy.cy.js"
+}
+
+@test "alertmanager can be accessed via kubectl proxy" {
+  cypress_test "alertmanager can be accessed via kubectl proxy"
+}

--- a/tests/end-to-end/kubernetes/authentication-admin.cy.js
+++ b/tests/end-to-end/kubernetes/authentication-admin.cy.js
@@ -1,10 +1,10 @@
 describe('kubernetes authentication', function () {
   before(function () {
-    cy.withTestKubeconfig('wc', 'static-admin', 'true')
+    cy.withTestKubeconfig({ cluster: 'wc', user: 'static-admin', refresh: 'true' })
   })
 
   after(function () {
-    cy.deleteTestKubeconfig('wc', 'static-admin')
+    cy.deleteTestKubeconfig({ cluster: 'wc', user: 'static-admin' })
   })
 
   it('can login via static dex user', function () {

--- a/tests/end-to-end/kubernetes/authentication-dev.cy.js
+++ b/tests/end-to-end/kubernetes/authentication-dev.cy.js
@@ -1,6 +1,6 @@
 describe('kubernetes authentication', function () {
   before(function () {
-    cy.withTestKubeconfig('wc', 'static-dev', 'true')
+    cy.withTestKubeconfig({ cluster: 'wc', user: 'static-dev', refresh: 'true' })
   })
 
   it('can login via extra static dex user', function () {

--- a/tests/end-to-end/kubernetes/authentication-dev.cy.js
+++ b/tests/end-to-end/kubernetes/authentication-dev.cy.js
@@ -3,13 +3,11 @@ describe('kubernetes authentication', function () {
     cy.withTestKubeconfig({ cluster: 'wc', user: 'static-dev', refresh: 'true' })
   })
 
-  it('can login via extra static dex user', function () {
-    cy.yqDig('sc', '.dex.enableStaticLogin').then((staticLoginEnabled) => {
-      if (staticLoginEnabled !== 'true') {
-        this.skip('dex static login is not enabled')
-      }
-    })
+  after(function () {
+    cy.deleteTestKubeconfig({ cluster: 'wc', user: 'static-dev' })
+  })
 
+  it('can login via extra static dex user', function () {
     cy.task('kubectlLogin', Cypress.env('KUBECONFIG'))
     cy.visit(`http://localhost:8000`)
 

--- a/tests/end-to-end/prometheus/via-proxy.cy.js
+++ b/tests/end-to-end/prometheus/via-proxy.cy.js
@@ -1,19 +1,18 @@
-describe("prometheus", function() {
-  it("can be accessed via kubectl proxy", () => {
-    cy.visitProxied(
-      "wc",
-      "static-dev",
-      "true",
-      "http://127.0.0.1:8001/api/v1/namespaces/monitoring/services/kube-prometheus-stack-prometheus:9090/proxy/targets?pool=serviceMonitor%2Fmonitoring%2Fkube-prometheus-stack-apiserver%2F0"
-    )
+describe('prometheus', function () {
+  it('can be accessed via kubectl proxy', () => {
+    cy.visitProxied({
+      cluster: 'wc',
+      user: 'static-dev',
+      refresh: 'true',
+      url: 'http://127.0.0.1:8001/api/v1/namespaces/monitoring/services/kube-prometheus-stack-prometheus:9090/proxy/targets?pool=serviceMonitor%2Fmonitoring%2Fkube-prometheus-stack-apiserver%2F0',
+    })
 
-    cy.origin("http://127.0.0.1:8001", () => {
-      cy.contains("span", "up")
-        .should("exist")
+    cy.origin('http://127.0.0.1:8001', () => {
+      cy.contains('span', 'up').should('exist')
     })
   })
 
   after(() => {
-    cy.cleanupProxy("wc", "static-dev")
+    cy.cleanupProxy({ cluster: 'wc', user: 'static-dev' })
   })
 })

--- a/tests/end-to-end/prometheus/via-proxy.cy.js
+++ b/tests/end-to-end/prometheus/via-proxy.cy.js
@@ -1,0 +1,19 @@
+describe("prometheus", function() {
+  it("can be accessed via kubectl proxy", () => {
+    cy.visitProxied(
+      "wc",
+      "static-dev",
+      "true",
+      "http://127.0.0.1:8001/api/v1/namespaces/monitoring/services/kube-prometheus-stack-prometheus:9090/proxy/targets?pool=serviceMonitor%2Fmonitoring%2Fkube-prometheus-stack-apiserver%2F0"
+    )
+
+    cy.origin("http://127.0.0.1:8001", () => {
+      cy.contains("span", "up")
+        .should("exist")
+    })
+  })
+
+  after(() => {
+    cy.cleanupProxy("wc", "static-dev")
+  })
+})

--- a/tests/end-to-end/prometheus/via-proxy.cy.js
+++ b/tests/end-to-end/prometheus/via-proxy.cy.js
@@ -5,6 +5,7 @@ describe('prometheus', function () {
       user: 'static-dev',
       refresh: 'true',
       url: 'http://127.0.0.1:8001/api/v1/namespaces/monitoring/services/kube-prometheus-stack-prometheus:9090/proxy/targets?pool=serviceMonitor%2Fmonitoring%2Fkube-prometheus-stack-apiserver%2F0',
+      checkAdmin: true,
     })
 
     cy.origin('http://127.0.0.1:8001', () => {

--- a/tests/end-to-end/prometheus/via-proxy.gen.bats
+++ b/tests/end-to-end/prometheus/via-proxy.gen.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+setup_file() {
+  load "../../bats.lib.bash"
+
+  cypress_setup "${ROOT}/tests/end-to-end/prometheus/via-proxy.cy.js"
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+}
+
+teardown_file() {
+  cypress_teardown "${ROOT}/tests/end-to-end/prometheus/via-proxy.cy.js"
+}
+
+@test "prometheus can be accessed via kubectl proxy" {
+  cypress_test "prometheus can be accessed via kubectl proxy"
+}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Adds support files and sample E2E tests for accessing proxy-able components such as Prometheus and Alertmanager.


- Fixes https://github.com/elastisys/ck8s-issue-tracker/issues/240

#### Information to reviewers

NOTE: this depends on the setup for access tests being done, so it has the [same prerequisites](https://github.com/elastisys/compliantkubernetes-apps/pull/2548). 

```
make run-end-to-end/prometheus
make run-end-to-end/alertmanager
```

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
