### PR TITLE
Exclude rook-ceph namespace in pdb constraint policy

### DIFF
--- a/helmfile.d/charts/gatekeeper/constraints/templates/restrict-pod-disruption-budgets/constraint.yaml
+++ b/helmfile.d/charts/gatekeeper/constraints/templates/restrict-pod-disruption-budgets/constraint.yaml
@@ -13,6 +13,6 @@ spec:
         kinds: ["Deployment", "StatefulSet", "ReplicaSet"]
       - apiGroups: ["policy"]
         kinds: ["PodDisruptionBudget"]
-    excludedNamespaces: ["kube-system", "kube-public", "kube-node-lease", "calico-system"]
+    excludedNamespaces: ["kube-system", "kube-public", "kube-node-lease", "calico-system", "rook-ceph"]
     # Note that this does not exclude all namespaces with label owner=operator
 {{- end }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
In environments on apps v0.47, with the addition of new Gatekeeper constraint policy for PDBs, nodes running rook-ceph-osd pods cannot be properly drained (e.g. for Kured reboot or Kubespray upgrades), see the rook-ceph-operator logs:

```
2025-07-17 07:48:02.606197 E | op-mon: failed to block mon drain. failed to update MaxUnavailable for mon PDB "rook-ceph-mon-pdb": admission webhook "validation.gatekeeper.sh" denied the request: [elastisys-restrict-pod-disruption-budgets] PodDisruptionBudget rejected: PodDisruptionBudget <rook-ceph-mon-pdb> has maxUnavailable of 0, only positive integers or percentages are allowed for maxUnavailable. Read more about this and possible solutions at https://elastisys.io/welkin/user-guide/safeguards/enforce-restricted-pod-disruption-budgets/
2025-07-17 07:50:31.580659 I | op-mon: allow voluntary mon drain after failover
2025-07-17 07:53:41.057901 I | clusterdisruption-controller: osd "rook-ceph-osd-15" is down and a possible node drain is detected
2025-07-17 07:53:44.669697 E | clusterdisruption-controller: failed to handle active drains: failed to create blocking pdb for "host" failure domain "wc-node-1": failed to create pdb "rook-ceph-osd-host-wc-node-1": admission webhook "validation.gatekeeper.sh" denied the request: [elastisys-restrict-pod-disruption-budgets] PodDisruptionBudget rejected: PodDisruptionBudget <rook-ceph-osd-host-wc-node-1> has maxUnavailable of 0, only positive integers or percentages are allowed for maxUnavailable. Read more about this and possible solutions at https://elastisys.io/welkin/user-guide/safeguards/enforce-restricted-pod-disruption-budgets/
```

We should let the rook-ceph operator handle node drains and exclude the namespace from this Gatekeeper policy.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
