### PR TITLE
Add missing opensearch perms + remove comments & exception handlers

### DIFF
--- a/helmfile.d/values/opensearch/securityadmin.yaml.gotmpl
+++ b/helmfile.d/values/opensearch/securityadmin.yaml.gotmpl
@@ -84,6 +84,7 @@ securityConfig:
         - cluster:admin/opendistro/alerting/destination/get
         - cluster:admin/opendistro/alerting/monitor/get
         - cluster:admin/opendistro/alerting/monitor/search
+        - cluster:admin/opensearch/ql/datasources/read
 
     # Allows users to view and acknowledge alerts
     alerting_ack_alerts:
@@ -98,6 +99,7 @@ securityConfig:
         - cluster_monitor
         - cluster:admin/opendistro/alerting/*
         - cluster:admin/opensearch/notifications/*
+        - cluster:admin/opensearch/ql/datasources/read
       index_permissions:
         - index_patterns:
             {{- if .Values.opensearch.indexPerNamespace }}

--- a/tests/common/cypress/opensearch.js
+++ b/tests/common/cypress/opensearch.js
@@ -1,27 +1,4 @@
 Cypress.Commands.add('opensearchDexStaticLogin', (ingress) => {
-  // Need to ignore error response from GET /api/dataconnections for non-authorized user.
-  //
-  // {
-  //     "statusCode": 403,
-  //     "error": "Forbidden",
-  //     "message": "{
-  //         "status": 403,
-  //       "error": {
-  //           "type": "OpenSearchSecurityException",
-  //         "reason": "There was internal problem at backend",
-  //         "details": "no permissions for [cluster:admin/opensearch/ql/datasources/read] and User [name=admin@example.com, backend_roles=[], requestedTenant=null]"
-  //       }
-  //   }"
-  // }
-  //
-  // TODO: Narrow this down to the specific request OR investigate if a user
-  //       actually should have this permission.
-  cy.on('uncaught:exception', (err, runnable) => {
-    if (err.message.includes('Forbidden')) {
-      return false
-    }
-  })
-
   cy.session([ingress], () => {
     cy.visit(`https://${ingress}`)
 

--- a/tests/end-to-end/grafana/datasources.cy.js
+++ b/tests/end-to-end/grafana/datasources.cy.js
@@ -21,7 +21,7 @@ function loginNavigate(cy, ingress, passwordKey) {
 
   cy.contains('Home').should('exist')
 
-  cy.on('uncaught:exception', (err, runnable) => {
+  cy.on('uncaught:exception', (err, _runnable) => {
     if (err.statusText.includes('Request was aborted')) {
       return false
     }

--- a/tests/end-to-end/opensearch/authentication.cy.js
+++ b/tests/end-to-end/opensearch/authentication.cy.js
@@ -6,29 +6,6 @@ describe('opensearch admin authentication', () => {
   })
 
   it('can login via static dex user', function () {
-    // Need to ignore error response from GET /api/dataconnections for non-authorized user.
-    //
-    // {
-    //     "statusCode": 403,
-    //     "error": "Forbidden",
-    //     "message": "{
-    //         "status": 403,
-    //       "error": {
-    //           "type": "OpenSearchSecurityException",
-    //         "reason": "There was internal problem at backend",
-    //         "details": "no permissions for [cluster:admin/opensearch/ql/datasources/read] and User [name=admin@example.com, backend_roles=[], requestedTenant=null]"
-    //       }
-    //   }"
-    // }
-    //
-    // TODO: Narrow this down to the specific request OR investigate if a user
-    //       actually should have this permission.
-    cy.on('uncaught:exception', (err, runnable) => {
-      if (err.message.includes('Forbidden')) {
-        return false
-      }
-    })
-
     cy.continueOn('sc', '.dex.enableStaticLogin')
 
     cy.visit(`https://${this.ingress}`)

--- a/tests/end-to-end/opensearch/dashboards.cy.js
+++ b/tests/end-to-end/opensearch/dashboards.cy.js
@@ -14,10 +14,11 @@ describe('opensearch dashboards', function () {
   beforeEach(function () {
     cy.opensearchDexStaticLogin(this.ingress)
 
-    cy.on('uncaught:exception', (err, runnable) => {
-      if (err.message.includes("Cannot read properties of undefined (reading 'split')")) {
-        return false
-      } else if (err.message.includes('location.href.split(...)[1] is undefined')) {
+    cy.on('uncaught:exception', (err, _runnable) => {
+      if (
+        err.message.includes("Cannot read properties of undefined (reading 'split')") ||
+        err.message.includes('location.href.split(...)[1] is undefined')
+      ) {
         return false
       }
     })


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [x] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Adds a missing OpenSearch permission called `cluster:admin/opensearch/ql/datasources/read`, so we stop receiving 403 statuses during test runs and can remove a bunch of block comments and `unhandled:exception` handlers.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
