### PR TITLE
feat: tell cypress to run in "headed" mode

### DIFF
--- a/scripts/run-from-container.sh
+++ b/scripts/run-from-container.sh
@@ -168,6 +168,7 @@ if [[ "${FORWARD_ENVIRONMENT:-false}" == "true" ]]; then
   # Prepare container env
   args+=("--env" "CK8S_CONFIG_PATH")
   args+=("--mount" "type=bind,src=${CK8S_CONFIG_PATH},dst=${CK8S_CONFIG_PATH}")
+  args+=("--env" "CK8S_HEADED_CYPRESS")
 fi
 
 # Check if we are in a work tree

--- a/tests/README.md
+++ b/tests/README.md
@@ -134,6 +134,12 @@ cypress open
 
 It will auto-reload and auto-execute as tests are updated, use `it.only` instead of `it` to run only selected tests.
 
+> [!note]
+> Set the `CK8S_HEADED_CYPRESS=true` environment variable to
+> force `cypress` to show its testing interface alongside the testing browser.
+>
+> This works when running tests through `make` or `bats`, but not when invoking `cypress` directly.
+
 ## Writing
 
 Currently it is possible to write three types of tests, bats tests, cypress tests, and template tests.

--- a/tests/bats.lib.bash
+++ b/tests/bats.lib.bash
@@ -251,6 +251,13 @@ cypress_setup() {
     log.fatal "invalid or missing file argument"
   fi
 
+  declare -a cypress_args
+  if [[ "${CK8S_HEADED_CYPRESS:-false}" == "true" ]]; then
+    cypress_args=("--runner-ui" "--headed")
+  else
+    cypress_args=("--no-runner-ui")
+  fi
+
   CYPRESS_REPORT="$(mktemp)"
 
   pushd "${ROOT}/tests" || exit 1
@@ -259,7 +266,7 @@ cypress_setup() {
   for seq in $(seq 3); do
     [[ "${seq}" == "1" ]] || log.trace "cypress run: try ${seq}/3"
 
-    cypress run --no-runner-ui --spec "$1" --reporter json-stream --quiet >"${CYPRESS_REPORT}" || true
+    cypress run "${cypress_args[@]}" --spec "$1" --reporter json-stream --quiet >"${CYPRESS_REPORT}" || true
 
     # This happen seemingly at random
     if ! grep "Fatal JavaScript out of memory" "${CYPRESS_REPORT}" &>/dev/null; then


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

You can now set the `CK8S_HEADED_CYPRESS=true` environment variable to tell the cypress tests to run in "headed" mode, which will show both the test interface and the testing browser.

NOTE: This works for running tests via `make` or `bats` but not directly through `cypress`.

#### Information to reviewers

```
export CK8S_HEADED_CYPRESS=1
make -C tests run-end-to-end/<any-test-suite>
```

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
