### PR TITLE
Falco E2E nits

### DIFF
--- a/tests/end-to-end/falco/alerts.cy.js
+++ b/tests/end-to-end/falco/alerts.cy.js
@@ -27,7 +27,8 @@ describe('falco', function () {
               .filter((alert) => !normalizedExpectedAlertRules.has(normalize(alert)))
           )
         ).toSorted()
-        //Assert all received falco alerts are triggered by even-generator syscalls
+
+        // Assert all received falco alerts are triggered by event-generator syscalls
         expect(
           unexpectedFalcoAlertRules,
           `Received unexpected falco alerts: ${unexpectedFalcoAlertRules.join(', ')}`

--- a/tests/end-to-end/falco/alerts.cy.js
+++ b/tests/end-to-end/falco/alerts.cy.js
@@ -16,7 +16,7 @@ describe('falco', function () {
 
         // Extract just the falco rules in firing alerts from the response body
         const receivedFalcoAlerts = response.body.filter(
-          (alert) => alert.labels.alertname == 'FalcoAlert'
+          (alert) => alert.labels.alertname === 'FalcoAlert'
         )
         expect(receivedFalcoAlerts).to.not.be.empty
 

--- a/tests/end-to-end/falco/setup_suite.bash
+++ b/tests/end-to-end/falco/setup_suite.bash
@@ -49,7 +49,7 @@ setup_suite() {
 
   echo -e "\033[1m[Setup kube proxy on sc]\033[0m Visit \"http://localhost:8000\" to authenticate into sc if the test gets stuck here for too long" >&3
   with_kubeconfig sc
-  "../scripts/kubeproxy-wrapper.sh" >/dev/null 2>&1 &
+  "../scripts/kubeproxy-wrapper.sh" >/dev/null 2>&1 3>&- &
 }
 
 teardown_suite() {

--- a/tests/end-to-end/falco/setup_suite.bash
+++ b/tests/end-to-end/falco/setup_suite.bash
@@ -18,7 +18,7 @@ wait_test_namespace() {
 
 # Usage: delete_test_namespace <namespace>
 delete_test_namespace() {
-  kubectl delete ns "${1}"
+  kubectl delete ns "${1}" --wait=true
 }
 
 # Usage: create_test_application <namespace> <applicationRepo> <applicationChart> <applicationName>

--- a/tests/end-to-end/falco/setup_suite.bash
+++ b/tests/end-to-end/falco/setup_suite.bash
@@ -7,7 +7,7 @@ falco_event_generator_chart="${falco_event_generator_name}"
 
 # Usage: create_test_namespace <namespace>
 create_test_namespace() {
-  kubectl create ns "${1}"
+  kubectl create ns "${1}" --dry-run=client -o yaml | kubectl apply -f -
 }
 
 # Usage: wait_test_namespace <namespace>

--- a/tests/end-to-end/falco/setup_suite.bash
+++ b/tests/end-to-end/falco/setup_suite.bash
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+falco_event_generator_name="event-generator"
+falco_event_generator_namespace="${falco_event_generator_name}"
+falco_event_generator_repo="https://falcosecurity.github.io/charts"
+falco_event_generator_chart="${falco_event_generator_name}"
+
 # Usage: create_test_namespace <namespace>
 create_test_namespace() {
   kubectl create ns "${1}"
@@ -34,18 +39,13 @@ delete_test_application() {
 setup_suite() {
   load "../../bats.lib.bash"
 
-  export EVENT_GENERATOR_NAME="event-generator"
-  export EVENT_GENERATOR_NAMESPACE="event-generator"
-  export EVENT_GENERATOR_REPO="https://falcosecurity.github.io/charts"
-  export EVENT_GENERATOR_CHART="event-generator"
-
   echo -e "\033[1m[Deploy event-generator on wc]\033[0m Visit \"http://localhost:8000\" to authenticate into wc if the test gets stuck here for too long" >&3
   with_kubeconfig wc
 
-  create_test_namespace "${EVENT_GENERATOR_NAMESPACE}"
-  wait_test_namespace "${EVENT_GENERATOR_NAMESPACE}"
+  create_test_namespace "${falco_event_generator_namespace}"
+  wait_test_namespace "${falco_event_generator_namespace}"
 
-  create_test_application "${EVENT_GENERATOR_NAMESPACE}" "${EVENT_GENERATOR_REPO}" "${EVENT_GENERATOR_CHART}" "${EVENT_GENERATOR_NAME}"
+  create_test_application "${falco_event_generator_namespace}" "${falco_event_generator_repo}" "${falco_event_generator_chart}" "${falco_event_generator_name}"
 
   echo -e "\033[1m[Setup kube proxy on sc]\033[0m Visit \"http://localhost:8000\" to authenticate into sc if the test gets stuck here for too long" >&3
   with_kubeconfig sc
@@ -55,8 +55,8 @@ setup_suite() {
 teardown_suite() {
   with_kubeconfig wc
 
-  delete_test_application "${EVENT_GENERATOR_NAMESPACE}" "${EVENT_GENERATOR_NAME}"
-  delete_test_namespace "${EVENT_GENERATOR_NAMESPACE}"
+  delete_test_application "${falco_event_generator_namespace}" "${falco_event_generator_name}"
+  delete_test_namespace "${falco_event_generator_namespace}"
 
   pkill -f "bash ../scripts/kubeproxy-wrapper.sh"
 }

--- a/tests/end-to-end/falco/setup_suite.bash
+++ b/tests/end-to-end/falco/setup_suite.bash
@@ -32,7 +32,6 @@ delete_test_application() {
 }
 
 setup_suite() {
-
   load "../../bats.lib.bash"
 
   export EVENT_GENERATOR_NAME="event-generator"
@@ -51,11 +50,9 @@ setup_suite() {
   echo -e "\033[1m[Setup kube proxy on sc]\033[0m Visit \"http://localhost:8000\" to authenticate into sc if the test gets stuck here for too long" >&3
   with_kubeconfig sc
   "../scripts/kubeproxy-wrapper.sh" >/dev/null 2>&1 &
-
 }
 
 teardown_suite() {
-
   with_kubeconfig wc
 
   delete_test_application "${EVENT_GENERATOR_NAMESPACE}" "${EVENT_GENERATOR_NAME}"


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [x] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

The OCD is strong today, found more nits in the main PR, though it's easier to go over them in a separate PR. 

Tried the test suite, works beautifully, just some troubles with idempotency (if namespace already exists, it will fail).

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
