### PR TITLE
E2E proxy tests cleanup

### DIFF
--- a/scripts/kubeproxy-wrapper.sh
+++ b/scripts/kubeproxy-wrapper.sh
@@ -34,8 +34,8 @@ curl_pid=$!
 # wait until port 8000 is open
 for _ in $(seq 1 30); do
   if nc -z 127.0.0.1 8000; then
-    redir_url="$(curl --silent -i http://127.0.0.1:8000/ | grep --only-matching --perl-regexp 'Location: \K.+')"
-    echo "$PROXY_READY_MARKER $redir_url"
+    dex_url="$(curl --silent -i http://127.0.0.1:8000/ | grep --only-matching --perl-regexp 'Location: \K.+')"
+    echo "$PROXY_READY_MARKER $dex_url"
     break
   fi
   sleep 1

--- a/tests/cypress.config.js
+++ b/tests/cypress.config.js
@@ -39,8 +39,8 @@ module.exports = defineConfig({
           return new Promise((resolve) => {
             proxy.stdout.on('data', (data) => {
               if (data.includes(PROXY_READY_MARKER)) {
-                const redirectUrl = data.toString().split(' ')[1]
-                resolve(redirectUrl)
+                const dexUrl = data.toString().split(' ')[1]
+                resolve(dexUrl)
               }
             })
           })

--- a/tests/cypress.index.d.ts
+++ b/tests/cypress.index.d.ts
@@ -48,7 +48,7 @@ declare namespace Cypress {
      * @example
      * cy.visitProxied({
      *   cluster: 'wc',
-     *   user: 'static-dev',
+     *   user: 'dev@example.com',
      *   url: 'http://127.0.0.1:8001/api/v1/namespaces/monitoring/services/kube-prometheus-stack-prometheus:9090/proxy/targets?pool=serviceMonitor%2Fmonitoring%2Fkube-prometheus-stack-apiserver%2F0',
      *   refresh: false,
      *   checkAdmin: true,
@@ -64,7 +64,7 @@ declare namespace Cypress {
 
     /**
      * @example
-     * cy.cleanupProxy({ cluster: 'sc', user: 'static-admin' })
+     * cy.cleanupProxy({ cluster: 'sc', user: 'dev@example.com' })
      */
     cleanupProxy(args: { cluster: string; user: string }): Chainable<any>
 
@@ -74,15 +74,15 @@ declare namespace Cypress {
      */
     withTestKubeconfig(args: {
       cluster: string
-      user: string
+      session: string
       url?: string
       refresh: boolean
     }): Chainable<string>
 
     /**
      * @example
-     * cy.deleteTestKubeconfig({ cluster: 'sc', user: 'static-admin' })
+     * cy.deleteTestKubeconfig({ cluster: 'sc', session: 'static-admin' })
      */
-    deleteTestKubeconfig(args: { cluster: string; user: string }): Chainable<any>
+    deleteTestKubeconfig(args: { cluster: string; session: string }): Chainable<any>
   }
 }

--- a/tests/cypress.index.d.ts
+++ b/tests/cypress.index.d.ts
@@ -50,7 +50,7 @@ declare namespace Cypress {
      *   cluster: 'wc',
      *   user: 'static-dev',
      *   url: 'http://127.0.0.1:8001/api/v1/namespaces/monitoring/services/kube-prometheus-stack-prometheus:9090/proxy/targets?pool=serviceMonitor%2Fmonitoring%2Fkube-prometheus-stack-apiserver%2F0',
-     *   refresh: 'true',
+     *   refresh: false,
      *   checkAdmin: true,
      * })
      */
@@ -58,7 +58,7 @@ declare namespace Cypress {
       cluster: string
       user: string
       url: string
-      refresh: boolean
+      refresh?: boolean
       checkAdmin?: boolean
     }): Chainable<any>
 

--- a/tests/cypress.support.js
+++ b/tests/cypress.support.js
@@ -135,8 +135,8 @@ Cypress.Commands.add(
     }
 
     cy.withTestKubeconfig({ cluster, user, url, refresh }).then(() => {
-      cy.task('wrapProxy', Cypress.env('KUBECONFIG')).then((redir_url) => {
-        cy.visit(`${redir_url}`)
+      cy.task('wrapProxy', Cypress.env('KUBECONFIG')).then((dex_url) => {
+        cy.visit(`${dex_url}`)
         cy.dexExtraStaticLogin('dev@example.com')
       })
     })

--- a/tests/cypress.support.js
+++ b/tests/cypress.support.js
@@ -122,7 +122,7 @@ Cypress.Commands.add('dexExtraStaticLogin', (email) => {
 
 Cypress.Commands.add(
   'visitProxied',
-  function ({ cluster, user, url, refresh, checkAdmin = false }) {
+  function ({ cluster, user, url, refresh = true, checkAdmin = true }) {
     if (checkAdmin) {
       cy.yqDigParse(cluster, '.user.adminUsers').then((adminUsers) => {
         if (!adminUsers.includes('dev@example.com')) {

--- a/tests/end-to-end/alertmanager/via-proxy.cy.js
+++ b/tests/end-to-end/alertmanager/via-proxy.cy.js
@@ -4,8 +4,10 @@ describe('alertmanager', function () {
 
     cy.visitProxied({
       cluster: 'wc',
-      user: 'static-dev',
-      url: 'http://127.0.0.1:8001/api/v1/namespaces/alertmanager/services/alertmanager-operated:9093/proxy/',
+      user: 'dev@example.com',
+      url:
+        'http://127.0.0.1:8001/api/v1/namespaces/alertmanager/services' +
+        '/alertmanager-operated:9093/proxy/',
     })
 
     cy.origin('http://127.0.0.1:8001', () => {
@@ -14,6 +16,6 @@ describe('alertmanager', function () {
   })
 
   after(() => {
-    cy.cleanupProxy({ cluster: 'wc', user: 'static-dev' })
+    cy.cleanupProxy({ cluster: 'wc', user: 'dev@example.com' })
   })
 })

--- a/tests/end-to-end/alertmanager/via-proxy.cy.js
+++ b/tests/end-to-end/alertmanager/via-proxy.cy.js
@@ -1,7 +1,5 @@
 describe('alertmanager', function () {
   it('can be accessed via kubectl proxy', () => {
-    cy.intercept('/api/**').as('api')
-
     cy.visitProxied({
       cluster: 'wc',
       user: 'dev@example.com',

--- a/tests/end-to-end/alertmanager/via-proxy.cy.js
+++ b/tests/end-to-end/alertmanager/via-proxy.cy.js
@@ -6,8 +6,6 @@ describe('alertmanager', function () {
       cluster: 'wc',
       user: 'static-dev',
       url: 'http://127.0.0.1:8001/api/v1/namespaces/alertmanager/services/alertmanager-operated:9093/proxy/',
-      refresh: true,
-      checkAdmin: true,
     })
 
     cy.origin('http://127.0.0.1:8001', () => {

--- a/tests/end-to-end/grafana/authentication.cy.js
+++ b/tests/end-to-end/grafana/authentication.cy.js
@@ -29,7 +29,7 @@ describe('grafana admin authentication', () => {
   it('can login via static dex user', function () {
     cy.continueOn('sc', '.dex.enableStaticLogin')
 
-    cy.yqDigParse('sc', '.grafana.ops.oidc.allowedDomains').then((domains) => {
+    cy.yqDigParse('sc', '.grafana.ops.oidc.allowedDomains').then(function (domains) {
       if (!domains.includes('example.com')) {
         this.skip('example.com not set in .grafana.ops.oidc.allowedDomains')
       }
@@ -78,7 +78,7 @@ describe('grafana dev authentication', function () {
   it('can login via static dex user', function () {
     cy.continueOn('sc', '.dex.enableStaticLogin')
 
-    cy.yqDigParse('sc', '.grafana.user.oidc.allowedDomains').then((domains) => {
+    cy.yqDigParse('sc', '.grafana.user.oidc.allowedDomains').then(function (domains) {
       if (!domains.includes('example.com')) {
         this.skip('example.com not set in .grafana.user.oidc.allowedDomains')
       }

--- a/tests/end-to-end/kubernetes/authentication-admin.cy.js
+++ b/tests/end-to-end/kubernetes/authentication-admin.cy.js
@@ -1,10 +1,10 @@
 describe('kubernetes authentication', function () {
   before(function () {
-    cy.withTestKubeconfig({ cluster: 'wc', user: 'static-admin', refresh: true })
+    cy.withTestKubeconfig({ cluster: 'wc', session: 'static-admin', refresh: true })
   })
 
   after(function () {
-    cy.deleteTestKubeconfig({ cluster: 'wc', user: 'static-admin' })
+    cy.deleteTestKubeconfig({ cluster: 'wc', session: 'static-admin' })
   })
 
   it('can login via static dex user', function () {

--- a/tests/end-to-end/kubernetes/authentication-admin.cy.js
+++ b/tests/end-to-end/kubernetes/authentication-admin.cy.js
@@ -11,7 +11,7 @@ describe('kubernetes authentication', function () {
     cy.continueOn('sc', '.dex.enableStaticLogin')
 
     cy.task('kubectlLogin', Cypress.env('KUBECONFIG'))
-    cy.visit(`http://localhost:8000`)
+    cy.visit('http://localhost:8000')
 
     cy.dexStaticLogin()
 

--- a/tests/end-to-end/kubernetes/authentication-dev.cy.js
+++ b/tests/end-to-end/kubernetes/authentication-dev.cy.js
@@ -9,7 +9,7 @@ describe('kubernetes authentication', function () {
 
   it('can login via extra static dex user', function () {
     cy.task('kubectlLogin', Cypress.env('KUBECONFIG'))
-    cy.visit(`http://localhost:8000`)
+    cy.visit('http://localhost:8000')
 
     cy.dexExtraStaticLogin('dev@example.com')
 

--- a/tests/end-to-end/kubernetes/authentication-dev.cy.js
+++ b/tests/end-to-end/kubernetes/authentication-dev.cy.js
@@ -1,10 +1,10 @@
 describe('kubernetes authentication', function () {
   before(function () {
-    cy.withTestKubeconfig({ cluster: 'wc', user: 'static-dev', refresh: true })
+    cy.withTestKubeconfig({ cluster: 'wc', session: 'static-dev', refresh: true })
   })
 
   after(function () {
-    cy.deleteTestKubeconfig({ cluster: 'wc', user: 'static-dev' })
+    cy.deleteTestKubeconfig({ cluster: 'wc', session: 'static-dev' })
   })
 
   it('can login via extra static dex user', function () {

--- a/tests/end-to-end/prometheus/via-proxy.cy.js
+++ b/tests/end-to-end/prometheus/via-proxy.cy.js
@@ -4,8 +4,6 @@ describe('prometheus', function () {
       cluster: 'wc',
       user: 'static-dev',
       url: 'http://127.0.0.1:8001/api/v1/namespaces/monitoring/services/kube-prometheus-stack-prometheus:9090/proxy/targets?pool=serviceMonitor%2Fmonitoring%2Fkube-prometheus-stack-apiserver%2F0',
-      refresh: true,
-      checkAdmin: true,
     })
 
     cy.origin('http://127.0.0.1:8001', () => {

--- a/tests/end-to-end/prometheus/via-proxy.cy.js
+++ b/tests/end-to-end/prometheus/via-proxy.cy.js
@@ -2,8 +2,11 @@ describe('prometheus', function () {
   it('can be accessed via kubectl proxy', () => {
     cy.visitProxied({
       cluster: 'wc',
-      user: 'static-dev',
-      url: 'http://127.0.0.1:8001/api/v1/namespaces/monitoring/services/kube-prometheus-stack-prometheus:9090/proxy/targets?pool=serviceMonitor%2Fmonitoring%2Fkube-prometheus-stack-apiserver%2F0',
+      user: 'dev@example.com',
+      url:
+        'http://127.0.0.1:8001/api/v1/namespaces/monitoring/services' +
+        '/kube-prometheus-stack-prometheus:9090/proxy/targets' +
+        '?pool=serviceMonitor%2Fmonitoring%2Fkube-prometheus-stack-apiserver%2F0',
     })
 
     cy.origin('http://127.0.0.1:8001', () => {
@@ -12,6 +15,6 @@ describe('prometheus', function () {
   })
 
   after(() => {
-    cy.cleanupProxy({ cluster: 'wc', user: 'static-dev' })
+    cy.cleanupProxy({ cluster: 'wc', user: 'dev@example.com' })
   })
 })


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [x] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Various fixes and refactorings done during the DEMO of https://github.com/elastisys/ck8s-issue-tracker/issues/240

- be explicit that the URL extracted from `localhost:8000` headers is a DEX url
- make a distinction between a `session` used at the `withTestKubeconfig` layer (e.g. `static-dev`, `static-admin`, which serves just as a label or suffix for the kubeconfig file) and an actual `user`, which is always represented through an email address. Functions that take `user` arguments automatically generate a session when they need to call into the lower layer, by using a conversion utility (`userToSession`).
- make `refresh=true` the default for `visitProxied` and remove it along with the `checkAdmin` argument for cleaner call sites
- various smaller fixes

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
