### PR TITLE
Add fluentd and log-manager e2e tests

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -106,10 +106,23 @@ COPY --from=node-deps /usr/local/lib/node_modules/welkin-test/node_modules /usr/
 # Container to run integration and end-to-end tests
 FROM unit AS main
 
+ENV DIST="noble"
+
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/keyrings/microsoft.gpg > /dev/null && \
+    chmod go+r /etc/apt/keyrings/microsoft.gpg && \
+    echo "Types: deb \n\
+URIs: https://packages.microsoft.com/repos/azure-cli/ \n\
+Suites: ${DIST} \n\
+Components: main \n\
+Architectures: $(dpkg --print-architecture) \n\
+Signed-by: /etc/apt/keyrings/microsoft.gpg" | tee /etc/apt/sources.list.d/azure-cli.sources
+
+ARG AZ_VERSION=2.63.0
 RUN apt-get update && \
-    apt-get install -y buildah docker.io libasound2t64 libatk1.0-0 libatk-bridge2.0-0 libcanberra-gtk-module \
+    apt-get install -y azure-cli=${AZ_VERSION}-1~${DIST} buildah docker.io libasound2t64 libatk1.0-0 libatk-bridge2.0-0 libcanberra-gtk-module \
     libcanberra-gtk3-module libcups2 libgbm-dev libgbm1 libglib2.0-0 libgtk2.0-0 libgtk2.0-0t64 libgtk-3-0 \
-    libgtk-3-0t64 libnotify-dev libnss3 libxss1 libxtst6 podman-remote skopeo socat xauth xvfb && \
+    libgtk-3-0t64 libnotify-dev libnss3 libxss1 libxtst6 podman-remote skopeo socat xauth xvfb zstd && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     ln -s /usr/bin/podman-remote /usr/bin/podman

--- a/tests/bats.lib.bash
+++ b/tests/bats.lib.bash
@@ -230,12 +230,26 @@ test_logs_contains() {
 }
 
 # note: expects with_kubeconfig and with_namespace to be set
-# usage: test_job_complete <name>
+# usage: test_job_complete <name> <timeout>
 test_job_complete() {
   # TODO: Would be nice to use DETIK here but it only supports looking at
   #       "status.phase" which jobs don't have.
-  run kubectl -n "${NAMESPACE}" wait --for=condition=complete "job/${1}" --timeout=30s
+  run kubectl -n "${NAMESPACE}" wait --for=condition=complete "job/${1}" --timeout="${2}s"
   assert_success
+}
+
+# note: expects with_kubeconfig and with_namespace to be set
+# usage: test_run_cronjob <name> <timeout>
+test_run_cronjob() {
+  local job_name
+  job_name="$(echo "${1}-$(uuid)" | head -c 63)"
+
+  test_cronjob "${1}"
+
+  run kubectl -n "${NAMESPACE}" create job --from "cronjob/${1}" "${job_name}"
+  assert_success
+
+  test_job_complete "${job_name}" "${2}"
 }
 
 auto_setup() {

--- a/tests/bats.lib.bash
+++ b/tests/bats.lib.bash
@@ -209,9 +209,10 @@ test_statefulset() {
 # note: expects with_kubeconfig and with_namespace to be set
 # usage: test_logs_contains <resource-type/name> <container> <regex>...
 test_logs_contains() {
-  run kubectl -n "${NAMESPACE}" logs "$1" grafana-sc-dashboard
+  run kubectl -n "${NAMESPACE}" logs "${1}/${2}"
+  assert_success
 
-  for arg in "${@:2}"; do
+  for arg in "${@:3}"; do
     assert_line --regexp "${arg}"
   done
 }

--- a/tests/common/bats/object-storage.bash
+++ b/tests/common/bats/object-storage.bash
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# Helpers for interacting with object storage:
+# - object_storage.load_env                                     - setup necessary variables for the object storage helper functions
+# - object_storage.wait [bucket] [prefix] [timeout in seconds]  - wait for at least one object to exists
+# - object_storage.download [bucket] [prefix] [destination]     - download objects recursively
+# - object_storage.download_one [bucket] [prefix] [destination] - download the first object found
+
+object_storage.load_env() {
+  local object_storage_type
+  object_storage_type="$(yq.get sc '.objectStorage.type')"
+  case "${object_storage_type}" in
+  "s3")
+    # No special setup needed
+    ;;
+  "azure")
+    # TODO: Maybe create a dedicated command similar to `ck8s s3cmd`?
+    AZURE_STORAGE_ACCOUNT="$(yq.get sc '.objectStorage.azure.storageAccountName')"
+    export AZURE_STORAGE_ACCOUNT
+    AZURE_STORAGE_KEY="$(yq.secret '.objectStorage.azure.storageAccountKey')"
+    export AZURE_STORAGE_KEY
+    ;;
+  *)
+    fail "Unsupported object storage type: ${object_storage_type}"
+    ;;
+  esac
+}
+
+object_storage.wait() {
+  local bucket="${1}"
+  local prefix="${2}"
+  local timeout="${3}"
+
+  timeout=$((timeout + SECONDS))
+  while [ "${SECONDS}" -lt "${timeout}" ]; do
+    run _object_storage_list_one "${bucket}" "${prefix}"
+    assert_success
+    assert_output --partial "${prefix}" && return
+    sleep 1
+  done
+
+  fail "timeout when waiting for object storage prefix to appear in bucket '${bucket}': ${prefix}"
+}
+
+object_storage.download() {
+  local bucket="${1}"
+  local prefix="${2}"
+  local destination="${3}"
+
+  local object_storage_type
+  object_storage_type="$(yq.get sc '.objectStorage.type')"
+  case "${object_storage_type}" in
+  "s3")
+    ck8s s3cmd get --recursive "s3://${bucket}/${prefix}" "${destination}"
+    ;;
+  "azure")
+    az storage blob download-batch --source "${bucket}" --pattern "${prefix}*" --destination "${destination}"
+    ;;
+  *)
+    fail "Unsupported object storage type: ${object_storage_type}"
+    ;;
+  esac
+}
+
+object_storage.download_one() {
+  # for --separate-stderr argument on 'run'
+  bats_require_minimum_version 1.11.1
+
+  local bucket="${1}"
+  local prefix="${2}"
+  local destination="${3}"
+
+  run --separate-stderr _object_storage_list_one "${bucket}" "${prefix}"
+  assert_success
+  assert_output --partial "${prefix}"
+
+  # shellcheck disable=SC2154
+  object_storage.download "${bucket}" "${output}" "${destination}"
+}
+
+_object_storage_list_one() {
+  local bucket="${1}"
+  local prefix="${2}"
+
+  local object_storage_type
+  object_storage_type="$(yq.get sc '.objectStorage.type')"
+  case "${object_storage_type}" in
+  "s3")
+    ck8s s3cmd ls --limit 1 --recursive "s3://${bucket}/${prefix}" | awk '{print $4}' | sed "s|s3://${bucket}/||"
+    ;;
+  "azure")
+    az storage blob list --num-results 1 --container-name "${bucket}" --prefix "${prefix}" --query '[].name' | jq -r '.[]'
+    ;;
+  *)
+    echo "Unsupported object storage type: ${object_storage_type}" >&2
+    return 1
+    ;;
+  esac
+}

--- a/tests/end-to-end/fluentd/audit-sc.gen.bats
+++ b/tests/end-to-end/fluentd/audit-sc.gen.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+# Generated from tests/end-to-end/fluentd/audit.bats.gotmpl
+
+# bats file_tags=fluentd,sc
+
+set -o pipefail
+
+setup_file() {
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../bats.lib.bash"
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  object_storage.load_env
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+}
+
+@test "fluentd forwards audit logs to object storage" {
+  local bucket
+  bucket="$(yq.get sc '.objectStorage.buckets.audit')"
+  local prefix
+  prefix="$(yq.get sc '.global.clusterName')/$(date +"%Y%m%d")/kubeaudit.var.log.kubernetes.audit.kube-apiserver-audit.log"
+
+  local destination="${BATS_TEST_TMPDIR}/audit-logs"
+  mkdir "${destination}"
+
+  object_storage.download_one "${bucket}" "${prefix}" "${destination}"
+
+  run _count_audit_log_events "${destination}"
+  assert_success
+  [ "${output}" -gt 0 ]
+}
+
+_count_audit_log_events() {
+  {
+    find "${1}" -type f \( -name "*.gz" -o -name "*.zst" \) -print0 | while IFS= read -r -d '' file; do
+      case "${file}" in
+      *.gz) zcat "${file}" ;;
+      *.zst) unzstd --stdout "${file}" ;;
+      esac
+    done
+  } | cut -d $'\t' -f 3 | jq --slurp 'map(select(.kind == "Event")) | length'
+}

--- a/tests/end-to-end/fluentd/audit-wc.gen.bats
+++ b/tests/end-to-end/fluentd/audit-wc.gen.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+# Generated from tests/end-to-end/fluentd/audit.bats.gotmpl
+
+# bats file_tags=fluentd,wc
+
+set -o pipefail
+
+setup_file() {
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../bats.lib.bash"
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  object_storage.load_env
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+}
+
+@test "fluentd forwards audit logs to object storage" {
+  local bucket
+  bucket="$(yq.get sc '.objectStorage.buckets.audit')"
+  local prefix
+  prefix="$(yq.get wc '.global.clusterName')/$(date +"%Y%m%d")/kubeaudit.var.log.kubernetes.audit.kube-apiserver-audit.log"
+
+  local destination="${BATS_TEST_TMPDIR}/audit-logs"
+  mkdir "${destination}"
+
+  object_storage.download_one "${bucket}" "${prefix}" "${destination}"
+
+  run _count_audit_log_events "${destination}"
+  assert_success
+  [ "${output}" -gt 0 ]
+}
+
+_count_audit_log_events() {
+  {
+    find "${1}" -type f \( -name "*.gz" -o -name "*.zst" \) -print0 | while IFS= read -r -d '' file; do
+      case "${file}" in
+      *.gz) zcat "${file}" ;;
+      *.zst) unzstd --stdout "${file}" ;;
+      esac
+    done
+  } | cut -d $'\t' -f 3 | jq --slurp 'map(select(.kind == "Event")) | length'
+}

--- a/tests/end-to-end/fluentd/audit.bats.gotmpl
+++ b/tests/end-to-end/fluentd/audit.bats.gotmpl
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+{{- define "template" -}}
+#!/usr/bin/env bats
+
+# Generated from {{ tmpl.Path }}
+
+# bats file_tags=fluentd,{{ .cluster }}
+
+set -o pipefail
+
+setup_file() {
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../bats.lib.bash"
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  object_storage.load_env
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+}
+
+@test "fluentd forwards audit logs to object storage" {
+  local bucket
+  bucket="$(yq.get sc '.objectStorage.buckets.audit')"
+  local prefix
+  prefix="$(yq.get {{ .cluster }} '.global.clusterName')/$(date +"%Y%m%d")/kubeaudit.var.log.kubernetes.audit.kube-apiserver-audit.log"
+
+  local destination="${BATS_TEST_TMPDIR}/audit-logs"
+  mkdir "${destination}"
+
+  object_storage.download_one "${bucket}" "${prefix}" "${destination}"
+
+  run _count_audit_log_events "${destination}"
+  assert_success
+  [ "${output}" -gt 0 ]
+}
+
+_count_audit_log_events() {
+  {
+    find "${1}" -type f \( -name "*.gz" -o -name "*.zst" \) -print0 | while IFS= read -r -d '' file; do
+      case "${file}" in
+      *.gz) zcat "${file}" ;;
+      *.zst) unzstd --stdout "${file}" ;;
+      esac
+    done
+  } | cut -d $'\t' -f 3 | jq --slurp 'map(select(.kind == "Event")) | length'
+}
+{{ end }}
+
+# These tests are generated into these files:
+{{- range $cluster := coll.Slice "sc" "wc" }}
+{{- $file := path.Join (tmpl.Path | path.Dir) (printf "./audit-%s.gen.bats" $cluster) }}
+# - {{ $file }}
+{{- coll.Dict "cluster" $cluster | tmpl.Exec "template" | file.Write $file }}
+{{- end }}

--- a/tests/end-to-end/fluentd/audit.gen.bats
+++ b/tests/end-to-end/fluentd/audit.gen.bats
@@ -1,0 +1,5 @@
+#!/usr/bin/env bats
+
+# These tests are generated into these files:
+# - tests/end-to-end/fluentd/audit-sc.gen.bats
+# - tests/end-to-end/fluentd/audit-wc.gen.bats

--- a/tests/end-to-end/fluentd/sc-logs.bats
+++ b/tests/end-to-end/fluentd/sc-logs.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+
+# bats file_tags=fluentd
+
+set -o pipefail
+
+setup_file() {
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../bats.lib.bash"
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  object_storage.load_env
+
+  with_kubeconfig sc
+  with_namespace "$(uuid)"
+
+  create_namespace
+}
+
+teardown_file() {
+  delete_namespace
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+}
+
+@test "fluentd forwards SC logs to object storage" {
+  local bucket
+  bucket="$(yq.get sc '.objectStorage.buckets.scFluentd')"
+  local prefix
+  prefix="logs/$(date +"%Y%m%d")/kubernetes.var.log.containers"
+
+  local destination="${BATS_TEST_TMPDIR}/audit-logs"
+  mkdir "${destination}"
+
+  object_storage.download_one "${bucket}" "${prefix}" "${destination}"
+
+  run _get_log_message "${destination}"
+  assert_success
+  [ "${output}" != "" ]
+}
+
+@test "fluentd forwards new SC logs to object storage" {
+  local max_fluent_interval_seconds="100"
+
+  local flush_interval
+  flush_interval="$(yq.get sc '.fluentd.aggregator.buffer.flushInterval')"
+
+  skip_time_gt "${flush_interval}" "${max_fluent_interval_seconds}s" "aggregator flush interval too long"
+
+  local log_message="sc-log test"
+
+  local job_name
+  job_name="$(uuid)"
+
+  local bucket
+  bucket="$(yq.get sc '.objectStorage.buckets.scFluentd')"
+  local prefix
+  prefix="logs/$(date +"%Y%m%d")/kubernetes.var.log.containers.${job_name}-"
+
+  local destination="${BATS_TEST_TMPDIR}/${job_name}"
+  mkdir "${destination}"
+
+  run kubectl -n "${NAMESPACE}" create job "${job_name}" --image=busybox:1.37.0 -- /bin/sh -c 'echo '"${log_message}"
+  assert_success
+
+  test_job_complete "${job_name}"
+
+  test_logs_contains job "${job_name}" "${log_message}"
+
+  object_storage.wait "${bucket}" "${prefix}" "$((max_fluent_interval_seconds + 120))"
+
+  object_storage.download "${bucket}" "${prefix}" "${destination}"
+
+  run _get_log_message "${destination}"
+  assert_success
+  assert_output "${log_message}"
+}
+
+_get_log_message() {
+  {
+    find "${1}" -type f \( -name "*.gz" -o -name "*.zst" \) -print0 | while IFS= read -r -d '' file; do
+      case "${file}" in
+      *.gz) zcat "${file}" ;;
+      *.zst) unzstd --stdout "${file}" ;;
+      esac
+    done
+  } | cut -d $'\t' -f 3 | jq -r '.message'
+}

--- a/tests/end-to-end/fluentd/sc-logs.bats
+++ b/tests/end-to-end/fluentd/sc-logs.bats
@@ -72,7 +72,7 @@ setup() {
   run kubectl -n "${NAMESPACE}" create job "${job_name}" --image=busybox:1.37.0 -- /bin/sh -c 'echo '"${log_message}"
   assert_success
 
-  test_job_complete "${job_name}"
+  test_job_complete "${job_name}" 30
 
   test_logs_contains job "${job_name}" "${log_message}"
 

--- a/tests/end-to-end/log-manager/compaction-audit-sc.gen.bats
+++ b/tests/end-to-end/log-manager/compaction-audit-sc.gen.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+
+# Generated from tests/end-to-end/log-manager/compaction.bats.gotmpl
+
+# bats file_tags=log-manager,audit-sc
+
+set -o pipefail
+
+setup_file() {
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../bats.lib.bash"
+  load_assert
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  object_storage.load_env
+
+  with_kubeconfig sc
+  with_namespace fluentd-system
+
+  CRONJOB_NAME="audit-$(yq.get sc '.global.ck8sEnvironmentName')-sc-compaction"
+  export CRONJOB_NAME
+
+  # TODO: Should probably make sure that the cronjob isn't currently running.
+  kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+
+  local cronjob_env_bucket
+  local cronjob_env_prefix
+
+  local object_storage_type
+  object_storage_type="$(yq.get sc '.objectStorage.type')"
+  case "${object_storage_type}" in
+  "s3")
+    cronjob_env_bucket="S3_BUCKET"
+    cronjob_env_prefix="S3_PREFIX"
+    ;;
+  "azure")
+    cronjob_env_bucket="AZURE_CONTAINER_NAME"
+    cronjob_env_prefix="AZURE_PREFIX"
+    ;;
+  *)
+    fail "Unsupported object storage type: ${object_storage_type}"
+    ;;
+  esac
+
+  BUCKET="$(_get_cronjob_env "${cronjob_env_bucket}")"
+  export BUCKET
+  PREFIX="$(_get_cronjob_env "${cronjob_env_prefix}")"
+  export PREFIX
+
+  [ -n "${BUCKET}" ] || fail "Failed to get bucket name from cronjob"
+  [ -n "${PREFIX}" ] || fail "Failed to get prefix from cronjob"
+
+  TEST_DATA_PREFIX="${PREFIX}/$(date +"%Y%m%d")/$(uuid)"
+  export TEST_DATA_PREFIX
+}
+
+teardown_file() {
+  object_storage.delete "${BUCKET}" "${TEST_DATA_PREFIX}"
+
+  kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : false}}'
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+  load_detik
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  with_kubeconfig sc
+  with_namespace fluentd-system
+}
+
+@test "audit-sc - log-manager compaction job compacts logs" {
+  _create_uncompacted_objects
+
+  object_storage.is_not_compacted "${BUCKET}" "${PREFIX}"
+
+  # TODO: This can take a long time. During testing it's been seen running for
+  #       over 10 minutes. Giving it 20 minutes timeout for now, however that
+  #       is still no guarantee.
+  test_run_cronjob "${CRONJOB_NAME}" 1200
+
+  object_storage.is_compacted "${BUCKET}" "${PREFIX}"
+}
+
+@test "audit-sc - log-manager compaction job runs fine when no logs needs compaction" {
+  object_storage.is_compacted "${BUCKET}" "${PREFIX}"
+
+  test_run_cronjob "${CRONJOB_NAME}" 60
+}
+
+_create_uncompacted_objects() {
+  local test_data_file_1
+  local test_data_file_2
+
+  test_data_file_1="${BATS_TEST_TMPDIR}/$(uuid).gz"
+  test_data_file_2="${BATS_TEST_TMPDIR}/$(uuid).gz"
+
+  echo 1 | gzip >"${test_data_file_1}"
+  echo 2 | gzip >"${test_data_file_2}"
+
+  object_storage.upload "${BUCKET}" "${TEST_DATA_PREFIX}/$(basename "${test_data_file_1}")" "${test_data_file_1}"
+  object_storage.upload "${BUCKET}" "${TEST_DATA_PREFIX}/$(basename "${test_data_file_2}")" "${test_data_file_2}"
+}
+
+_get_cronjob_env() {
+  kubectl -n "${NAMESPACE}" get cronjob "${CRONJOB_NAME}" -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].env[?(@.name=="'"${1}"'")].value}'
+}

--- a/tests/end-to-end/log-manager/compaction-audit-wc.gen.bats
+++ b/tests/end-to-end/log-manager/compaction-audit-wc.gen.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+
+# Generated from tests/end-to-end/log-manager/compaction.bats.gotmpl
+
+# bats file_tags=log-manager,audit-wc
+
+set -o pipefail
+
+setup_file() {
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../bats.lib.bash"
+  load_assert
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  object_storage.load_env
+
+  with_kubeconfig sc
+  with_namespace fluentd-system
+
+  CRONJOB_NAME="audit-$(yq.get sc '.global.ck8sEnvironmentName')-wc-compaction"
+  export CRONJOB_NAME
+
+  # TODO: Should probably make sure that the cronjob isn't currently running.
+  kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+
+  local cronjob_env_bucket
+  local cronjob_env_prefix
+
+  local object_storage_type
+  object_storage_type="$(yq.get sc '.objectStorage.type')"
+  case "${object_storage_type}" in
+  "s3")
+    cronjob_env_bucket="S3_BUCKET"
+    cronjob_env_prefix="S3_PREFIX"
+    ;;
+  "azure")
+    cronjob_env_bucket="AZURE_CONTAINER_NAME"
+    cronjob_env_prefix="AZURE_PREFIX"
+    ;;
+  *)
+    fail "Unsupported object storage type: ${object_storage_type}"
+    ;;
+  esac
+
+  BUCKET="$(_get_cronjob_env "${cronjob_env_bucket}")"
+  export BUCKET
+  PREFIX="$(_get_cronjob_env "${cronjob_env_prefix}")"
+  export PREFIX
+
+  [ -n "${BUCKET}" ] || fail "Failed to get bucket name from cronjob"
+  [ -n "${PREFIX}" ] || fail "Failed to get prefix from cronjob"
+
+  TEST_DATA_PREFIX="${PREFIX}/$(date +"%Y%m%d")/$(uuid)"
+  export TEST_DATA_PREFIX
+}
+
+teardown_file() {
+  object_storage.delete "${BUCKET}" "${TEST_DATA_PREFIX}"
+
+  kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : false}}'
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+  load_detik
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  with_kubeconfig sc
+  with_namespace fluentd-system
+}
+
+@test "audit-wc - log-manager compaction job compacts logs" {
+  _create_uncompacted_objects
+
+  object_storage.is_not_compacted "${BUCKET}" "${PREFIX}"
+
+  # TODO: This can take a long time. During testing it's been seen running for
+  #       over 10 minutes. Giving it 20 minutes timeout for now, however that
+  #       is still no guarantee.
+  test_run_cronjob "${CRONJOB_NAME}" 1200
+
+  object_storage.is_compacted "${BUCKET}" "${PREFIX}"
+}
+
+@test "audit-wc - log-manager compaction job runs fine when no logs needs compaction" {
+  object_storage.is_compacted "${BUCKET}" "${PREFIX}"
+
+  test_run_cronjob "${CRONJOB_NAME}" 60
+}
+
+_create_uncompacted_objects() {
+  local test_data_file_1
+  local test_data_file_2
+
+  test_data_file_1="${BATS_TEST_TMPDIR}/$(uuid).gz"
+  test_data_file_2="${BATS_TEST_TMPDIR}/$(uuid).gz"
+
+  echo 1 | gzip >"${test_data_file_1}"
+  echo 2 | gzip >"${test_data_file_2}"
+
+  object_storage.upload "${BUCKET}" "${TEST_DATA_PREFIX}/$(basename "${test_data_file_1}")" "${test_data_file_1}"
+  object_storage.upload "${BUCKET}" "${TEST_DATA_PREFIX}/$(basename "${test_data_file_2}")" "${test_data_file_2}"
+}
+
+_get_cronjob_env() {
+  kubectl -n "${NAMESPACE}" get cronjob "${CRONJOB_NAME}" -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].env[?(@.name=="'"${1}"'")].value}'
+}

--- a/tests/end-to-end/log-manager/compaction-sc-logs.gen.bats
+++ b/tests/end-to-end/log-manager/compaction-sc-logs.gen.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+
+# Generated from tests/end-to-end/log-manager/compaction.bats.gotmpl
+
+# bats file_tags=log-manager,sc-logs
+
+set -o pipefail
+
+setup_file() {
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../bats.lib.bash"
+  load_assert
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  object_storage.load_env
+
+  with_kubeconfig sc
+  with_namespace fluentd-system
+
+  CRONJOB_NAME="sc-logs-logs-compaction"
+  export CRONJOB_NAME
+
+  # TODO: Should probably make sure that the cronjob isn't currently running.
+  kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+
+  local cronjob_env_bucket
+  local cronjob_env_prefix
+
+  local object_storage_type
+  object_storage_type="$(yq.get sc '.objectStorage.type')"
+  case "${object_storage_type}" in
+  "s3")
+    cronjob_env_bucket="S3_BUCKET"
+    cronjob_env_prefix="S3_PREFIX"
+    ;;
+  "azure")
+    cronjob_env_bucket="AZURE_CONTAINER_NAME"
+    cronjob_env_prefix="AZURE_PREFIX"
+    ;;
+  *)
+    fail "Unsupported object storage type: ${object_storage_type}"
+    ;;
+  esac
+
+  BUCKET="$(_get_cronjob_env "${cronjob_env_bucket}")"
+  export BUCKET
+  PREFIX="$(_get_cronjob_env "${cronjob_env_prefix}")"
+  export PREFIX
+
+  [ -n "${BUCKET}" ] || fail "Failed to get bucket name from cronjob"
+  [ -n "${PREFIX}" ] || fail "Failed to get prefix from cronjob"
+
+  TEST_DATA_PREFIX="${PREFIX}/$(date +"%Y%m%d")/$(uuid)"
+  export TEST_DATA_PREFIX
+}
+
+teardown_file() {
+  object_storage.delete "${BUCKET}" "${TEST_DATA_PREFIX}"
+
+  kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : false}}'
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+  load_detik
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  with_kubeconfig sc
+  with_namespace fluentd-system
+}
+
+@test "sc-logs - log-manager compaction job compacts logs" {
+  _create_uncompacted_objects
+
+  object_storage.is_not_compacted "${BUCKET}" "${PREFIX}"
+
+  # TODO: This can take a long time. During testing it's been seen running for
+  #       over 10 minutes. Giving it 20 minutes timeout for now, however that
+  #       is still no guarantee.
+  test_run_cronjob "${CRONJOB_NAME}" 1200
+
+  object_storage.is_compacted "${BUCKET}" "${PREFIX}"
+}
+
+@test "sc-logs - log-manager compaction job runs fine when no logs needs compaction" {
+  object_storage.is_compacted "${BUCKET}" "${PREFIX}"
+
+  test_run_cronjob "${CRONJOB_NAME}" 60
+}
+
+_create_uncompacted_objects() {
+  local test_data_file_1
+  local test_data_file_2
+
+  test_data_file_1="${BATS_TEST_TMPDIR}/$(uuid).gz"
+  test_data_file_2="${BATS_TEST_TMPDIR}/$(uuid).gz"
+
+  echo 1 | gzip >"${test_data_file_1}"
+  echo 2 | gzip >"${test_data_file_2}"
+
+  object_storage.upload "${BUCKET}" "${TEST_DATA_PREFIX}/$(basename "${test_data_file_1}")" "${test_data_file_1}"
+  object_storage.upload "${BUCKET}" "${TEST_DATA_PREFIX}/$(basename "${test_data_file_2}")" "${test_data_file_2}"
+}
+
+_get_cronjob_env() {
+  kubectl -n "${NAMESPACE}" get cronjob "${CRONJOB_NAME}" -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].env[?(@.name=="'"${1}"'")].value}'
+}

--- a/tests/end-to-end/log-manager/compaction.bats.gotmpl
+++ b/tests/end-to-end/log-manager/compaction.bats.gotmpl
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+
+{{- define "template" -}}
+#!/usr/bin/env bats
+
+# Generated from {{ tmpl.Path }}
+
+# bats file_tags=log-manager,{{ .name }}
+
+set -o pipefail
+
+setup_file() {
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../bats.lib.bash"
+  load_assert
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  object_storage.load_env
+
+  with_kubeconfig sc
+  with_namespace fluentd-system
+
+  CRONJOB_NAME="{{ .cronjob }}"
+  export CRONJOB_NAME
+
+  # TODO: Should probably make sure that the cronjob isn't currently running.
+  kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+
+  local cronjob_env_bucket
+  local cronjob_env_prefix
+
+  local object_storage_type
+  object_storage_type="$(yq.get sc '.objectStorage.type')"
+  case "${object_storage_type}" in
+  "s3")
+    cronjob_env_bucket="S3_BUCKET"
+    cronjob_env_prefix="S3_PREFIX"
+    ;;
+  "azure")
+    cronjob_env_bucket="AZURE_CONTAINER_NAME"
+    cronjob_env_prefix="AZURE_PREFIX"
+    ;;
+  *)
+    fail "Unsupported object storage type: ${object_storage_type}"
+    ;;
+  esac
+
+  BUCKET="$(_get_cronjob_env "${cronjob_env_bucket}")"
+  export BUCKET
+  PREFIX="$(_get_cronjob_env "${cronjob_env_prefix}")"
+  export PREFIX
+
+  [ -n "${BUCKET}" ] || fail "Failed to get bucket name from cronjob"
+  [ -n "${PREFIX}" ] || fail "Failed to get prefix from cronjob"
+
+  TEST_DATA_PREFIX="${PREFIX}/$(date +"%Y%m%d")/$(uuid)"
+  export TEST_DATA_PREFIX
+}
+
+teardown_file() {
+  object_storage.delete "${BUCKET}" "${TEST_DATA_PREFIX}"
+
+  kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : false}}'
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+  load_detik
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  with_kubeconfig sc
+  with_namespace fluentd-system
+}
+
+@test "{{ .name }} - log-manager compaction job compacts logs" {
+  _create_uncompacted_objects
+
+  object_storage.is_not_compacted "${BUCKET}" "${PREFIX}"
+
+  # TODO: This can take a long time. During testing it's been seen running for
+  #       over 10 minutes. Giving it 20 minutes timeout for now, however that
+  #       is still no guarantee.
+  test_run_cronjob "${CRONJOB_NAME}" 1200
+
+  object_storage.is_compacted "${BUCKET}" "${PREFIX}"
+}
+
+@test "{{ .name }} - log-manager compaction job runs fine when no logs needs compaction" {
+  object_storage.is_compacted "${BUCKET}" "${PREFIX}"
+
+  test_run_cronjob "${CRONJOB_NAME}" 60
+}
+
+_create_uncompacted_objects() {
+  local test_data_file_1
+  local test_data_file_2
+
+  test_data_file_1="${BATS_TEST_TMPDIR}/$(uuid).gz"
+  test_data_file_2="${BATS_TEST_TMPDIR}/$(uuid).gz"
+
+  echo 1 | gzip >"${test_data_file_1}"
+  echo 2 | gzip >"${test_data_file_2}"
+
+  object_storage.upload "${BUCKET}" "${TEST_DATA_PREFIX}/$(basename "${test_data_file_1}")" "${test_data_file_1}"
+  object_storage.upload "${BUCKET}" "${TEST_DATA_PREFIX}/$(basename "${test_data_file_2}")" "${test_data_file_2}"
+}
+
+_get_cronjob_env() {
+  kubectl -n "${NAMESPACE}" get cronjob "${CRONJOB_NAME}" -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].env[?(@.name=="'"${1}"'")].value}'
+}
+{{ end }}
+
+# These tests are generated into these files:
+{{- range $name, $cronjob := (coll.Dict
+  "sc-logs" "sc-logs-logs-compaction"
+  "audit-sc" "audit-$(yq.get sc '.global.ck8sEnvironmentName')-sc-compaction"
+  "audit-wc" "audit-$(yq.get sc '.global.ck8sEnvironmentName')-wc-compaction"
+) }}
+{{- $file := path.Join (tmpl.Path | path.Dir) (printf "./compaction-%s.gen.bats" $name) }}
+# - {{ $file }}
+{{- coll.Dict "name" $name "cronjob" $cronjob | tmpl.Exec "template" | file.Write $file }}
+{{- end }}

--- a/tests/end-to-end/log-manager/compaction.gen.bats
+++ b/tests/end-to-end/log-manager/compaction.gen.bats
@@ -1,0 +1,6 @@
+#!/usr/bin/env bats
+
+# These tests are generated into these files:
+# - tests/end-to-end/log-manager/compaction-audit-sc.gen.bats
+# - tests/end-to-end/log-manager/compaction-audit-wc.gen.bats
+# - tests/end-to-end/log-manager/compaction-sc-logs.gen.bats

--- a/tests/end-to-end/log-manager/retention-audit-sc.gen.bats
+++ b/tests/end-to-end/log-manager/retention-audit-sc.gen.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+# Generated from tests/end-to-end/log-manager/retention.bats.gotmpl
+
+# bats file_tags=log-manager,audit-sc
+
+set -o pipefail
+
+setup_file() {
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../bats.lib.bash"
+  load_assert
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  object_storage.load_env
+
+  with_kubeconfig sc
+  with_namespace fluentd-system
+
+  CRONJOB_NAME="audit-$(yq.get sc '.global.ck8sEnvironmentName')-sc-retention"
+  export CRONJOB_NAME
+
+  # TODO: Should probably make sure that the cronjob isn't currently running.
+  kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+
+  local cronjob_env_bucket
+  local cronjob_env_prefix
+
+  local object_storage_type
+  object_storage_type="$(yq.get sc '.objectStorage.type')"
+  case "${object_storage_type}" in
+  "s3")
+    cronjob_env_bucket="S3_BUCKET"
+    cronjob_env_prefix="S3_PREFIX"
+    ;;
+  "azure")
+    cronjob_env_bucket="AZURE_CONTAINER_NAME"
+    cronjob_env_prefix="AZURE_PREFIX"
+    ;;
+  *)
+    fail "Unsupported object storage type: ${object_storage_type}"
+    ;;
+  esac
+
+  BUCKET="$(_get_cronjob_env "${cronjob_env_bucket}")"
+  export BUCKET
+  PREFIX="$(_get_cronjob_env "${cronjob_env_prefix}")"
+  export PREFIX
+
+  [ -n "${BUCKET}" ] || fail "Failed to get bucket name from cronjob"
+  [ -n "${PREFIX}" ] || fail "Failed to get prefix from cronjob"
+
+  TEST_DATA_PREFIX="${PREFIX}/19991231"
+  export TEST_DATA_PREFIX
+  TEST_DATA_FILE="$(uuid).gz"
+  export TEST_DATA_FILE
+}
+
+teardown_file() {
+  kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : false}}'
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+  load_detik
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  with_kubeconfig sc
+  with_namespace fluentd-system
+}
+
+@test "audit-sc - log-manager retention job deletes old logs" {
+  echo 1 | gzip >"${BATS_TEST_TMPDIR}/${TEST_DATA_FILE}"
+
+  object_storage.upload "${BUCKET}" "${TEST_DATA_PREFIX}/${TEST_DATA_FILE}" "${BATS_TEST_TMPDIR}/${TEST_DATA_FILE}"
+
+  object_storage.has "${BUCKET}" "${TEST_DATA_PREFIX}"
+
+  test_run_cronjob "${CRONJOB_NAME}" 300
+
+  # TODO: This could be improved to make sure that _all_ objects that should
+  #       have been deleted has been deleted. Now it only verifies that the
+  #       test data is deleted by the retention job.
+  object_storage.has_none "${BUCKET}" "${TEST_DATA_PREFIX}"
+}
+
+@test "audit-sc - log-manager retention job runs fine when no logs needs to be deleted" {
+  test_run_cronjob "${CRONJOB_NAME}" 60
+}
+
+_get_cronjob_env() {
+  kubectl -n "${NAMESPACE}" get cronjob "${CRONJOB_NAME}" -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].env[?(@.name=="'"${1}"'")].value}'
+}

--- a/tests/end-to-end/log-manager/retention-audit-wc.gen.bats
+++ b/tests/end-to-end/log-manager/retention-audit-wc.gen.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+# Generated from tests/end-to-end/log-manager/retention.bats.gotmpl
+
+# bats file_tags=log-manager,audit-wc
+
+set -o pipefail
+
+setup_file() {
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../bats.lib.bash"
+  load_assert
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  object_storage.load_env
+
+  with_kubeconfig sc
+  with_namespace fluentd-system
+
+  CRONJOB_NAME="audit-$(yq.get sc '.global.ck8sEnvironmentName')-wc-retention"
+  export CRONJOB_NAME
+
+  # TODO: Should probably make sure that the cronjob isn't currently running.
+  kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+
+  local cronjob_env_bucket
+  local cronjob_env_prefix
+
+  local object_storage_type
+  object_storage_type="$(yq.get sc '.objectStorage.type')"
+  case "${object_storage_type}" in
+  "s3")
+    cronjob_env_bucket="S3_BUCKET"
+    cronjob_env_prefix="S3_PREFIX"
+    ;;
+  "azure")
+    cronjob_env_bucket="AZURE_CONTAINER_NAME"
+    cronjob_env_prefix="AZURE_PREFIX"
+    ;;
+  *)
+    fail "Unsupported object storage type: ${object_storage_type}"
+    ;;
+  esac
+
+  BUCKET="$(_get_cronjob_env "${cronjob_env_bucket}")"
+  export BUCKET
+  PREFIX="$(_get_cronjob_env "${cronjob_env_prefix}")"
+  export PREFIX
+
+  [ -n "${BUCKET}" ] || fail "Failed to get bucket name from cronjob"
+  [ -n "${PREFIX}" ] || fail "Failed to get prefix from cronjob"
+
+  TEST_DATA_PREFIX="${PREFIX}/19991231"
+  export TEST_DATA_PREFIX
+  TEST_DATA_FILE="$(uuid).gz"
+  export TEST_DATA_FILE
+}
+
+teardown_file() {
+  kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : false}}'
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+  load_detik
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  with_kubeconfig sc
+  with_namespace fluentd-system
+}
+
+@test "audit-wc - log-manager retention job deletes old logs" {
+  echo 1 | gzip >"${BATS_TEST_TMPDIR}/${TEST_DATA_FILE}"
+
+  object_storage.upload "${BUCKET}" "${TEST_DATA_PREFIX}/${TEST_DATA_FILE}" "${BATS_TEST_TMPDIR}/${TEST_DATA_FILE}"
+
+  object_storage.has "${BUCKET}" "${TEST_DATA_PREFIX}"
+
+  test_run_cronjob "${CRONJOB_NAME}" 300
+
+  # TODO: This could be improved to make sure that _all_ objects that should
+  #       have been deleted has been deleted. Now it only verifies that the
+  #       test data is deleted by the retention job.
+  object_storage.has_none "${BUCKET}" "${TEST_DATA_PREFIX}"
+}
+
+@test "audit-wc - log-manager retention job runs fine when no logs needs to be deleted" {
+  test_run_cronjob "${CRONJOB_NAME}" 60
+}
+
+_get_cronjob_env() {
+  kubectl -n "${NAMESPACE}" get cronjob "${CRONJOB_NAME}" -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].env[?(@.name=="'"${1}"'")].value}'
+}

--- a/tests/end-to-end/log-manager/retention-sc-logs.gen.bats
+++ b/tests/end-to-end/log-manager/retention-sc-logs.gen.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+# Generated from tests/end-to-end/log-manager/retention.bats.gotmpl
+
+# bats file_tags=log-manager,sc-logs
+
+set -o pipefail
+
+setup_file() {
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../bats.lib.bash"
+  load_assert
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  object_storage.load_env
+
+  with_kubeconfig sc
+  with_namespace fluentd-system
+
+  CRONJOB_NAME="sc-logs-logs-retention"
+  export CRONJOB_NAME
+
+  # TODO: Should probably make sure that the cronjob isn't currently running.
+  kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+
+  local cronjob_env_bucket
+  local cronjob_env_prefix
+
+  local object_storage_type
+  object_storage_type="$(yq.get sc '.objectStorage.type')"
+  case "${object_storage_type}" in
+  "s3")
+    cronjob_env_bucket="S3_BUCKET"
+    cronjob_env_prefix="S3_PREFIX"
+    ;;
+  "azure")
+    cronjob_env_bucket="AZURE_CONTAINER_NAME"
+    cronjob_env_prefix="AZURE_PREFIX"
+    ;;
+  *)
+    fail "Unsupported object storage type: ${object_storage_type}"
+    ;;
+  esac
+
+  BUCKET="$(_get_cronjob_env "${cronjob_env_bucket}")"
+  export BUCKET
+  PREFIX="$(_get_cronjob_env "${cronjob_env_prefix}")"
+  export PREFIX
+
+  [ -n "${BUCKET}" ] || fail "Failed to get bucket name from cronjob"
+  [ -n "${PREFIX}" ] || fail "Failed to get prefix from cronjob"
+
+  TEST_DATA_PREFIX="${PREFIX}/19991231"
+  export TEST_DATA_PREFIX
+  TEST_DATA_FILE="$(uuid).gz"
+  export TEST_DATA_FILE
+}
+
+teardown_file() {
+  kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : false}}'
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+  load_detik
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  with_kubeconfig sc
+  with_namespace fluentd-system
+}
+
+@test "sc-logs - log-manager retention job deletes old logs" {
+  echo 1 | gzip >"${BATS_TEST_TMPDIR}/${TEST_DATA_FILE}"
+
+  object_storage.upload "${BUCKET}" "${TEST_DATA_PREFIX}/${TEST_DATA_FILE}" "${BATS_TEST_TMPDIR}/${TEST_DATA_FILE}"
+
+  object_storage.has "${BUCKET}" "${TEST_DATA_PREFIX}"
+
+  test_run_cronjob "${CRONJOB_NAME}" 300
+
+  # TODO: This could be improved to make sure that _all_ objects that should
+  #       have been deleted has been deleted. Now it only verifies that the
+  #       test data is deleted by the retention job.
+  object_storage.has_none "${BUCKET}" "${TEST_DATA_PREFIX}"
+}
+
+@test "sc-logs - log-manager retention job runs fine when no logs needs to be deleted" {
+  test_run_cronjob "${CRONJOB_NAME}" 60
+}
+
+_get_cronjob_env() {
+  kubectl -n "${NAMESPACE}" get cronjob "${CRONJOB_NAME}" -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].env[?(@.name=="'"${1}"'")].value}'
+}

--- a/tests/end-to-end/log-manager/retention.bats.gotmpl
+++ b/tests/end-to-end/log-manager/retention.bats.gotmpl
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+
+{{- define "template" -}}
+#!/usr/bin/env bats
+
+# Generated from {{ tmpl.Path }}
+
+# bats file_tags=log-manager,{{ .name }}
+
+set -o pipefail
+
+setup_file() {
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
+  load "../../bats.lib.bash"
+  load_assert
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  object_storage.load_env
+
+  with_kubeconfig sc
+  with_namespace fluentd-system
+
+  CRONJOB_NAME="{{ .cronjob }}"
+  export CRONJOB_NAME
+
+  # TODO: Should probably make sure that the cronjob isn't currently running.
+  kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+
+  local cronjob_env_bucket
+  local cronjob_env_prefix
+
+  local object_storage_type
+  object_storage_type="$(yq.get sc '.objectStorage.type')"
+  case "${object_storage_type}" in
+  "s3")
+    cronjob_env_bucket="S3_BUCKET"
+    cronjob_env_prefix="S3_PREFIX"
+    ;;
+  "azure")
+    cronjob_env_bucket="AZURE_CONTAINER_NAME"
+    cronjob_env_prefix="AZURE_PREFIX"
+    ;;
+  *)
+    fail "Unsupported object storage type: ${object_storage_type}"
+    ;;
+  esac
+
+  BUCKET="$(_get_cronjob_env "${cronjob_env_bucket}")"
+  export BUCKET
+  PREFIX="$(_get_cronjob_env "${cronjob_env_prefix}")"
+  export PREFIX
+
+  [ -n "${BUCKET}" ] || fail "Failed to get bucket name from cronjob"
+  [ -n "${PREFIX}" ] || fail "Failed to get prefix from cronjob"
+
+  TEST_DATA_PREFIX="${PREFIX}/19991231"
+  export TEST_DATA_PREFIX
+  TEST_DATA_FILE="$(uuid).gz"
+  export TEST_DATA_FILE
+}
+
+teardown_file() {
+  kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : false}}'
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+  load_detik
+
+  load_common "object-storage.bash"
+  load_common "yq.bash"
+
+  with_kubeconfig sc
+  with_namespace fluentd-system
+}
+
+@test "{{ .name }} - log-manager retention job deletes old logs" {
+  echo 1 | gzip >"${BATS_TEST_TMPDIR}/${TEST_DATA_FILE}"
+
+  object_storage.upload "${BUCKET}" "${TEST_DATA_PREFIX}/${TEST_DATA_FILE}" "${BATS_TEST_TMPDIR}/${TEST_DATA_FILE}"
+
+  object_storage.has "${BUCKET}" "${TEST_DATA_PREFIX}"
+
+  test_run_cronjob "${CRONJOB_NAME}" 300
+
+  # TODO: This could be improved to make sure that _all_ objects that should
+  #       have been deleted has been deleted. Now it only verifies that the
+  #       test data is deleted by the retention job.
+  object_storage.has_none "${BUCKET}" "${TEST_DATA_PREFIX}"
+}
+
+@test "{{ .name }} - log-manager retention job runs fine when no logs needs to be deleted" {
+  test_run_cronjob "${CRONJOB_NAME}" 60
+}
+
+_get_cronjob_env() {
+  kubectl -n "${NAMESPACE}" get cronjob "${CRONJOB_NAME}" -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].env[?(@.name=="'"${1}"'")].value}'
+}
+{{ end }}
+
+# These tests are generated into these files:
+{{- range $name, $cronjob := (coll.Dict
+  "sc-logs" "sc-logs-logs-retention"
+  "audit-sc" "audit-$(yq.get sc '.global.ck8sEnvironmentName')-sc-retention"
+  "audit-wc" "audit-$(yq.get sc '.global.ck8sEnvironmentName')-wc-retention"
+) }}
+{{- $file := path.Join (tmpl.Path | path.Dir) (printf "./retention-%s.gen.bats" $name) }}
+# - {{ $file }}
+{{- coll.Dict "name" $name "cronjob" $cronjob | tmpl.Exec "template" | file.Write $file }}
+{{- end }}

--- a/tests/end-to-end/log-manager/retention.gen.bats
+++ b/tests/end-to-end/log-manager/retention.gen.bats
@@ -1,0 +1,6 @@
+#!/usr/bin/env bats
+
+# These tests are generated into these files:
+# - tests/end-to-end/log-manager/retention-audit-sc.gen.bats
+# - tests/end-to-end/log-manager/retention-audit-wc.gen.bats
+# - tests/end-to-end/log-manager/retention-sc-logs.gen.bats

--- a/tests/end-to-end/log-manager/setup_suite.bash
+++ b/tests/end-to-end/log-manager/setup_suite.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+setup_suite() {
+  export CK8S_AUTO_APPROVE="true"
+
+  load "../../bats.lib.bash"
+
+  with_kubeconfig sc
+  with_namespace fluentd-system
+
+  # Pause logs being flushed to object storage
+  fluentd_aggregator_replicas="$(kubectl -n "${NAMESPACE}" get statefulset fluentd-aggregator -o jsonpath='{.spec.replicas}')"
+  kubectl -n "${NAMESPACE}" scale statefulset fluentd-aggregator --replicas 0 --timeout 5m
+}
+
+teardown_suite() {
+  load "../../bats.lib.bash"
+
+  # Unpause logs being flushed to object storage
+  kubectl -n "${NAMESPACE}" scale statefulset fluentd-aggregator --replicas "${fluentd_aggregator_replicas}" --timeout 5m
+}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This adds e2e tests for fluentd that verifies that audit and SC logs are forwarded to object storage as well as tests that verifies the log manager log compaction and retention.

- Fixes https://github.com/elastisys/ck8s-issue-tracker/issues/447

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
