### PR TITLE
Add support for accessing Service Cluster components through kube proxy in Cypress tests

### DIFF
--- a/scripts/kubeproxy-wrapper.sh
+++ b/scripts/kubeproxy-wrapper.sh
@@ -1,17 +1,20 @@
 #!/usr/bin/env bash
 
-# Starts a `kubectl proxy` process in the background
-# and continually "prods" it with curl until the port 127.0.0.1:8000 becomes open,
-# a good indication that further authentication is needed.
+# Starts a `kubectl proxy` process in the background and continually "prods" it
+# with curl until either:
 #
-# Then, it extracts the Dex redirect URL from visiting http://127.0.0.1:8000
-# and outputs a "ready" marker along with the extracted URL.
+# - the port 127.0.0.1:8001 becomes open, a good indication that the proxy is ready,
+#   in which case we emit the PROXY_READY_MARKER;
 #
-# TODO - randomized ports
+# - the port 127.0.0.1:8000 becomes open, a good indication that further (dex)
+#   authentication is needed. In this case, it extracts the Dex redirect URL from visiting
+#   http://127.0.0.1:8000 and outputs the PROXY_WAITING_FOR_DEX_MARKER along with the
+#   redirect URL.
 
 set -euo pipefail
 
 PROXY_READY_MARKER='%%PROXY_READY%%'
+PROXY_WAITING_FOR_DEX_MARKER='%%PROXY_WAITING_FOR_DEX%%'
 
 cleanup() {
   if [[ -n "$proxy_pid" ]] && kill -0 "$proxy_pid" 2>/dev/null; then
@@ -33,9 +36,15 @@ curl_pid=$!
 
 # wait until port 8000 is open
 for _ in $(seq 1 30); do
+  if ! kill -0 "${curl_pid}" >/dev/null 2>&1; then
+    # must've already authenticated, emit READY marker without redirect url and break
+    echo "$PROXY_READY_MARKER"
+    break
+  fi
   if nc -z 127.0.0.1 8000; then
     dex_url="$(curl --silent -i http://127.0.0.1:8000/ | grep --only-matching --perl-regexp 'Location: \K.+')"
-    echo "$PROXY_READY_MARKER $dex_url"
+    # waiting for local authentication through Dex
+    echo "$PROXY_WAITING_FOR_DEX_MARKER $dex_url"
     break
   fi
   sleep 1

--- a/tests/common/cypress/index.d.ts
+++ b/tests/common/cypress/index.d.ts
@@ -73,20 +73,15 @@ declare namespace Cypress {
 
     /**
      * @example
-     * cy.withTestKubeconfig({ cluster: 'sc', session: 'static-admin', refresh: true })
+     * cy.withTestKubeconfig({ session: 'static-admin', refresh: true })
      */
-    withTestKubeconfig(args: {
-      cluster: Cluster
-      session: string
-      url?: string
-      refresh: boolean
-    }): Chainable<string>
+    withTestKubeconfig(args: { session: string; url?: string; refresh: boolean }): Chainable<string>
 
     /**
      * @example
-     * cy.deleteTestKubeconfig({ cluster: 'sc', session: 'static-admin' })
+     * cy.deleteTestKubeconfig('static-admin' )
      */
-    deleteTestKubeconfig(args: { cluster: Cluster; session: string }): Chainable<any>
+    deleteTestKubeconfig(session: string): Chainable<any>
 
     /**
      * @example

--- a/tests/common/cypress/support.d.ts
+++ b/tests/common/cypress/support.d.ts
@@ -66,9 +66,10 @@ declare namespace Cypress {
 
     /**
      * @example
-     * cy.cleanupProxy({ cluster: 'sc', user: 'dev@example.com' })
+     * cy.cleanupProxy('wc', 'dev@example.com')
+     * cy.cleanupProxy('sc')
      */
-    cleanupProxy(args: { cluster: Cluster; user: string }): Chainable<any>
+    cleanupProxy(cluster: Cluster, user?: string): Chainable<any>
 
     /**
      * @example

--- a/tests/common/cypress/support.d.ts
+++ b/tests/common/cypress/support.d.ts
@@ -57,21 +57,12 @@ declare namespace Cypress {
 
     /**
      * @example
-     * cy.visitProxied({
-     *   cluster: 'wc',
-     *   user: 'dev@example.com',
-     *   url: 'http://127.0.0.1:8001/api/v1/namespaces/monitoring/services/kube-prometheus-stack-prometheus:9090/proxy/targets?pool=serviceMonitor%2Fmonitoring%2Fkube-prometheus-stack-apiserver%2F0',
-     *   refresh: true,
-     *   checkAdmin: true,
-     * })
+     * cy.visitProxiedWc(
+     *   'http://127.0.0.1:8001/api/v1/namespaces/monitoring/services/kube-prometheus-stack-prometheus:9090/proxy/targets?pool=serviceMonitor%2Fmonitoring%2Fkube-prometheus-stack-apiserver%2F0',
+     *   'dev@example.com'
+     * )
      */
-    visitProxied(args: {
-      cluster: Cluster
-      user: string
-      url: string
-      refresh?: boolean
-      checkAdmin?: boolean
-    }): Chainable<any>
+    visitProxiedWc(url: string, user?: string): Chainable<any>
 
     /**
      * @example

--- a/tests/common/cypress/support.d.ts
+++ b/tests/common/cypress/support.d.ts
@@ -1,10 +1,18 @@
+type Cluster = 'sc' | 'wc'
+type GrafanaRole = 'Admin' | 'Editor' | 'Viewer'
+
+declare const yqArgsToConfigFiles: (cluster: Cluster, expression: string) => string
+declare const userToSession: (user: string) => string
+
 /// <reference types="cypress" />
 
 declare namespace Cypress {
-  type Cluster = 'sc' | 'wc'
-  type GrafanaRole = 'Admin' | 'Editor' | 'Viewer'
-
   interface Chainable<Subject> {
+    /**
+     * Apparently this was removed in Cypress v10...
+     */
+    fail(message: string): void
+
     /**
      * @example
      *  cy.yq('sc', '.harbor.subdomain')

--- a/tests/common/cypress/support.d.ts
+++ b/tests/common/cypress/support.d.ts
@@ -66,6 +66,12 @@ declare namespace Cypress {
 
     /**
      * @example
+     * cy.visitProxiedSc('http://127.0.0.1:8001/api/v1/namespaces/monitoring/services/kube-prometheus-stack-prometheus:9090/proxy/targets?pool=serviceMonitor%2Fmonitoring%2Fkube-prometheus-stack-apiserver%2F0')
+     */
+    visitProxiedSc(url: string): Chainable<any>
+
+    /**
+     * @example
      * cy.cleanupProxy('wc', 'dev@example.com')
      * cy.cleanupProxy('sc')
      */

--- a/tests/common/cypress/support.js
+++ b/tests/common/cypress/support.js
@@ -143,9 +143,9 @@ Cypress.Commands.add('visitProxiedWc', function (url, user = 'dev@example.com') 
   })
 })
 
-Cypress.Commands.add('cleanupProxy', function ({ cluster, user }) {
+Cypress.Commands.add('cleanupProxy', function (cluster, user = 'dev@example.com') {
   cy.task('pKill', 'kubeproxy-wrapper.sh')
-  if (cluster === 'wc') {
+  if (cluster === 'wc' && user !== null) {
     cy.deleteTestKubeconfig(userToSession(user))
   }
 })

--- a/tests/common/cypress/support.js
+++ b/tests/common/cypress/support.js
@@ -1,3 +1,5 @@
+const DEV_USER = 'dev@example.com'
+
 const yqArgsToConfigFiles = (cluster, expression) => {
   const configPath = Cypress.env('CK8S_CONFIG_PATH')
   if (typeof configPath === 'undefined') {
@@ -124,7 +126,7 @@ Cypress.Commands.add('dexExtraStaticLogin', (email) => {
   )
 })
 
-Cypress.Commands.add('visitProxiedWc', function (url, user = 'dev@example.com') {
+Cypress.Commands.add('visitProxiedWc', function (url, user = DEV_USER) {
   cy.yqDigParse('wc', '.user.adminUsers').then((adminUsers) => {
     if (!adminUsers.includes(user)) {
       cy.fail(
@@ -159,7 +161,7 @@ Cypress.Commands.add('visitProxiedSc', function (url) {
   })
 })
 
-Cypress.Commands.add('cleanupProxy', function (cluster, user = 'dev@example.com') {
+Cypress.Commands.add('cleanupProxy', function (cluster, user = DEV_USER) {
   cy.task('pKill', 'kubeproxy-wrapper.sh')
   if (cluster === 'wc' && user !== null) {
     cy.deleteTestKubeconfig(userToSession(user))

--- a/tests/common/cypress/support.js
+++ b/tests/common/cypress/support.js
@@ -1,4 +1,4 @@
-const yqArgsToConfigFiles = function (cluster, expression) {
+const yqArgsToConfigFiles = (cluster, expression) => {
   const configPath = Cypress.env('CK8S_CONFIG_PATH')
   if (typeof configPath === 'undefined') {
     cy.fail('yq: CK8S_CONFIG_PATH is unset')
@@ -71,7 +71,7 @@ Cypress.Commands.add('yqSecrets', (expression) => {
 
 // Available as cy.continueOn("sc|wc", "expression") expression should evaluate to true to continue
 Cypress.Commands.add('continueOn', function (cluster, expression) {
-  cy.yqDig(cluster, expression).then((result) => {
+  cy.yqDig(cluster, expression).then(function (result) {
     if (result !== 'true') {
       this.skip(`${cluster}/${expression} is disabled`)
     }

--- a/tests/common/cypress/support.js
+++ b/tests/common/cypress/support.js
@@ -124,29 +124,24 @@ Cypress.Commands.add('dexExtraStaticLogin', (email) => {
   )
 })
 
-Cypress.Commands.add(
-  'visitProxied',
-  function ({ cluster, user, url, refresh = true, checkAdmin = true }) {
-    if (checkAdmin) {
-      cy.yqDigParse(cluster, '.user.adminUsers').then((adminUsers) => {
-        if (!adminUsers.includes(user)) {
-          cy.fail(
-            `${user} not found in .user.adminUsers\n` +
-              `Please add it and run 'ck8s ops helmfile ${cluster} -lapp=dev-rbac apply' to update the RBAC rules.`
-          )
-        }
-      })
+Cypress.Commands.add('visitProxiedWc', function (url, user = 'dev@example.com') {
+  cy.yqDigParse('wc', '.user.adminUsers').then((adminUsers) => {
+    if (!adminUsers.includes(user)) {
+      cy.fail(
+        `${user} not found in .user.adminUsers\n` +
+          `Please add it and run 'ck8s ops helmfile wc -lapp=dev-rbac apply' to update the RBAC rules.`
+      )
     }
+  })
 
-    cy.withTestKubeconfig({ session: userToSession(user), url, refresh }).then(() => {
-      cy.task('wrapProxy', Cypress.env('KUBECONFIG')).then((dex_url) => {
-        assert(dex_url, 'could not extract Dex URL from kube proxy')
-        cy.visit(`${dex_url}`)
-        cy.dexExtraStaticLogin(user)
-      })
+  cy.withTestKubeconfig({ session: userToSession(user), url, refresh: true }).then(() => {
+    cy.task('wrapProxy', Cypress.env('KUBECONFIG')).then((dex_url) => {
+      assert(dex_url, 'could not extract Dex URL from kube proxy')
+      cy.visit(`${dex_url}`)
+      cy.dexExtraStaticLogin(user)
     })
-  }
-)
+  })
+})
 
 Cypress.Commands.add('cleanupProxy', function ({ cluster, user }) {
   cy.task('pKill', 'kubeproxy-wrapper.sh')

--- a/tests/common/cypress/support.js
+++ b/tests/common/cypress/support.js
@@ -143,6 +143,22 @@ Cypress.Commands.add('visitProxiedWc', function (url, user = 'dev@example.com') 
   })
 })
 
+Cypress.Commands.add('visitProxiedSc', function (url) {
+  Cypress.env('KUBECONFIG', Cypress.env('CK8S_CONFIG_PATH') + '/.state/kube_config_sc.yaml')
+  cy.task('wrapProxy', Cypress.env('KUBECONFIG')).then((dex_url) => {
+    if (dex_url === null) {
+      // pre-authenticated, attempt to visit
+      cy.visit(url)
+    } else {
+      cy.log(
+        'If this test gets stuck here for too long, visit "http://localhost:8000" in your browser in case you need to authenticate'
+      )
+      cy.exec(`xdg-open "${dex_url}"`, { failOnNonZeroExit: false })
+      cy.visit(url, { retryOnStatusCodeFailure: true })
+    }
+  })
+})
+
 Cypress.Commands.add('cleanupProxy', function (cluster, user = 'dev@example.com') {
   cy.task('pKill', 'kubeproxy-wrapper.sh')
   if (cluster === 'wc' && user !== null) {

--- a/tests/common/cypress/support.js
+++ b/tests/common/cypress/support.js
@@ -140,6 +140,7 @@ Cypress.Commands.add(
 
     cy.withTestKubeconfig({ session: userToSession(user), url, refresh }).then(() => {
       cy.task('wrapProxy', Cypress.env('KUBECONFIG')).then((dex_url) => {
+        assert(dex_url, 'could not extract Dex URL from kube proxy')
         cy.visit(`${dex_url}`)
         cy.dexExtraStaticLogin(user)
       })

--- a/tests/cypress.config.js
+++ b/tests/cypress.config.js
@@ -1,6 +1,7 @@
 const { defineConfig } = require('cypress')
 
 const PROXY_READY_MARKER = '%%PROXY_READY%%'
+const PROXY_WAITING_FOR_DEX_MARKER = '%%PROXY_WAITING_FOR_DEX%%'
 const DEFAULT_TIMEOUT = 60 * 1000
 
 module.exports = defineConfig({
@@ -39,9 +40,10 @@ module.exports = defineConfig({
           })
           return new Promise((resolve) => {
             proxy.stdout.on('data', (data) => {
-              if (data.includes(PROXY_READY_MARKER)) {
-                const dexUrl = data.toString().split(' ')[1]
-                resolve(dexUrl)
+              if (data.includes(PROXY_WAITING_FOR_DEX_MARKER)) {
+                resolve(data.toString().split(' ')[1])
+              } else if (data.includes(PROXY_READY_MARKER)) {
+                resolve(null)
               }
             })
           })

--- a/tests/cypress.config.js
+++ b/tests/cypress.config.js
@@ -28,8 +28,9 @@ module.exports = defineConfig({
           process.env.KUBECONFIG = kubeconfig
 
           const path = require('path')
+          const batsFile = /** @type {string} */ (process.env.BATS_TEST_FILENAME)
           const wrapperPath = path.resolve(
-            path.dirname(process.env.BATS_TEST_FILENAME) + '/../../../scripts/kubeproxy-wrapper.sh'
+            path.dirname(batsFile) + '/../../../scripts/kubeproxy-wrapper.sh'
           )
 
           const proxy = spawn(wrapperPath, [], {

--- a/tests/end-to-end/alertmanager/via-proxy.cy.js
+++ b/tests/end-to-end/alertmanager/via-proxy.cy.js
@@ -1,13 +1,10 @@
-describe('alertmanager', function () {
+describe('workload cluster alertmanager', function () {
   it('can be accessed via kubectl proxy', () => {
-    cy.visitProxied({
-      cluster: 'wc',
-      user: 'dev@example.com',
-      url:
-        'http://127.0.0.1:8001/api/v1/namespaces/alertmanager/services' +
-        '/alertmanager-operated:9093/proxy/',
-    })
+    cy.visitProxiedWc(
+      'http://127.0.0.1:8001/api/v1/namespaces/alertmanager/services/alertmanager-operated:9093/proxy/'
+    )
 
+    // Note the change of origin is needed because we got here via a redirect
     cy.origin('http://127.0.0.1:8001', () => {
       cy.contains('span', 'alertname="Watchdog"').should('exist')
     })

--- a/tests/end-to-end/alertmanager/via-proxy.cy.js
+++ b/tests/end-to-end/alertmanager/via-proxy.cy.js
@@ -14,3 +14,17 @@ describe('workload cluster alertmanager', function () {
     cy.cleanupProxy('wc')
   })
 })
+
+describe('service cluster alertmanager', function () {
+  it('can be accessed via kubectl proxy', () => {
+    cy.visitProxiedSc(
+      'http://127.0.0.1:8001/api/v1/namespaces/monitoring/services/alertmanager-operated:9093/proxy/'
+    )
+
+    cy.contains('span', 'alertname="Watchdog"').should('exist')
+  })
+
+  after(() => {
+    cy.cleanupProxy('sc')
+  })
+})

--- a/tests/end-to-end/alertmanager/via-proxy.cy.js
+++ b/tests/end-to-end/alertmanager/via-proxy.cy.js
@@ -11,6 +11,6 @@ describe('workload cluster alertmanager', function () {
   })
 
   after(() => {
-    cy.cleanupProxy({ cluster: 'wc', user: 'dev@example.com' })
+    cy.cleanupProxy('wc')
   })
 })

--- a/tests/end-to-end/alertmanager/via-proxy.gen.bats
+++ b/tests/end-to-end/alertmanager/via-proxy.gen.bats
@@ -18,3 +18,7 @@ teardown_file() {
 @test "workload cluster alertmanager can be accessed via kubectl proxy" {
   cypress_test "workload cluster alertmanager can be accessed via kubectl proxy"
 }
+
+@test "service cluster alertmanager can be accessed via kubectl proxy" {
+  cypress_test "service cluster alertmanager can be accessed via kubectl proxy"
+}

--- a/tests/end-to-end/alertmanager/via-proxy.gen.bats
+++ b/tests/end-to-end/alertmanager/via-proxy.gen.bats
@@ -15,6 +15,6 @@ teardown_file() {
   cypress_teardown
 }
 
-@test "alertmanager can be accessed via kubectl proxy" {
-  cypress_test "alertmanager can be accessed via kubectl proxy"
+@test "workload cluster alertmanager can be accessed via kubectl proxy" {
+  cypress_test "workload cluster alertmanager can be accessed via kubectl proxy"
 }

--- a/tests/end-to-end/kubernetes/authentication-admin.cy.js
+++ b/tests/end-to-end/kubernetes/authentication-admin.cy.js
@@ -1,10 +1,10 @@
 describe('kubernetes authentication', function () {
   before(function () {
-    cy.withTestKubeconfig({ cluster: 'wc', session: 'static-admin', refresh: true })
+    cy.withTestKubeconfig({ session: 'static-admin', refresh: true })
   })
 
   after(function () {
-    cy.deleteTestKubeconfig({ cluster: 'wc', session: 'static-admin' })
+    cy.deleteTestKubeconfig('static-admin')
   })
 
   it('can login via static dex user', function () {

--- a/tests/end-to-end/kubernetes/authentication-dev.cy.js
+++ b/tests/end-to-end/kubernetes/authentication-dev.cy.js
@@ -1,10 +1,10 @@
 describe('kubernetes authentication', function () {
   before(function () {
-    cy.withTestKubeconfig({ cluster: 'wc', session: 'static-dev', refresh: true })
+    cy.withTestKubeconfig({ session: 'static-dev', refresh: true })
   })
 
   after(function () {
-    cy.deleteTestKubeconfig({ cluster: 'wc', session: 'static-dev' })
+    cy.deleteTestKubeconfig('static-dev')
   })
 
   it('can login via extra static dex user', function () {

--- a/tests/end-to-end/prometheus/via-proxy.cy.js
+++ b/tests/end-to-end/prometheus/via-proxy.cy.js
@@ -1,13 +1,10 @@
-describe('prometheus', function () {
+describe('workload cluster prometheus', function () {
   it('can be accessed via kubectl proxy', () => {
-    cy.visitProxied({
-      cluster: 'wc',
-      user: 'dev@example.com',
-      url:
-        'http://127.0.0.1:8001/api/v1/namespaces/monitoring/services' +
+    cy.visitProxiedWc(
+      'http://127.0.0.1:8001/api/v1/namespaces/monitoring/services' +
         '/kube-prometheus-stack-prometheus:9090/proxy/targets' +
-        '?pool=serviceMonitor%2Fmonitoring%2Fkube-prometheus-stack-apiserver%2F0',
-    })
+        '?pool=serviceMonitor%2Fmonitoring%2Fkube-prometheus-stack-apiserver%2F0'
+    )
 
     cy.origin('http://127.0.0.1:8001', () => {
       cy.contains('span', 'up').should('exist')

--- a/tests/end-to-end/prometheus/via-proxy.cy.js
+++ b/tests/end-to-end/prometheus/via-proxy.cy.js
@@ -12,6 +12,6 @@ describe('workload cluster prometheus', function () {
   })
 
   after(() => {
-    cy.cleanupProxy({ cluster: 'wc', user: 'dev@example.com' })
+    cy.cleanupProxy('wc')
   })
 })

--- a/tests/end-to-end/prometheus/via-proxy.cy.js
+++ b/tests/end-to-end/prometheus/via-proxy.cy.js
@@ -15,3 +15,19 @@ describe('workload cluster prometheus', function () {
     cy.cleanupProxy('wc')
   })
 })
+
+describe('service cluster prometheus', function () {
+  it('can be accessed via kubectl proxy', () => {
+    cy.visitProxiedSc(
+      'http://127.0.0.1:8001/api/v1/namespaces/monitoring/services' +
+        '/kube-prometheus-stack-prometheus:9090/proxy/targets' +
+        '?pool=serviceMonitor%2Fmonitoring%2Fkube-prometheus-stack-apiserver%2F0'
+    )
+
+    cy.contains('span', 'up').should('exist')
+  })
+
+  after(() => {
+    cy.cleanupProxy('sc')
+  })
+})

--- a/tests/end-to-end/prometheus/via-proxy.gen.bats
+++ b/tests/end-to-end/prometheus/via-proxy.gen.bats
@@ -18,3 +18,7 @@ teardown_file() {
 @test "workload cluster prometheus can be accessed via kubectl proxy" {
   cypress_test "workload cluster prometheus can be accessed via kubectl proxy"
 }
+
+@test "service cluster prometheus can be accessed via kubectl proxy" {
+  cypress_test "service cluster prometheus can be accessed via kubectl proxy"
+}

--- a/tests/end-to-end/prometheus/via-proxy.gen.bats
+++ b/tests/end-to-end/prometheus/via-proxy.gen.bats
@@ -15,6 +15,6 @@ teardown_file() {
   cypress_teardown
 }
 
-@test "prometheus can be accessed via kubectl proxy" {
-  cypress_test "prometheus can be accessed via kubectl proxy"
+@test "workload cluster prometheus can be accessed via kubectl proxy" {
+  cypress_test "workload cluster prometheus can be accessed via kubectl proxy"
 }

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -9,5 +9,5 @@
     "skipLibCheck": true,
     "noImplicitAny": false
   },
-  "include": ["**/*.cy.js", "**/*.d.ts"]
+  "include": ["**/*.js", "**/*.d.ts"]
 }


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This addresses an important feedback item from the [Expected Alertmanager alerts](https://github.com/elastisys/compliantkubernetes-apps/pull/2627) and [Network Policies](https://github.com/elastisys/compliantkubernetes-apps/pull/2624) e2e test suites: these test suites need to be evaluated for the Service/Management cluster too. 

Before this PR, the test suite was equipped to only support proxying for the Workload Cluster.

Prerequisite of:
- https://github.com/elastisys/ck8s-issue-tracker/issues/241
- https://github.com/elastisys/ck8s-issue-tracker/issues/238

> [!note]
> The authentication for kube proxy in the WC can proceed with static users in a Dex instances opened in the Cypress browser itself.
>
> But in the SC/MC case, it needs to happen in the user's browser on the host system (since it's using our global Dex and a real user account).
>
> Hence, the test suite might get stuck indefinitely if the `xdg-open` support is buggy, or the `localhost:8000` pop-up doesn't consistently open. There are plans to address this in a future PR.


#### Information to reviewers

Since this is a medium-sized changeset, it's best to review it commit by commit :)

The test suites for proxied access to Prometheus and Alertmanager have been updated to include the MC, might be worthwhile re-running:

```shell
make -C tests run-end-to-end/alertmanager/via-proxy.gen.bats

make -C tests run-end-to-end/prometheus/via-proxy.gen.bats
```

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
