### PR TITLE
Upgrade Grafana chart to 9.2.10

### DIFF
--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -128,10 +128,10 @@ grafana:
     resources:
       requests:
         cpu: 50m
-        memory: 80Mi
+        memory: 150Mi
       limits:
         cpu: 100m
-        memory: 160Mi
+        memory: 300Mi
     tolerations: []
     affinity: {}
     nodeSelector: {}

--- a/helmfile.d/lists/images.yaml
+++ b/helmfile.d/lists/images.yaml
@@ -63,7 +63,7 @@ images:
     alertmanager: quay.io/prometheus/alertmanager:v0.28.1
     prometheus: quay.io/prometheus/prometheus:v3.2.1
     admissionWebhooksPatch: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.2
-    grafana: docker.io/grafana/grafana:11.5.1
+    grafana: docker.io/grafana/grafana:12.0.2
     grafanaSidecar: quay.io/kiwigrid/k8s-sidecar:1.30.0
     blackboxExporter: quay.io/prometheus/blackbox-exporter:v0.24.0
     grafanaLabelEnforcer: quay.io/prometheuscommunity/prom-label-proxy:v0.11.0

--- a/helmfile.d/upstream/README.md
+++ b/helmfile.d/upstream/README.md
@@ -83,4 +83,3 @@ Check for chart verification:
 
 1. All rules are split between alerts and records, modified to preserve the cluster label in aggregations, and maintained separately in [prometheus-alerts chart](../charts/prometheus-alerts/)
 1. The user Grafana needs to be updated separately in [grafana chart](./grafana)
-1. The user AlertManager needs to be updated separately in [user-alertmanager chart](../charts/user-alertmanager)

--- a/helmfile.d/upstream/README.md
+++ b/helmfile.d/upstream/README.md
@@ -40,6 +40,9 @@ Pull the chart:
 > 1. the state file contains `./bases/upstream.yaml` as a base to include the upstream index, and
 > 2. the release spec contains `inherit: [ template: <chart-name> ]` to include the chart template.
 
+> [!NOTE]
+> Images needs to be updated separately in the [images.yaml list file](../lists/images.yaml).
+
 ## Updating charts
 
 Update the chart in the index:

--- a/helmfile.d/upstream/grafana/grafana/Chart.yaml
+++ b/helmfile.d/upstream/grafana/grafana/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/grafana/grafana
 apiVersion: v2
-appVersion: 11.5.1
+appVersion: 12.0.2
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.com
 icon: https://artifacthub.io/image/b4fed1a7-6c8f-4945-b99d-096efa3e4116
@@ -32,4 +32,4 @@ sources:
 - https://github.com/grafana/grafana
 - https://github.com/grafana/helm-charts
 type: application
-version: 8.9.1
+version: 9.2.10

--- a/helmfile.d/upstream/grafana/grafana/README.md
+++ b/helmfile.d/upstream/grafana/grafana/README.md
@@ -130,6 +130,7 @@ need to instead set `global.imageRegistry`.
 | `initChownData.image.sha`                 | init-chown-data container image sha (optional)| `""`                                                    |
 | `initChownData.image.pullPolicy`          | init-chown-data container image pull policy   | `IfNotPresent`                                          |
 | `initChownData.resources`                 | init-chown-data pod resource requests & limits | `{}`                                                   |
+| `initChownData.securityContext`           | init-chown-data pod securityContext           | `{"readOnlyRootFilesystem": false, "runAsNonRoot": false}`, "runAsUser": 0, "seccompProfile": {"type": "RuntimeDefault"}, "capabilities": {"add": ["CHOWN"], "drop": ["ALL"]}}` |
 | `schedulerName`                           | Alternate scheduler name                      | `nil`                                                   |
 | `env`                                     | Extra environment variables passed to pods    | `{}`                                                    |
 | `envValueFrom`                            | Environment variables from alternate sources. See the API docs on [EnvVarSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core) for format details. Can be templated | `{}` |
@@ -150,6 +151,7 @@ need to instead set `global.imageRegistry`.
 | `alerting`                                | Configure grafana alerting (passed through tpl) | `{}`                                                  |
 | `notifiers`                               | Configure grafana notifiers                   | `{}`                                                    |
 | `dashboardProviders`                      | Configure grafana dashboard providers         | `{}`                                                    |
+| `defaultCurlOptions`                      | Configure default curl short options for all dashboards, the beginning dash is required  | `-skf`       |
 | `dashboards`                              | Dashboards to import                          | `{}`                                                    |
 | `dashboardsConfigMaps`                    | ConfigMaps reference that contains dashboards | `{}`                                                    |
 | `grafana.ini`                             | Grafana's primary configuration               | `{}`                                                    |
@@ -173,8 +175,8 @@ need to instead set `global.imageRegistry`.
 | `sidecar.securityContext`                 | Sidecar securityContext                       | `{}`                                                    |
 | `sidecar.enableUniqueFilenames`           | Sets the kiwigrid/k8s-sidecar UNIQUE_FILENAMES environment variable. If set to `true` the sidecar will create unique filenames where duplicate data keys exist between ConfigMaps and/or Secrets within the same or multiple Namespaces. | `false`                           |
 | `sidecar.alerts.enabled`             | Enables the cluster wide search for alerts and adds/updates/deletes them in grafana |`false`       |
-| `sidecar.alerts.label`               | Label that config maps with alerts should have to be added | `grafana_alert`                               |
-| `sidecar.alerts.labelValue`          | Label value that config maps with alerts should have to be added | `""`                                |
+| `sidecar.alerts.label`               | Label that config maps with alerts should have to be added (can be templated) | `grafana_alert`                               |
+| `sidecar.alerts.labelValue`          | Label value that config maps with alerts should have to be added (can be templated) | `""`                                |
 | `sidecar.alerts.searchNamespace`     | Namespaces list. If specified, the sidecar will search for alerts config-maps  inside these namespaces. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces. | `nil`                               |
 | `sidecar.alerts.watchMethod`         | Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds. | `WATCH` |
 | `sidecar.alerts.resource`            | Should the sidecar looks into secrets, configmaps or both. | `both`                               |
@@ -194,8 +196,8 @@ need to instead set `global.imageRegistry`.
 | `sidecar.dashboards.provider.foldersFromFilesStructure`        | Allow Grafana to replicate dashboard structure from filesystem.                                 | `false`                                                  |
 | `sidecar.dashboards.watchMethod`          | Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds. | `WATCH` |
 | `sidecar.skipTlsVerify`                   | Set to true to skip tls verification for kube api calls | `nil`                                         |
-| `sidecar.dashboards.label`                | Label that config maps with dashboards should have to be added | `grafana_dashboard`                                |
-| `sidecar.dashboards.labelValue`                | Label value that config maps with dashboards should have to be added | `""`                                |
+| `sidecar.dashboards.label`                | Label that config maps with dashboards should have to be added (can be templated) | `grafana_dashboard`                                |
+| `sidecar.dashboards.labelValue`                | Label value that config maps with dashboards should have to be added (can be templated) | `""`                                |
 | `sidecar.dashboards.folder`               | Folder in the pod that should hold the collected dashboards (unless `sidecar.dashboards.defaultFolderName` is set). This path will be mounted. | `/tmp/dashboards`    |
 | `sidecar.dashboards.folderAnnotation`     | The annotation the sidecar will look for in configmaps to override the destination folder for files | `nil`                                                  |
 | `sidecar.dashboards.defaultFolderName`    | The default folder name, it will create a subfolder under the `sidecar.dashboards.folder` and put dashboards in there instead | `nil`                                |
@@ -206,8 +208,8 @@ need to instead set `global.imageRegistry`.
 | `sidecar.dashboards.resource`             | Should the sidecar looks into secrets, configmaps or both. | `both`                               |
 | `sidecar.dashboards.extraMounts`          | Additional dashboard sidecar volume mounts. | `[]`                               |
 | `sidecar.datasources.enabled`             | Enables the cluster wide search for datasources and adds/updates/deletes them in grafana |`false`       |
-| `sidecar.datasources.label`               | Label that config maps with datasources should have to be added | `grafana_datasource`                               |
-| `sidecar.datasources.labelValue`          | Label value that config maps with datasources should have to be added | `""`                                |
+| `sidecar.datasources.label`               | Label that config maps with datasources should have to be added (can be templated) | `grafana_datasource`                               |
+| `sidecar.datasources.labelValue`          | Label value that config maps with datasources should have to be added (can be templated) | `""`                                |
 | `sidecar.datasources.searchNamespace`     | Namespaces list. If specified, the sidecar will search for datasources config-maps  inside these namespaces. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces. | `nil`                               |
 | `sidecar.datasources.watchMethod`         | Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds. | `WATCH` |
 | `sidecar.datasources.resource`            | Should the sidecar looks into secrets, configmaps or both. | `both`                               |
@@ -215,8 +217,8 @@ need to instead set `global.imageRegistry`.
 | `sidecar.datasources.skipReload`          | Enabling this omits defining the REQ_URL and REQ_METHOD environment variables | `false` |
 | `sidecar.datasources.initDatasources`     | Set to true to deploy the datasource sidecar as an initContainer in addition to a container. This is needed if skipReload is true, to load any datasources defined at startup time. | `false` |
 | `sidecar.notifiers.enabled`               | Enables the cluster wide search for notifiers and adds/updates/deletes them in grafana | `false`        |
-| `sidecar.notifiers.label`                 | Label that config maps with notifiers should have to be added | `grafana_notifier`                               |
-| `sidecar.notifiers.labelValue`            | Label value that config maps with notifiers should have to be added | `""`                                |
+| `sidecar.notifiers.label`                 | Label that config maps with notifiers should have to be added (can be templated) | `grafana_notifier`                               |
+| `sidecar.notifiers.labelValue`            | Label value that config maps with notifiers should have to be added (can be templated) | `""`                                |
 | `sidecar.notifiers.searchNamespace`       | Namespaces list. If specified, the sidecar will search for notifiers config-maps (or secrets) inside these namespaces. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces. | `nil`                               |
 | `sidecar.notifiers.watchMethod`           | Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds. | `WATCH` |
 | `sidecar.notifiers.resource`              | Should the sidecar looks into secrets, configmaps or both. | `both`                               |
@@ -275,6 +277,7 @@ need to instead set `global.imageRegistry`.
 | `imageRenderer.image.repository`           | image-renderer Image repository                                                    | `grafana/grafana-image-renderer` |
 | `imageRenderer.image.tag`                  | image-renderer Image tag                                                           | `latest`                         |
 | `imageRenderer.image.sha`                  | image-renderer Image sha (optional)                                                | `""`                             |
+| `imageRenderer.image.pullSecrets`                  |  image-renderer Image pull secrets (optional)                              | `[]`                             |
 | `imageRenderer.image.pullPolicy`           | image-renderer ImagePullPolicy                                                     | `Always`                         |
 | `imageRenderer.env`                        | extra env-vars for image-renderer                                                  | `{}`                             |
 | `imageRenderer.envValueFrom`               | Environment variables for image-renderer from alternate sources. See the API docs on [EnvVarSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvarsource-v1-core) for format details. Can be templated | `{}` |
@@ -394,7 +397,16 @@ dashboards:
       - name: DS_LOKI
         value: Loki
     local-dashboard:
-      url: https://raw.githubusercontent.com/user/repository/master/dashboards/dashboard.json
+      url: https://github.com/cloudnative-pg/grafana-dashboards/blob/main/charts/cluster/grafana-dashboard.json
+      # redirects to:
+      # https://raw.githubusercontent.com/cloudnative-pg/grafana-dashboards/refs/heads/main/charts/cluster/grafana-dashboard.json
+
+      # default: -skf
+      # -s  - silent mode
+      # -k  - allow insecure (eg: non-TLS) connections
+      # -f  - fail fast
+      # -L  - follow HTTP redirects
+      curlOptions: -Lf
 ```
 
 ## BASE64 dashboards
@@ -778,6 +790,7 @@ grafana.ini:
     ha_peers: {{ Name }}-headless:9094
     ha_listen_address: ${POD_IP}:9094
     ha_advertise_address: ${POD_IP}:9094
+    rule_version_record_limit: "5"
 
   alerting:
     enabled: false

--- a/helmfile.d/upstream/grafana/grafana/ci/with-sidecars-envvaluefrom-values.yaml
+++ b/helmfile.d/upstream/grafana/grafana/ci/with-sidecars-envvaluefrom-values.yaml
@@ -14,6 +14,21 @@ extraObjects:
       var2: "dmFsdWUy"
 
 sidecar:
+  alerts:
+    enabled: true
+    envValueFrom:
+      VAR1:
+        configMapKeyRef:
+          name: '{{ include "grafana.fullname" . }}-test'
+          key: var1
+      VAR2:
+        secretKeyRef:
+          name: '{{ include "grafana.fullname" . }}-test'
+          key: var2
+      VAR3:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.namespace
   dashboards:
     enabled: true
     envValueFrom:

--- a/helmfile.d/upstream/grafana/grafana/templates/_config.tpl
+++ b/helmfile.d/upstream/grafana/grafana/templates/_config.tpl
@@ -85,7 +85,7 @@ download_dashboards.sh: |
 {{- range $provider, $dashboards := .Values.dashboards }}
   {{- range $key, $value := $dashboards }}
     {{- if (or (hasKey $value "gnetId") (hasKey $value "url")) }}
-  curl -skf \
+  curl {{ get $value "curlOptions" | default $.Values.defaultCurlOptions }} \
   --connect-timeout 60 \
   --max-time 60 \
     {{- if not $value.b64content }}

--- a/helmfile.d/upstream/grafana/grafana/templates/_pod.tpl
+++ b/helmfile.d/upstream/grafana/grafana/templates/_pod.tpl
@@ -6,6 +6,7 @@ schedulerName: "{{ . }}"
 {{- end }}
 serviceAccountName: {{ include "grafana.serviceAccountName" . }}
 automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+shareProcessNamespace: {{ .Values.shareProcessNamespace }}
 {{- with .Values.securityContext }}
 securityContext:
   {{- toYaml . | nindent 2 }}
@@ -24,7 +25,7 @@ dnsConfig:
 {{- with .Values.priorityClassName }}
 priorityClassName: {{ . }}
 {{- end }}
-{{- if ( or .Values.persistence.enabled .Values.dashboards .Values.extraInitContainers (and .Values.sidecar.alerts.enabled .Values.sidecar.alerts.initAlerts) (and .Values.sidecar.datasources.enabled .Values.sidecar.datasources.initDatasources) (and .Values.sidecar.notifiers.enabled .Values.sidecar.notifiers.initNotifiers)) }}
+{{- if ( or (and .Values.persistence.enabled .Values.initChownData.enabled) .Values.dashboards .Values.extraInitContainers (and .Values.sidecar.alerts.enabled .Values.sidecar.alerts.initAlerts) (and .Values.sidecar.datasources.enabled .Values.sidecar.datasources.initDatasources) (and .Values.sidecar.notifiers.enabled .Values.sidecar.notifiers.initNotifiers)) }}
 initContainers:
 {{- end }}
 {{- if ( and .Values.persistence.enabled .Values.initChownData.enabled ) }}
@@ -119,6 +120,11 @@ initContainers:
       - name: "{{ $key }}"
         value: "{{ $value }}"
       {{- end }}
+      {{- range $key, $value := .Values.sidecar.alerts.envValueFrom }}
+      - name: {{ $key | quote }}
+        valueFrom:
+          {{- tpl (toYaml $value) $ | nindent 10 }}
+      {{- end }}
       {{- if .Values.sidecar.alerts.ignoreAlreadyProcessed }}
       - name: IGNORE_ALREADY_PROCESSED
         value: "true"
@@ -126,10 +132,10 @@ initContainers:
       - name: METHOD
         value: "LIST"
       - name: LABEL
-        value: "{{ .Values.sidecar.alerts.label }}"
+        value: "{{ tpl .Values.sidecar.alerts.label $root }}"
       {{- with .Values.sidecar.alerts.labelValue }}
       - name: LABEL_VALUE
-        value: {{ quote . }}
+        value: {{ quote (tpl . $root) }}
       {{- end }}
       {{- if or .Values.sidecar.logLevel .Values.sidecar.alerts.logLevel }}
       - name: LOG_LEVEL
@@ -204,10 +210,10 @@ initContainers:
       - name: METHOD
         value: "LIST"
       - name: LABEL
-        value: "{{ .Values.sidecar.datasources.label }}"
+        value: "{{ tpl .Values.sidecar.datasources.label $root }}"
       {{- with .Values.sidecar.datasources.labelValue }}
       - name: LABEL_VALUE
-        value: {{ quote . }}
+        value: {{ quote (tpl . $root) }}
       {{- end }}
       {{- if or .Values.sidecar.logLevel .Values.sidecar.datasources.logLevel }}
       - name: LOG_LEVEL
@@ -229,6 +235,10 @@ initContainers:
       - name: SKIP_TLS_VERIFY
         value: "{{ . }}"
       {{- end }}
+      {{- with .Values.sidecar.datasources.script }}
+      - name: SCRIPT
+        value: {{ quote . }}
+      {{- end }}
     {{- with .Values.sidecar.resources }}
     resources:
       {{- toYaml . | nindent 6 }}
@@ -240,6 +250,9 @@ initContainers:
     volumeMounts:
       - name: sc-datasources-volume
         mountPath: "/etc/grafana/provisioning/datasources"
+      {{- with .Values.sidecar.datasources.extraMounts }}
+      {{- toYaml . | trim | nindent 6 }}
+      {{- end }}
 {{- end }}
 {{- if and .Values.sidecar.notifiers.enabled .Values.sidecar.notifiers.initNotifiers }}
   - name: {{ include "grafana.name" . }}-init-sc-notifiers
@@ -262,10 +275,10 @@ initContainers:
       - name: METHOD
         value: LIST
       - name: LABEL
-        value: "{{ .Values.sidecar.notifiers.label }}"
+        value: "{{ tpl .Values.sidecar.notifiers.label $root }}"
       {{- with .Values.sidecar.notifiers.labelValue }}
       - name: LABEL_VALUE
-        value: {{ quote . }}
+        value: {{ quote (tpl . $root) }}
       {{- end }}
       {{- if or .Values.sidecar.logLevel .Values.sidecar.notifiers.logLevel }}
       - name: LOG_LEVEL
@@ -287,6 +300,10 @@ initContainers:
       - name: SKIP_TLS_VERIFY
         value: "{{ . }}"
       {{- end }}
+      {{- with .Values.sidecar.notifiers.script }}
+      - name: SCRIPT
+        value: {{ quote . }}
+      {{- end }}
     {{- with .Values.sidecar.livenessProbe }}
     livenessProbe:
       {{- toYaml . | nindent 6 }}
@@ -306,6 +323,9 @@ initContainers:
     volumeMounts:
       - name: sc-notifiers-volume
         mountPath: "/etc/grafana/provisioning/notifiers"
+      {{- with .Values.sidecar.notifiers.extraMounts }}
+      {{- toYaml . | trim | nindent 6 }}
+      {{- end }}
 {{- end}}
 {{- with .Values.extraInitContainers }}
   {{- tpl (toYaml .) $root | nindent 2 }}
@@ -339,10 +359,10 @@ containers:
       - name: METHOD
         value: {{ .Values.sidecar.alerts.watchMethod }}
       - name: LABEL
-        value: "{{ .Values.sidecar.alerts.label }}"
+        value: "{{ tpl .Values.sidecar.alerts.label $root }}"
       {{- with .Values.sidecar.alerts.labelValue }}
       - name: LABEL_VALUE
-        value: {{ quote . }}
+        value: {{ quote (tpl . $root) }}
       {{- end }}
       {{- if or .Values.sidecar.logLevel .Values.sidecar.alerts.logLevel }}
       - name: LOG_LEVEL
@@ -352,6 +372,10 @@ containers:
         value: "/etc/grafana/provisioning/alerting"
       - name: RESOURCE
         value: {{ quote .Values.sidecar.alerts.resource }}
+      {{- if .Values.sidecar.alerts.resourceName }}
+      - name: RESOURCE_NAME
+        value: {{ quote .Values.sidecar.alerts.resourceName }}
+      {{- end }}
       {{- with .Values.sidecar.enableUniqueFilenames }}
       - name: UNIQUE_FILENAMES
         value: "{{ . }}"
@@ -463,10 +487,10 @@ containers:
       - name: METHOD
         value: {{ .Values.sidecar.dashboards.watchMethod }}
       - name: LABEL
-        value: "{{ .Values.sidecar.dashboards.label }}"
+        value: "{{ tpl .Values.sidecar.dashboards.label $root }}"
       {{- with .Values.sidecar.dashboards.labelValue }}
       - name: LABEL_VALUE
-        value: {{ quote . }}
+        value: {{ quote (tpl . $root) }}
       {{- end }}
       {{- if or .Values.sidecar.logLevel .Values.sidecar.dashboards.logLevel }}
       - name: LOG_LEVEL
@@ -476,6 +500,10 @@ containers:
         value: "{{ .Values.sidecar.dashboards.folder }}{{- with .Values.sidecar.dashboards.defaultFolderName }}/{{ . }}{{- end }}"
       - name: RESOURCE
         value: {{ quote .Values.sidecar.dashboards.resource }}
+      {{- if .Values.sidecar.dashboards.resourceName }}
+      - name: RESOURCE_NAME
+        value: {{ quote .Values.sidecar.dashboards.resourceName }}
+      {{- end }}
       {{- with .Values.sidecar.enableUniqueFilenames }}
       - name: UNIQUE_FILENAMES
         value: "{{ . }}"
@@ -494,7 +522,7 @@ containers:
       {{- end }}
       {{- with .Values.sidecar.dashboards.script }}
       - name: SCRIPT
-        value: "{{ . }}"
+        value: {{ quote . }}
       {{- end }}
       {{- if not .Values.sidecar.dashboards.skipReload }}
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
@@ -591,10 +619,10 @@ containers:
       - name: METHOD
         value: {{ .Values.sidecar.datasources.watchMethod }}
       - name: LABEL
-        value: "{{ .Values.sidecar.datasources.label }}"
+        value: "{{ tpl .Values.sidecar.datasources.label $root }}"
       {{- with .Values.sidecar.datasources.labelValue }}
       - name: LABEL_VALUE
-        value: {{ quote . }}
+        value: {{ quote (tpl . $root) }}
       {{- end }}
       {{- if or .Values.sidecar.logLevel .Values.sidecar.datasources.logLevel }}
       - name: LOG_LEVEL
@@ -604,6 +632,10 @@ containers:
         value: "/etc/grafana/provisioning/datasources"
       - name: RESOURCE
         value: {{ quote .Values.sidecar.datasources.resource }}
+      {{- if .Values.sidecar.datasources.resourceName }}
+      - name: RESOURCE_NAME
+        value: {{ quote .Values.sidecar.datasources.resourceName }}
+      {{- end }}
       {{- with .Values.sidecar.enableUniqueFilenames }}
       - name: UNIQUE_FILENAMES
         value: "{{ . }}"
@@ -616,9 +648,9 @@ containers:
       - name: SKIP_TLS_VERIFY
         value: "{{ .Values.sidecar.skipTlsVerify }}"
       {{- end }}
-      {{- if .Values.sidecar.datasources.script }}
+      {{- with .Values.sidecar.datasources.script }}
       - name: SCRIPT
-        value: "{{ .Values.sidecar.datasources.script }}"
+        value: {{ quote . }}
       {{- end }}
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_USERNAME
@@ -710,10 +742,10 @@ containers:
       - name: METHOD
         value: {{ .Values.sidecar.notifiers.watchMethod }}
       - name: LABEL
-        value: "{{ .Values.sidecar.notifiers.label }}"
+        value: "{{ tpl .Values.sidecar.notifiers.label $root }}"
       {{- with .Values.sidecar.notifiers.labelValue }}
       - name: LABEL_VALUE
-        value: {{ quote . }}
+        value: {{ quote (tpl . $root) }}
       {{- end }}
       {{- if or .Values.sidecar.logLevel .Values.sidecar.notifiers.logLevel }}
       - name: LOG_LEVEL
@@ -723,6 +755,10 @@ containers:
         value: "/etc/grafana/provisioning/notifiers"
       - name: RESOURCE
         value: {{ quote .Values.sidecar.notifiers.resource }}
+      {{- if .Values.sidecar.notifiers.resourceName }}
+      - name: RESOURCE_NAME
+        value: {{ quote .Values.sidecar.notifiers.resourceName }}
+      {{- end }}
       {{- if .Values.sidecar.enableUniqueFilenames }}
       - name: UNIQUE_FILENAMES
         value: "{{ .Values.sidecar.enableUniqueFilenames }}"
@@ -735,9 +771,9 @@ containers:
       - name: SKIP_TLS_VERIFY
         value: "{{ . }}"
       {{- end }}
-      {{- if .Values.sidecar.notifiers.script }}
+      {{- with .Values.sidecar.notifiers.script }}
       - name: SCRIPT
-        value: "{{ .Values.sidecar.notifiers.script }}"
+        value: {{ quote . }}
       {{- end }}
       {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_USERNAME
@@ -829,10 +865,10 @@ containers:
       - name: METHOD
         value: {{ .Values.sidecar.plugins.watchMethod }}
       - name: LABEL
-        value: "{{ .Values.sidecar.plugins.label }}"
+        value: "{{ tpl .Values.sidecar.plugins.label $root }}"
       {{- if .Values.sidecar.plugins.labelValue }}
       - name: LABEL_VALUE
-        value: {{ quote .Values.sidecar.plugins.labelValue }}
+        value: {{ quote (tpl .Values.sidecar.plugins.labelValue $) }}
       {{- end }}
       {{- if or .Values.sidecar.logLevel .Values.sidecar.plugins.logLevel }}
       - name: LOG_LEVEL
@@ -842,6 +878,10 @@ containers:
         value: "/etc/grafana/provisioning/plugins"
       - name: RESOURCE
         value: {{ quote .Values.sidecar.plugins.resource }}
+      {{- if .Values.sidecar.plugins.resourceName }}
+      - name: RESOURCE_NAME
+        value: {{ quote .Values.sidecar.plugins.resourceName }}
+      {{- end }}
       {{- with .Values.sidecar.enableUniqueFilenames }}
       - name: UNIQUE_FILENAMES
         value: "{{ . }}"
@@ -852,7 +892,7 @@ containers:
       {{- end }}
       {{- with .Values.sidecar.plugins.script }}
       - name: SCRIPT
-        value: "{{ . }}"
+        value: {{ quote . }}
       {{- end }}
       {{- with .Values.sidecar.skipTlsVerify }}
       - name: SKIP_TLS_VERIFY
@@ -1290,21 +1330,25 @@ volumes:
   {{- end }}
   {{- if .Values.sidecar.alerts.enabled }}
   - name: sc-alerts-volume
+    {{- if .Values.sidecar.alerts.sizeLimit }}
     emptyDir:
       {{- with .Values.sidecar.alerts.sizeLimit }}
       sizeLimit: {{ . }}
-      {{- else }}
-      {}
       {{- end }}
+    {{- else }}
+    emptyDir: {}
+    {{- end }}
   {{- end }}
   {{- if .Values.sidecar.dashboards.enabled }}
   - name: sc-dashboard-volume
+    {{- if .Values.sidecar.dashboards.sizeLimit }}
     emptyDir:
       {{- with .Values.sidecar.dashboards.sizeLimit }}
       sizeLimit: {{ . }}
-      {{- else }}
-      {}
       {{- end }}
+    {{- else }}
+    emptyDir: {}
+    {{- end }}
   {{- if .Values.sidecar.dashboards.SCProvider }}
   - name: sc-dashboard-provider
     configMap:
@@ -1313,30 +1357,36 @@ volumes:
   {{- end }}
   {{- if .Values.sidecar.datasources.enabled }}
   - name: sc-datasources-volume
+    {{- if .Values.sidecar.datasources.sizeLimit }}
     emptyDir:
       {{- with .Values.sidecar.datasources.sizeLimit }}
       sizeLimit: {{ . }}
-      {{- else }}
-      {}
       {{- end }}
+    {{- else }}
+    emptyDir: {}
+    {{- end }}
   {{- end }}
   {{- if .Values.sidecar.plugins.enabled }}
   - name: sc-plugins-volume
+    {{- if .Values.sidecar.plugins.sizeLimit }}
     emptyDir:
       {{- with .Values.sidecar.plugins.sizeLimit }}
       sizeLimit: {{ . }}
-      {{- else }}
-      {}
       {{- end }}
+    {{- else }}
+    emptyDir: {}
+    {{- end }}
   {{- end }}
   {{- if .Values.sidecar.notifiers.enabled }}
   - name: sc-notifiers-volume
+    {{- if .Values.sidecar.notifiers.sizeLimit }}
     emptyDir:
       {{- with .Values.sidecar.notifiers.sizeLimit }}
       sizeLimit: {{ . }}
-      {{- else }}
-      {}
       {{- end }}
+    {{- else }}
+    emptyDir: {}
+    {{- end }}
   {{- end }}
   {{- range .Values.extraSecretMounts }}
   {{- if .secretName }}

--- a/helmfile.d/upstream/grafana/grafana/templates/extra-manifests.yaml
+++ b/helmfile.d/upstream/grafana/grafana/templates/extra-manifests.yaml
@@ -1,4 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
-{{ tpl (toYaml .) $ }}
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{ else }}
+{{ tpl (. | toYaml) $ }}
+{{- end }}
 {{ end }}

--- a/helmfile.d/upstream/grafana/grafana/templates/hpa.yaml
+++ b/helmfile.d/upstream/grafana/grafana/templates/hpa.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    {{- if has .Values.persistence.type $sts }}
+    {{- if (or (.Values.useStatefulSet) (and .Values.persistence.enabled (not .Values.persistence.existingClaim) (has .Values.persistence.type $sts)))}}
     kind: StatefulSet
     {{- else }}
     kind: Deployment

--- a/helmfile.d/upstream/grafana/grafana/templates/image-renderer-deployment.yaml
+++ b/helmfile.d/upstream/grafana/grafana/templates/image-renderer-deployment.yaml
@@ -58,11 +58,9 @@ spec:
       {{- with .Values.imageRenderer.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
-      {{- with .Values.imageRenderer.image.pullSecrets }}
+      {{- if or .Values.imageRenderer.image.pullSecrets .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        {{- range . }}
-        - name: {{ tpl . $root }}
-        {{- end}}
+        {{- include "grafana.imagePullSecrets" (dict "root" $root "imagePullSecrets" .Values.imageRenderer.image.pullSecrets) | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-image-renderer

--- a/helmfile.d/upstream/grafana/grafana/templates/image-renderer-service.yaml
+++ b/helmfile.d/upstream/grafana/grafana/templates/image-renderer-service.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
   {{- with .Values.imageRenderer.service.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml . | nindent 4) $ }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/helmfile.d/upstream/grafana/grafana/templates/image-renderer-servicemonitor.yaml
+++ b/helmfile.d/upstream/grafana/grafana/templates/image-renderer-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.imageRenderer.serviceMonitor.enabled }}
+{{- if and .Values.imageRenderer.enabled .Values.imageRenderer.serviceMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/helmfile.d/upstream/grafana/grafana/templates/poddisruptionbudget.yaml
+++ b/helmfile.d/upstream/grafana/grafana/templates/poddisruptionbudget.yaml
@@ -19,4 +19,7 @@ spec:
   selector:
     matchLabels:
       {{- include "grafana.selectorLabels" . | nindent 6 }}
+  {{- with .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
 {{- end }}

--- a/helmfile.d/upstream/grafana/grafana/templates/route.yaml
+++ b/helmfile.d/upstream/grafana/grafana/templates/route.yaml
@@ -32,6 +32,9 @@ spec:
     - backendRefs:
         - name: {{ include "grafana.fullname" $ }}
           port: {{ $.Values.service.port }}
+          group: ''
+          kind: Service
+          weight: 1
       {{- with $route.filters }}
       filters:
         {{- toYaml . | nindent 8 }}

--- a/helmfile.d/upstream/grafana/grafana/templates/statefulset.yaml
+++ b/helmfile.d/upstream/grafana/grafana/templates/statefulset.yaml
@@ -46,6 +46,9 @@ spec:
     spec:
       accessModes: {{ .Values.persistence.accessModes }}
       storageClassName: {{ .Values.persistence.storageClassName }}
+      {{- with .Values.persistence.volumeName }}
+      volumeName: {{ . | quote }}
+      {{- end }}
       resources:
         requests:
           storage: {{ .Values.persistence.size }}

--- a/helmfile.d/upstream/grafana/grafana/templates/tests/test.yaml
+++ b/helmfile.d/upstream/grafana/grafana/templates/tests/test.yaml
@@ -37,6 +37,10 @@ spec:
       image: "{{ .Values.global.imageRegistry | default .Values.testFramework.image.registry }}/{{ .Values.testFramework.image.repository }}:{{ .Values.testFramework.image.tag }}"
       imagePullPolicy: "{{ .Values.testFramework.imagePullPolicy}}"
       command: ["/opt/bats/bin/bats", "-t", "/tests/run.sh"]
+      {{- with .Values.testFramework.containerSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumeMounts:
         - mountPath: /tests
           name: tests

--- a/helmfile.d/upstream/grafana/grafana/values.yaml
+++ b/helmfile.d/upstream/grafana/grafana/values.yaml
@@ -70,6 +70,7 @@ podDisruptionBudget: {}
 #  apiVersion: ""
 #  minAvailable: 1
 #  maxUnavailable: 1
+#  unhealthyPodEvictionPolicy: IfHealthyBudget
 
 ## See `kubectl explain deployment.spec.strategy` for more
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
@@ -125,6 +126,7 @@ testFramework:
     tag: "v1.4.1"
   imagePullPolicy: IfNotPresent
   securityContext: {}
+  containerSecurityContext: {}
   resources: {}
   #  limits:
   #    cpu: 100m
@@ -415,6 +417,8 @@ persistence:
   type: pvc
   enabled: false
   # storageClassName: default
+  ## (Optional) Use this to bind the claim to an existing PersistentVolume (PV) by name.
+  volumeName: ""
   accessModes:
     - ReadWriteOnce
   size: 10Gi
@@ -472,6 +476,7 @@ initChownData:
   #    cpu: 100m
   #    memory: 128Mi
   securityContext:
+    readOnlyRootFilesystem: false
     runAsNonRoot: false
     runAsUser: 0
     seccompProfile:
@@ -479,6 +484,8 @@ initChownData:
     capabilities:
       add:
         - CHOWN
+      drop:
+        - ALL
 
 # Administrator credentials when not using an existing secret (see below)
 adminUser: admin
@@ -803,6 +810,18 @@ dashboardProviders: {}
 #      options:
 #        path: /var/lib/grafana/dashboards/default
 
+## Configure how curl fetches remote dashboards. The beginning dash is required.
+## NOTE: This sets the default short flags for all dashboards, but these
+##       defaults can be overridden individually for each dashboard by setting
+##       curlOptions. See the example dashboards section below.
+##
+## -s  - silent mode
+## -k  - allow insecure (eg: non-TLS) connections
+## -f  - fail fast
+## See the curl documentation for additional options
+##
+defaultCurlOptions: "-skf"
+
 ## Configure grafana dashboard to import
 ## NOTE: To use dashboards you must also enable/configure dashboardProviders
 ## ref: https://grafana.com/dashboards
@@ -822,6 +841,7 @@ dashboards: {}
   #     datasource: Prometheus
   #   local-dashboard:
   #     url: https://example.com/repository/test.json
+  #     curlOptions: "-sLf"
   #     token: ''
   #   local-dashboard-base64:
   #     url: https://example.com/repository/test-b64.json
@@ -889,6 +909,10 @@ grafana.ini:
   #   enabled: true
   #   allow_sign_up: true
   #   config_file: /etc/grafana/ldap.toml
+## Grafana's alerting configuration
+  # unified_alerting:
+  #   enabled: true
+  #   rule_version_record_limit: "5"
 
 ## Grafana's LDAP configuration
 ## Templated by the template in _helpers.tpl
@@ -913,6 +937,11 @@ ldap:
   #   ssl_skip_verify = false
   #   bind_dn = "uid=%s,ou=users,dc=myorg,dc=com"
 
+# When process namespace sharing is enabled, processes in a container are visible to all other containers in the same pod
+# This parameter is added because the ldap reload api is not working https://grafana.com/docs/grafana/latest/developers/http_api/admin/#reload-ldap-configuration
+# To allow an extraContainer to restart the Grafana container
+shareProcessNamespace: false
+
 ## Grafana's SMTP configuration
 ## NOTE: To enable, grafana.ini must be configured with smtp.enabled
 ## ref: http://docs.grafana.org/installation/configuration/#smtp
@@ -930,7 +959,7 @@ sidecar:
     # -- The Docker registry
     registry: quay.io
     repository: kiwigrid/k8s-sidecar
-    tag: 1.30.0
+    tag: 1.30.3
     sha: ""
   imagePullPolicy: IfNotPresent
   resources: {}
@@ -958,11 +987,24 @@ sidecar:
     enabled: false
     # Additional environment variables for the alerts sidecar
     env: {}
+    ## "valueFrom" environment variable references that will be added to deployment pods. Name is templated.
+    ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvarsource-v1-core
+    ## Renders in container spec as:
+    ##   env:
+    ##     ...
+    ##     - name: <key>
+    ##       valueFrom:
+    ##         <value rendered as YAML>
+    envValueFrom: {}
+    #  ENV_NAME:
+    #    configMapKeyRef:
+    #      name: configmap-name
+    #      key: value_key
     # Do not reprocess already processed unchanged resources on k8s API reconnect.
     # ignoreAlreadyProcessed: true
-    # label that the configmaps with alert are marked with
+    # label that the configmaps with alert are marked with (can be templated)
     label: grafana_alert
-    # value of label that the configmaps with alert are set to
+    # value of label that the configmaps with alert are set to (can be templated)
     labelValue: ""
     # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
     # logLevel: INFO
@@ -974,6 +1016,13 @@ sidecar:
     watchMethod: WATCH
     # search in configmap, secret or both
     resource: both
+    #
+    # resourceName: comma separated list of resource names to be fetched/checked by this sidecar.
+    # per default all resources of the type defined in {{ .Values.sidecar.alerts.resource }} will be checked.
+    # This e.g. allows stricter RBAC rules which are limited to the resources meant for the sidecars.
+    # resourceName: "secret/alerts-1,configmap/alerts-0"
+    resourceName: ""
+    #
     # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
     # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
     # watchServerTimeout: 3600
@@ -1003,7 +1052,9 @@ sidecar:
     #
     # Endpoint to send request to reload alerts
     reloadURL: "http://localhost:3000/api/admin/provisioning/alerting/reload"
-    # Absolute path to shell script to execute after a alert got reloaded
+    # Absolute path to a script to execute after a configmap got reloaded.
+    # It runs before calls to REQ_URI. If the file is not executable it will be passed to sh.
+    # Otherwise, it's executed as is. Shebangs known to work are #!/bin/sh and #!/usr/bin/env python
     script: null
     skipReload: false
     # This is needed if skipReload is true, to load any alerts defined at startup time.
@@ -1012,7 +1063,7 @@ sidecar:
     # Additional alerts sidecar volume mounts
     extraMounts: []
     # Sets the size limit of the alert sidecar emptyDir volume
-    sizeLimit: {}
+    sizeLimit: ""
   dashboards:
     enabled: false
     # Additional environment variables for the dashboards sidecar
@@ -1033,9 +1084,9 @@ sidecar:
     # Do not reprocess already processed unchanged resources on k8s API reconnect.
     # ignoreAlreadyProcessed: true
     SCProvider: true
-    # label that the configmaps with dashboards are marked with
+    # label that the configmaps with dashboards are marked with (can be templated)
     label: grafana_dashboard
-    # value of label that the configmaps with dashboards are set to
+    # value of label that the configmaps with dashboards are set to (can be templated)
     labelValue: ""
     # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
     # logLevel: INFO
@@ -1054,6 +1105,12 @@ sidecar:
     # If specified, the sidecar will look for annotation with this name to create folder and put graph here.
     # You can use this parameter together with `provider.foldersFromFilesStructure`to annotate configmaps and create folder structure.
     folderAnnotation: null
+    #
+    # resourceName: comma separated list of resource names to be fetched/checked by this sidecar.
+    # per default all resources of the type defined in {{ .Values.sidecar.dashboards.resource }} will be checked.
+    # This e.g. allows stricter RBAC rules which are limited to the resources meant for the sidecars.
+    # resourceName: "secret/dashboards-0,configmap/dashboards-1"
+    resourceName: ""
     #
     # maxTotalRetries: Total number of retries to allow for any http request.
     # Takes precedence over other counts. Applies to all requests to reloadURL and k8s api requests.
@@ -1074,7 +1131,9 @@ sidecar:
     #
     # Endpoint to send request to reload alerts
     reloadURL: "http://localhost:3000/api/admin/provisioning/dashboards/reload"
-    # Absolute path to shell script to execute after a configmap got reloaded
+    # Absolute path to a script to execute after a configmap got reloaded.
+    # It runs before calls to REQ_URI. If the file is not executable it will be passed to sh.
+    # Otherwise, it's executed as is. Shebangs known to work are #!/bin/sh and #!/usr/bin/env python
     script: null
     skipReload: false
     # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
@@ -1108,7 +1167,7 @@ sidecar:
     # Additional dashboards sidecar volume mounts
     extraMounts: []
     # Sets the size limit of the dashboard sidecar emptyDir volume
-    sizeLimit: {}
+    sizeLimit: ""
   datasources:
     enabled: false
     # Additional environment variables for the datasourcessidecar
@@ -1128,9 +1187,9 @@ sidecar:
     #      key: value_key
     # Do not reprocess already processed unchanged resources on k8s API reconnect.
     # ignoreAlreadyProcessed: true
-    # label that the configmaps with datasources are marked with
+    # label that the configmaps with datasources are marked with (can be templated)
     label: grafana_datasource
-    # value of label that the configmaps with datasources are set to
+    # value of label that the configmaps with datasources are set to (can be templated)
     labelValue: ""
     # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
     # logLevel: INFO
@@ -1142,6 +1201,13 @@ sidecar:
     watchMethod: WATCH
     # search in configmap, secret or both
     resource: both
+    #
+    # resourceName: comma separated list of resource names to be fetched/checked by this sidecar.
+    # per default all resources of the type defined in {{ .Values.sidecar.datasources.resource }} will be checked.
+    # This e.g. allows stricter RBAC rules which are limited to the resources meant for the sidecars.
+    # resourceName: "secret/datasources-0,configmap/datasources-15"
+    resourceName: ""
+    #
     # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
     # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
     # watchServerTimeout: 3600
@@ -1171,7 +1237,9 @@ sidecar:
     #
     # Endpoint to send request to reload datasources
     reloadURL: "http://localhost:3000/api/admin/provisioning/datasources/reload"
-    # Absolute path to shell script to execute after a datasource got reloaded
+    # Absolute path to a script to execute after a configmap got reloaded.
+    # It runs before calls to REQ_URI. If the file is not executable it will be passed to sh.
+    # Otherwise, it's executed as is. Shebangs known to work are #!/bin/sh and #!/usr/bin/env python
     script: null
     skipReload: false
     # This is needed if skipReload is true, to load any datasources defined at startup time.
@@ -1180,16 +1248,16 @@ sidecar:
     # Additional datasources sidecar volume mounts
     extraMounts: []
     # Sets the size limit of the datasource sidecar emptyDir volume
-    sizeLimit: {}
+    sizeLimit: ""
   plugins:
     enabled: false
     # Additional environment variables for the plugins sidecar
     env: {}
     # Do not reprocess already processed unchanged resources on k8s API reconnect.
     # ignoreAlreadyProcessed: true
-    # label that the configmaps with plugins are marked with
+    # label that the configmaps with plugins are marked with (can be templated)
     label: grafana_plugin
-    # value of label that the configmaps with plugins are set to
+    # value of label that the configmaps with plugins are set to (can be templated)
     labelValue: ""
     # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
     # logLevel: INFO
@@ -1201,6 +1269,13 @@ sidecar:
     watchMethod: WATCH
     # search in configmap, secret or both
     resource: both
+    #
+    # resourceName: comma separated list of resource names to be fetched/checked by this sidecar.
+    # per default all resources of the type defined in {{ .Values.sidecar.plugins.resource }} will be checked.
+    # This e.g. allows stricter RBAC rules which are limited to the resources meant for the sidecars.
+    # resourceName: "secret/plugins-0,configmap/plugins-1"
+    resourceName: ""
+    #
     # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
     # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
     # watchServerTimeout: 3600
@@ -1230,7 +1305,9 @@ sidecar:
     #
     # Endpoint to send request to reload plugins
     reloadURL: "http://localhost:3000/api/admin/provisioning/plugins/reload"
-    # Absolute path to shell script to execute after a plugin got reloaded
+    # Absolute path to a script to execute after a configmap got reloaded.
+    # It runs before calls to REQ_URI. If the file is not executable it will be passed to sh.
+    # Otherwise, it's executed as is. Shebangs known to work are #!/bin/sh and #!/usr/bin/env python
     script: null
     skipReload: false
     # Deploy the datasource sidecar as an initContainer in addition to a container.
@@ -1239,16 +1316,16 @@ sidecar:
     # Additional plugins sidecar volume mounts
     extraMounts: []
     # Sets the size limit of the plugin sidecar emptyDir volume
-    sizeLimit: {}
+    sizeLimit: ""
   notifiers:
     enabled: false
     # Additional environment variables for the notifierssidecar
     env: {}
     # Do not reprocess already processed unchanged resources on k8s API reconnect.
     # ignoreAlreadyProcessed: true
-    # label that the configmaps with notifiers are marked with
+    # label that the configmaps with notifiers are marked with (can be templated)
     label: grafana_notifier
-    # value of label that the configmaps with notifiers are set to
+    # value of label that the configmaps with notifiers are set to (can be templated)
     labelValue: ""
     # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
     # logLevel: INFO
@@ -1260,6 +1337,13 @@ sidecar:
     watchMethod: WATCH
     # search in configmap, secret or both
     resource: both
+    #
+    # resourceName: comma separated list of resource names to be fetched/checked by this sidecar.
+    # per default all resources of the type defined in {{ .Values.sidecar.notifiers.resource }} will be checked.
+    # This e.g. allows stricter RBAC rules which are limited to the resources meant for the sidecars.
+    # resourceName: "secret/notifiers-2,configmap/notifiers-1"
+    resourceName: ""
+    #
     # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
     # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
     # watchServerTimeout: 3600
@@ -1289,7 +1373,9 @@ sidecar:
     #
     # Endpoint to send request to reload notifiers
     reloadURL: "http://localhost:3000/api/admin/provisioning/notifications/reload"
-    # Absolute path to shell script to execute after a notifier got reloaded
+    # Absolute path to a script to execute after a configmap got reloaded.
+    # It runs before calls to REQ_URI. If the file is not executable it will be passed to sh.
+    # Otherwise, it's executed as is. Shebangs known to work are #!/bin/sh and #!/usr/bin/env python
     script: null
     skipReload: false
     # Deploy the notifier sidecar as an initContainer in addition to a container.
@@ -1298,7 +1384,7 @@ sidecar:
     # Additional notifiers sidecar volume mounts
     extraMounts: []
     # Sets the size limit of the notifier sidecar emptyDir volume
-    sizeLimit: {}
+    sizeLimit: ""
 
 ## Override the deployment namespace
 ##
@@ -1334,6 +1420,8 @@ imageRenderer:
     tag: latest
     # image-renderer Image sha (optional)
     sha: ""
+    # image-renderer Image pull secrets (optional)
+    pullSecrets: []
     # image-renderer ImagePullPolicy
     pullPolicy: Always
   # extra environment variables
@@ -1528,17 +1616,32 @@ networkPolicy:
 # Enable backward compatibility of kubernetes where version below 1.13 doesn't have the enableServiceLinks option
 enableKubeBackwardCompatibility: false
 useStatefulSet: false
-# Create a dynamic manifests via values:
+
+# extraObjects could be utilized to add dynamic manifests via values
 extraObjects: []
-  # - apiVersion: "kubernetes-client.io/v1"
-  #   kind: ExternalSecret
-  #   metadata:
-  #     name: grafana-secrets
-  #   spec:
-  #     backendType: gcpSecretsManager
-  #     data:
-  #       - key: grafana-admin-password
-  #         name: adminPassword
+# Examples:
+# extraObjects:
+# - apiVersion: kubernetes-client.io/v1
+#   kind: ExternalSecret
+#   metadata:
+#     name: grafana-secrets-{{ .Release.Name }}
+#   spec:
+#     backendType: gcpSecretsManager
+#     data:
+#     - key: grafana-admin-password
+#       name: adminPassword
+# Alternatively, you can use strings, which lets you use additional templating features:
+# extraObjects:
+# - |
+#   apiVersion: kubernetes-client.io/v1
+#   kind: ExternalSecret
+#   metadata:
+#     name: grafana-secrets-{{ .Release.Name }}
+#   spec:
+#     backendType: gcpSecretsManager
+#     data:
+#     - key: grafana-admin-password
+#       name: {{ include "some-other-template" }}
 
 # assertNoLeakedSecrets is a helper function defined in _helpers.tpl that checks if secret
 # values are not exposed in the rendered grafana.ini configmap. It is enabled by default.

--- a/helmfile.d/upstream/index.yaml
+++ b/helmfile.d/upstream/index.yaml
@@ -49,7 +49,7 @@ charts:
 
   goharbor/harbor: 1.17.1
 
-  grafana/grafana: 8.9.1
+  grafana/grafana: 9.2.10
 
   jetstack/cert-manager: v1.17.1
 

--- a/helmfile.d/values/grafana/grafana-dashboards.yaml.gotmpl
+++ b/helmfile.d/values/grafana/grafana-dashboards.yaml.gotmpl
@@ -37,18 +37,27 @@ disabledDashboards:
   - k8s-resources-multicluster-dashboard
   - controller-manager-dashboard
   - scheduler-dashboard
+  {{- if ne .Values.networkPlugin.type "cilium" }}
+  - cilium-metrics-dashboard
+  - cilium-operator-dashboard
+  {{- end }}
+  {{- if ne .Values.networkPlugin.type "calico" }}
+  - calicofelix-dashboard
+  {{- end }}
 notDeveloperVisible:
-  - hnc-dashboard
-  - uptime-dashboard
-  - velero-dashboard
-  - daily-dashboard
+  - calicofelix-dashboard
   - cephcluster-dashboard
   - cephosdsingle-dashboard
   - cephpools-dashboard
-  - calicofelix-dashboard
-  - prometheus-timeseries-dashboard
-  - cluster-api-dashboard
+  - cilium-metrics-dashboard
+  - cilium-operator-dashboard
   - cluster-api-autoscaling-dashboard
+  - cluster-api-dashboard
+  - daily-dashboard
+  - hnc-dashboard
+  - prometheus-timeseries-dashboard
+  - uptime-dashboard
+  - velero-dashboard
 
 {{- if .Values.objectStorage.sync.enabled }}
 sync:

--- a/tests/end-to-end/grafana/dashboards-discovery.bats
+++ b/tests/end-to-end/grafana/dashboards-discovery.bats
@@ -14,6 +14,7 @@ grafana_logs() {
 }
 
 @test "grafana admin can discover dashboards" {
+  echo "If this test gets stuck here for too long, visit \"http://localhost:8000\" in your browser in case you need to authenticate" >&3
   with_kubeconfig "sc"
 
   readarray -t dashboards < <(helmfile -e service_cluster -f "${ROOT}/helmfile.d" -l name=grafana-dashboards template | yq -N 'select(.kind == "ConfigMap") | .data | keys | .[]')

--- a/tests/end-to-end/grafana/datasources.cy.js
+++ b/tests/end-to-end/grafana/datasources.cy.js
@@ -29,7 +29,7 @@ function loginNavigate(cy, ingress, passwordKey) {
 
   cy.get('button[aria-label="Open menu"]').click()
 
-  cy.get('button[aria-label="Expand section Connections"]').click()
+  cy.get('button[aria-label="Expand section: Connections"]').click()
 
   cy.contains('Data sources').click()
 }


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [x] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

### Application Developer notice

Grafana was upgraded to new major version 12, this comes some new features such as the ["Drilldown" page](https://grafana.com/blog/2025/02/20/grafana-drilldown-apps-the-improved-queryless-experience-formerly-known-as-the-explore-apps/). Please refer to the upstream release notes to see all [changes](https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v12-0/).

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Upgrading Grafana to keep it up to date.
Needed to increase default memory as it kept getting OOMkilled after upgrading, looking at other environments running older versions of Grafana, the current resources seemed a bit low (averaged around ~120-160Mi).
After adjusting the pods no longer kept crashing/restarting.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

Grafana end-to-end tests passed:

```consolke
✗ make run-end-to-end/grafana
--- run end-to-end/grafana
1..28
# cypress run: /compliantkubernetes-apps/tests/end-to-end/grafana/authentication.cy.js
ok 1 grafana admin authentication can login via static admin user
ok 2 grafana admin authentication can login via static dex user
ok 3 grafana dev authentication can login via static admin user
ok 4 grafana dev authentication can login via static dex user
If this test gets stuck here for too long, visit "http://localhost:8000" in your browser in case you need to authenticate
ok 5 grafana admin can discover dashboards
ok 6 grafana admin can load dashboards without error
ok 7 grafana dev can discover dashboards
ok 8 grafana dev can load dashboards without error
# cypress run: /compliantkubernetes-apps/tests/end-to-end/grafana/dashboards.cy.js
ok 9 grafana admin dashboards open the Backup status dashboard
ok 10 grafana admin dashboards open the Trivy Operator Dashboard
ok 11 grafana admin dashboards open the NetworkPolicy Dashboard
ok 12 grafana admin dashboards open the Kubernetes cluster status dashboard
ok 13 grafana admin dashboards open the Gatekeeper dashboard
ok 14 grafana admin dashboards open the NGINX Ingress controller dashboard
ok 15 grafana admin dashboards open the Falco dashboard
ok 16 grafana dev dashboards   //open the Backup status dashboard # skip cypress skipped this test
ok 17 grafana dev dashboards open the Trivy Operator Dashboard
ok 18 grafana dev dashboards open the NetworkPolicy Dashboard
ok 19 grafana dev dashboards open the Kubernetes cluster status dashboard
ok 20 grafana dev dashboards open the Gatekeeper dashboard
ok 21 grafana dev dashboards open the NGINX Ingress controller dashboard
ok 22 grafana dev dashboards open the Falco dashboard
# cypress run: /compliantkubernetes-apps/tests/end-to-end/grafana/datasources.cy.js
ok 23 grafana admin datasources has prometheus
ok 24 grafana admin datasources has thanos all
ok 25 grafana admin datasources has thanos sc
ok 26 grafana admin datasources has thanos wc
ok 27 grafana dev datasources has service cluster
ok 28 grafana dev datasources has workload cluster
```

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [x] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [x] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
