### PR TITLE
fix: prettified too much

### DIFF
--- a/tests/cypress.support.js
+++ b/tests/cypress.support.js
@@ -112,7 +112,7 @@ Cypress.Commands.add('yqSecrets', (expression) => {
 })
 
 // Available as cy.continueOn("sc|wc", "expression") expression should evaluate to true to continue
-Cypress.Commands.add('continueOn', (cluster, expression) => {
+Cypress.Commands.add('continueOn', function (cluster, expression) {
   cy.yqDig(cluster, expression).then((result) => {
     if (result !== 'true') {
       this.skip(`${cluster}/${expression} is disabled`)

--- a/tests/end-to-end/grafana/authentication.cy.js
+++ b/tests/end-to-end/grafana/authentication.cy.js
@@ -1,5 +1,5 @@
 describe('grafana admin authentication', () => {
-  before(() => {
+  before(function () {
     cy.yq('sc', '.grafana.ops.subdomain + "." + .global.opsDomain')
       .should('not.contain.empty')
       .as('ingress')
@@ -10,7 +10,7 @@ describe('grafana admin authentication', () => {
     )
   })
 
-  it('can login via static admin user', () => {
+  it('can login via static admin user', function () {
     cy.visit(`https://${this.ingress}`)
 
     cy.yqSecrets('.grafana.password').then((password) => {
@@ -26,7 +26,7 @@ describe('grafana admin authentication', () => {
     cy.contains('Welcome to Grafana').should('exist')
   })
 
-  it('can login via static dex user', () => {
+  it('can login via static dex user', function () {
     cy.yqDig('sc', '.dex.enableStaticLogin').then((staticLoginEnabled) => {
       if (staticLoginEnabled !== 'true') {
         this.skip('dex static login is not enabled')
@@ -51,8 +51,8 @@ describe('grafana admin authentication', () => {
   })
 })
 
-describe('grafana dev authentication', () => {
-  before(() => {
+describe('grafana dev authentication', function () {
+  before(function () {
     cy.yq('sc', '.grafana.user.subdomain + "." + .global.baseDomain')
       .should('not.contain.empty')
       .as('ingress')
@@ -63,7 +63,7 @@ describe('grafana dev authentication', () => {
     )
   })
 
-  it('can login via static admin user', () => {
+  it('can login via static admin user', function () {
     cy.visit(`https://${this.ingress}`)
 
     cy.yqSecrets('.user.grafanaPassword').then((password) => {
@@ -79,7 +79,7 @@ describe('grafana dev authentication', () => {
     cy.contains('Welcome to Welkin').should('exist')
   })
 
-  it('can login via static dex user', () => {
+  it('can login via static dex user', function () {
     cy.yqDig('sc', '.dex.enableStaticLogin').then((staticLoginEnabled) => {
       if (staticLoginEnabled !== 'true') {
         this.skip('dex static login is not enabled')

--- a/tests/end-to-end/grafana/dashboards.cy.js
+++ b/tests/end-to-end/grafana/dashboards.cy.js
@@ -68,7 +68,7 @@ describe('grafana admin dashboards', () => {
 })
 
 describe('grafana dev dashboards', () => {
-  before(() => {
+  before(function () {
     cy.yq('sc', '.grafana.user.subdomain + "." + .global.baseDomain')
       .should('not.contain.empty')
       .as('ingress')
@@ -95,13 +95,13 @@ describe('grafana dev dashboards', () => {
   //     .should('exist')
   // })
 
-  it('open the Trivy Operator Dashboard', () => {
+  it('open the Trivy Operator Dashboard', function () {
     cy.testGrafanaDashboard(this.ingress, 'Trivy Operator Dashboard', false, 20)
 
     cy.get('[data-testid="data-testid Panel menu Security Overview"]').should('exist')
   })
 
-  it('open the NetworkPolicy Dashboard', () => {
+  it('open the NetworkPolicy Dashboard', function () {
     cy.testGrafanaDashboard(this.ingress, 'NetworkPolicy Dashboard', false, 14)
 
     cy.get(
@@ -109,25 +109,25 @@ describe('grafana dev dashboards', () => {
     ).should('exist')
   })
 
-  it('open the Kubernetes cluster status dashboard', () => {
+  it('open the Kubernetes cluster status dashboard', function () {
     cy.testGrafanaDashboard(this.ingress, 'Kubernetes cluster status', false, 30)
 
     cy.get('[data-testid="data-testid Panel menu Running pods not ready"]').should('exist')
   })
 
-  it('open the Gatekeeper dashboard', () => {
+  it('open the Gatekeeper dashboard', function () {
     cy.testGrafanaDashboard(this.ingress, 'Gatekeeper', 18)
 
     cy.get('[data-testid="data-testid Panel header Gatekeeper logs"]').should('exist')
   })
 
-  it('open the NGINX Ingress controller dashboard', () => {
+  it('open the NGINX Ingress controller dashboard', function () {
     cy.testGrafanaDashboard(this.ingress, 'NGINX Ingress controller', false, 26)
 
     cy.get('[data-testid="data-testid Panel header Controller Request Volume"]').should('exist')
   })
 
-  it('open the Falco dashboard', () => {
+  it('open the Falco dashboard', function () {
     cy.testGrafanaDashboard(this.ingress, 'Falco', false, 21)
 
     cy.get('[data-testid="data-testid Panel header Falco logs"]').should('exist')

--- a/tests/end-to-end/grafana/datasources.cy.js
+++ b/tests/end-to-end/grafana/datasources.cy.js
@@ -35,7 +35,7 @@ function loginNavigate(cy, ingress, passwordKey) {
 }
 
 describe('grafana admin datasources', () => {
-  before(() => {
+  before(function () {
     cy.yq('sc', '.grafana.ops.subdomain + "." + .global.opsDomain')
       .should('not.contain.empty')
       .as('ingress')
@@ -81,7 +81,7 @@ describe('grafana admin datasources', () => {
 })
 
 describe('grafana dev datasources', () => {
-  before(() => {
+  before(function () {
     cy.yq('sc', '.grafana.user.subdomain + "." + .global.baseDomain')
       .should('not.contain.empty')
       .as('ingress')

--- a/tests/end-to-end/harbor/dex-auth.cy.js
+++ b/tests/end-to-end/harbor/dex-auth.cy.js
@@ -3,16 +3,16 @@
 
 import '../../common/cypress/harbor.js'
 
-describe('harbor dex auth', () => {
-  before(() => {
+describe('harbor dex auth', function () {
+  before(function () {
     cy.yq('sc', '.harbor.subdomain + "." + .global.baseDomain').should('not.be.empty').as('ingress')
   })
 
-  it('can login via static admin user', () => {
+  it('can login via static admin user', function () {
     cy.harborAdminLogin(this.ingress)
   })
 
-  it('can login via static dex user', () => {
+  it('can login via static dex user', function () {
     cy.yqDig('sc', '.dex.enableStaticLogin').then((staticLoginEnabled) => {
       if (staticLoginEnabled !== 'true') {
         this.skip('dex static login is not enabled')
@@ -22,7 +22,7 @@ describe('harbor dex auth', () => {
     cy.harborStaticDexLogin(this.ingress)
   })
 
-  it('can promote static dex user to admin', () => {
+  it('can promote static dex user to admin', function () {
     cy.yqDig('sc', '.dex.enableStaticLogin').then((staticLoginEnabled) => {
       if (staticLoginEnabled !== 'true') {
         this.skip('dex static login is not enabled')

--- a/tests/end-to-end/harbor/use-ui.cy.js
+++ b/tests/end-to-end/harbor/use-ui.cy.js
@@ -7,7 +7,7 @@ const opt = { matchCase: false }
 const slug = 'end-to-end-tests-harbor-manage-resources'
 
 describe('harbor ui', () => {
-  before(() => {
+  before(function () {
     cy.yq('sc', '.harbor.subdomain + "." + .global.baseDomain')
       .should('not.be.empty')
       .as('ingress')

--- a/tests/end-to-end/kubernetes/authentication-admin.cy.js
+++ b/tests/end-to-end/kubernetes/authentication-admin.cy.js
@@ -7,7 +7,7 @@ describe('kubernetes authentication', function () {
     cy.deleteTestKubeconfig('wc', 'static-admin')
   })
 
-  it('can login via static dex user', () => {
+  it('can login via static dex user', function () {
     cy.yqDig('sc', '.dex.enableStaticLogin').then((staticLoginEnabled) => {
       if (staticLoginEnabled !== 'true') {
         this.skip('dex static login is not enabled')

--- a/tests/end-to-end/kubernetes/authentication-dev.cy.js
+++ b/tests/end-to-end/kubernetes/authentication-dev.cy.js
@@ -3,7 +3,7 @@ describe('kubernetes authentication', function () {
     cy.withTestKubeconfig('wc', 'static-dev', 'true')
   })
 
-  it('can login via extra static dex user', () => {
+  it('can login via extra static dex user', function () {
     cy.yqDig('sc', '.dex.enableStaticLogin').then((staticLoginEnabled) => {
       if (staticLoginEnabled !== 'true') {
         this.skip('dex static login is not enabled')

--- a/tests/end-to-end/opensearch/authentication.cy.js
+++ b/tests/end-to-end/opensearch/authentication.cy.js
@@ -1,11 +1,11 @@
 describe('opensearch admin authentication', () => {
-  before(() => {
+  before(function () {
     cy.yq('sc', '.opensearch.dashboards.subdomain + "." + .global.baseDomain')
       .should('not.contain.empty')
       .as('ingress')
   })
 
-  it('can login via static dex user', () => {
+  it('can login via static dex user', function () {
     // Need to ignore error response from GET /api/dataconnections for non-authorized user.
     //
     // {

--- a/tests/end-to-end/opensearch/dashboards.cy.js
+++ b/tests/end-to-end/opensearch/dashboards.cy.js
@@ -57,8 +57,8 @@ function opensearchTestIndexPattern(cy, indexPattern) {
   cy.contains('hits', opt).should('be.visible')
 }
 
-describe('opensearch dashboards', () => {
-  before(() => {
+describe('opensearch dashboards', function () {
+  before(function () {
     cy.yq('sc', '.opensearch.dashboards.subdomain + "." + .global.baseDomain')
       .should('not.be.empty')
       .as('ingress')
@@ -66,7 +66,7 @@ describe('opensearch dashboards', () => {
     cy.yqDig('sc', '.opensearch.indexPerNamespace').should('not.be.empty').as('indexPerNamespace')
   })
 
-  beforeEach(() => {
+  beforeEach(function () {
     opensearchDexStaticLogin(cy, this.ingress)
 
     cy.on('uncaught:exception', (err, runnable) => {
@@ -82,7 +82,7 @@ describe('opensearch dashboards', () => {
     Cypress.session.clearAllSavedSessions()
   })
 
-  it('open the audit user dashboard', () => {
+  it('open the audit user dashboard', function () {
     // open sidebar menu
     cy.contains('title', 'menu', opt).parents('button').click()
 

--- a/tests/integration/harbor/dex-auth.cy.js
+++ b/tests/integration/harbor/dex-auth.cy.js
@@ -8,16 +8,16 @@
 
 import '../../common/cypress/harbor.js'
 
-describe('harbor dex auth', () => {
-  before(() => {
+describe('harbor dex auth', function () {
+  before(function () {
     cy.yq('sc', '.harbor.subdomain + "." + .global.baseDomain').should('not.be.empty').as('ingress')
   })
 
-  it('can login via static admin user', () => {
+  it('can login via static admin user', function () {
     cy.harborAdminLogin(this.ingress)
   })
 
-  it('can login via static dex user', () => {
+  it('can login via static dex user', function () {
     cy.yqDig('sc', '.dex.enableStaticLogin').then((staticLoginEnabled) => {
       if (staticLoginEnabled !== 'true') {
         this.skip('dex static login is not enabled')
@@ -27,7 +27,7 @@ describe('harbor dex auth', () => {
     cy.harborStaticDexLogin(this.ingress)
   })
 
-  it('can promote static dex user to admin', () => {
+  it('can promote static dex user to admin', function () {
     cy.yqDig('sc', '.dex.enableStaticLogin').then((staticLoginEnabled) => {
       if (staticLoginEnabled !== 'true') {
         this.skip('dex static login is not enabled')

--- a/tests/integration/harbor/use-ui.cy.js
+++ b/tests/integration/harbor/use-ui.cy.js
@@ -11,8 +11,8 @@ import '../../common/cypress/harbor.js'
 const opt = { matchCase: false }
 const slug = 'integration-tests-harbor-manage-resources'
 
-describe('harbor ui', () => {
-  before(() => {
+describe('harbor ui', function () {
+  before(function () {
     cy.yq('sc', '.harbor.subdomain + "." + .global.baseDomain')
       .should('not.be.empty')
       .as('ingress')
@@ -29,7 +29,7 @@ describe('harbor ui', () => {
       })
   })
 
-  beforeEach(() => {
+  beforeEach(function () {
     cy.session([this.ingress], () => {
       cy.harborStaticDexLogin(this.ingress)
     })


### PR DESCRIPTION
…ccessed

<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Prettified too much, not realizing that replacing function objects `function() { ... }` with fat arrow closures `() => { ... }` in JS is a _bad idea_, as the latter don't get access to the special `this` context. 

Integration tests of `main` [are failing](https://github.com/elastisys/compliantkubernetes-apps/actions/runs/16315324097/job/46080283049) - this PR aims to fix them.

Branch name starts with `release` so it triggers the integration test workflow.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
