### PR TITLE
Add E2E tests for packets handled by network policies

### DIFF
--- a/tests/end-to-end/netpol/netpol.cy.js
+++ b/tests/end-to-end/netpol/netpol.cy.js
@@ -74,14 +74,14 @@ const assertNoDrops = (res, metricType, direction) => {
 
   const result = res.body.data.result
 
-  const drops = result.filter(filterDrops(metricType)).map(mapDrops)
+  const drops = result.filter(filterNonZero(metricType)).map(mapDrops)
 
   if (drops.length > 0) {
     cy.fail(formatError(drops, direction))
   }
 }
 
-const filterDrops = (metricType) => {
+const filterNonZero = (metricType) => {
   return (item) => item.metric.type === metricType && item.value && item.value[1] !== '0'
 }
 

--- a/tests/end-to-end/netpol/netpol.cy.js
+++ b/tests/end-to-end/netpol/netpol.cy.js
@@ -1,10 +1,10 @@
-const proxyBaseUrl =
+const PROMETHEUS_URL =
   'http://127.0.0.1:8001/api/v1/namespaces/monitoring/services' +
   '/kube-prometheus-stack-prometheus:9090/proxy'
 
 describe('workload cluster network policies', function () {
   before(function () {
-    cy.visitProxiedWC(proxyBaseUrl)
+    cy.visitProxiedWC(PROMETHEUS_URL)
   })
 
   it('are not dropping any packets from workloads', function () {
@@ -34,7 +34,7 @@ describe('workload cluster network policies', function () {
 
 describe('service cluster network policies', function () {
   before(function () {
-    cy.visitProxiedSC(proxyBaseUrl)
+    cy.visitProxiedSC(PROMETHEUS_URL)
   })
 
   it('are not dropping any packets from workloads', function () {
@@ -74,7 +74,7 @@ const assertServerTime = (res) => {
 
 const makeQueryURL = (serverTime) => {
   const metric = encodeURI('round(increase(no_policy_drop_counter[15m]))')
-  return `${proxyBaseUrl}/api/v1/query?query=${metric}&${new URLSearchParams({ time: serverTime })}`
+  return `${PROMETHEUS_URL}/api/v1/query?query=${metric}&${new URLSearchParams({ time: serverTime })}`
 }
 
 const assertNoDrops = (res, metricType, direction) => {

--- a/tests/end-to-end/netpol/netpol.cy.js
+++ b/tests/end-to-end/netpol/netpol.cy.js
@@ -1,0 +1,110 @@
+const proxyBaseUrl =
+  'http://127.0.0.1:8001/api/v1/namespaces/monitoring/services' +
+  '/kube-prometheus-stack-prometheus:9090/proxy'
+
+describe('workload cluster network policies', function () {
+  before(function () {
+    cy.visitProxiedWC(proxyBaseUrl)
+  })
+
+  it('are not dropping any packets from workloads', function () {
+    cy.request('GET', `${proxyBaseUrl}/api/v1/status/runtimeinfo`).then((res) => {
+      const serverTime = assertServerTime(res)
+
+      cy.request('GET', makeQueryURL(serverTime)).then((res) => {
+        assertNoDrops(res, 'fw', 'from')
+      })
+    })
+  })
+
+  it('are not dropping any packets to workloads', function () {
+    cy.request('GET', `${proxyBaseUrl}/api/v1/status/runtimeinfo`).then((res) => {
+      const serverTime = assertServerTime(res)
+
+      cy.request('GET', makeQueryURL(serverTime)).then((res) => {
+        assertNoDrops(res, 'tw', 'to')
+      })
+    })
+  })
+
+  after(() => {
+    cy.cleanupProxy('wc')
+  })
+})
+
+describe('service cluster network policies', function () {
+  before(function () {
+    cy.visitProxiedSC(proxyBaseUrl)
+  })
+
+  it('are not dropping any packets from workloads', function () {
+    cy.request('GET', `${proxyBaseUrl}/api/v1/status/runtimeinfo`).then((res) => {
+      const serverTime = assertServerTime(res)
+
+      cy.request('GET', makeQueryURL(serverTime)).then((res) => {
+        assertNoDrops(res, 'fw', 'from')
+      })
+    })
+  })
+
+  it('are not dropping any packets to workloads', function () {
+    cy.request('GET', `${proxyBaseUrl}/api/v1/status/runtimeinfo`).then((res) => {
+      const serverTime = assertServerTime(res)
+
+      cy.request('GET', makeQueryURL(serverTime)).then((res) => {
+        assertNoDrops(res, 'tw', 'to')
+      })
+    })
+  })
+
+  after(() => {
+    cy.cleanupProxy('sc')
+  })
+})
+
+const assertServerTime = (res) => {
+  expect(res.status).to.eq(200)
+
+  const runtimeInfo = res.body
+  expect(runtimeInfo.status).to.eq('success')
+  expect(runtimeInfo.data.serverTime).to.be.a('string')
+
+  return runtimeInfo.data.serverTime
+}
+
+const makeQueryURL = (serverTime) => {
+  const metric = encodeURI('round(increase(no_policy_drop_counter[15m]))')
+  return `${proxyBaseUrl}/api/v1/query?query=${metric}&${new URLSearchParams({ time: serverTime })}`
+}
+
+const assertNoDrops = (res, metricType, direction) => {
+  expect(res.status).to.eq(200)
+  expect(res.body.data.result).to.be.a('array')
+
+  const result = res.body.data.result
+
+  const toWorkloadDrops = result.filter(filterDrops(metricType)).map(mapDrops)
+
+  if (toWorkloadDrops.length > 0) {
+    cy.fail(formatError(toWorkloadDrops, direction))
+  }
+}
+
+const filterDrops = (metricType) => {
+  return (item) => item.metric.type === metricType && item.value && item.value[1] !== '0'
+}
+
+const mapDrops = (item) => {
+  return {
+    podName: item.metric.exported_pod,
+    podNamespace: item.metric.pod_namespace,
+    drops: parseInt(item.value[1]),
+  }
+}
+
+const formatError = (drops, direction) => {
+  const fmtDrops = drops
+    .map((item) => `- ${item.podNamespace}/${item.podName} had ${item.drops} dropped packets`)
+    .join('\n')
+  return `\nFound packets dropped ${direction} workloads:\n${fmtDrops}\n`
+}

--- a/tests/end-to-end/netpol/netpol.cy.js
+++ b/tests/end-to-end/netpol/netpol.cy.js
@@ -5,25 +5,20 @@ const PROMETHEUS_URL =
 describe('workload cluster network policies', function () {
   before(function () {
     cy.visitProxiedWC(PROMETHEUS_URL)
+    cy.request('GET', `${PROMETHEUS_URL}/api/v1/status/runtimeinfo`)
+      .then(assertServerTime)
+      .as('serverTime')
   })
 
   it('are not dropping any packets from workloads', function () {
-    cy.request('GET', `${proxyBaseUrl}/api/v1/status/runtimeinfo`).then((res) => {
-      const serverTime = assertServerTime(res)
-
-      cy.request('GET', makeQueryURL(serverTime)).then((res) => {
-        assertNoDrops(res, 'fw', 'from')
-      })
+    cy.request('GET', makeQueryURL(this.serverTime)).then((res) => {
+      assertNoDrops(res, 'fw', 'from')
     })
   })
 
   it('are not dropping any packets to workloads', function () {
-    cy.request('GET', `${proxyBaseUrl}/api/v1/status/runtimeinfo`).then((res) => {
-      const serverTime = assertServerTime(res)
-
-      cy.request('GET', makeQueryURL(serverTime)).then((res) => {
-        assertNoDrops(res, 'tw', 'to')
-      })
+    cy.request('GET', makeQueryURL(this.serverTime)).then((res) => {
+      assertNoDrops(res, 'tw', 'to')
     })
   })
 
@@ -35,25 +30,20 @@ describe('workload cluster network policies', function () {
 describe('service cluster network policies', function () {
   before(function () {
     cy.visitProxiedSC(PROMETHEUS_URL)
+    cy.request('GET', `${PROMETHEUS_URL}/api/v1/status/runtimeinfo`)
+      .then(assertServerTime)
+      .as('serverTime')
   })
 
   it('are not dropping any packets from workloads', function () {
-    cy.request('GET', `${proxyBaseUrl}/api/v1/status/runtimeinfo`).then((res) => {
-      const serverTime = assertServerTime(res)
-
-      cy.request('GET', makeQueryURL(serverTime)).then((res) => {
-        assertNoDrops(res, 'fw', 'from')
-      })
+    cy.request('GET', makeQueryURL(this.serverTime)).then((res) => {
+      assertNoDrops(res, 'fw', 'from')
     })
   })
 
   it('are not dropping any packets to workloads', function () {
-    cy.request('GET', `${proxyBaseUrl}/api/v1/status/runtimeinfo`).then((res) => {
-      const serverTime = assertServerTime(res)
-
-      cy.request('GET', makeQueryURL(serverTime)).then((res) => {
-        assertNoDrops(res, 'tw', 'to')
-      })
+    cy.request('GET', makeQueryURL(this.serverTime)).then((res) => {
+      assertNoDrops(res, 'tw', 'to')
     })
   })
 

--- a/tests/end-to-end/netpol/netpol.cy.js
+++ b/tests/end-to-end/netpol/netpol.cy.js
@@ -83,10 +83,10 @@ const assertNoDrops = (res, metricType, direction) => {
 
   const result = res.body.data.result
 
-  const toWorkloadDrops = result.filter(filterDrops(metricType)).map(mapDrops)
+  const drops = result.filter(filterDrops(metricType)).map(mapDrops)
 
-  if (toWorkloadDrops.length > 0) {
-    cy.fail(formatError(toWorkloadDrops, direction))
+  if (drops.length > 0) {
+    cy.fail(formatError(drops, direction))
   }
 }
 

--- a/tests/end-to-end/netpol/netpol.cy.js
+++ b/tests/end-to-end/netpol/netpol.cy.js
@@ -1,6 +1,7 @@
 const PROMETHEUS_URL =
   'http://127.0.0.1:8001/api/v1/namespaces/monitoring/services' +
   '/kube-prometheus-stack-prometheus:9090/proxy'
+const DROP_QUERY = 'round(increase(no_policy_drop_counter[15m]))'
 
 describe('workload cluster network policies', function () {
   before(function () {
@@ -11,13 +12,13 @@ describe('workload cluster network policies', function () {
   })
 
   it('are not dropping any packets from workloads', function () {
-    cy.request('GET', makeQueryURL(this.serverTime)).then((res) => {
+    cy.request('GET', makeQueryURL(DROP_QUERY, this.serverTime)).then((res) => {
       assertNoDrops(res, 'fw', 'from')
     })
   })
 
   it('are not dropping any packets to workloads', function () {
-    cy.request('GET', makeQueryURL(this.serverTime)).then((res) => {
+    cy.request('GET', makeQueryURL(DROP_QUERY, this.serverTime)).then((res) => {
       assertNoDrops(res, 'tw', 'to')
     })
   })
@@ -36,13 +37,13 @@ describe('service cluster network policies', function () {
   })
 
   it('are not dropping any packets from workloads', function () {
-    cy.request('GET', makeQueryURL(this.serverTime)).then((res) => {
+    cy.request('GET', makeQueryURL(DROP_QUERY, this.serverTime)).then((res) => {
       assertNoDrops(res, 'fw', 'from')
     })
   })
 
   it('are not dropping any packets to workloads', function () {
-    cy.request('GET', makeQueryURL(this.serverTime)).then((res) => {
+    cy.request('GET', makeQueryURL(DROP_QUERY, this.serverTime)).then((res) => {
       assertNoDrops(res, 'tw', 'to')
     })
   })
@@ -62,8 +63,8 @@ const assertServerTime = (res) => {
   return runtimeInfo.data.serverTime
 }
 
-const makeQueryURL = (serverTime) => {
-  const metric = encodeURI('round(increase(no_policy_drop_counter[15m]))')
+const makeQueryURL = (query, serverTime) => {
+  const metric = encodeURI(query)
   return `${PROMETHEUS_URL}/api/v1/query?query=${metric}&${new URLSearchParams({ time: serverTime })}`
 }
 

--- a/tests/end-to-end/netpol/netpol.gen.bats
+++ b/tests/end-to-end/netpol/netpol.gen.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+setup_file() {
+  load "../../bats.lib.bash"
+
+  cypress_setup "${ROOT}/tests/end-to-end/netpol/netpol.cy.js"
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+}
+
+teardown_file() {
+  cypress_teardown
+}
+
+@test "workload cluster network policies are not dropping any packets from workloads" {
+  cypress_test "workload cluster network policies are not dropping any packets from workloads"
+}
+
+@test "workload cluster network policies are not dropping any packets to workloads" {
+  cypress_test "workload cluster network policies are not dropping any packets to workloads"
+}
+
+@test "service cluster network policies are not dropping any packets from workloads" {
+  cypress_test "service cluster network policies are not dropping any packets from workloads"
+}
+
+@test "service cluster network policies are not dropping any packets to workloads" {
+  cypress_test "service cluster network policies are not dropping any packets to workloads"
+}

--- a/tests/end-to-end/netpol/netpol.gen.bats
+++ b/tests/end-to-end/netpol/netpol.gen.bats
@@ -23,10 +23,18 @@ teardown_file() {
   cypress_test "workload cluster network policies are not dropping any packets to workloads"
 }
 
+@test "workload cluster network policies are accepting allowed traffic" {
+  cypress_test "workload cluster network policies are accepting allowed traffic"
+}
+
 @test "service cluster network policies are not dropping any packets from workloads" {
   cypress_test "service cluster network policies are not dropping any packets from workloads"
 }
 
 @test "service cluster network policies are not dropping any packets to workloads" {
   cypress_test "service cluster network policies are not dropping any packets to workloads"
+}
+
+@test "service cluster network policies are accepting allowed traffic" {
+  cypress_test "service cluster network policies are accepting allowed traffic"
 }


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Accesses metrics through the proxied Prometheus API endpoint and checks we're not dropping any packets to/from workloads due to missing network policies.

- Fixes https://github.com/elastisys/ck8s-issue-tracker/issues/241

#### Information to reviewers

```shell
make -C tests run-end-to-end/netpol/netpol.gen.bats
```

> [!note]
> This builds upon a prerequisite [pull request](https://github.com/elastisys/compliantkubernetes-apps/pull/2623) that cleans up the code for the proxied
> tests and adds the distinction between an _user_ and a _session_.
>
> The diff here would be much smaller if I get some reviews and merge it first.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
