### PR TITLE
apps: added rbac and opa policies for allowing ephemeral containers

### DIFF
--- a/helmfile.d/charts/gatekeeper/templates/policies/image-registry.rego
+++ b/helmfile.d/charts/gatekeeper/templates/policies/image-registry.rego
@@ -73,3 +73,18 @@ get_init_containers = res {
     input.review.object.kind == "CronJob"
     res := input.review.object.spec.jobTemplate.spec.template.spec.initContainers
 }
+
+# Ephemeral containers
+violation[{"msg": msg}] {
+  container := get_ephemeral_containers[_]
+
+  satisfied := [good | repo = input.parameters.repos[_]; good = startswith(container.image, repo)]
+  not any(satisfied)
+
+  msg := sprintf("The ephemeral container named <%v> does not have an allowed image registry <%v>, allowed registries are <%v>. Elastisys Welkin® requires that all images come from trusted registries. Read more at https://elastisys.io/welkin/user-guide/safeguards/enforce-trusted-registries/", [container.name, container.image, input.parameters.repos])
+}
+
+get_ephemeral_containers = res {
+  input.review.object.kind == "Pod"
+  res := input.review.object.spec.ephemeralContainers
+}

--- a/helmfile.d/charts/gatekeeper/templates/policies/tests/image-registries.rego
+++ b/helmfile.d/charts/gatekeeper/templates/policies/tests/image-registries.rego
@@ -128,6 +128,23 @@ generate_cronJob_with_initContainer(repos, containers, initContainers) = obj {
     }
 }
 
+generate_pod_with_ephemeralContainer(repos, containers, ephemeralContainers) = obj {
+    obj := {
+        "parameters": {
+            "repos": repos
+        },
+        "review": {
+            "object": {
+                "kind": "Pod",
+                "spec": {
+                    "containers": containers,
+                    "ephemeralContainers": ephemeralContainers
+                }
+            }
+        }
+    }
+}
+
 #
 # Tests
 #
@@ -557,5 +574,29 @@ test_cronJob_multiple_containers_and_initContainers_deny {
                 "image": "harbor.bad.com/test/ubuntu"
             }
         ],
+    )
+}
+
+test_pod_bad_ephemeralContainer_deny {
+    count(k8sallowedrepos.violation) == 1 with input as generate_pod_with_ephemeralContainer(
+        ["harbor.example.com"],
+        [
+            { "name": "main", "image": "harbor.example.com/app:latest" }
+        ],
+        [
+            { "name": "debug", "image": "bad.registry.com/debug:latest" }
+        ]
+    )
+}
+
+test_pod_good_ephemeralContainer_allow {
+    count(k8sallowedrepos.violation) == 0 with input as generate_pod_with_ephemeralContainer(
+        ["harbor.example.com"],
+        [
+            { "name": "main", "image": "harbor.example.com/app:latest" }
+        ],
+        [
+            { "name": "debug", "image": "harbor.example.com/debug-tool:latest" }
+        ]
     )
 }

--- a/helmfile.d/charts/user-rbac/templates/clusterroles/user-admin.yaml
+++ b/helmfile.d/charts/user-rbac/templates/clusterroles/user-admin.yaml
@@ -12,3 +12,6 @@ rules:
 - apiGroups: ["monitoring.coreos.com"]
   resources: ["servicemonitors", "podmonitors", "prometheusrules", "probes"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["pods/ephemeralcontainers"]
+  verbs: ["patch"]


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This add new RBAC policies and opa policies to application developers have patch on pods/ephemeralcontainers in "", thus having the ability to run kubectl debug.
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2422 
- 
#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
