### PR TITLE
apps: upgrade velero to 1.16.1, chart to 10.0.11

### DIFF
--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -10,6 +10,6 @@ pkg:golang/github.com/databus23/helm-diff/v3@v3.10.0
 pkg:golang/github.com/helmfile/helmfile@v0.171.0
 pkg:golang/github.com/mikefarah/yq/v4@v4.45.1
 pkg:golang/github.com/neilpa/yajsv@v1.4.1
-pkg:golang/github.com/vmware-tanzu/velero@v1.13.0
+pkg:golang/github.com/vmware-tanzu/velero@v1.16.1
 pkg:golang/getsops/sops/v3@v3.10.1
 pkg:golang/helm.sh/helm/v3@v3.18.4

--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -706,7 +706,7 @@ velero:
   enabled: true
   tolerations: []
   nodeSelector: {}
-  uploaderType: restic
+  uploaderType: kopia
   useVolumeSnapshots: false
   schedule: 0 0 * * * # once per day
   retentionPeriod: 720h0m0s

--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -707,7 +707,7 @@ velero:
   tolerations: []
   nodeSelector: {}
   uploaderType: kopia
-  useVolumeSnapshots: false
+  useVolumeSnapshots: true
   schedule: 0 0 * * * # once per day
   retentionPeriod: 720h0m0s
   resources:

--- a/helmfile.d/charts/networkpolicy/common/templates/velero/maintenance-job.yaml
+++ b/helmfile.d/charts/networkpolicy/common/templates/velero/maintenance-job.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.velero.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-velero-maintenance-jobs
+  namespace: velero
+spec:
+  podSelector:
+    matchExpressions:
+    - key: velero.io/repo-name
+      operator: Exists
+  policyTypes:
+    - Egress
+  egress:
+    {{- if and .Values.global.apiserver.ips .Values.global.apiserver.port }}
+    - to:
+        {{- range $IP := .Values.global.apiserver.ips }}
+        - ipBlock:
+            cidr: {{ $IP }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.global.apiserver.port }}
+    {{- end }}
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.global.clusterDns }}/32
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+        - podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+    {{- if and .Values.global.objectStorage.ips .Values.global.objectStorage.ports }}
+    - to:
+        {{- range $ip := .Values.global.objectStorage.ips }}
+        - ipBlock:
+            cidr: {{ $ip }}
+        {{- end }}
+      ports:
+        {{- range $port := .Values.global.objectStorage.ports }}
+        - protocol: TCP
+          port: {{ $port }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/helmfile.d/charts/networkpolicy/common/values.yaml
+++ b/helmfile.d/charts/networkpolicy/common/values.yaml
@@ -127,3 +127,6 @@ coredns:
 
 dnsAutoscaler:
   enabled: true
+
+velero:
+  enabled: true

--- a/helmfile.d/lists/images.yaml
+++ b/helmfile.d/lists/images.yaml
@@ -88,7 +88,7 @@ images:
   thanos:
     image: ghcr.io/elastisys/bitnami/thanos:0.37.2-debian-12-r8
   velero:
-    image: docker.io/velero/velero:v1.13.0
+    image: docker.io/velero/velero:v1.16.1
     pluginCsi: docker.io/velero/velero-plugin-for-csi:v0.7.1
     pluginAws: docker.io/velero/velero-plugin-for-aws:v1.9.0
     pluginGcp: docker.io/velero/velero-plugin-for-gcp:v1.9.1

--- a/helmfile.d/upstream/index.yaml
+++ b/helmfile.d/upstream/index.yaml
@@ -76,6 +76,6 @@ charts:
   prometheus-community/prometheus-blackbox-exporter: 8.13.0
   prometheus-community/prometheus-elasticsearch-exporter: 6.1.0
 
-  vmware-tanzu/velero: 6.0.0
+  vmware-tanzu/velero: 10.0.11
 
   nvidia/gpu-operator: v24.9.2

--- a/helmfile.d/upstream/vmware-tanzu/velero/Chart.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.13.0
+appVersion: 1.16.1
 description: A Helm chart for velero
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
@@ -9,11 +9,9 @@ maintainers:
   name: jenting
 - email: jiangd@vmware.com
   name: reasonerjt
-- email: mqiu@vmware.com
-  name: qiuming-best
 - email: yinw@vmware.com
   name: ywk253100
 name: velero
 sources:
 - https://github.com/vmware-tanzu/velero
-version: 6.0.0
+version: 10.0.11

--- a/helmfile.d/upstream/vmware-tanzu/velero/OWNERS
+++ b/helmfile.d/upstream/vmware-tanzu/velero/OWNERS
@@ -1,10 +1,8 @@
 approvers:
 - jenting
 - reasonerjt
-- qiuming-best
 - ywk253100
 reviewers:
 - jenting
 - reasonerjt
-- qiuming-best
 - ywk253100

--- a/helmfile.d/upstream/vmware-tanzu/velero/README.md
+++ b/helmfile.d/upstream/vmware-tanzu/velero/README.md
@@ -16,11 +16,15 @@ Kubernetes v1.16+, because this helm chart uses CustomResourceDefinition `apiext
 
 ### Velero version
 
-This helm chart installs Velero version v1.13 https://velero.io/docs/v1.13/. See the [#Upgrading](#upgrading) section for information on how to upgrade from other versions.
+This helm chart installs Velero version v1.16 https://velero.io/docs/v1.16/. See the [#Upgrading](#upgrading) section for information on how to upgrade from other versions.
 
 ### Provider credentials
 
 When installing using the Helm chart, the provider's credential information will need to be appended into your values. The easiest way to do this is with the `--set-file` argument, available in Helm 2.10 and higher. See your cloud provider's documentation for the contents and creation of the `credentials-velero` file.
+
+### Azure resources
+
+When using the Azure plug-in, requests and limits must be set. See https://github.com/vmware-tanzu/velero/issues/3234 and https://github.com/vmware-tanzu/helm-charts/issues/469 for details.
 
 ### Installing
 
@@ -89,11 +93,28 @@ helm upgrade vmware-tanzu/velero <RELEASE NAME> --reuse-values --set configurati
 ```
 ## Upgrading Chart
 
+### Upgrading to 7.0.0
+
+Delete the CSI plugin. Because the Velero CSI plugin is already merged into the Velero, need to remove the existing CSI plugin InitContainer. Otherwise, the Velero server plugin would fail to start due to same plugin registered twice.
+CSI plugin has been merged into velero repo in v1.14 release. It will be installed by default as an internal plugin.
+
 ### Upgrading to 6.0.0
 
 This version removes the `nodeAgent.privileged` field, you should use `nodeAgent.containerSecurityContext.privileged` instead
 
 ## Upgrading Velero
+
+### Upgrading to v1.16
+
+The [instructions found here](https://velero.io/docs/v1.16/upgrade-to-1.16/) will assist you in upgrading from version v1.15.x to v1.16.
+
+### Upgrading to v1.15
+
+The [instructions found here](https://velero.io/docs/v1.15/upgrade-to-1.15/) will assist you in upgrading from version v1.14.x to v1.15.
+
+### Upgrading to v1.14
+
+The [instructions found here](https://velero.io/docs/v1.14/upgrade-to-1.14/) will assist you in upgrading from version v1.13.x to v1.14.
 
 ### Upgrading to v1.13
 

--- a/helmfile.d/upstream/vmware-tanzu/velero/crds/backuprepositories.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/crds/backuprepositories.yaml
@@ -2,10 +2,10 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
   labels:
     component: velero
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
   name: backuprepositories.velero.io
 spec:
   group: velero.io
@@ -28,14 +28,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -43,13 +48,21 @@ spec:
             description: BackupRepositorySpec is the specification for a BackupRepository.
             properties:
               backupStorageLocation:
-                description: BackupStorageLocation is the name of the BackupStorageLocation
+                description: |-
+                  BackupStorageLocation is the name of the BackupStorageLocation
                   that should contain this repository.
                 type: string
               maintenanceFrequency:
                 description: MaintenanceFrequency is how often maintenance should
                   be run.
                 type: string
+              repositoryConfig:
+                additionalProperties:
+                  type: string
+                description: RepositoryConfig is for repository-specific configuration
+                  fields.
+                nullable: true
+                type: object
               repositoryType:
                 description: RepositoryType indicates the type of the backend repository
                 enum:
@@ -58,12 +71,14 @@ spec:
                 - ""
                 type: string
               resticIdentifier:
-                description: ResticIdentifier is the full restic-compatible string
-                  for identifying this repository.
+                description: |-
+                  ResticIdentifier is the full restic-compatible string for identifying
+                  this repository.
                 type: string
               volumeNamespace:
-                description: VolumeNamespace is the namespace this backup repository
-                  contains pod volume backups for.
+                description: |-
+                  VolumeNamespace is the namespace this backup repository contains
+                  pod volume backups for.
                 type: string
             required:
             - backupStorageLocation
@@ -75,8 +90,8 @@ spec:
             description: BackupRepositoryStatus is the current status of a BackupRepository.
             properties:
               lastMaintenanceTime:
-                description: LastMaintenanceTime is the last time maintenance was
-                  run.
+                description: LastMaintenanceTime is the last time repo maintenance
+                  succeeded.
                 format: date-time
                 nullable: true
                 type: string
@@ -91,6 +106,34 @@ spec:
                 - Ready
                 - NotReady
                 type: string
+              recentMaintenance:
+                description: RecentMaintenance is status of the recent repo maintenance.
+                items:
+                  properties:
+                    completeTimestamp:
+                      description: CompleteTimestamp is the completion time of the
+                        repo maintenance.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: Message is a message about the current status
+                        of the repo maintenance.
+                      type: string
+                    result:
+                      description: Result is the result of the repo maintenance.
+                      enum:
+                      - Succeeded
+                      - Failed
+                      type: string
+                    startTimestamp:
+                      description: StartTimestamp is the start time of the repo
+                        maintenance.
+                      format: date-time
+                      nullable: true
+                      type: string
+                  type: object
+                type: array
             type: object
         type: object
     served: true

--- a/helmfile.d/upstream/vmware-tanzu/velero/crds/backups.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/crds/backups.yaml
@@ -2,10 +2,10 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
   labels:
     component: velero
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
   name: backups.velero.io
 spec:
   group: velero.io
@@ -19,18 +19,24 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Backup is a Velero resource that represents the capture of Kubernetes
+        description: |-
+          Backup is a Velero resource that represents the capture of Kubernetes
           cluster state at a point in time (API objects and associated volume state).
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -38,55 +44,62 @@ spec:
             description: BackupSpec defines the specification for a Velero backup.
             properties:
               csiSnapshotTimeout:
-                description: CSISnapshotTimeout specifies the time used to wait for
-                  CSI VolumeSnapshot status turns to ReadyToUse during creation, before
-                  returning error as timeout. The default value is 10 minute.
+                description: |-
+                  CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to
+                  ReadyToUse during creation, before returning error as timeout.
+                  The default value is 10 minute.
                 type: string
               datamover:
-                description: DataMover specifies the data mover to be used by the
-                  backup. If DataMover is "" or "velero", the built-in data mover
-                  will be used.
+                description: |-
+                  DataMover specifies the data mover to be used by the backup.
+                  If DataMover is "" or "velero", the built-in data mover will be used.
                 type: string
               defaultVolumesToFsBackup:
-                description: DefaultVolumesToFsBackup specifies whether pod volume
-                  file system backup should be used for all volumes by default.
+                description: |-
+                  DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used
+                  for all volumes by default.
                 nullable: true
                 type: boolean
               defaultVolumesToRestic:
-                description: "DefaultVolumesToRestic specifies whether restic should
-                  be used to take a backup of all pod volumes by default. \n Deprecated:
-                  this field is no longer used and will be removed entirely in future.
-                  Use DefaultVolumesToFsBackup instead."
+                description: |-
+                  DefaultVolumesToRestic specifies whether restic should be used to take a
+                  backup of all pod volumes by default.
+
+                  Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.
                 nullable: true
                 type: boolean
               excludedClusterScopedResources:
-                description: ExcludedClusterScopedResources is a slice of cluster-scoped
-                  resource type names to exclude from the backup. If set to "*", all
-                  cluster-scoped resource types are excluded. The default value is
-                  empty.
+                description: |-
+                  ExcludedClusterScopedResources is a slice of cluster-scoped
+                  resource type names to exclude from the backup.
+                  If set to "*", all cluster-scoped resource types are excluded.
+                  The default value is empty.
                 items:
                   type: string
                 nullable: true
                 type: array
               excludedNamespaceScopedResources:
-                description: ExcludedNamespaceScopedResources is a slice of namespace-scoped
-                  resource type names to exclude from the backup. If set to "*", all
-                  namespace-scoped resource types are excluded. The default value
-                  is empty.
+                description: |-
+                  ExcludedNamespaceScopedResources is a slice of namespace-scoped
+                  resource type names to exclude from the backup.
+                  If set to "*", all namespace-scoped resource types are excluded.
+                  The default value is empty.
                 items:
                   type: string
                 nullable: true
                 type: array
               excludedNamespaces:
-                description: ExcludedNamespaces contains a list of namespaces that
-                  are not included in the backup.
+                description: |-
+                  ExcludedNamespaces contains a list of namespaces that are not
+                  included in the backup.
                 items:
                   type: string
                 nullable: true
                 type: array
               excludedResources:
-                description: ExcludedResources is a slice of resource names that are
-                  not included in the backup.
+                description: |-
+                  ExcludedResources is a slice of resource names that are not
+                  included in the backup.
                 items:
                   type: string
                 nullable: true
@@ -99,9 +112,9 @@ spec:
                     description: Resources are hooks that should be executed when
                       backing up individual instances of a resource.
                     items:
-                      description: BackupResourceHookSpec defines one or more BackupResourceHooks
-                        that should be executed based on the rules defined for namespaces,
-                        resources, and label selector.
+                      description: |-
+                        BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on
+                        the rules defined for namespaces, resources, and label selector.
                       properties:
                         excludedNamespaces:
                           description: ExcludedNamespaces specifies the namespaces
@@ -111,39 +124,39 @@ spec:
                           nullable: true
                           type: array
                         excludedResources:
-                          description: ExcludedResources specifies the resources to
-                            which this hook spec does not apply.
+                          description: ExcludedResources specifies the resources
+                            to which this hook spec does not apply.
                           items:
                             type: string
                           nullable: true
                           type: array
                         includedNamespaces:
-                          description: IncludedNamespaces specifies the namespaces
-                            to which this hook spec applies. If empty, it applies
+                          description: |-
+                            IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
                             to all namespaces.
                           items:
                             type: string
                           nullable: true
                           type: array
                         includedResources:
-                          description: IncludedResources specifies the resources to
-                            which this hook spec applies. If empty, it applies to
-                            all resources.
+                          description: |-
+                            IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
+                            to all resources.
                           items:
                             type: string
                           nullable: true
                           type: array
                         labelSelector:
-                          description: LabelSelector, if specified, filters the resources
-                            to which this hook spec applies.
+                          description: LabelSelector, if specified, filters the
+                            resources to which this hook spec applies.
                           nullable: true
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
                                 requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
@@ -151,33 +164,33 @@ spec:
                                       applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 required:
                                 - key
                                 - operator
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
@@ -185,12 +198,12 @@ spec:
                           description: Name is the name of this hook.
                           type: string
                         post:
-                          description: PostHooks is a list of BackupResourceHooks
-                            to execute after storing the item in the backup. These
-                            are executed after all "additional items" from item actions
-                            are processed.
+                          description: |-
+                            PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup.
+                            These are executed after all "additional items" from item actions are processed.
                           items:
-                            description: BackupResourceHook defines a hook for a resource.
+                            description: BackupResourceHook defines a hook for a
+                              resource.
                             properties:
                               exec:
                                 description: Exec defines an exec hook.
@@ -203,23 +216,22 @@ spec:
                                     minItems: 1
                                     type: array
                                   container:
-                                    description: Container is the container in the
-                                      pod where the command should be executed. If
-                                      not specified, the pod's first container is
-                                      used.
+                                    description: |-
+                                      Container is the container in the pod where the command should be executed. If not specified,
+                                      the pod's first container is used.
                                     type: string
                                   onError:
                                     description: OnError specifies how Velero should
-                                      behave if it encounters an error executing this
-                                      hook.
+                                      behave if it encounters an error executing
+                                      this hook.
                                     enum:
                                     - Continue
                                     - Fail
                                     type: string
                                   timeout:
-                                    description: Timeout defines the maximum amount
-                                      of time Velero should wait for the hook to complete
-                                      before considering the execution a failure.
+                                    description: |-
+                                      Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                      considering the execution a failure.
                                     type: string
                                 required:
                                 - command
@@ -229,12 +241,12 @@ spec:
                             type: object
                           type: array
                         pre:
-                          description: PreHooks is a list of BackupResourceHooks to
-                            execute prior to storing the item in the backup. These
-                            are executed before any "additional items" from item actions
-                            are processed.
+                          description: |-
+                            PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup.
+                            These are executed before any "additional items" from item actions are processed.
                           items:
-                            description: BackupResourceHook defines a hook for a resource.
+                            description: BackupResourceHook defines a hook for a
+                              resource.
                             properties:
                               exec:
                                 description: Exec defines an exec hook.
@@ -247,23 +259,22 @@ spec:
                                     minItems: 1
                                     type: array
                                   container:
-                                    description: Container is the container in the
-                                      pod where the command should be executed. If
-                                      not specified, the pod's first container is
-                                      used.
+                                    description: |-
+                                      Container is the container in the pod where the command should be executed. If not specified,
+                                      the pod's first container is used.
                                     type: string
                                   onError:
                                     description: OnError specifies how Velero should
-                                      behave if it encounters an error executing this
-                                      hook.
+                                      behave if it encounters an error executing
+                                      this hook.
                                     enum:
                                     - Continue
                                     - Fail
                                     type: string
                                   timeout:
-                                    description: Timeout defines the maximum amount
-                                      of time Velero should wait for the hook to complete
-                                      before considering the execution a failure.
+                                    description: |-
+                                      Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                      considering the execution a failure.
                                     type: string
                                 required:
                                 - command
@@ -279,91 +290,99 @@ spec:
                     type: array
                 type: object
               includeClusterResources:
-                description: IncludeClusterResources specifies whether cluster-scoped
-                  resources should be included for consideration in the backup.
+                description: |-
+                  IncludeClusterResources specifies whether cluster-scoped resources
+                  should be included for consideration in the backup.
                 nullable: true
                 type: boolean
               includedClusterScopedResources:
-                description: IncludedClusterScopedResources is a slice of cluster-scoped
-                  resource type names to include in the backup. If set to "*", all
-                  cluster-scoped resource types are included. The default value is
-                  empty, which means only related cluster-scoped resources are included.
+                description: |-
+                  IncludedClusterScopedResources is a slice of cluster-scoped
+                  resource type names to include in the backup.
+                  If set to "*", all cluster-scoped resource types are included.
+                  The default value is empty, which means only related
+                  cluster-scoped resources are included.
                 items:
                   type: string
                 nullable: true
                 type: array
               includedNamespaceScopedResources:
-                description: IncludedNamespaceScopedResources is a slice of namespace-scoped
-                  resource type names to include in the backup. The default value
-                  is "*".
+                description: |-
+                  IncludedNamespaceScopedResources is a slice of namespace-scoped
+                  resource type names to include in the backup.
+                  The default value is "*".
                 items:
                   type: string
                 nullable: true
                 type: array
               includedNamespaces:
-                description: IncludedNamespaces is a slice of namespace names to include
-                  objects from. If empty, all namespaces are included.
+                description: |-
+                  IncludedNamespaces is a slice of namespace names to include objects
+                  from. If empty, all namespaces are included.
                 items:
                   type: string
                 nullable: true
                 type: array
               includedResources:
-                description: IncludedResources is a slice of resource names to include
+                description: |-
+                  IncludedResources is a slice of resource names to include
                   in the backup. If empty, all resources are included.
                 items:
                   type: string
                 nullable: true
                 type: array
               itemOperationTimeout:
-                description: ItemOperationTimeout specifies the time used to wait
-                  for asynchronous BackupItemAction operations The default value is
-                  1 hour.
+                description: |-
+                  ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations
+                  The default value is 4 hour.
                 type: string
               labelSelector:
-                description: LabelSelector is a metav1.LabelSelector to filter with
-                  when adding individual objects to the backup. If empty or nil, all
-                  objects are included. Optional.
+                description: |-
+                  LabelSelector is a metav1.LabelSelector to filter with
+                  when adding individual objects to the backup. If empty
+                  or nil, all objects are included. Optional.
                 nullable: true
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
@@ -375,56 +394,58 @@ spec:
                     type: object
                 type: object
               orLabelSelectors:
-                description: OrLabelSelectors is list of metav1.LabelSelector to filter
-                  with when adding individual objects to the backup. If multiple provided
+                description: |-
+                  OrLabelSelectors is list of metav1.LabelSelector to filter with
+                  when adding individual objects to the backup. If multiple provided
                   they will be joined by the OR operator. LabelSelector as well as
-                  OrLabelSelectors cannot co-exist in backup request, only one of
-                  them can be used.
+                  OrLabelSelectors cannot co-exist in backup request, only one of them
+                  can be used.
                 items:
-                  description: A label selector is a label query over a set of resources.
-                    The result of matchLabels and matchExpressions are ANDed. An empty
-                    label selector matches all objects. A null label selector matches
-                    no objects.
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
+                      description: matchExpressions is a list of label selector
+                        requirements. The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies
-                              to.
+                            description: key is the label key that the selector
+                              applies to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                         required:
                         - key
                         - operator
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
@@ -433,11 +454,10 @@ spec:
               orderedResources:
                 additionalProperties:
                   type: string
-                description: OrderedResources specifies the backup order of resources
-                  of specific Kind. The map key is the resource name and value is
-                  a list of object names separated by commas. Each resource name has
-                  format "namespace/objectname".  For cluster resources, simply use
-                  "objectname".
+                description: |-
+                  OrderedResources specifies the backup order of resources of specific Kind.
+                  The map key is the resource name and value is a list of object names separated by commas.
+                  Each resource name has format "namespace/objectname".  For cluster resources, simply use "objectname".
                 nullable: true
                 type: object
               resourcePolicy:
@@ -445,10 +465,10 @@ spec:
                   that backup should follow
                 properties:
                   apiGroup:
-                    description: APIGroup is the group for the resource being referenced.
-                      If APIGroup is not specified, the specified Kind must be in
-                      the core API group. For any other third-party types, APIGroup
-                      is required.
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
                     type: string
                   kind:
                     description: Kind is the type of resource being referenced
@@ -467,20 +487,24 @@ spec:
                 nullable: true
                 type: boolean
               snapshotVolumes:
-                description: SnapshotVolumes specifies whether to take snapshots of
-                  any PV's referenced in the set of objects included in the Backup.
+                description: |-
+                  SnapshotVolumes specifies whether to take snapshots
+                  of any PV's referenced in the set of objects included
+                  in the Backup.
                 nullable: true
                 type: boolean
               storageLocation:
-                description: StorageLocation is a string containing the name of a
-                  BackupStorageLocation where the backup should be stored.
+                description: StorageLocation is a string containing the name of
+                  a BackupStorageLocation where the backup should be stored.
                 type: string
               ttl:
-                description: TTL is a time.Duration-parseable string describing how
-                  long the Backup should be retained for.
+                description: |-
+                  TTL is a time.Duration-parseable string describing how long
+                  the Backup should be retained for.
                 type: string
               uploaderConfig:
-                description: UploaderConfig specifies the configuration for the uploader.
+                description: UploaderConfig specifies the configuration for the
+                  uploader.
                 nullable: true
                 properties:
                   parallelFilesUpload:
@@ -489,8 +513,8 @@ spec:
                     type: integer
                 type: object
               volumeSnapshotLocations:
-                description: VolumeSnapshotLocations is a list containing names of
-                  VolumeSnapshotLocations associated with this backup.
+                description: VolumeSnapshotLocations is a list containing names
+                  of VolumeSnapshotLocations associated with this backup.
                 items:
                   type: string
                 type: array
@@ -499,39 +523,44 @@ spec:
             description: BackupStatus captures the current status of a Velero backup.
             properties:
               backupItemOperationsAttempted:
-                description: BackupItemOperationsAttempted is the total number of
-                  attempted async BackupItemAction operations for this backup.
+                description: |-
+                  BackupItemOperationsAttempted is the total number of attempted
+                  async BackupItemAction operations for this backup.
                 type: integer
               backupItemOperationsCompleted:
-                description: BackupItemOperationsCompleted is the total number of
-                  successfully completed async BackupItemAction operations for this
-                  backup.
+                description: |-
+                  BackupItemOperationsCompleted is the total number of successfully completed
+                  async BackupItemAction operations for this backup.
                 type: integer
               backupItemOperationsFailed:
-                description: BackupItemOperationsFailed is the total number of async
-                  BackupItemAction operations for this backup which ended with an
-                  error.
+                description: |-
+                  BackupItemOperationsFailed is the total number of async
+                  BackupItemAction operations for this backup which ended with an error.
                 type: integer
               completionTimestamp:
-                description: CompletionTimestamp records the time a backup was completed.
-                  Completion time is recorded even on failed backups. Completion time
-                  is recorded before uploading the backup object. The server's time
-                  is used for CompletionTimestamps
+                description: |-
+                  CompletionTimestamp records the time a backup was completed.
+                  Completion time is recorded even on failed backups.
+                  Completion time is recorded before uploading the backup object.
+                  The server's time is used for CompletionTimestamps
                 format: date-time
                 nullable: true
                 type: string
               csiVolumeSnapshotsAttempted:
-                description: CSIVolumeSnapshotsAttempted is the total number of attempted
+                description: |-
+                  CSIVolumeSnapshotsAttempted is the total number of attempted
                   CSI VolumeSnapshots for this backup.
                 type: integer
               csiVolumeSnapshotsCompleted:
-                description: CSIVolumeSnapshotsCompleted is the total number of successfully
+                description: |-
+                  CSIVolumeSnapshotsCompleted is the total number of successfully
                   completed CSI VolumeSnapshots for this backup.
                 type: integer
               errors:
-                description: Errors is a count of all error messages that were generated
-                  during execution of the backup.  The actual errors are in the backup's
-                  log file in object storage.
+                description: |-
+                  Errors is a count of all error messages that were generated during
+                  execution of the backup.  The actual errors are in the backup's log
+                  file in object storage.
                 type: integer
               expiration:
                 description: Expiration is when this Backup is eligible for garbage-collection.
@@ -547,19 +576,19 @@ spec:
                   major, minor, and patch version.
                 type: string
               hookStatus:
-                description: HookStatus contains information about the status of the
-                  hooks.
+                description: HookStatus contains information about the status of
+                  the hooks.
                 nullable: true
                 properties:
                   hooksAttempted:
-                    description: HooksAttempted is the total number of attempted hooks
-                      Specifically, HooksAttempted represents the number of hooks
-                      that failed to execute and the number of hooks that executed
-                      successfully.
+                    description: |-
+                      HooksAttempted is the total number of attempted hooks
+                      Specifically, HooksAttempted represents the number of hooks that failed to execute
+                      and the number of hooks that executed successfully.
                     type: integer
                   hooksFailed:
-                    description: HooksFailed is the total number of hooks which ended
-                      with an error
+                    description: HooksFailed is the total number of hooks which
+                      ended with an error
                     type: integer
                 type: object
               phase:
@@ -578,53 +607,62 @@ spec:
                 - Deleting
                 type: string
               progress:
-                description: Progress contains information about the backup's execution
-                  progress. Note that this information is best-effort only -- if Velero
-                  fails to update it during a backup for any reason, it may be inaccurate/stale.
+                description: |-
+                  Progress contains information about the backup's execution progress. Note
+                  that this information is best-effort only -- if Velero fails to update it
+                  during a backup for any reason, it may be inaccurate/stale.
                 nullable: true
                 properties:
                   itemsBackedUp:
-                    description: ItemsBackedUp is the number of items that have actually
-                      been written to the backup tarball so far.
+                    description: |-
+                      ItemsBackedUp is the number of items that have actually been written to the
+                      backup tarball so far.
                     type: integer
                   totalItems:
-                    description: TotalItems is the total number of items to be backed
-                      up. This number may change throughout the execution of the backup
-                      due to plugins that return additional related items to back
-                      up, the velero.io/exclude-from-backup label, and various other
+                    description: |-
+                      TotalItems is the total number of items to be backed up. This number may change
+                      throughout the execution of the backup due to plugins that return additional related
+                      items to back up, the velero.io/exclude-from-backup label, and various other
                       filters that happen as items are processed.
                     type: integer
                 type: object
               startTimestamp:
-                description: StartTimestamp records the time a backup was started.
-                  Separate from CreationTimestamp, since that value changes on restores.
+                description: |-
+                  StartTimestamp records the time a backup was started.
+                  Separate from CreationTimestamp, since that value changes
+                  on restores.
                   The server's time is used for StartTimestamps
                 format: date-time
                 nullable: true
                 type: string
               validationErrors:
-                description: ValidationErrors is a slice of all validation errors
-                  (if applicable).
+                description: |-
+                  ValidationErrors is a slice of all validation errors (if
+                  applicable).
                 items:
                   type: string
                 nullable: true
                 type: array
               version:
-                description: 'Version is the backup format major version. Deprecated:
-                  Please see FormatVersion'
+                description: |-
+                  Version is the backup format major version.
+                  Deprecated: Please see FormatVersion
                 type: integer
               volumeSnapshotsAttempted:
-                description: VolumeSnapshotsAttempted is the total number of attempted
+                description: |-
+                  VolumeSnapshotsAttempted is the total number of attempted
                   volume snapshots for this backup.
                 type: integer
               volumeSnapshotsCompleted:
-                description: VolumeSnapshotsCompleted is the total number of successfully
+                description: |-
+                  VolumeSnapshotsCompleted is the total number of successfully
                   completed volume snapshots for this backup.
                 type: integer
               warnings:
-                description: Warnings is a count of all warning messages that were
-                  generated during execution of the backup. The actual warnings are
-                  in the backup's log file in object storage.
+                description: |-
+                  Warnings is a count of all warning messages that were generated during
+                  execution of the backup. The actual warnings are in the backup's log
+                  file in object storage.
                 type: integer
             type: object
         type: object

--- a/helmfile.d/upstream/vmware-tanzu/velero/crds/backupstoragelocations.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/crds/backupstoragelocations.yaml
@@ -2,10 +2,10 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
   labels:
     component: velero
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
   name: backupstoragelocations.velero.io
 spec:
   group: velero.io
@@ -23,8 +23,8 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
-    - description: LastValidationTime is the last time the backup store location was
-        validated
+    - description: LastValidationTime is the last time the backup store location
+        was validated
       jsonPath: .status.lastValidationTime
       name: Last Validated
       type: date
@@ -42,20 +42,25 @@ spec:
           objects
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: BackupStorageLocationSpec defines the desired state of a
-              Velero BackupStorageLocation
+            description: BackupStorageLocationSpec defines the desired state of
+              a Velero BackupStorageLocation
             properties:
               accessMode:
                 description: AccessMode defines the permissions for the backup storage
@@ -79,12 +84,17 @@ spec:
                   to be used with this location
                 properties:
                   key:
-                    description: The key of the secret to select from.  Must be a
-                      valid secret key.
+                    description: The key of the secret to select from.  Must be
+                      a valid secret key.
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
                   optional:
                     description: Specify whether the Secret or its key must be defined
@@ -129,33 +139,38 @@ spec:
             - provider
             type: object
           status:
-            description: BackupStorageLocationStatus defines the observed state of
-              BackupStorageLocation
+            description: BackupStorageLocationStatus defines the observed state
+              of BackupStorageLocation
             properties:
               accessMode:
-                description: "AccessMode is an unused field. \n Deprecated: there
-                  is now an AccessMode field on the Spec and this field will be removed
-                  entirely as of v2.0."
+                description: |-
+                  AccessMode is an unused field.
+
+                  Deprecated: there is now an AccessMode field on the Spec and this field
+                  will be removed entirely as of v2.0.
                 enum:
                 - ReadOnly
                 - ReadWrite
                 type: string
               lastSyncedRevision:
-                description: "LastSyncedRevision is the value of the `metadata/revision`
-                  file in the backup storage location the last time the BSL's contents
-                  were synced into the cluster. \n Deprecated: this field is no longer
-                  updated or used for detecting changes to the location's contents
-                  and will be removed entirely in v2.0."
+                description: |-
+                  LastSyncedRevision is the value of the `metadata/revision` file in the backup
+                  storage location the last time the BSL's contents were synced into the cluster.
+
+                  Deprecated: this field is no longer updated or used for detecting changes to
+                  the location's contents and will be removed entirely in v2.0.
                 type: string
               lastSyncedTime:
-                description: LastSyncedTime is the last time the contents of the location
-                  were synced into the cluster.
+                description: |-
+                  LastSyncedTime is the last time the contents of the location were synced into
+                  the cluster.
                 format: date-time
                 nullable: true
                 type: string
               lastValidationTime:
-                description: LastValidationTime is the last time the backup store
-                  location was validated the cluster.
+                description: |-
+                  LastValidationTime is the last time the backup store location was validated
+                  the cluster.
                 format: date-time
                 nullable: true
                 type: string

--- a/helmfile.d/upstream/vmware-tanzu/velero/crds/datadownloads.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/crds/datadownloads.yaml
@@ -2,10 +2,10 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
   labels:
     component: velero
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
   name: datadownloads.velero.io
 spec:
   group: velero.io
@@ -35,7 +35,8 @@ spec:
       jsonPath: .status.progress.totalBytes
       name: Total Bytes
       type: integer
-    - description: Name of the Backup Storage Location where the backup data is stored
+    - description: Name of the Backup Storage Location where the backup data is
+        stored
       jsonPath: .spec.backupStorageLocation
       name: Storage Location
       type: string
@@ -54,14 +55,19 @@ spec:
           and data mover controller for the datamover restore operation
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -69,12 +75,14 @@ spec:
             description: DataDownloadSpec is the specification for a DataDownload.
             properties:
               backupStorageLocation:
-                description: BackupStorageLocation is the name of the backup storage
-                  location where the backup repository is stored.
+                description: |-
+                  BackupStorageLocation is the name of the backup storage location
+                  where the backup repository is stored.
                 type: string
               cancel:
-                description: Cancel indicates request to cancel the ongoing DataDownload.
-                  It can be set when the DataDownload is in InProgress phase
+                description: |-
+                  Cancel indicates request to cancel the ongoing DataDownload. It can be set
+                  when the DataDownload is in InProgress phase
                 type: boolean
               dataMoverConfig:
                 additionalProperties:
@@ -83,22 +91,31 @@ spec:
                   fields.
                 type: object
               datamover:
-                description: DataMover specifies the data mover to be used by the
-                  backup. If DataMover is "" or "velero", the built-in data mover
-                  will be used.
+                description: |-
+                  DataMover specifies the data mover to be used by the backup.
+                  If DataMover is "" or "velero", the built-in data mover will be used.
+                type: string
+              nodeOS:
+                description: NodeOS is OS of the node where the DataDownload is
+                  processed.
+                enum:
+                - auto
+                - linux
+                - windows
                 type: string
               operationTimeout:
-                description: OperationTimeout specifies the time used to wait internal
-                  operations, before returning error as timeout.
+                description: |-
+                  OperationTimeout specifies the time used to wait internal operations,
+                  before returning error as timeout.
                 type: string
               snapshotID:
-                description: SnapshotID is the ID of the Velero backup snapshot to
-                  be restored from.
+                description: SnapshotID is the ID of the Velero backup snapshot
+                  to be restored from.
                 type: string
               sourceNamespace:
-                description: SourceNamespace is the original namespace where the volume
-                  is backed up from. It may be different from SourcePVC's namespace
-                  if namespace is remapped during restore.
+                description: |-
+                  SourceNamespace is the original namespace where the volume is backed up from.
+                  It may be different from SourcePVC's namespace if namespace is remapped during restore.
                 type: string
               targetVolume:
                 description: TargetVolume is the information of the target PVC and
@@ -108,8 +125,8 @@ spec:
                     description: Namespace is the target namespace
                     type: string
                   pv:
-                    description: PV is the name of the target PV that is created by
-                      Velero restore
+                    description: PV is the name of the target PV that is created
+                      by Velero restore
                     type: string
                   pvc:
                     description: PVC is the name of the target PVC that is created
@@ -130,10 +147,21 @@ spec:
           status:
             description: DataDownloadStatus is the current status of a DataDownload.
             properties:
+              acceptedByNode:
+                description: Node is name of the node where the DataUpload is prepared.
+                type: string
+              acceptedTimestamp:
+                description: |-
+                  AcceptedTimestamp records the time the DataUpload is to be prepared.
+                  The server's time is used for AcceptedTimestamp
+                format: date-time
+                nullable: true
+                type: string
               completionTimestamp:
-                description: CompletionTimestamp records the time a restore was completed.
-                  Completion time is recorded even on failed restores. The server's
-                  time is used for CompletionTimestamps
+                description: |-
+                  CompletionTimestamp records the time a restore was completed.
+                  Completion time is recorded even on failed restores.
+                  The server's time is used for CompletionTimestamps
                 format: date-time
                 nullable: true
                 type: string
@@ -141,7 +169,8 @@ spec:
                 description: Message is a message about the DataDownload's status.
                 type: string
               node:
-                description: Node is name of the node where the DataDownload is processed.
+                description: Node is name of the node where the DataDownload is
+                  processed.
                 type: string
               phase:
                 description: Phase is the current state of the DataDownload.
@@ -156,9 +185,10 @@ spec:
                 - Failed
                 type: string
               progress:
-                description: Progress holds the total number of bytes of the snapshot
-                  and the current number of restored bytes. This can be used to display
-                  progress information about the restore operation.
+                description: |-
+                  Progress holds the total number of bytes of the snapshot and the current
+                  number of restored bytes. This can be used to display progress information
+                  about the restore operation.
                 properties:
                   bytesDone:
                     format: int64
@@ -168,7 +198,8 @@ spec:
                     type: integer
                 type: object
               startTimestamp:
-                description: StartTimestamp records the time a restore was started.
+                description: |-
+                  StartTimestamp records the time a restore was started.
                   The server's time is used for StartTimestamps
                 format: date-time
                 nullable: true

--- a/helmfile.d/upstream/vmware-tanzu/velero/crds/datauploads.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/crds/datauploads.yaml
@@ -2,10 +2,10 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
   labels:
     component: velero
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
   name: datauploads.velero.io
 spec:
   group: velero.io
@@ -35,8 +35,8 @@ spec:
       jsonPath: .status.progress.totalBytes
       name: Total Bytes
       type: integer
-    - description: Name of the Backup Storage Location where this backup should be
-        stored
+    - description: Name of the Backup Storage Location where this backup should
+        be stored
       jsonPath: .spec.backupStorageLocation
       name: Storage Location
       type: string
@@ -51,18 +51,23 @@ spec:
     name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: DataUpload acts as the protocol between data mover plugins and
-          data mover controller for the datamover backup operation
+        description: DataUpload acts as the protocol between data mover plugins
+          and data mover controller for the datamover backup operation
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -70,12 +75,14 @@ spec:
             description: DataUploadSpec is the specification for a DataUpload.
             properties:
               backupStorageLocation:
-                description: BackupStorageLocation is the name of the backup storage
-                  location where the backup repository is stored.
+                description: |-
+                  BackupStorageLocation is the name of the backup storage location
+                  where the backup repository is stored.
                 type: string
               cancel:
-                description: Cancel indicates request to cancel the ongoing DataUpload.
-                  It can be set when the DataUpload is in InProgress phase
+                description: |-
+                  Cancel indicates request to cancel the ongoing DataUpload. It can be set
+                  when the DataUpload is in InProgress phase
                 type: boolean
               csiSnapshot:
                 description: If SnapshotType is CSI, CSISnapshot provides the information
@@ -83,8 +90,8 @@ spec:
                 nullable: true
                 properties:
                   snapshotClass:
-                    description: SnapshotClass is the name of the snapshot class that
-                      the volume snapshot is created with
+                    description: SnapshotClass is the name of the snapshot class
+                      that the volume snapshot is created with
                     type: string
                   storageClass:
                     description: StorageClass is the name of the storage class of
@@ -106,26 +113,27 @@ spec:
                 nullable: true
                 type: object
               datamover:
-                description: DataMover specifies the data mover to be used by the
-                  backup. If DataMover is "" or "velero", the built-in data mover
-                  will be used.
+                description: |-
+                  DataMover specifies the data mover to be used by the backup.
+                  If DataMover is "" or "velero", the built-in data mover will be used.
                 type: string
               operationTimeout:
-                description: OperationTimeout specifies the time used to wait internal
-                  operations, before returning error as timeout.
+                description: |-
+                  OperationTimeout specifies the time used to wait internal operations,
+                  before returning error as timeout.
                 type: string
               snapshotType:
                 description: SnapshotType is the type of the snapshot to be backed
                   up.
                 type: string
               sourceNamespace:
-                description: SourceNamespace is the original namespace where the volume
-                  is backed up from. It is the same namespace for SourcePVC and CSI
-                  namespaced objects.
+                description: |-
+                  SourceNamespace is the original namespace where the volume is backed up from.
+                  It is the same namespace for SourcePVC and CSI namespaced objects.
                 type: string
               sourcePVC:
-                description: SourcePVC is the name of the PVC which the snapshot is
-                  taken for.
+                description: SourcePVC is the name of the PVC which the snapshot
+                  is taken for.
                 type: string
             required:
             - backupStorageLocation
@@ -137,11 +145,23 @@ spec:
           status:
             description: DataUploadStatus is the current status of a DataUpload.
             properties:
+              acceptedByNode:
+                description: AcceptedByNode is name of the node where the DataUpload
+                  is prepared.
+                type: string
+              acceptedTimestamp:
+                description: |-
+                  AcceptedTimestamp records the time the DataUpload is to be prepared.
+                  The server's time is used for AcceptedTimestamp
+                format: date-time
+                nullable: true
+                type: string
               completionTimestamp:
-                description: CompletionTimestamp records the time a backup was completed.
-                  Completion time is recorded even on failed backups. Completion time
-                  is recorded before uploading the backup object. The server's time
-                  is used for CompletionTimestamps
+                description: |-
+                  CompletionTimestamp records the time a backup was completed.
+                  Completion time is recorded even on failed backups.
+                  Completion time is recorded before uploading the backup object.
+                  The server's time is used for CompletionTimestamps
                 format: date-time
                 nullable: true
                 type: string
@@ -158,9 +178,16 @@ spec:
               node:
                 description: Node is name of the node where the DataUpload is processed.
                 type: string
+              nodeOS:
+                description: NodeOS is OS of the node where the DataUpload is processed.
+                enum:
+                - auto
+                - linux
+                - windows
+                type: string
               path:
-                description: Path is the full path of the snapshot volume being backed
-                  up.
+                description: Path is the full path of the snapshot volume being
+                  backed up.
                 type: string
               phase:
                 description: Phase is the current state of the DataUpload.
@@ -175,9 +202,10 @@ spec:
                 - Failed
                 type: string
               progress:
-                description: Progress holds the total number of bytes of the volume
-                  and the current number of backed up bytes. This can be used to display
-                  progress information about the backup operation.
+                description: |-
+                  Progress holds the total number of bytes of the volume and the current
+                  number of backed up bytes. This can be used to display progress information
+                  about the backup operation.
                 properties:
                   bytesDone:
                     format: int64
@@ -191,8 +219,10 @@ spec:
                   backup repository.
                 type: string
               startTimestamp:
-                description: StartTimestamp records the time a backup was started.
-                  Separate from CreationTimestamp, since that value changes on restores.
+                description: |-
+                  StartTimestamp records the time a backup was started.
+                  Separate from CreationTimestamp, since that value changes
+                  on restores.
                   The server's time is used for StartTimestamps
                 format: date-time
                 nullable: true

--- a/helmfile.d/upstream/vmware-tanzu/velero/crds/deletebackuprequests.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/crds/deletebackuprequests.yaml
@@ -2,10 +2,10 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
   labels:
     component: velero
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
   name: deletebackuprequests.velero.io
 spec:
   group: velero.io
@@ -31,20 +31,25 @@ spec:
         description: DeleteBackupRequest is a request to delete one or more backups.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DeleteBackupRequestSpec is the specification for which backups
-              to delete.
+            description: DeleteBackupRequestSpec is the specification for which
+              backups to delete.
             properties:
               backupName:
                 type: string

--- a/helmfile.d/upstream/vmware-tanzu/velero/crds/downloadrequests.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/crds/downloadrequests.yaml
@@ -2,10 +2,10 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
   labels:
     component: velero
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
   name: downloadrequests.velero.io
 spec:
   group: velero.io
@@ -19,23 +19,30 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: DownloadRequest is a request to download an artifact from backup
-          object storage, such as a backup log file.
+        description: |-
+          DownloadRequest is a request to download an artifact from backup object storage, such as a backup
+          log file.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DownloadRequestSpec is the specification for a download request.
+            description: DownloadRequestSpec is the specification for a download
+              request.
             properties:
               target:
                 description: Target is what to download (e.g. logs for a backup).
@@ -56,6 +63,7 @@ spec:
                     - CSIBackupVolumeSnapshots
                     - CSIBackupVolumeSnapshotContents
                     - BackupVolumeInfos
+                    - RestoreVolumeInfo
                     type: string
                   name:
                     description: Name is the name of the Kubernetes resource with
@@ -76,8 +84,8 @@ spec:
                   file.
                 type: string
               expiration:
-                description: Expiration is when this DownloadRequest expires and can
-                  be deleted by the system.
+                description: Expiration is when this DownloadRequest expires and
+                  can be deleted by the system.
                 format: date-time
                 nullable: true
                 type: string

--- a/helmfile.d/upstream/vmware-tanzu/velero/crds/podvolumebackups.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/crds/podvolumebackups.yaml
@@ -2,10 +2,10 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
   labels:
     component: velero
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
   name: podvolumebackups.velero.io
 spec:
   group: velero.io
@@ -41,8 +41,8 @@ spec:
       jsonPath: .spec.uploaderType
       name: Uploader Type
       type: string
-    - description: Name of the Backup Storage Location where this backup should be
-        stored
+    - description: Name of the Backup Storage Location where this backup should
+        be stored
       jsonPath: .spec.backupStorageLocation
       name: Storage Location
       type: string
@@ -54,14 +54,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -69,48 +74,55 @@ spec:
             description: PodVolumeBackupSpec is the specification for a PodVolumeBackup.
             properties:
               backupStorageLocation:
-                description: BackupStorageLocation is the name of the backup storage
-                  location where the backup repository is stored.
+                description: |-
+                  BackupStorageLocation is the name of the backup storage location
+                  where the backup repository is stored.
                 type: string
               node:
                 description: Node is the name of the node that the Pod is running
                   on.
                 type: string
               pod:
-                description: Pod is a reference to the pod containing the volume to
-                  be backed up.
+                description: Pod is a reference to the pod containing the volume
+                  to be backed up.
                 properties:
                   apiVersion:
                     description: API version of the referent.
                     type: string
                   fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
                     type: string
                   kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
                   namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                     type: string
                   resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                     type: string
                   uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
@@ -120,27 +132,30 @@ spec:
               tags:
                 additionalProperties:
                   type: string
-                description: Tags are a map of key-value pairs that should be applied
-                  to the volume backup as tags.
+                description: |-
+                  Tags are a map of key-value pairs that should be applied to the
+                  volume backup as tags.
                 type: object
               uploaderSettings:
                 additionalProperties:
                   type: string
-                description: UploaderSettings are a map of key-value pairs that should
-                  be applied to the uploader configuration.
+                description: |-
+                  UploaderSettings are a map of key-value pairs that should be applied to the
+                  uploader configuration.
                 nullable: true
                 type: object
               uploaderType:
-                description: UploaderType is the type of the uploader to handle the
-                  data transfer.
+                description: UploaderType is the type of the uploader to handle
+                  the data transfer.
                 enum:
                 - kopia
                 - restic
                 - ""
                 type: string
               volume:
-                description: Volume is the name of the volume within the Pod to be
-                  backed up.
+                description: |-
+                  Volume is the name of the volume within the Pod to be backed
+                  up.
                 type: string
             required:
             - backupStorageLocation
@@ -153,15 +168,17 @@ spec:
             description: PodVolumeBackupStatus is the current status of a PodVolumeBackup.
             properties:
               completionTimestamp:
-                description: CompletionTimestamp records the time a backup was completed.
-                  Completion time is recorded even on failed backups. Completion time
-                  is recorded before uploading the backup object. The server's time
-                  is used for CompletionTimestamps
+                description: |-
+                  CompletionTimestamp records the time a backup was completed.
+                  Completion time is recorded even on failed backups.
+                  Completion time is recorded before uploading the backup object.
+                  The server's time is used for CompletionTimestamps
                 format: date-time
                 nullable: true
                 type: string
               message:
-                description: Message is a message about the pod volume backup's status.
+                description: Message is a message about the pod volume backup's
+                  status.
                 type: string
               path:
                 description: Path is the full path within the controller pod being
@@ -176,9 +193,10 @@ spec:
                 - Failed
                 type: string
               progress:
-                description: Progress holds the total number of bytes of the volume
-                  and the current number of backed up bytes. This can be used to display
-                  progress information about the backup operation.
+                description: |-
+                  Progress holds the total number of bytes of the volume and the current
+                  number of backed up bytes. This can be used to display progress information
+                  about the backup operation.
                 properties:
                   bytesDone:
                     format: int64
@@ -192,8 +210,10 @@ spec:
                   pod volume.
                 type: string
               startTimestamp:
-                description: StartTimestamp records the time a backup was started.
-                  Separate from CreationTimestamp, since that value changes on restores.
+                description: |-
+                  StartTimestamp records the time a backup was started.
+                  Separate from CreationTimestamp, since that value changes
+                  on restores.
                   The server's time is used for StartTimestamps
                 format: date-time
                 nullable: true

--- a/helmfile.d/upstream/vmware-tanzu/velero/crds/podvolumerestores.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/crds/podvolumerestores.yaml
@@ -2,10 +2,10 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
   labels:
     component: velero
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
   name: podvolumerestores.velero.io
 spec:
   group: velero.io
@@ -55,14 +55,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -70,44 +75,51 @@ spec:
             description: PodVolumeRestoreSpec is the specification for a PodVolumeRestore.
             properties:
               backupStorageLocation:
-                description: BackupStorageLocation is the name of the backup storage
-                  location where the backup repository is stored.
+                description: |-
+                  BackupStorageLocation is the name of the backup storage location
+                  where the backup repository is stored.
                 type: string
               pod:
-                description: Pod is a reference to the pod containing the volume to
-                  be restored.
+                description: Pod is a reference to the pod containing the volume
+                  to be restored.
                 properties:
                   apiVersion:
                     description: API version of the referent.
                     type: string
                   fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
                     type: string
                   kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
                   namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                     type: string
                   resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                     type: string
                   uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
@@ -124,21 +136,22 @@ spec:
               uploaderSettings:
                 additionalProperties:
                   type: string
-                description: UploaderSettings are a map of key-value pairs that should
-                  be applied to the uploader configuration.
+                description: |-
+                  UploaderSettings are a map of key-value pairs that should be applied to the
+                  uploader configuration.
                 nullable: true
                 type: object
               uploaderType:
-                description: UploaderType is the type of the uploader to handle the
-                  data transfer.
+                description: UploaderType is the type of the uploader to handle
+                  the data transfer.
                 enum:
                 - kopia
                 - restic
                 - ""
                 type: string
               volume:
-                description: Volume is the name of the volume within the Pod to be
-                  restored.
+                description: Volume is the name of the volume within the Pod to
+                  be restored.
                 type: string
             required:
             - backupStorageLocation
@@ -152,14 +165,16 @@ spec:
             description: PodVolumeRestoreStatus is the current status of a PodVolumeRestore.
             properties:
               completionTimestamp:
-                description: CompletionTimestamp records the time a restore was completed.
-                  Completion time is recorded even on failed restores. The server's
-                  time is used for CompletionTimestamps
+                description: |-
+                  CompletionTimestamp records the time a restore was completed.
+                  Completion time is recorded even on failed restores.
+                  The server's time is used for CompletionTimestamps
                 format: date-time
                 nullable: true
                 type: string
               message:
-                description: Message is a message about the pod volume restore's status.
+                description: Message is a message about the pod volume restore's
+                  status.
                 type: string
               phase:
                 description: Phase is the current state of the PodVolumeRestore.
@@ -170,9 +185,10 @@ spec:
                 - Failed
                 type: string
               progress:
-                description: Progress holds the total number of bytes of the snapshot
-                  and the current number of restored bytes. This can be used to display
-                  progress information about the restore operation.
+                description: |-
+                  Progress holds the total number of bytes of the snapshot and the current
+                  number of restored bytes. This can be used to display progress information
+                  about the restore operation.
                 properties:
                   bytesDone:
                     format: int64
@@ -182,7 +198,8 @@ spec:
                     type: integer
                 type: object
               startTimestamp:
-                description: StartTimestamp records the time a restore was started.
+                description: |-
+                  StartTimestamp records the time a restore was started.
                   The server's time is used for StartTimestamps
                 format: date-time
                 nullable: true

--- a/helmfile.d/upstream/vmware-tanzu/velero/crds/restores.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/crds/restores.yaml
@@ -2,10 +2,10 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
   labels:
     component: velero
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
   name: restores.velero.io
 spec:
   group: velero.io
@@ -19,18 +19,24 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Restore is a Velero resource that represents the application
-          of resources from a Velero backup to a target Kubernetes cluster.
+        description: |-
+          Restore is a Velero resource that represents the application of
+          resources from a Velero backup to a target Kubernetes cluster.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -38,19 +44,22 @@ spec:
             description: RestoreSpec defines the specification for a Velero restore.
             properties:
               backupName:
-                description: BackupName is the unique name of the Velero backup to
-                  restore from.
+                description: |-
+                  BackupName is the unique name of the Velero backup to restore
+                  from.
                 type: string
               excludedNamespaces:
-                description: ExcludedNamespaces contains a list of namespaces that
-                  are not included in the restore.
+                description: |-
+                  ExcludedNamespaces contains a list of namespaces that are not
+                  included in the restore.
                 items:
                   type: string
                 nullable: true
                 type: array
               excludedResources:
-                description: ExcludedResources is a slice of resource names that are
-                  not included in the restore.
+                description: |-
+                  ExcludedResources is a slice of resource names that are not
+                  included in the restore.
                 items:
                   type: string
                 nullable: true
@@ -66,9 +75,9 @@ spec:
                 properties:
                   resources:
                     items:
-                      description: RestoreResourceHookSpec defines one or more RestoreResrouceHooks
-                        that should be executed based on the rules defined for namespaces,
-                        resources, and label selector.
+                      description: |-
+                        RestoreResourceHookSpec defines one or more RestoreResrouceHooks that should be executed based on
+                        the rules defined for namespaces, resources, and label selector.
                       properties:
                         excludedNamespaces:
                           description: ExcludedNamespaces specifies the namespaces
@@ -78,39 +87,39 @@ spec:
                           nullable: true
                           type: array
                         excludedResources:
-                          description: ExcludedResources specifies the resources to
-                            which this hook spec does not apply.
+                          description: ExcludedResources specifies the resources
+                            to which this hook spec does not apply.
                           items:
                             type: string
                           nullable: true
                           type: array
                         includedNamespaces:
-                          description: IncludedNamespaces specifies the namespaces
-                            to which this hook spec applies. If empty, it applies
+                          description: |-
+                            IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
                             to all namespaces.
                           items:
                             type: string
                           nullable: true
                           type: array
                         includedResources:
-                          description: IncludedResources specifies the resources to
-                            which this hook spec applies. If empty, it applies to
-                            all resources.
+                          description: |-
+                            IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
+                            to all resources.
                           items:
                             type: string
                           nullable: true
                           type: array
                         labelSelector:
-                          description: LabelSelector, if specified, filters the resources
-                            to which this hook spec applies.
+                          description: LabelSelector, if specified, filters the
+                            resources to which this hook spec applies.
                           nullable: true
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
                                 requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
@@ -118,33 +127,33 @@ spec:
                                       applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 required:
                                 - key
                                 - operator
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
@@ -163,27 +172,26 @@ spec:
                                 properties:
                                   command:
                                     description: Command is the command and arguments
-                                      to execute from within a container after a pod
-                                      has been restored.
+                                      to execute from within a container after a
+                                      pod has been restored.
                                     items:
                                       type: string
                                     minItems: 1
                                     type: array
                                   container:
-                                    description: Container is the container in the
-                                      pod where the command should be executed. If
-                                      not specified, the pod's first container is
-                                      used.
+                                    description: |-
+                                      Container is the container in the pod where the command should be executed. If not specified,
+                                      the pod's first container is used.
                                     type: string
                                   execTimeout:
-                                    description: ExecTimeout defines the maximum amount
-                                      of time Velero should wait for the hook to complete
-                                      before considering the execution a failure.
+                                    description: |-
+                                      ExecTimeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                      considering the execution a failure.
                                     type: string
                                   onError:
                                     description: OnError specifies how Velero should
-                                      behave if it encounters an error executing this
-                                      hook.
+                                      behave if it encounters an error executing
+                                      this hook.
                                     enum:
                                     - Continue
                                     - Fail
@@ -195,9 +203,9 @@ spec:
                                     nullable: true
                                     type: boolean
                                   waitTimeout:
-                                    description: WaitTimeout defines the maximum amount
-                                      of time Velero should wait for the container
-                                      to be Ready before attempting to run the command.
+                                    description: |-
+                                      WaitTimeout defines the maximum amount of time Velero should wait for the container to be Ready
+                                      before attempting to run the command.
                                     type: string
                                 required:
                                 - command
@@ -206,8 +214,9 @@ spec:
                                 description: Init defines an init restore hook.
                                 properties:
                                   initContainers:
-                                    description: InitContainers is list of init containers
-                                      to be added to a pod during its restore.
+                                    description: InitContainers is list of init
+                                      containers to be added to a pod during its
+                                      restore.
                                     items:
                                       type: object
                                       x-kubernetes-preserve-unknown-fields: true
@@ -227,144 +236,153 @@ spec:
                     type: array
                 type: object
               includeClusterResources:
-                description: IncludeClusterResources specifies whether cluster-scoped
-                  resources should be included for consideration in the restore. If
-                  null, defaults to true.
+                description: |-
+                  IncludeClusterResources specifies whether cluster-scoped resources
+                  should be included for consideration in the restore. If null, defaults
+                  to true.
                 nullable: true
                 type: boolean
               includedNamespaces:
-                description: IncludedNamespaces is a slice of namespace names to include
-                  objects from. If empty, all namespaces are included.
+                description: |-
+                  IncludedNamespaces is a slice of namespace names to include objects
+                  from. If empty, all namespaces are included.
                 items:
                   type: string
                 nullable: true
                 type: array
               includedResources:
-                description: IncludedResources is a slice of resource names to include
+                description: |-
+                  IncludedResources is a slice of resource names to include
                   in the restore. If empty, all resources in the backup are included.
                 items:
                   type: string
                 nullable: true
                 type: array
               itemOperationTimeout:
-                description: ItemOperationTimeout specifies the time used to wait
-                  for RestoreItemAction operations The default value is 1 hour.
+                description: |-
+                  ItemOperationTimeout specifies the time used to wait for RestoreItemAction operations
+                  The default value is 4 hour.
                 type: string
               labelSelector:
-                description: LabelSelector is a metav1.LabelSelector to filter with
-                  when restoring individual objects from the backup. If empty or nil,
-                  all objects are included. Optional.
+                description: |-
+                  LabelSelector is a metav1.LabelSelector to filter with
+                  when restoring individual objects from the backup. If empty
+                  or nil, all objects are included. Optional.
                 nullable: true
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
               namespaceMapping:
                 additionalProperties:
                   type: string
-                description: NamespaceMapping is a map of source namespace names to
-                  target namespace names to restore into. Any source namespaces not
-                  included in the map will be restored into namespaces of the same
-                  name.
+                description: |-
+                  NamespaceMapping is a map of source namespace names
+                  to target namespace names to restore into. Any source
+                  namespaces not included in the map will be restored into
+                  namespaces of the same name.
                 type: object
               orLabelSelectors:
-                description: OrLabelSelectors is list of metav1.LabelSelector to filter
-                  with when restoring individual objects from the backup. If multiple
-                  provided they will be joined by the OR operator. LabelSelector as
-                  well as OrLabelSelectors cannot co-exist in restore request, only
-                  one of them can be used
+                description: |-
+                  OrLabelSelectors is list of metav1.LabelSelector to filter with
+                  when restoring individual objects from the backup. If multiple provided
+                  they will be joined by the OR operator. LabelSelector as well as
+                  OrLabelSelectors cannot co-exist in restore request, only one of them
+                  can be used
                 items:
-                  description: A label selector is a label query over a set of resources.
-                    The result of matchLabels and matchExpressions are ANDed. An empty
-                    label selector matches all objects. A null label selector matches
-                    no objects.
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
+                      description: matchExpressions is a list of label selector
+                        requirements. The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector applies
-                              to.
+                            description: key is the label key that the selector
+                              applies to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                         required:
                         - key
                         - operator
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
                 nullable: true
                 type: array
               preserveNodePorts:
-                description: PreserveNodePorts specifies whether to restore old nodePorts
-                  from backup.
+                description: PreserveNodePorts specifies whether to restore old
+                  nodePorts from backup.
                 nullable: true
                 type: boolean
               resourceModifier:
@@ -373,10 +391,10 @@ spec:
                 nullable: true
                 properties:
                   apiGroup:
-                    description: APIGroup is the group for the resource being referenced.
-                      If APIGroup is not specified, the specified Kind must be in
-                      the core API group. For any other third-party types, APIGroup
-                      is required.
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
                     type: string
                   kind:
                     description: Kind is the type of resource being referenced
@@ -390,13 +408,15 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               restorePVs:
-                description: RestorePVs specifies whether to restore all included
+                description: |-
+                  RestorePVs specifies whether to restore all included
                   PVs from snapshot
                 nullable: true
                 type: boolean
               restoreStatus:
-                description: RestoreStatus specifies which resources we should restore
-                  the status field. If nil, no objects are included. Optional.
+                description: |-
+                  RestoreStatus specifies which resources we should restore the status
+                  field. If nil, no objects are included. Optional.
                 nullable: true
                 properties:
                   excludedResources:
@@ -407,65 +427,70 @@ spec:
                     nullable: true
                     type: array
                   includedResources:
-                    description: IncludedResources specifies the resources to which
-                      will restore the status. If empty, it applies to all resources.
+                    description: |-
+                      IncludedResources specifies the resources to which will restore the status.
+                      If empty, it applies to all resources.
                     items:
                       type: string
                     nullable: true
                     type: array
                 type: object
               scheduleName:
-                description: ScheduleName is the unique name of the Velero schedule
-                  to restore from. If specified, and BackupName is empty, Velero will
-                  restore from the most recent successful backup created from this
-                  schedule.
+                description: |-
+                  ScheduleName is the unique name of the Velero schedule to restore
+                  from. If specified, and BackupName is empty, Velero will restore
+                  from the most recent successful backup created from this schedule.
                 type: string
               uploaderConfig:
-                description: UploaderConfig specifies the configuration for the restore.
+                description: UploaderConfig specifies the configuration for the
+                  restore.
                 nullable: true
                 properties:
+                  parallelFilesDownload:
+                    description: ParallelFilesDownload is the concurrency number
+                      setting for restore.
+                    type: integer
                   writeSparseFiles:
-                    description: WriteSparseFiles is a flag to indicate whether write
-                      files sparsely or not.
+                    description: WriteSparseFiles is a flag to indicate whether
+                      write files sparsely or not.
                     nullable: true
                     type: boolean
                 type: object
-            required:
-            - backupName
             type: object
           status:
             description: RestoreStatus captures the current status of a Velero restore
             properties:
               completionTimestamp:
-                description: CompletionTimestamp records the time the restore operation
-                  was completed. Completion time is recorded even on failed restore.
+                description: |-
+                  CompletionTimestamp records the time the restore operation was completed.
+                  Completion time is recorded even on failed restore.
                   The server's time is used for StartTimestamps
                 format: date-time
                 nullable: true
                 type: string
               errors:
-                description: Errors is a count of all error messages that were generated
-                  during execution of the restore. The actual errors are stored in
-                  object storage.
+                description: |-
+                  Errors is a count of all error messages that were generated during
+                  execution of the restore. The actual errors are stored in object storage.
                 type: integer
               failureReason:
                 description: FailureReason is an error that caused the entire restore
                   to fail.
                 type: string
               hookStatus:
-                description: HookStatus contains information about the status of the
-                  hooks.
+                description: HookStatus contains information about the status of
+                  the hooks.
                 nullable: true
                 properties:
                   hooksAttempted:
-                    description: HooksAttempted is the total number of attempted hooks
-                      Specifically, HooksAttempted represents the number of hooks
-                      that failed to execute and the number of hooks that executed
-                      successfully.
+                    description: |-
+                      HooksAttempted is the total number of attempted hooks
+                      Specifically, HooksAttempted represents the number of hooks that failed to execute
+                      and the number of hooks that executed successfully.
                     type: integer
                   hooksFailed:
-                    description: HooksFailed is the total number of hooks which ended
-                      with an error
+                    description: HooksFailed is the total number of hooks which
+                      ended with an error
                     type: integer
                 type: object
               phase:
@@ -479,54 +504,61 @@ spec:
                 - Completed
                 - PartiallyFailed
                 - Failed
+                - Finalizing
+                - FinalizingPartiallyFailed
                 type: string
               progress:
-                description: Progress contains information about the restore's execution
-                  progress. Note that this information is best-effort only -- if Velero
-                  fails to update it during a restore for any reason, it may be inaccurate/stale.
+                description: |-
+                  Progress contains information about the restore's execution progress. Note
+                  that this information is best-effort only -- if Velero fails to update it
+                  during a restore for any reason, it may be inaccurate/stale.
                 nullable: true
                 properties:
                   itemsRestored:
-                    description: ItemsRestored is the number of items that have actually
-                      been restored so far
+                    description: ItemsRestored is the number of items that have
+                      actually been restored so far
                     type: integer
                   totalItems:
-                    description: TotalItems is the total number of items to be restored.
-                      This number may change throughout the execution of the restore
-                      due to plugins that return additional related items to restore
+                    description: |-
+                      TotalItems is the total number of items to be restored. This number may change
+                      throughout the execution of the restore due to plugins that return additional related
+                      items to restore
                     type: integer
                 type: object
               restoreItemOperationsAttempted:
-                description: RestoreItemOperationsAttempted is the total number of
-                  attempted async RestoreItemAction operations for this restore.
+                description: |-
+                  RestoreItemOperationsAttempted is the total number of attempted
+                  async RestoreItemAction operations for this restore.
                 type: integer
               restoreItemOperationsCompleted:
-                description: RestoreItemOperationsCompleted is the total number of
-                  successfully completed async RestoreItemAction operations for this
-                  restore.
+                description: |-
+                  RestoreItemOperationsCompleted is the total number of successfully completed
+                  async RestoreItemAction operations for this restore.
                 type: integer
               restoreItemOperationsFailed:
-                description: RestoreItemOperationsFailed is the total number of async
-                  RestoreItemAction operations for this restore which ended with an
-                  error.
+                description: |-
+                  RestoreItemOperationsFailed is the total number of async
+                  RestoreItemAction operations for this restore which ended with an error.
                 type: integer
               startTimestamp:
-                description: StartTimestamp records the time the restore operation
-                  was started. The server's time is used for StartTimestamps
+                description: |-
+                  StartTimestamp records the time the restore operation was started.
+                  The server's time is used for StartTimestamps
                 format: date-time
                 nullable: true
                 type: string
               validationErrors:
-                description: ValidationErrors is a slice of all validation errors
-                  (if applicable)
+                description: |-
+                  ValidationErrors is a slice of all validation errors (if
+                  applicable)
                 items:
                   type: string
                 nullable: true
                 type: array
               warnings:
-                description: Warnings is a count of all warning messages that were
-                  generated during execution of the restore. The actual warnings are
-                  stored in object storage.
+                description: |-
+                  Warnings is a count of all warning messages that were generated during
+                  execution of the restore. The actual warnings are stored in object storage.
                 type: integer
             type: object
         type: object

--- a/helmfile.d/upstream/vmware-tanzu/velero/crds/schedules.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/crds/schedules.yaml
@@ -2,10 +2,10 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
   labels:
     component: velero
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
   name: schedules.velero.io
 spec:
   group: velero.io
@@ -38,18 +38,24 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: Schedule is a Velero resource that represents a pre-scheduled
-          or periodic Backup that should be run.
+        description: |-
+          Schedule is a Velero resource that represents a pre-scheduled or
+          periodic Backup that should be run.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -57,91 +63,98 @@ spec:
             description: ScheduleSpec defines the specification for a Velero schedule
             properties:
               paused:
-                description: Paused specifies whether the schedule is paused or not
+                description: Paused specifies whether the schedule is paused or
+                  not
                 type: boolean
               schedule:
-                description: Schedule is a Cron expression defining when to run the
-                  Backup.
+                description: |-
+                  Schedule is a Cron expression defining when to run
+                  the Backup.
                 type: string
               skipImmediately:
-                description: 'SkipImmediately specifies whether to skip backup if
-                  schedule is due immediately from `schedule.status.lastBackup` timestamp
-                  when schedule is unpaused or if schedule is new. If true, backup
-                  will be skipped immediately when schedule is unpaused if it is due
-                  based on .Status.LastBackupTimestamp or schedule is new, and will
-                  run at next schedule time. If false, backup will not be skipped
-                  immediately when schedule is unpaused, but will run at next schedule
-                  time. If empty, will follow server configuration (default: false).'
+                description: |-
+                  SkipImmediately specifies whether to skip backup if schedule is due immediately from `schedule.status.lastBackup` timestamp when schedule is unpaused or if schedule is new.
+                  If true, backup will be skipped immediately when schedule is unpaused if it is due based on .Status.LastBackupTimestamp or schedule is new, and will run at next schedule time.
+                  If false, backup will not be skipped immediately when schedule is unpaused, but will run at next schedule time.
+                  If empty, will follow server configuration (default: false).
                 type: boolean
               template:
-                description: Template is the definition of the Backup to be run on
-                  the provided schedule
+                description: |-
+                  Template is the definition of the Backup to be run
+                  on the provided schedule
                 properties:
                   csiSnapshotTimeout:
-                    description: CSISnapshotTimeout specifies the time used to wait
-                      for CSI VolumeSnapshot status turns to ReadyToUse during creation,
-                      before returning error as timeout. The default value is 10 minute.
+                    description: |-
+                      CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to
+                      ReadyToUse during creation, before returning error as timeout.
+                      The default value is 10 minute.
                     type: string
                   datamover:
-                    description: DataMover specifies the data mover to be used by
-                      the backup. If DataMover is "" or "velero", the built-in data
-                      mover will be used.
+                    description: |-
+                      DataMover specifies the data mover to be used by the backup.
+                      If DataMover is "" or "velero", the built-in data mover will be used.
                     type: string
                   defaultVolumesToFsBackup:
-                    description: DefaultVolumesToFsBackup specifies whether pod volume
-                      file system backup should be used for all volumes by default.
+                    description: |-
+                      DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used
+                      for all volumes by default.
                     nullable: true
                     type: boolean
                   defaultVolumesToRestic:
-                    description: "DefaultVolumesToRestic specifies whether restic
-                      should be used to take a backup of all pod volumes by default.
-                      \n Deprecated: this field is no longer used and will be removed
-                      entirely in future. Use DefaultVolumesToFsBackup instead."
+                    description: |-
+                      DefaultVolumesToRestic specifies whether restic should be used to take a
+                      backup of all pod volumes by default.
+
+                      Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.
                     nullable: true
                     type: boolean
                   excludedClusterScopedResources:
-                    description: ExcludedClusterScopedResources is a slice of cluster-scoped
-                      resource type names to exclude from the backup. If set to "*",
-                      all cluster-scoped resource types are excluded. The default
-                      value is empty.
+                    description: |-
+                      ExcludedClusterScopedResources is a slice of cluster-scoped
+                      resource type names to exclude from the backup.
+                      If set to "*", all cluster-scoped resource types are excluded.
+                      The default value is empty.
                     items:
                       type: string
                     nullable: true
                     type: array
                   excludedNamespaceScopedResources:
-                    description: ExcludedNamespaceScopedResources is a slice of namespace-scoped
-                      resource type names to exclude from the backup. If set to "*",
-                      all namespace-scoped resource types are excluded. The default
-                      value is empty.
+                    description: |-
+                      ExcludedNamespaceScopedResources is a slice of namespace-scoped
+                      resource type names to exclude from the backup.
+                      If set to "*", all namespace-scoped resource types are excluded.
+                      The default value is empty.
                     items:
                       type: string
                     nullable: true
                     type: array
                   excludedNamespaces:
-                    description: ExcludedNamespaces contains a list of namespaces
-                      that are not included in the backup.
+                    description: |-
+                      ExcludedNamespaces contains a list of namespaces that are not
+                      included in the backup.
                     items:
                       type: string
                     nullable: true
                     type: array
                   excludedResources:
-                    description: ExcludedResources is a slice of resource names that
-                      are not included in the backup.
+                    description: |-
+                      ExcludedResources is a slice of resource names that are not
+                      included in the backup.
                     items:
                       type: string
                     nullable: true
                     type: array
                   hooks:
-                    description: Hooks represent custom behaviors that should be executed
-                      at different phases of the backup.
+                    description: Hooks represent custom behaviors that should be
+                      executed at different phases of the backup.
                     properties:
                       resources:
-                        description: Resources are hooks that should be executed when
-                          backing up individual instances of a resource.
+                        description: Resources are hooks that should be executed
+                          when backing up individual instances of a resource.
                         items:
-                          description: BackupResourceHookSpec defines one or more
-                            BackupResourceHooks that should be executed based on the
-                            rules defined for namespaces, resources, and label selector.
+                          description: |-
+                            BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on
+                            the rules defined for namespaces, resources, and label selector.
                           properties:
                             excludedNamespaces:
                               description: ExcludedNamespaces specifies the namespaces
@@ -158,67 +171,67 @@ spec:
                               nullable: true
                               type: array
                             includedNamespaces:
-                              description: IncludedNamespaces specifies the namespaces
-                                to which this hook spec applies. If empty, it applies
+                              description: |-
+                                IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
                                 to all namespaces.
                               items:
                                 type: string
                               nullable: true
                               type: array
                             includedResources:
-                              description: IncludedResources specifies the resources
-                                to which this hook spec applies. If empty, it applies
+                              description: |-
+                                IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
                                 to all resources.
                               items:
                                 type: string
                               nullable: true
                               type: array
                             labelSelector:
-                              description: LabelSelector, if specified, filters the
-                                resources to which this hook spec applies.
+                              description: LabelSelector, if specified, filters
+                                the resources to which this hook spec applies.
                               nullable: true
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
+                                    selector requirements. The requirements are
+                                    ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
                                         description: key is the label key that the
                                           selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     required:
                                     - key
                                     - operator
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
@@ -226,10 +239,9 @@ spec:
                               description: Name is the name of this hook.
                               type: string
                             post:
-                              description: PostHooks is a list of BackupResourceHooks
-                                to execute after storing the item in the backup. These
-                                are executed after all "additional items" from item
-                                actions are processed.
+                              description: |-
+                                PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup.
+                                These are executed after all "additional items" from item actions are processed.
                               items:
                                 description: BackupResourceHook defines a hook for
                                   a resource.
@@ -238,17 +250,16 @@ spec:
                                     description: Exec defines an exec hook.
                                     properties:
                                       command:
-                                        description: Command is the command and arguments
-                                          to execute.
+                                        description: Command is the command and
+                                          arguments to execute.
                                         items:
                                           type: string
                                         minItems: 1
                                         type: array
                                       container:
-                                        description: Container is the container in
-                                          the pod where the command should be executed.
-                                          If not specified, the pod's first container
-                                          is used.
+                                        description: |-
+                                          Container is the container in the pod where the command should be executed. If not specified,
+                                          the pod's first container is used.
                                         type: string
                                       onError:
                                         description: OnError specifies how Velero
@@ -259,10 +270,9 @@ spec:
                                         - Fail
                                         type: string
                                       timeout:
-                                        description: Timeout defines the maximum amount
-                                          of time Velero should wait for the hook
-                                          to complete before considering the execution
-                                          a failure.
+                                        description: |-
+                                          Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                          considering the execution a failure.
                                         type: string
                                     required:
                                     - command
@@ -272,10 +282,9 @@ spec:
                                 type: object
                               type: array
                             pre:
-                              description: PreHooks is a list of BackupResourceHooks
-                                to execute prior to storing the item in the backup.
-                                These are executed before any "additional items" from
-                                item actions are processed.
+                              description: |-
+                                PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup.
+                                These are executed before any "additional items" from item actions are processed.
                               items:
                                 description: BackupResourceHook defines a hook for
                                   a resource.
@@ -284,17 +293,16 @@ spec:
                                     description: Exec defines an exec hook.
                                     properties:
                                       command:
-                                        description: Command is the command and arguments
-                                          to execute.
+                                        description: Command is the command and
+                                          arguments to execute.
                                         items:
                                           type: string
                                         minItems: 1
                                         type: array
                                       container:
-                                        description: Container is the container in
-                                          the pod where the command should be executed.
-                                          If not specified, the pod's first container
-                                          is used.
+                                        description: |-
+                                          Container is the container in the pod where the command should be executed. If not specified,
+                                          the pod's first container is used.
                                         type: string
                                       onError:
                                         description: OnError specifies how Velero
@@ -305,10 +313,9 @@ spec:
                                         - Fail
                                         type: string
                                       timeout:
-                                        description: Timeout defines the maximum amount
-                                          of time Velero should wait for the hook
-                                          to complete before considering the execution
-                                          a failure.
+                                        description: |-
+                                          Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                          considering the execution a failure.
                                         type: string
                                     required:
                                     - command
@@ -324,50 +331,56 @@ spec:
                         type: array
                     type: object
                   includeClusterResources:
-                    description: IncludeClusterResources specifies whether cluster-scoped
-                      resources should be included for consideration in the backup.
+                    description: |-
+                      IncludeClusterResources specifies whether cluster-scoped resources
+                      should be included for consideration in the backup.
                     nullable: true
                     type: boolean
                   includedClusterScopedResources:
-                    description: IncludedClusterScopedResources is a slice of cluster-scoped
-                      resource type names to include in the backup. If set to "*",
-                      all cluster-scoped resource types are included. The default
-                      value is empty, which means only related cluster-scoped resources
-                      are included.
+                    description: |-
+                      IncludedClusterScopedResources is a slice of cluster-scoped
+                      resource type names to include in the backup.
+                      If set to "*", all cluster-scoped resource types are included.
+                      The default value is empty, which means only related
+                      cluster-scoped resources are included.
                     items:
                       type: string
                     nullable: true
                     type: array
                   includedNamespaceScopedResources:
-                    description: IncludedNamespaceScopedResources is a slice of namespace-scoped
-                      resource type names to include in the backup. The default value
-                      is "*".
+                    description: |-
+                      IncludedNamespaceScopedResources is a slice of namespace-scoped
+                      resource type names to include in the backup.
+                      The default value is "*".
                     items:
                       type: string
                     nullable: true
                     type: array
                   includedNamespaces:
-                    description: IncludedNamespaces is a slice of namespace names
-                      to include objects from. If empty, all namespaces are included.
+                    description: |-
+                      IncludedNamespaces is a slice of namespace names to include objects
+                      from. If empty, all namespaces are included.
                     items:
                       type: string
                     nullable: true
                     type: array
                   includedResources:
-                    description: IncludedResources is a slice of resource names to
-                      include in the backup. If empty, all resources are included.
+                    description: |-
+                      IncludedResources is a slice of resource names to include
+                      in the backup. If empty, all resources are included.
                     items:
                       type: string
                     nullable: true
                     type: array
                   itemOperationTimeout:
-                    description: ItemOperationTimeout specifies the time used to wait
-                      for asynchronous BackupItemAction operations The default value
-                      is 1 hour.
+                    description: |-
+                      ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations
+                      The default value is 4 hour.
                     type: string
                   labelSelector:
-                    description: LabelSelector is a metav1.LabelSelector to filter
-                      with when adding individual objects to the backup. If empty
+                    description: |-
+                      LabelSelector is a metav1.LabelSelector to filter with
+                      when adding individual objects to the backup. If empty
                       or nil, all objects are included. Optional.
                     nullable: true
                     properties:
@@ -375,41 +388,42 @@ spec:
                         description: matchExpressions is a list of label selector
                           requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
                               description: key is the label key that the selector
                                 applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                           required:
                           - key
                           - operator
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
@@ -421,56 +435,58 @@ spec:
                         type: object
                     type: object
                   orLabelSelectors:
-                    description: OrLabelSelectors is list of metav1.LabelSelector
-                      to filter with when adding individual objects to the backup.
-                      If multiple provided they will be joined by the OR operator.
-                      LabelSelector as well as OrLabelSelectors cannot co-exist in
-                      backup request, only one of them can be used.
+                    description: |-
+                      OrLabelSelectors is list of metav1.LabelSelector to filter with
+                      when adding individual objects to the backup. If multiple provided
+                      they will be joined by the OR operator. LabelSelector as well as
+                      OrLabelSelectors cannot co-exist in backup request, only one of them
+                      can be used.
                     items:
-                      description: A label selector is a label query over a set of
-                        resources. The result of matchLabels and matchExpressions
-                        are ANDed. An empty label selector matches all objects. A
-                        null label selector matches no objects.
+                      description: |-
+                        A label selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty label selector matches all objects. A null
+                        label selector matches no objects.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector
                             requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector
                                   applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                             required:
                             - key
                             - operator
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
@@ -479,11 +495,10 @@ spec:
                   orderedResources:
                     additionalProperties:
                       type: string
-                    description: OrderedResources specifies the backup order of resources
-                      of specific Kind. The map key is the resource name and value
-                      is a list of object names separated by commas. Each resource
-                      name has format "namespace/objectname".  For cluster resources,
-                      simply use "objectname".
+                    description: |-
+                      OrderedResources specifies the backup order of resources of specific Kind.
+                      The map key is the resource name and value is a list of object names separated by commas.
+                      Each resource name has format "namespace/objectname".  For cluster resources, simply use "objectname".
                     nullable: true
                     type: object
                   resourcePolicy:
@@ -491,10 +506,10 @@ spec:
                       policies that backup should follow
                     properties:
                       apiGroup:
-                        description: APIGroup is the group for the resource being
-                          referenced. If APIGroup is not specified, the specified
-                          Kind must be in the core API group. For any other third-party
-                          types, APIGroup is required.
+                        description: |-
+                          APIGroup is the group for the resource being referenced.
+                          If APIGroup is not specified, the specified Kind must be in the core API group.
+                          For any other third-party types, APIGroup is required.
                         type: string
                       kind:
                         description: Kind is the type of resource being referenced
@@ -513,27 +528,29 @@ spec:
                     nullable: true
                     type: boolean
                   snapshotVolumes:
-                    description: SnapshotVolumes specifies whether to take snapshots
-                      of any PV's referenced in the set of objects included in the
-                      Backup.
+                    description: |-
+                      SnapshotVolumes specifies whether to take snapshots
+                      of any PV's referenced in the set of objects included
+                      in the Backup.
                     nullable: true
                     type: boolean
                   storageLocation:
-                    description: StorageLocation is a string containing the name of
-                      a BackupStorageLocation where the backup should be stored.
+                    description: StorageLocation is a string containing the name
+                      of a BackupStorageLocation where the backup should be stored.
                     type: string
                   ttl:
-                    description: TTL is a time.Duration-parseable string describing
-                      how long the Backup should be retained for.
+                    description: |-
+                      TTL is a time.Duration-parseable string describing how long
+                      the Backup should be retained for.
                     type: string
                   uploaderConfig:
-                    description: UploaderConfig specifies the configuration for the
-                      uploader.
+                    description: UploaderConfig specifies the configuration for
+                      the uploader.
                     nullable: true
                     properties:
                       parallelFilesUpload:
-                        description: ParallelFilesUpload is the number of files parallel
-                          uploads to perform when using the uploader.
+                        description: ParallelFilesUpload is the number of files
+                          parallel uploads to perform when using the uploader.
                         type: integer
                     type: object
                   volumeSnapshotLocations:
@@ -544,8 +561,9 @@ spec:
                     type: array
                 type: object
               useOwnerReferencesInBackup:
-                description: UseOwnerReferencesBackup specifies whether to use OwnerReferences
-                  on backups created by this Schedule.
+                description: |-
+                  UseOwnerReferencesBackup specifies whether to use
+                  OwnerReferences on backups created by this Schedule.
                 nullable: true
                 type: boolean
             required:
@@ -556,7 +574,8 @@ spec:
             description: ScheduleStatus captures the current state of a Velero schedule
             properties:
               lastBackup:
-                description: LastBackup is the last time a Backup was run for this
+                description: |-
+                  LastBackup is the last time a Backup was run for this
                   Schedule schedule
                 format: date-time
                 nullable: true
@@ -574,8 +593,9 @@ spec:
                 - FailedValidation
                 type: string
               validationErrors:
-                description: ValidationErrors is a slice of all validation errors
-                  (if applicable)
+                description: |-
+                  ValidationErrors is a slice of all validation errors (if
+                  applicable)
                 items:
                   type: string
                 type: array

--- a/helmfile.d/upstream/vmware-tanzu/velero/crds/serverstatusrequests.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/crds/serverstatusrequests.yaml
@@ -2,10 +2,10 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
   labels:
     component: velero
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
   name: serverstatusrequests.velero.io
 spec:
   group: velero.io
@@ -21,18 +21,24 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: ServerStatusRequest is a request to access current status information
-          about the Velero server.
+        description: |-
+          ServerStatusRequest is a request to access current status information about
+          the Velero server.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -49,8 +55,8 @@ spec:
                 - Processed
                 type: string
               plugins:
-                description: Plugins list information about the plugins running on
-                  the Velero server
+                description: Plugins list information about the plugins running
+                  on the Velero server
                 items:
                   description: PluginInfo contains attributes of a Velero plugin
                   properties:
@@ -65,8 +71,9 @@ spec:
                 nullable: true
                 type: array
               processedTimestamp:
-                description: ProcessedTimestamp is when the ServerStatusRequest was
-                  processed by the ServerStatusRequestController.
+                description: |-
+                  ProcessedTimestamp is when the ServerStatusRequest was processed
+                  by the ServerStatusRequestController.
                 format: date-time
                 nullable: true
                 type: string

--- a/helmfile.d/upstream/vmware-tanzu/velero/crds/volumesnapshotlocations.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/crds/volumesnapshotlocations.yaml
@@ -2,10 +2,10 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
   labels:
     component: velero
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
   name: volumesnapshotlocations.velero.io
 spec:
   group: velero.io
@@ -25,14 +25,19 @@ spec:
           snapshots.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -50,12 +55,17 @@ spec:
                   to be used with this location
                 properties:
                   key:
-                    description: The key of the secret to select from.  Must be a
-                      valid secret key.
+                    description: The key of the secret to select from.  Must be
+                      a valid secret key.
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
                   optional:
                     description: Specify whether the Secret or its key must be defined
@@ -75,8 +85,8 @@ spec:
               of a Velero VolumeSnapshotLocation.
             properties:
               phase:
-                description: VolumeSnapshotLocationPhase is the lifecycle phase of
-                  a Velero VolumeSnapshotLocation.
+                description: VolumeSnapshotLocationPhase is the lifecycle phase
+                  of a Velero VolumeSnapshotLocation.
                 enum:
                 - Available
                 - Unavailable

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/NOTES.txt
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/NOTES.txt
@@ -63,13 +63,14 @@ More info on the official site: https://velero.io/docs
 {{- end }}
 
 {{- range $key, $value := .Values.configMaps }}
-{{- eq $key "fs-restore-action-config" }}
+{{- if eq $key "fs-restore-action-config" }}
 {{- if hasKey $value.labels "velero.io/restic" }}
 {{- $breaking = print $breaking "\n\nREMOVED: velero.io/restic has been removed, and it is named velero.io/pod-volume-restore" }}
 {{- end }}
 {{- if and $value.data.image }}
 {{- if contains "velero-restic-restore-helper" $value.data.image }}
 {{- $breaking = print $breaking "\n\nREMOVED: restore helper image velero-restic-restore-helper has been changed to velero-restore-helper" }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/_helpers.tpl
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/_helpers.tpl
@@ -65,11 +65,33 @@ Create the Velero priority class name.
 {{- end -}}
 
 {{/*
+Create the Velero runtime class name.
+*/}}
+{{- define "velero.runtimeClassName" -}}
+{{- if .Values.runtimeClassName -}}
+  {{- .Values.runtimeClassName -}}
+{{- else -}}
+  {{- include "velero.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the node-Agent priority class name.
 */}}
 {{- define "velero.nodeAgent.priorityClassName" -}}
 {{- if .Values.nodeAgent.priorityClassName -}}
   {{- .Values.nodeAgent.priorityClassName -}}
+{{- else -}}
+  {{- include "velero.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the node-Agent runtime class name.
+*/}}
+{{- define "velero.nodeAgent.runtimeClassName" -}}
+{{- if .Values.nodeAgent.runtimeClassName -}}
+  {{- .Values.nodeAgent.runtimeClassName -}}
 {{- else -}}
   {{- include "velero.fullname" . -}}
 {{- end -}}

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/backupstoragelocation.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/backupstoragelocation.yaml
@@ -8,6 +8,12 @@ kind: BackupStorageLocation
 metadata:
   name: {{ .name | default "default" }}
   namespace: {{ $.Release.Namespace }}
+  {{- with .annotations }}
+  annotations:
+      {{- range $key, $value := . }}
+    {{- $key | nindent 4 }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/deployment.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/deployment.yaml
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     helm.sh/chart: {{ include "velero.chart" . }}
     component: velero
     {{- with .Values.labels }}
@@ -20,7 +21,7 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
-  {{- if .Values.revisionHistoryLimit }}
+  {{- if hasKey .Values "revisionHistoryLimit" }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   {{- end }}
   strategy:
@@ -36,6 +37,7 @@ spec:
         app.kubernetes.io/name: {{ include "velero.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         helm.sh/chart: {{ include "velero.chart" . }}
         {{- if .Values.podLabels }}
           {{- toYaml .Values.podLabels | nindent 8 }}
@@ -55,6 +57,10 @@ spec:
       {{- end }}
     {{- end }}
     spec:
+      {{- with .Values.hostAliases }}
+      hostAliases:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.imagePullSecrets }}
@@ -63,8 +69,12 @@ spec:
     {{- end }}
       restartPolicy: Always
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.server.automountServiceAccountToken }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ include "velero.priorityClassName" . }}
+      {{- end }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ include "velero.runtimeClassName" . }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
@@ -123,8 +133,14 @@ spec:
             {{- with .disableControllers }}
             - --disable-controllers={{ . }}
             {{- end }}
+            {{- with .disableInformerCache }}
+            - --disable-informer-cache={{ . }}
+            {{- end }}
             {{- with .garbageCollectionFrequency }}
             - --garbage-collection-frequency={{ . }}
+            {{- end }}
+            {{- with .itemBlockWorkerCount }}
+            - --item-block-worker-count={{ . }}
             {{- end }}
             {{- with .logFormat }}
             - --log-format={{ . }}
@@ -162,6 +178,31 @@ spec:
             {{- end }}
             {{- with .namespace }}
             - --namespace={{ . }}
+            {{- end }}
+            {{- with .repositoryMaintenanceJob }}
+            {{- with .requests }}
+            {{- with .cpu }}
+            - --maintenance-job-cpu-request={{ . }}
+            {{- end }}
+            {{- with .memory }}
+            - --maintenance-job-mem-request={{ . }}
+            {{- end }}
+            {{- end }}
+            {{- with .limits }}
+            {{- with .cpu }}
+            - --maintenance-job-cpu-limit={{ . }}
+            {{- end }}
+            {{- with .memory }}
+            - --maintenance-job-mem-limit={{ . }}
+            {{- end }}
+            {{- end }}
+            {{- with .latestJobsCount }}
+            - --keep-latest-maintenance-jobs={{ . }}
+            {{- end }}
+            {{- end }}
+            {{- with .extraArgs }}
+            ### User-supplied overwrite flags
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
           {{- with .Values.resources }}
@@ -222,10 +263,7 @@ spec:
               value: /credentials/cloud
           {{- end }}
           {{- with .Values.configuration.extraEnvVars }}
-          {{- range $key, $value := . }}
-            - name: {{ default "none" $key }}
-              value: {{ tpl (default "none" $value) $ | quote }}
-          {{- end }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.credentials.extraEnvVars }}
           {{- range $key, $value := . }}

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/label-namespace/labelnamespace.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/label-namespace/labelnamespace.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     spec:
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.server.automountServiceAccountToken }}
       containers:
       - name: label-namespace
         {{- if .Values.kubectl.image.digest }}
@@ -33,7 +34,15 @@ spec:
           {{- range .Values.namespace.labels }}
           kubectl label namespace {{ $.Release.Namespace }} {{ .key }}={{ .value }}
           {{- end }}
+        {{- if .Values.kubectl.extraVolumeMounts }}
+        volumeMounts:
+        {{- toYaml .Values.kubectl.extraVolumeMounts | nindent 8 }}
+        {{- end }}
       restartPolicy: Never
+      {{- if .Values.kubectl.extraVolumes }}
+      volumes:
+      {{- toYaml .Values.kubectl.extraVolumes | nindent 6 }}
+      {{- end }}
   backoffLimit: 3
 {{- end }}
 {{- end }}

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/node-agent-daemonset.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/node-agent-daemonset.yaml
@@ -26,12 +26,13 @@ spec:
     metadata:
       labels:
         name: node-agent
+        role: node-agent
         app.kubernetes.io/name: {{ include "velero.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         helm.sh/chart: {{ include "velero.chart" . }}
-      {{- if .Values.podLabels }}
-        {{- toYaml .Values.podLabels | nindent 8 }}
+      {{- if .Values.nodeAgent.podLabels }}
+        {{- toYaml .Values.nodeAgent.podLabels | nindent 8 }}
       {{- end }}
     {{- if or .Values.podAnnotations .Values.metrics.enabled (and .Values.credentials.useSecret (not .Values.credentials.existingSecret)) }}
       annotations:
@@ -48,6 +49,10 @@ spec:
       {{- end }}
     {{- end }}
     spec:
+      {{- with .Values.nodeAgent.hostAliases }}
+      hostAliases:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.imagePullSecrets }}
@@ -55,12 +60,16 @@ spec:
       {{- end }}
     {{- end }}
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.server.automountServiceAccountToken }}
       {{- with .Values.nodeAgent.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeAgent.priorityClassName }}
       priorityClassName: {{ include "velero.nodeAgent.priorityClassName" . }}
+      {{- end }}
+      {{- if .Values.nodeAgent.runtimeClassName }}
+      runtimeClassName: {{ include "velero.nodeAgent.runtimeClassName" . }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       volumes:
@@ -72,6 +81,9 @@ spec:
         - name: host-pods
           hostPath:
             path: {{ .Values.nodeAgent.podVolumePath }}
+        - name: host-plugins
+          hostPath:
+            path: {{ .Values.nodeAgent.pluginVolumePath | default "/var/lib/kubelet/plugins" }}
         {{- if .Values.nodeAgent.useScratchEmptyDir }}
         - name: scratch
           emptyDir: {}
@@ -102,12 +114,18 @@ spec:
             {{- with .features }}
             - --features={{ . }}
             {{- end }}
+            {{- with .dataMoverPrepareTimeout }}
+            - --data-mover-prepare-timeout={{ . }}
+            {{- end }}
             {{- with .logLevel }}
             - --log-level={{ . }}
             {{- end }}
             {{- with .logFormat }}
             - --log-format={{ . }}
             {{- end }}
+          {{- end }}
+          {{- with .Values.nodeAgent.extraArgs }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
             {{- if .Values.credentials.useSecret }}
@@ -116,6 +134,9 @@ spec:
             {{- end }}
             - name: host-pods
               mountPath: /host_pods
+              mountPropagation: HostToContainer
+            - name: host-plugins
+              mountPath: /host_plugins
               mountPropagation: HostToContainer
             {{- if .Values.nodeAgent.useScratchEmptyDir }}
             - name: scratch
@@ -151,10 +172,7 @@ spec:
               value: /credentials/cloud
           {{- end }}
           {{- with .Values.configuration.extraEnvVars }}
-          {{- range $key, $value := . }}
-            - name: {{ default "none" $key }}
-              value: {{ tpl (default "none" $value) $ | quote }}
-          {{- end }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.credentials.extraEnvVars }}
           {{- range $key, $value := . }}
@@ -166,10 +184,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- with .Values.nodeAgent.extraEnvVars }}
-          {{- range $key, $value := . }}
-            - name: {{ default "none" $key }}
-              value: {{ default "none" $value | quote }}
-          {{- end }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.lifecycle }}
           lifecycle: {{ toYaml .Values.nodeAgent.lifecycle | nindent 12 }}
@@ -194,8 +209,12 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.nodeAgent.dnsConfig }}
-    dnsConfig:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- with .Values.nodeAgent.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with .Values.nodeAgent.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/podmonitor.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/podmonitor.yaml
@@ -27,7 +27,7 @@ spec:
       app.kubernetes.io/name: {{ include "velero.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       name: node-agent
-    {{- with .Values.nodeAgent.labels }}
+    {{- with .Values.nodeAgent.podLabels }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
   podMetricsEndpoints:

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/schedule.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/schedule.yaml
@@ -5,8 +5,8 @@ kind: Schedule
 metadata:
   name: {{ include "velero.fullname" $ }}-{{ $scheduleName }}
   namespace: {{ $.Release.Namespace }}
-  annotations:
   {{- if $schedule.annotations }}
+  annotations:
     {{- toYaml $schedule.annotations | nindent 4 }}
   {{- end }}
   labels:
@@ -18,8 +18,14 @@ metadata:
       {{- toYaml $schedule.labels | nindent 4 }}
     {{- end }}
 spec:
+{{- if $schedule.paused }}
+  paused: {{ $schedule.paused }}
+{{- end }}
 {{- if $schedule.useOwnerReferencesInBackup }}
   useOwnerReferencesInBackup: {{ $schedule.useOwnerReferencesInBackup }}
+{{- end }}
+{{- if $schedule.skipImmediately }}
+  skipImmediately: {{ $schedule.skipImmediately }}
 {{- end }}
   schedule: {{ $schedule.schedule | quote }}
 {{- with $schedule.template }}

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/service.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/service.yaml
@@ -17,10 +17,25 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  type: ClusterIP
+  {{- if .Values.metrics.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.metrics.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if .Values.metrics.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ .Values.metrics.service.internalTrafficPolicy }}
+  {{- end }}
+  {{- if .Values.metrics.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.metrics.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.metrics.service.ipFamilies }}
+  ipFamilies: {{ toYaml .Values.metrics.service.ipFamilies | nindent 4 }}
+  {{- end }}
+  type: {{ .Values.metrics.service.type }}
   ports:
     - name: http-monitoring
       port: 8085
+      {{- if ( and (eq .Values.metrics.service.type "NodePort" ) (not (empty .Values.metrics.service.nodePort)) ) }}
+      nodePort: {{ .Values.metrics.service.nodePort }}
+      {{- end }}
       targetPort: http-monitoring
   selector:
     name: velero

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/serviceaccount-server.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/serviceaccount-server.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 {{- if .Values.serviceAccount.server.annotations }}
   annotations:
-{{ toYaml .Values.serviceAccount.server.annotations | nindent 4 }}
+{{- toYaml .Values.serviceAccount.server.annotations | nindent 4 }}
 {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
@@ -16,4 +16,11 @@ metadata:
 {{- with .Values.serviceAccount.server.labels }}
   {{- toYaml . | nindent 4 }}
 {{- end }}
+{{- if .Values.serviceAccount.server.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.serviceAccount.server.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.server.automountServiceAccountToken }}
 {{- end }}

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/upgrade-crds/serviceaccount-upgrade.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/upgrade-crds/serviceaccount-upgrade.yaml
@@ -9,7 +9,7 @@ metadata:
     "helm.sh/hook-weight": "-4"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 {{- if .Values.serviceAccount.server.annotations }}
-{{ toYaml .Values.serviceAccount.server.annotations | nindent 4 }}
+{{- toYaml .Values.serviceAccount.server.annotations | nindent 4 }}
 {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
@@ -19,4 +19,11 @@ metadata:
 {{- with .Values.serviceAccount.server.labels }}
   {{- toYaml . | nindent 4 }}
 {{- end }}
+{{- if .Values.serviceAccount.server.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.serviceAccount.server.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+automountServiceAccountToken: {{ .Values.upgradeCRDsJob.automountServiceAccountToken }}
 {{- end }}

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -39,6 +39,7 @@ spec:
       {{- end }}
     {{- end }}
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}-upgrade-crds
+      automountServiceAccountToken: {{ .Values.upgradeCRDsJob.automountServiceAccountToken }}
       initContainers:
         - name: kubectl
           {{- if .Values.kubectl.image.digest }}
@@ -74,10 +75,10 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - /tmp/sh
+            - {{ .Values.upgradeCRDsJob.shellCmd | default "/tmp/sh" }}
           args:
             - -c
-            - /velero install --crds-only --dry-run -o yaml | /tmp/kubectl apply -f -
+            - {{ .Values.upgradeCRDsJob.updateCmd | default "/velero install --crds-only --dry-run -o yaml | /tmp/kubectl apply -f -" }}
           {{- with .Values.upgradeJobResources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -95,10 +96,7 @@ spec:
           {{- if (.Values.upgradeCRDsJob).extraEnvVars }}
           env:
           {{- with .Values.upgradeCRDsJob.extraEnvVars }}
-          {{- range $key, $value := . }}
-            - name: {{ default "none" $key }}
-              value: {{ default "none" $value | quote }}
-          {{- end }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
       volumes:

--- a/helmfile.d/upstream/vmware-tanzu/velero/templates/volumesnapshotlocation.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/templates/volumesnapshotlocation.yaml
@@ -8,6 +8,12 @@ kind: VolumeSnapshotLocation
 metadata:
   name: {{ .name | default "default" }}
   namespace: {{ $.Release.Namespace }}
+  {{- with .annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{- $key | nindent 4 }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}

--- a/helmfile.d/upstream/vmware-tanzu/velero/values.schema.json
+++ b/helmfile.d/upstream/vmware-tanzu/velero/values.schema.json
@@ -1,0 +1,731 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Schema for Velero helm chart",
+    "type": "object",
+    "properties": {
+        "namespace": {
+            "type": "object",
+            "properties": {
+                "labels": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+            },
+            "required": []
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                },
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "items": {}
+                }
+            },
+            "required": [
+                "repository",
+                "tag",
+                "pullPolicy"
+            ]
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "annotations": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        },
+        "secretAnnotations": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        },
+        "labels": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        },
+        "podAnnotations": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        },
+        "podLabels": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        },
+        "resources": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        },
+        "upgradeJobResources": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        },
+        "upgradeCRDsJob": {
+            "type": "object",
+            "properties": {
+                "extraVolumes": {
+                    "type": "array",
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "items": {}
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "automountServiceAccountToken"
+            ]
+        },
+        "dnsPolicy": {
+            "type": "string"
+        },
+        "initContainers": {
+            "type": ["array", "null"],
+            "items": {}
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        },
+        "containerSecurityContext": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        },
+        "lifecycle": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        },
+        "priorityClassName": {
+            "type": "string"
+        },
+        "runtimeClassName": {
+            "type": "string"
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "number"
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        },
+        "tolerations": {
+            "type": "array",
+            "items": {}
+        },
+        "affinity": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        },
+        "nodeSelector": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        },
+        "dnsConfig": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        },
+        "extraVolumes": {
+            "type": "array",
+            "items": {}
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "items": {}
+        },
+        "extraObjects": {
+            "type": "array",
+            "items": {}
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "scrapeInterval": {
+                    "type": "string"
+                },
+                "scrapeTimeout": {
+                    "type": "string"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "properties": {},
+                            "required": []
+                        },
+                        "labels": {
+                            "type": "object",
+                            "properties": {},
+                            "required": []
+                        }
+                    },
+                    "required": []
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus.io/scrape": {
+                            "type": "string"
+                        },
+                        "prometheus.io/port": {
+                            "type": "string"
+                        },
+                        "prometheus.io/path": {
+                            "type": "string"
+                        }
+                    },
+                    "required": []
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "autodetect": {
+                            "type": "boolean"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {},
+                            "required": []
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "properties": {},
+                            "required": []
+                        }
+                    },
+                    "required": [
+                        "autodetect",
+                        "enabled"
+                    ]
+                },
+                "nodeAgentPodMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "autodetect": {
+                            "type": "boolean"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {},
+                            "required": []
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "properties": {},
+                            "required": []
+                        }
+                    },
+                    "required": [
+                        "autodetect",
+                        "enabled"
+                    ]
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "autodetect": {
+                            "type": "boolean"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "additionalLabels": {
+                            "type": "object",
+                            "properties": {},
+                            "required": []
+                        },
+                        "spec": {
+                            "type": "array",
+                            "items": {}
+                        }
+                    },
+                    "required": [
+                        "autodetect",
+                        "enabled"
+                    ]
+                }
+            },
+            "required": [
+                "enabled",
+                "scrapeInterval",
+                "scrapeTimeout",
+                "service",
+                "podAnnotations",
+                "serviceMonitor",
+                "nodeAgentPodMonitor",
+                "prometheusRule"
+            ]
+        },
+        "kubectl": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "repository": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "repository"
+                    ]
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                },
+                "annotations": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                },
+                "labels": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "items": {}
+                }
+            },
+            "required": [
+                "image"
+            ]
+        },
+        "upgradeCRDs": {
+            "type": "boolean"
+        },
+        "cleanUpCRDs": {
+            "type": "boolean"
+        },
+        "configuration": {
+            "type": "object",
+            "properties": {
+                "backupStorageLocation": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": ["string", "null"]
+                            },
+                            "provider": {
+                                "type": ["string"]
+                            },
+                            "bucket": {
+                                "type": ["string"]
+                            },
+                            "caCert": {
+                                "type": ["string", "null"]
+                            },
+                            "prefix": {
+                                "type": ["string", "null"]
+                            },
+                            "default": {
+                                "type": ["boolean", "null"]
+                            },
+                            "validationFrequency": {
+                                "type": ["string", "null"]
+                            },
+                            "accessMode": {
+                                "type": ["string", "null"]
+                            },
+                            "credential": {
+                                "type": "object",
+                                "properties": {},
+                                "required": []
+                            },
+                            "config": {
+                                "type": "object",
+                                "properties": {},
+                                "required": []
+                            },
+                            "annotations": {
+                                "type": "object",
+                                "properties": {},
+                                "required": []
+                            }
+                        },
+                        "required": [
+                            "provider",
+                            "bucket"
+                        ]
+                    }
+                },
+                "volumeSnapshotLocation": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": ["string", "null"]
+                            },
+                            "provider": {
+                                "type": ["string"]
+                            },
+                            "credential": {
+                                "type": "object",
+                                "properties": {},
+                                "required": []
+                            },
+                            "config": {
+                                "type": "object",
+                                "properties": {},
+                                "required": []
+                            },
+                            "annotations": {
+                                "type": "object",
+                                "properties": {},
+                                "required": []
+                            }
+                        },
+                        "required": [
+                           "provider"
+                        ]
+                    }
+                },
+                "repositoryMaintenanceJob": {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": ["object", "null"],
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": []
+                        },
+                        "limits": {
+                            "type": ["object", "null"],
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": []
+                        },
+                        "latestJobsCount": {
+                            "type": "number"
+                        }
+                    },
+                    "required": []
+                },
+                "namespace": {
+                    "type": ["string", "null"]
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "items": {}
+                }
+            },
+            "required": []
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean"
+                },
+                "clusterAdministrator": {
+                    "type": "boolean"
+                },
+                "clusterAdministratorName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "create",
+                "clusterAdministrator",
+                "clusterAdministratorName"
+            ]
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "server": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": ["string", "null"]
+                        },
+                        "annotations": {
+                            "type": ["object", "null"],
+                            "properties": {},
+                            "required": []
+                        },
+                        "labels": {
+                            "type": ["object", "null"],
+                            "properties": {},
+                            "required": []
+                        },
+                        "imagePullSecrets": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": [
+                        "create",
+                        "automountServiceAccountToken"
+                    ]
+                }
+            },
+            "required": [
+                "server"
+            ]
+        },
+        "credentials": {
+            "type": "object",
+            "properties": {
+                "useSecret": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": ["string", "null"]
+                },
+                "existingSecret": {
+                    "type": ["string", "null"]
+                },
+                "secretContents": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                },
+                "extraEnvVars": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                },
+                "extraSecretRef": {
+                    "type": "string"
+                }
+            },
+            "required": []
+        },
+        "backupsEnabled": {
+            "type": "boolean"
+        },
+        "snapshotsEnabled": {
+            "type": "boolean"
+        },
+        "deployNodeAgent": {
+            "type": "boolean"
+        },
+        "nodeAgent": {
+            "type": "object",
+            "properties": {
+                "podVolumePath": {
+                    "type": "string"
+                },
+                "pluginVolumePath": {
+                    "type": "string"
+                },
+                "priorityClassName": {
+                    "type": "string"
+                },
+                "runtimeClassName": {
+                    "type": "string"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                },
+                "tolerations": {
+                    "type": "array",
+                    "items": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                },
+                "labels": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                },
+                "podLabels": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                },
+                "useScratchEmptyDir": {
+                    "type": "boolean"
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "items": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "items": {}
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "items": {}
+                },
+                "dnsPolicy": {
+                    "type": "string"
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                },
+                "lifecycle": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                },
+                "affinity": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                },
+                "dnsConfig": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+            },
+            "required": [
+                "podVolumePath",
+                "dnsPolicy"
+            ]
+        },
+        "schedules": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        },
+        "configMaps": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        }
+    },
+    "required": [
+        "image",
+        "upgradeCRDsJob",
+        "dnsPolicy",
+        "metrics",
+        "kubectl",
+        "configuration",
+        "rbac",
+        "serviceAccount",
+        "credentials",
+        "configMaps"
+    ],
+    "dependencies": {
+      "deployNodeAgent": {
+        "oneOf": [
+          {
+            "properties": {
+              "deployNodeAgent": { "const": false }
+            }
+          },
+          {
+            "properties": {
+              "deployNodeAgent": { "const": true }
+            },
+            "required": ["nodeAgent"]
+          }
+        ]
+      }
+    }
+}

--- a/helmfile.d/upstream/vmware-tanzu/velero/values.yaml
+++ b/helmfile.d/upstream/vmware-tanzu/velero/values.yaml
@@ -33,7 +33,7 @@ namespace:
 # enabling node-agent). Required.
 image:
   repository: velero/velero
-  tag: v1.13.0
+  tag: v1.16.1
   # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
   # If used, it will take precedence over the image.tag.
   # digest:
@@ -73,13 +73,21 @@ podLabels: {}
 
 # Resource requests/limits to specify for the Velero deployment.
 # https://velero.io/docs/v1.6/customize-installation/#customize-resource-requests-and-limits
-resources:
-  requests:
-    cpu: 500m
-    memory: 128Mi
-  limits:
-    cpu: 1000m
-    memory: 512Mi
+resources: {}
+  # requests:
+  #   cpu: 500m
+  #   memory: 128Mi
+  # limits:
+  #   cpu: 1000m
+  #   memory: 512Mi
+
+# Configure hostAliases for Velero deployment. Optional
+# For more information, check: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
+hostAliases: []
+  # - ip: "127.0.0.1"
+  #   hostnames:
+  #     - "foo.local"
+  #     - "bar.local"
 
 # Resource requests/limits to specify for the upgradeCRDs job pod. Need to be adjusted by user accordingly.
 upgradeJobResources: {}
@@ -94,9 +102,23 @@ upgradeCRDsJob:
   extraVolumes: []
   # Extra volumeMounts for the Upgrade CRDs Job. Optional.
   extraVolumeMounts: []
-  # Extra key/value pairs to be used as environment variables. Optional.
-  extraEnvVars: {}
+  # Additional values to be used as environment variables. Optional.
+  extraEnvVars: []
+    # Simple value
+    # - name: SIMPLE_VAR
+    #   value: "simple-value"
 
+    # FieldRef example
+    # - name: MY_POD_LABEL
+    #   valueFrom:
+    #     fieldRef:
+    #       fieldPath: metadata.labels['my_label']
+
+  # Configure if API credential for Service Account is automounted.
+  automountServiceAccountToken: true
+  # Configure the shell cmd in case you are using custom image
+  # shellCmd: /tmp/sh
+  # updateCmd: /velero install --crds-only --dry-run -o yaml | /tmp/kubectl apply -f -
 
 # Configure the dnsPolicy of the Velero deployment
 # See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
@@ -105,14 +127,8 @@ dnsPolicy: ClusterFirst
 # Init containers to add to the Velero deployment's pod spec. At least one plugin provider image is required.
 # If the value is a string then it is evaluated as a template.
 initContainers:
-  # - name: velero-plugin-for-csi
-  #   image: velero/velero-plugin-for-csi:v0.7.0
-  #   imagePullPolicy: IfNotPresent
-  #   volumeMounts:
-  #     - mountPath: /target
-  #       name: plugins
   # - name: velero-plugin-for-aws
-  #   image: velero/velero-plugin-for-aws:v1.9.0
+  #   image: velero/velero-plugin-for-aws:v1.12.1
   #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target
@@ -138,6 +154,9 @@ lifecycle: {}
 
 # Pod priority class name to use for the Velero deployment. Optional.
 priorityClassName: ""
+
+# Pod runtime class name to use for the Velero deployment. Optional.
+runtimeClassName: ""
 
 # The number of seconds to allow for graceful termination of the pod. Optional.
 terminationGracePeriodSeconds: 3600
@@ -219,7 +238,19 @@ metrics:
   # service metdata if metrics are enabled
   service:
     annotations: {}
+    type: ClusterIP
     labels: {}
+    nodePort: null
+
+    # External/Internal traffic policy setting (Cluster, Local)
+    # https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-policies
+    externalTrafficPolicy: ""
+    internalTrafficPolicy: ""
+
+    # the IP family policy for the metrics Service to be able to configure dual-stack; see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services).
+    ipFamilyPolicy: ""
+    # a list of IP families for the metrics Service that should be supported, in the order in which they should be applied to ClusterIP. Can be "IPv4" and/or "IPv6".
+    ipFamilies: []
 
   # Pod annotations for Prometheus
   podAnnotations:
@@ -265,19 +296,40 @@ metrics:
     # namespace: ""
     # Rules to be deployed
     spec: []
-    # - alert: VeleroBackupPartialFailures
+    # - alert: VeleroBackupFailed
     #   annotations:
-    #     message: Velero backup {{ $labels.schedule }} has {{ $value | humanizePercentage }} partialy failed backups.
+    #     message: Velero backup {{ $labels.schedule }} has failed
     #   expr: |-
-    #     velero_backup_partial_failure_total{schedule!=""} / velero_backup_attempt_total{schedule!=""} > 0.25
+    #     velero_backup_last_status{schedule!=""} != 1
     #   for: 15m
     #   labels:
     #     severity: warning
-    # - alert: VeleroBackupFailures
+    # - alert: VeleroBackupFailing
     #   annotations:
-    #     message: Velero backup {{ $labels.schedule }} has {{ $value | humanizePercentage }} failed backups.
+    #     message: Velero backup {{ $labels.schedule }} has been failing for the last 12h
     #   expr: |-
-    #     velero_backup_failure_total{schedule!=""} / velero_backup_attempt_total{schedule!=""} > 0.25
+    #     velero_backup_last_status{schedule!=""} != 1
+    #   for: 12h
+    #   labels:
+    #     severity: critical
+    # - alert: VeleroNoNewBackup
+    #   annotations:
+    #     message: Velero backup {{ $labels.schedule }} has not run successfuly in the last 30h
+    #   expr: |-
+    #     (
+    #     rate(velero_backup_last_successful_timestamp{schedule!=""}[15m]) <=bool 0
+    #     or
+    #     absent(velero_backup_last_successful_timestamp{schedule!=""})
+    #     ) == 1
+    #   for: 30h
+    #   labels:
+    #     severity: critical
+    # - alert: VeleroBackupPartialFailures
+    #   annotations:
+    #     message: Velero backup {{ $labels.schedule }} has {{ $value | humanizePercentage }} partialy failed backups
+    #   expr: |-
+    #     rate(velero_backup_partial_failure_total{schedule!=""}[25m])
+    #       / rate(velero_backup_attempt_total{schedule!=""}[25m]) > 0.5
     #   for: 15m
     #   labels:
     #     severity: warning
@@ -299,6 +351,10 @@ kubectl:
   annotations: {}
   # Labels to set for the upgrade/cleanup job. Optional.
   labels: {}
+  # Extra volumes for the upgrade/cleanup job. Optional.
+  extraVolumes: []
+  # Extra volumeMounts for the upgrade/cleanup job.. Optional.
+  extraVolumeMounts: []
 
 # This job upgrades the CRDs.
 upgradeCRDs: true
@@ -324,15 +380,15 @@ configuration:
     # a backup storage location will be created with the name "default". Optional.
   - name:
     # provider is the name for the backup storage location provider.
-    provider:
+    provider: ""
     # bucket is the name of the bucket to store backups in. Required.
-    bucket:
+    bucket: ""
     # caCert defines a base64 encoded CA bundle to use when verifying TLS connections to the provider. Optional.
     caCert:
     # prefix is the directory under which all Velero data should be stored within the bucket. Optional.
     prefix:
     # default indicates this location is the default backup storage location. Optional.
-    default:
+    default: false
     # validationFrequency defines how frequently Velero should validate the object storage. Optional.
     validationFrequency:
     # accessMode determines if velero can write to this backup storage location. Optional.
@@ -362,13 +418,17 @@ configuration:
     #  flag. For Velero client Command like velero backup describe, velero backup logs needs to add the flag --insecure-skip-tls-verify
     #  insecureSkipTLSVerify:
 
+    # annotations allows adding arbitrary annotations to this BackupStorageLocation resource. Optional.
+    annotations: {}
+
   # Parameters for the VolumeSnapshotLocation(s). Configure multiple by adding other element(s) to the volumeSnapshotLocation slice.
   # See https://velero.io/docs/v1.6/api-types/volumesnapshotlocation/
   volumeSnapshotLocation:
-    # name is the name of the volume snapshot location where snapshots are being taken. Required.
+    # name is the name of the volume snapshot location where snapshots are being taken. If a name is not provided,
+    # a volume snapshot location will be created with the name "default". Optional.
   - name:
     # provider is the name for the volume snapshot provider.
-    provider:
+    provider: ""
     credential:
       # name of the secret used by this volumeSnapshotLocation.
       name:
@@ -385,6 +445,9 @@ configuration:
   #    incremental:
   #    snapshotLocation:
   #    project:
+
+    # annotations allows adding arbitrary annotations to this VolumeSnapshotLocation resource. Optional.
+    annotations: {}
 
   # These are server-level settings passed as CLI flags to the `velero server` command. Velero
   # uses default values if they're not passed in, so they only need to be explicitly specified
@@ -413,8 +476,12 @@ configuration:
   defaultVolumeSnapshotLocations:
   # `velero server` default: empty
   disableControllers:
+  # `velero server` default: false
+  disableInformerCache: false
   # `velero server` default: 1h
   garbageCollectionFrequency:
+  # `velero server` default: 1
+  itemBlockWorkerCount:
   # Set log-format for Velero pod. Default: text. Other option: json.
   logFormat:
   # Set log-level for Velero pod. Default: info. Other options: debug, warning, error, fatal, panic.
@@ -438,11 +505,36 @@ configuration:
   # Comma separated list of velero feature flags. default: empty
   # features: EnableCSI
   features:
+  # Configures the timeout for provisioning the volume created from the CSI snapshot. Default: 30m
+  dataMoverPrepareTimeout:
+  # Resource requests/limits to specify for the repository-maintenance job. Optional.
+  # https://velero.io/docs/v1.14/repository-maintenance/#resource-limitation
+  repositoryMaintenanceJob:
+    requests:
+    #   cpu: 500m
+    #   memory: 512Mi
+    limits:
+    #   cpu: 1000m
+    #   memory: 1024Mi
+    # Number of latest maintenance jobs to keep for each repository
+    latestJobsCount: 3
   # `velero server` default: velero
   namespace:
+  # additional command-line arguments that will be passed to the `velero server`
+  # e.g.: extraArgs: ["--foo=bar"]
+  extraArgs: []
 
-  # additional key/value pairs to be used as environment variables such as "AWS_CLUSTER_NAME: 'yourcluster.domain.tld'"
-  extraEnvVars: {}
+  # Additional values to be used as environment variables. Optional.
+  extraEnvVars: []
+    # Simple value
+    # - name: SIMPLE_VAR
+    #   value: "simple-value"
+
+    # FieldRef example
+    # - name: MY_POD_LABEL
+    #   valueFrom:
+    #     fieldRef:
+    #       fieldPath: metadata.labels['my_label']
 
   # Set true for backup all pod volumes without having to apply annotation on the pod when used file system backup Default: false.
   defaultVolumesToFsBackup:
@@ -474,6 +566,10 @@ serviceAccount:
     name:
     annotations:
     labels:
+    imagePullSecrets: []
+    # - registrySecretName
+    # Configure if API credential for Service Account is automounted.
+    automountServiceAccountToken: true
 
 # Info about the secret to be used by the Velero deployment, which
 # should contain credentials for the cloud provider IAM account you've
@@ -518,17 +614,20 @@ deployNodeAgent: false
 
 nodeAgent:
   podVolumePath: /var/lib/kubelet/pods
+  pluginVolumePath: /var/lib/kubelet/plugins
   # Pod priority class name to use for the node-agent daemonset. Optional.
   priorityClassName: ""
+  # Pod runtime class name to use for the node-agent daemonset. Optional.
+  runtimeClassName: ""
   # Resource requests/limits to specify for the node-agent daemonset deployment. Optional.
   # https://velero.io/docs/v1.6/customize-installation/#customize-resource-requests-and-limits
-  resources:
-    requests:
-      cpu: 500m
-      memory: 512Mi
-    limits:
-      cpu: 1000m
-      memory: 1024Mi
+  resources: {}
+    # requests:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # limits:
+    #   cpu: 1000m
+    #   memory: 1024Mi
 
   # Tolerations to use for the node-agent daemonset. Optional.
   tolerations: []
@@ -538,6 +637,10 @@ nodeAgent:
 
   # labels to set for the node-agent daemonset. Optional.
   labels: {}
+
+  # Additional pod labels for the node-agent daemonset. Optional
+  # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
 
   # will map /scratch to emptyDir. Set to false and specify your own volume
   # via extraVolumes and extraVolumeMounts that maps to /scratch
@@ -550,12 +653,33 @@ nodeAgent:
   # Extra volumeMounts for the node-agent daemonset. Optional.
   extraVolumeMounts: []
 
-  # Key/value pairs to be used as environment variables for the node-agent daemonset. Optional.
-  extraEnvVars: {}
+  # Additional values to be used as environment variables for node-agent daemonset. Optional.
+  extraEnvVars: []
+    # Simple key/value
+    # - name: SIMPLE_VAR
+    #   value: "simple-value"
+
+    # FieldRef example
+    # - name: MY_POD_LABEL
+    #   valueFrom:
+    #     fieldRef:
+    #       fieldPath: metadata.labels['my_label']
+
+  # Additional command-line arguments that will be passed to the node-agent. Optional.
+  # e.g.: extraArgs: ["--foo=bar"]
+  extraArgs: []
 
   # Configure the dnsPolicy of the node-agent daemonset
   # See: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ClusterFirst
+
+  # Configure hostAliases for node-agent daemonset. Optional
+  # For more information, check: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
+  hostAliases: []
+    # - ip: "127.0.0.1"
+    #   hostnames:
+    #   - "foo.local"
+    #   - "bar.local"
 
   # SecurityContext to use for the Velero deployment. Optional.
   # Set fsGroup for `AWS IAM Roles for Service Accounts`
@@ -580,6 +704,9 @@ nodeAgent:
   # DNS configuration to use for the node-agent daemonset. Optional.
   dnsConfig: {}
 
+  # Update strategy to use for the node-agent daemonset. Optional.
+  updateStrategy: {}
+
 # Backup schedules to create.
 # Eg:
 # schedules:
@@ -591,11 +718,18 @@ nodeAgent:
 #       myenv: foo
 #     schedule: "0 0 * * *"
 #     useOwnerReferencesInBackup: false
+#     paused: false
+#     skipImmediately: false
 #     template:
 #       ttl: "240h"
 #       storageLocation: default
 #       includedNamespaces:
 #       - foo
+#       # See: https://velero.io/docs/v1.14/resource-filtering/#excludes
+#       excludedNamespaceScopedResources:
+#       - persistentVolumeClaims
+#       excludedClusterScopedResources:
+#       - persistentVolumes
 schedules: {}
 
 # Velero ConfigMaps.

--- a/helmfile.d/values/networkpolicy/common.yaml.gotmpl
+++ b/helmfile.d/values/networkpolicy/common.yaml.gotmpl
@@ -65,6 +65,7 @@ global:
         - protocol: TCP
           port: {{ . }}
         {{- end }}
+  clusterDns: {{ .Values.global.clusterDns}}
 
 monitoring:
   enabled: {{ .Values.networkPolicies.monitoring.enabled }}

--- a/helmfile.d/values/podsecuritypolicies/common/velero.yaml.gotmpl
+++ b/helmfile.d/values/podsecuritypolicies/common/velero.yaml.gotmpl
@@ -12,6 +12,8 @@ constraints:
         allowedHostPaths:
           - pathPrefix: /var/lib/kubelet/pods
             readOnly: false
+          - pathPrefix: /var/lib/kubelet/plugins
+            readOnly: false
         runAsUser:
           rule: RunAsAny
         privileged: true

--- a/helmfile.d/values/podsecuritypolicies/common/velero.yaml.gotmpl
+++ b/helmfile.d/values/podsecuritypolicies/common/velero.yaml.gotmpl
@@ -35,3 +35,15 @@ constraints:
           rule: MustRunAsNonRoot
       mutation:
         runAsUser: 1000
+    repo-maintenance:
+      podSelectorExpressions:
+        - key: velero.io/repo-name
+          operator: Exists
+      allow:
+        runAsUser:
+          rule: MustRunAsNonRoot
+      metadata:
+        labels:
+          app: velero-repo-maintenance
+      mutation:
+        runAsUser: 1002

--- a/helmfile.d/values/velero/sc.yaml.gotmpl
+++ b/helmfile.d/values/velero/sc.yaml.gotmpl
@@ -13,22 +13,9 @@ nodeSelector: {{- toYaml .Values.velero.nodeSelector | nindent 2  }}
   "repository" (ternary (dig "uri" "" .Values.images.global.repository) "" .Values.images.global.repository.enabled)
 }}
 initContainers:
-  {{- if .Values.velero.useVolumeSnapshots }}
-  - name: velero-plugin-for-csi
-    image: {{ include "velero.plugin_image" (dict "images" .Values.images "key" "pluginCsi" "default" "velero/velero-plugin-for-csi:v0.7.1") }}
-    imagePullPolicy: IfNotPresent
-    securityContext:
-      allowPrivilegeEscalation: false
-      runAsNonRoot: true
-      runAsGroup: 10000
-      runAsUser: 10000
-    volumeMounts:
-      - mountPath: /target
-        name: plugins
-  {{- end }}
   {{- if eq .Values.objectStorage.type "s3" }}
   - name: velero-plugin-for-aws
-    image: {{ include "velero.plugin_image" (dict "images" .Values.images "key" "pluginAws" "default" "velero/velero-plugin-for-aws:v1.9.0") }}
+    image: {{ include "velero.plugin_image" (dict "images" .Values.images "key" "pluginAws" "default" "velero/velero-plugin-for-aws:v1.12.2") }}
     imagePullPolicy: IfNotPresent
     securityContext:
       allowPrivilegeEscalation: false
@@ -40,7 +27,7 @@ initContainers:
         name: plugins
   {{- else if eq .Values.objectStorage.type "gcs" }}
   - name: velero-plugin-for-gcs
-    image: {{ include "velero.plugin_image" (dict "images" .Values.images "key" "pluginGcp" "default" "velero/velero-plugin-for-gcp:v1.9.1") }}
+    image: {{ include "velero.plugin_image" (dict "images" .Values.images "key" "pluginGcp" "default" "velero/velero-plugin-for-gcp:v1.12.2") }}
     imagePullPolicy: IfNotPresent
     securityContext:
       allowPrivilegeEscalation: false
@@ -52,7 +39,7 @@ initContainers:
         name: plugins
   {{- else if eq .Values.objectStorage.type "azure" }}
   - name: velero-plugin-for-microsoft-azure
-    image: {{ include "velero.plugin_image" (dict "images" .Values.images "key" "pluginAzure" "default" "velero/velero-plugin-for-microsoft-azure:v1.9.2") }}
+    image: {{ include "velero.plugin_image" (dict "images" .Values.images "key" "pluginAzure" "default" "velero/velero-plugin-for-microsoft-azure:v1.12.2") }}
     imagePullPolicy: IfNotPresent
     securityContext:
       allowPrivilegeEscalation: false

--- a/helmfile.d/values/velero/wc.yaml.gotmpl
+++ b/helmfile.d/values/velero/wc.yaml.gotmpl
@@ -13,22 +13,9 @@ nodeSelector: {{- toYaml .Values.velero.nodeSelector | nindent 2  }}
   "repository" (ternary (dig "uri" "" .Values.images.global.repository) "" .Values.images.global.repository.enabled)
 }}
 initContainers:
-  {{- if .Values.velero.useVolumeSnapshots }}
-  - name: velero-plugin-for-csi
-    image: {{ include "velero.plugin_image" (dict "images" .Values.images "key" "pluginCsi" "default" "velero/velero-plugin-for-csi:v0.7.1") }}
-    imagePullPolicy: IfNotPresent
-    securityContext:
-      allowPrivilegeEscalation: false
-      runAsNonRoot: true
-      runAsGroup: 10000
-      runAsUser: 10000
-    volumeMounts:
-      - mountPath: /target
-        name: plugins
-  {{- end }}
   {{- if eq .Values.objectStorage.type "s3" }}
   - name: velero-plugin-for-aws
-    image: {{ include "velero.plugin_image" (dict "images" .Values.images "key" "pluginAws" "default" "velero/velero-plugin-for-aws:v1.9.0") }}
+    image: {{ include "velero.plugin_image" (dict "images" .Values.images "key" "pluginAws" "default" "velero/velero-plugin-for-aws:v1.12.2") }}
     imagePullPolicy: IfNotPresent
     securityContext:
       allowPrivilegeEscalation: false
@@ -40,7 +27,7 @@ initContainers:
         name: plugins
   {{- else if eq .Values.objectStorage.type "gcs" }}
   - name: velero-plugin-for-gcs
-    image: {{ include "velero.plugin_image" (dict "images" .Values.images "key" "pluginGcp" "default" "velero/velero-plugin-for-gcp:v1.9.1") }}
+    image: {{ include "velero.plugin_image" (dict "images" .Values.images "key" "pluginGcp" "default" "velero/velero-plugin-for-gcp:v1.12.2") }}
     imagePullPolicy: IfNotPresent
     securityContext:
       allowPrivilegeEscalation: false
@@ -52,7 +39,7 @@ initContainers:
         name: plugins
   {{- else if eq .Values.objectStorage.type "azure" }}
   - name: velero-plugin-for-microsoft-azure
-    image: {{ include "velero.plugin_image" (dict "images" .Values.images "key" "pluginAzure" "default" "velero/velero-plugin-for-microsoft-azure:v1.9.2") }}
+    image: {{ include "velero.plugin_image" (dict "images" .Values.images "key" "pluginAzure" "default" "velero/velero-plugin-for-microsoft-azure:v1.12.2") }}
     imagePullPolicy: IfNotPresent
     securityContext:
       allowPrivilegeEscalation: false

--- a/migration/v0.49/README.md
+++ b/migration/v0.49/README.md
@@ -1,0 +1,164 @@
+# Upgrade to v0.49.x
+
+> [!WARNING]
+> Upgrade only supported from v0.48.x.
+
+<!--
+Notice to developers on writing migration steps:
+
+- Migration steps:
+  - are written per minor version and placed in a subdirectory of the migration directory with the name `vX.Y/`,
+  - are written to be idempotent and usable no matter which patch version you are upgrading from and to,
+  - are documented in this document to be able to run them manually,
+  - are divided into prepare and apply steps:
+    - Prepare steps:
+      - are placed in the `prepare/` directory,
+      - may **only** modify the configuration of the environment,
+      - may **not** modify the state of the environment,
+      - steps are run in order of their names use two digit prefixes.
+    - Apply steps:
+      - are placed in the `apply/` directory,
+      - may **only** modify the state of the environment,
+      - may **not** modify the configuration of the environment,
+      - are run in order of their names use two digit prefixes,
+      - are run with the argument `execute` on upgrade and should return 1 on failure and 2 on successful internal rollback,
+      - are rerun with the argument `rollback` on execute failure and should return 1 on failure.
+
+For prepare the init step is given.
+For apply the bootstrap and the apply steps are given, it is expected that releases upgraded in custom steps are excluded from the apply step.
+
+Upgrades of components that are dependent on each other should be done within the same snippet to easily manage the upgrade to a working state and to be able to rollback to a working state.
+
+Steps should use the `scripts/migration/lib.sh` which will provide helper functions, see the file for available helper functions.
+This script expects the `ROOT` environment variable to be set pointing to the root of the repository.
+As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
+-->
+
+## Prerequisites
+
+- [ ] Read through the changelog to check if there are any changes you need to be aware of. Read through the release notes, Platform Administrator notices, Application Developer notices, and Security notice.
+- [ ] Notify the users (if any) before the upgrade starts;
+- [ ] Check if there are any pending changes to the environment;
+- [ ] Check the state of the environment, pods, nodes and backup jobs:
+
+    ```bash
+    ./bin/ck8s test sc|wc
+    ./bin/ck8s ops kubectl sc|wc get pods -A -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-false:status.containerStatuses[*].ready,REASON:status.containerStatuses[*].state.terminated.reason | grep false | grep -v Completed
+    ./bin/ck8s ops kubectl sc|wc get nodes
+    ./bin/ck8s ops kubectl sc|wc get jobs -A
+    ./bin/ck8s ops helm sc|wc list -A --all
+    ./bin/ck8s ops velero sc|wc get backup
+    ```
+
+- [ ] Silence the notifications for the alerts. e.g you can use [alertmanager silences](https://prometheus.io/docs/alerting/latest/alertmanager/#silences);
+
+## Automatic method
+
+1. Pull the latest changes and switch to the correct branch:
+
+    ```bash
+    git pull
+    git switch -d v0.49.x
+    ```
+
+1. Prepare upgrade - _non-disruptive_
+
+    > _Done before maintenance window._
+
+    ```bash
+    ./bin/ck8s upgrade both v0.49 prepare
+
+    # check if the netpol IPs need to be updated
+    ./bin/ck8s update-ips both dry-run
+    # if you agree with the changes apply
+    ./bin/ck8s update-ips both apply
+    ```
+
+    > **Note:**
+    > It is possible to upgrade `wc` and `sc` clusters separately by replacing `both` when running the `upgrade` command, e.g. the following will only upgrade the workload cluster:
+
+    ```bash
+    ./bin/ck8s upgrade wc v0.49 prepare
+    ./bin/ck8s upgrade wc v0.49 apply
+    ```
+
+1. Apply upgrade - _disruptive_
+
+    > _Done during maintenance window._
+
+    ```bash
+    ./bin/ck8s upgrade both v0.49 apply
+    ```
+
+## Manual method
+
+### Prepare upgrade - _non-disruptive_
+
+> _Done before maintenance window._
+
+1. Pull the latest changes and switch to the correct branch:
+
+    ```bash
+    git pull
+    git switch -d v0.49.x
+    ```
+
+1. Set whether or not upgrade should be prepared for `both` clusters or for one of `sc` or `wc`:
+
+    ```bash
+    export CK8S_CLUSTER=<wc|sc|both>
+    ```
+
+1. Update apps configuration:
+
+    This will take a backup into `backups/` before modifying any files.
+
+    ```bash
+    ./bin/ck8s init ${CK8S_CLUSTER}
+    # or
+    ./migration/v0.49/prepare/50-init.sh
+
+    # check if the netpol IPs need to be updated
+    ./bin/ck8s update-ips ${CK8S_CLUSTER} dry-run
+    # if you agree with the changes apply
+    ./bin/ck8s update-ips ${CK8S_CLUSTER} apply
+    ```
+
+### Apply upgrade - _disruptive_
+
+> _Done during maintenance window._
+
+1. Set whether or not upgrade should be applied for `both` clusters or for one of `sc` or `wc`:
+
+    ```bash
+    export CK8S_CLUSTER=<wc|sc|both>
+    ```
+
+1. Upgrade applications:
+
+    ```bash
+    ./bin/ck8s apply {sc|wc}
+    # or
+    ./migration/v0.49/apply/80-apply.sh execute
+    ```
+
+## Postrequisite
+
+- [ ] Check the state of the environment, pods and nodes:
+
+    ```bash
+    ./bin/ck8s test sc|wc
+    ./bin/ck8s ops kubectl sc|wc get pods -A -o custom-columns=NAMESPACE:metadata.namespace,POD:metadata.name,READY-false:status.containerStatuses[*].ready,REASON:status.containerStatuses[*].state.terminated.reason | grep false | grep -v Completed
+    ./bin/ck8s ops kubectl sc|wc get nodes
+    ./bin/ck8s ops helm sc|wc list -A --all
+    ```
+
+- [ ] Enable the notifications for the alerts;
+- [ ] Notify the users (if any) when the upgrade is complete;
+
+> [!NOTE]
+> Additionally it is good to check:
+>
+> - if any alerts generated by the upgrade didn't close;
+> - if you can login to Grafana, Opensearch or Harbor;
+> - you can see fresh metrics and logs.

--- a/migration/v0.49/apply/00-template.sh
+++ b/migration/v0.49/apply/00-template.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+# functions currently available in the library:
+#   - logging:
+#     - log_info(_no_newline) <message>
+#     - log_warn(_no_newline) <message>
+#     - log_error(_no_newline) <message>
+#     - log_fatal <message> # this will call "exit 1"
+#
+#   - kubectl
+#     # Use kubectl with kubeconfig set
+#     - kubectl_do <sc|wc> <kubectl args...>
+#     # Perform kubectl delete, will not cause errors if the resource is missing
+#     - kubectl_delete <sc|wc> <resource> <namespace> <name>
+#
+#   - helm
+#     # Use helm with kubeconfig set
+#     - helm_do <sc|wc> <helm args...>
+#     # Checks if a release is installed
+#     - helm_installed <sc|wc> <namespace> <release>
+#     # Uninstalls a release if it is installed
+#     - helm_uninstall <sc|wc> <namespace> <release>
+#
+#   - helmfile
+#     # Use helmfile with kubeconfig set
+#     - helmfile_do <sc|wc> <helmfile args...>
+#     # For selector args all will be prefixed with "-l"
+#     # List releases matching the selector
+#     - helmfile_list <sc|wc> <selectors...>
+#     # Apply releases matching the selector
+#     - helmfile_apply <sc|wc> <selectors...>
+#     # Check for changes on releases matching the selector
+#     - helmfile_change <sc|wc> <selectors...>
+#     # Destroy releases matching the selector
+#     - helmfile_destroy <sc|wc> <selectors...>
+#     # Replaces the releases matching the selector, performing destroy and apply on each release individually
+#     - helmfile_replace <sc|wc> <selectors...>
+#     # Upgrades the releases matching the selector, performing automatic rollback on failure set "CK8S_ROLLBACK=false" to disable
+#     - helmfile_upgrade <sc|wc> <selectors...>
+
+run() {
+  case "${1:-}" in
+  execute)
+    # Note: 00-template.sh will be skipped by the upgrade command
+    log_info "no operation: this is a template"
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      log_info "operation on service cluster"
+    fi
+    if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+      log_info "operation on workload cluster"
+    fi
+    ;;
+  rollback)
+    log_warn "rollback not implemented"
+
+    # if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+    #   log_info "rollback operation on service cluster"
+    # fi
+    # if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+    #   log_info "rollback operation on workload cluster"
+    # fi
+    ;;
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.49/apply/10-velero-crds.sh
+++ b/migration/v0.49/apply/10-velero-crds.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+run() {
+  case "${1:-}" in
+  execute)
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      log_info "installing gatekeeper crds in service cluster"
+      helmfile_do sc -l app=velero apply --set upgradeCRDs=true
+    fi
+    if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+      log_info "installing gatekeeper crds in workload cluster"
+      helmfile_do wc -l app=velero apply --set upgradeCRDs=true
+    fi
+    ;;
+  rollback)
+    log_warn "rollback not implemented"
+    ;;
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.49/apply/10-velero-crds.sh
+++ b/migration/v0.49/apply/10-velero-crds.sh
@@ -10,11 +10,11 @@ run() {
   execute)
 
     if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
-      log_info "installing gatekeeper crds in service cluster"
+      log_info "installing Velero CRDs in the service cluster"
       helmfile_do sc -l app=velero apply --set upgradeCRDs=true
     fi
     if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
-      log_info "installing gatekeeper crds in workload cluster"
+      log_info "installing Velero CRDs in the workload cluster"
       helmfile_do wc -l app=velero apply --set upgradeCRDs=true
     fi
     ;;

--- a/migration/v0.49/apply/80-apply.sh
+++ b/migration/v0.49/apply/80-apply.sh
@@ -40,13 +40,6 @@ run() {
 
   rollback)
     log_warn "rollback not implemented"
-
-    # if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
-    #   log_info "rollback operation on service cluster"
-    # fi
-    # if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
-    #   log_info "rollback operation on workload cluster"
-    # fi
     ;;
 
   *)

--- a/migration/v0.49/apply/80-apply.sh
+++ b/migration/v0.49/apply/80-apply.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+# Add selector filters if covered by other snippets.
+# Example: "app!=something"
+declare -a skipped
+skipped=(
+)
+declare -a skipped_sc
+skipped_sc=(
+  "app!=velero"
+)
+declare -a skipped_wc
+skipped_wc=(
+  "app!=velero"
+)
+
+run() {
+  case "${1:-}" in
+  execute)
+    local -a filters
+    local selector
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      filters=("${skipped[@]}" "${skipped_sc[@]}")
+      selector="${filters[*]:-"app!=null"}"
+      helmfile_upgrade sc "${selector// /,}"
+    fi
+
+    if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+      filters=("${skipped[@]}" "${skipped_wc[@]}")
+      selector="${filters[*]:-"app!=null"}"
+      helmfile_upgrade wc "${selector// /,}"
+    fi
+    ;;
+
+  rollback)
+    log_warn "rollback not implemented"
+
+    # if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+    #   log_info "rollback operation on service cluster"
+    # fi
+    # if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+    #   log_info "rollback operation on workload cluster"
+    # fi
+    ;;
+
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+run "${@}"

--- a/migration/v0.49/prepare/00-template.sh
+++ b/migration/v0.49/prepare/00-template.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+# functions currently available in the library:
+#   - logging:
+#     - log_info(_no_newline) <message>
+#     - log_warn(_no_newline) <message>
+#     - log_error(_no_newline) <message>
+#     - log_fatal <message> # this will call "exit 1"
+#
+#  - yq:
+#     - yq_null <common|sc|wc> <target>
+#     - yq_copy <common|sc|wc> <source> <destination>
+#     - yq_move <common|sc|wc> <source> <destination>
+#     - yq_remove <common|sc|wc> <target>
+#     - yq_add <common|sc|wc> <destination> <value>
+
+# Note: 00-template.sh will be skipped by the upgrade command
+log_info "no operation: this is a template"
+
+if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+  log_info "operation on service cluster"
+fi
+if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+  log_info "operation on workload cluster"
+fi

--- a/migration/v0.49/prepare/50-init.sh
+++ b/migration/v0.49/prepare/50-init.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+case "${CK8S_CLUSTER}" in
+both | sc | wc)
+  "${ROOT}/bin/ck8s" init "${CK8S_CLUSTER}"
+  ;;
+*)
+  log_fatal "usage: 50-init.sh <wc|sc|both>"
+  ;;
+esac

--- a/tests/end-to-end/velero/resources/backup-spec-sc.yaml
+++ b/tests/end-to-end/velero/resources/backup-spec-sc.yaml
@@ -19,6 +19,6 @@ labelSelector:
   matchLabels:
     velero: backup
 metadata: {}
-snapshotMoveData: false
+snapshotMoveData: true
 storageLocation: default
 ttl: 720h0m0s

--- a/tests/end-to-end/velero/resources/backup-spec-wc.yaml
+++ b/tests/end-to-end/velero/resources/backup-spec-wc.yaml
@@ -42,6 +42,6 @@ labelSelector:
     - key: compliantkubernetes.io/nobackup
       operator: DoesNotExist
 metadata: {}
-snapshotMoveData: false
+snapshotMoveData: true
 storageLocation: default
 ttl: 720h0m0s


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Upgrades the vmware-tanzu/velero chart version to `v10.0.11` and velero to `v.1.16.1`.

Got some deprecation warnings for restic while testing, so changed uploader type to kopia as well, which [should be seemless](https://github.com/vmware-tanzu/velero/discussions/7739#discussioncomment-9225969). Some backups weren't working with kopia until i enabled snapshots.

Removed csi plugin as it is built into velero since [1.14](https://velero.io/docs/v1.14/upgrade-to-1.14/).

Repository maintenance was moved out of velero to a job, so i had to add some podsecuritypolicies and networkpolicies for the new job.

I tested taking new backups and doing restore on both old and new backups and did not see any issues.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2264 

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [x] The change requires migration steps
    - [x] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [x] The metrics are still exposed and present in Grafana after the change
    - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [x] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [x] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [x] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [x] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [x] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [x] Any changed Pod is covered by Network Policies
    - [x] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [x] The change does not cause any unnecessary Kubernetes audit events
    - [x] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
