### PR TITLE
apps: added group labels to alerts

### DIFF
--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -1123,6 +1123,8 @@ alerts:
     #   {{ end }}
   opsGenie:
     apiUrl: https://api.eu.opsgenie.com
+    # Set updateAlerts to true if you intend to group alerts
+    updateAlerts: false
   # Configure custom alert receivers
   customReceivers: []
   customRoutes: []

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -4199,6 +4199,10 @@ properties:
             type: string
             format: uri
             default: https://api.eu.opsgenie.com
+          updateAlerts:
+            title: Whether to dynamically update existing alerts
+            type: boolean
+            default: false
       opsGenieHeartbeat:
         title: Alert OpsGenie Heartbeat
         description: Configure heartbeats to OpsGenie.

--- a/helmfile.d/charts/prometheus-alerts/README.md
+++ b/helmfile.d/charts/prometheus-alerts/README.md
@@ -1,3 +1,21 @@
-# Deviations from the upstream alerts
+# Prometheus-alerts
+
+All Welkin alerts must have a severity label to dictate which priority the alert should have.
+The different severity levels are:
+
+- critical
+- warning _or_ high
+- medium
+- low
+
+All Welkin alerts must also have a group label.
+If the alert does not fit into any specific group or should not be grouped together with other alerts, give the group label the same name as the alert.
+
+## Deviations from the upstream alerts
 
 1. In `fluentd.yaml` we set severity to warning and evaluation time to 10m for `FluentdRecordsCountsHigh`
+
+## OpsGenie
+
+If you want to group alerts for OpsGenie, set `.alerts.opsGenie.updateAlerts` to `true` and also `prometheus.alertmanagerSpec.groupBy` to `[group,severity,cluster]`.
+By default no alerts are grouped.

--- a/helmfile.d/charts/prometheus-alerts/files/cluster-api.yaml
+++ b/helmfile.d/charts/prometheus-alerts/files/cluster-api.yaml
@@ -10,6 +10,7 @@
       labels:
         rulesgroup: cluster-api
         severity: warning
+        group: ClusterApiCluster
       expr: |
         sum(capi_cluster_spec_paused) by (name) != 0
       for: 15m
@@ -23,6 +24,7 @@
       labels:
         rulesgroup: cluster-api
         severity: warning
+        group: ClusterApiCluster
       expr: |
         sum(capi_cluster_status_condition{type="ControlPlaneInitialized", status="True"}) by (name) != 1
       for: 15m
@@ -36,6 +38,7 @@
       labels:
         rulesgroup: cluster-api
         severity: high
+        group: ClusterApiCluster
       expr: |
         sum(capi_cluster_status_condition{type="ControlPlaneReady", status="True"}) by (name) != 1
       for: 5m
@@ -49,6 +52,7 @@
       labels:
         rulesgroup: cluster-api
         severity: high
+        group: ClusterApiCluster
       expr: |
         sum(capi_cluster_status_condition{type="InfrastructureReady", status="True"}) by (name) != 1
       for: 15m
@@ -62,6 +66,7 @@
       labels:
         rulesgroup: cluster-api
         severity: warning
+        group: ClusterApiCluster
       expr: |
         capi_cluster_status_phase{phase!="Provisioned"} == 1
       for: 15m
@@ -75,6 +80,7 @@
       labels:
         rulesgroup: cluster-api
         severity: high
+        group: ClusterApiCluster
       expr: |
         capi_cluster_status_phase{phase!="Provisioned"} == 1
       for: 60m
@@ -90,6 +96,7 @@
       labels:
         rulesgroup: cluster-api
         severity: warning
+        group: ClusterApiKubeadmControlPlane
       expr: |
         sum(capi_kubeadmcontrolplane_status_replicas_ready / capi_kubeadmcontrolplane_status_replicas) by (cluster_name, name) != 1
       for: 10m
@@ -103,6 +110,7 @@
       labels:
         rulesgroup: cluster-api
         severity: warning
+        group: ClusterApiKubeadmControlPlane
       expr: |
         sum(capi_kubeadmcontrolplane_status_replicas_ready / capi_kubeadmcontrolplane_status_replicas) by (cluster_name, name) < 0.5
       for: 10m
@@ -116,6 +124,7 @@
       labels:
         rulesgroup: cluster-api
         severity: high
+        group: ClusterApiKubeadmControlPlane
       expr: |
         sum(capi_kubeadmcontrolplane_status_replicas_ready / capi_kubeadmcontrolplane_status_replicas) by (cluster_name, name) < 0.5
       for: 2m
@@ -131,6 +140,7 @@
       labels:
         rulesgroup: cluster-api
         severity: warning
+        group: ClusterApiMachineDeployment
       expr: |
         sum(capi_machinedeployment_status_replicas_ready / (capi_machinedeployment_status_replicas > 0)) by (cluster_name, name) != 1
       for: 15m
@@ -144,6 +154,7 @@
       labels:
         rulesgroup: cluster-api
         severity: high
+        group: ClusterApiMachineDeployment
       expr: |
         sum(capi_machinedeployment_status_replicas_ready / capi_machinedeployment_status_replicas) by (cluster_name, name) < 0.5
       for: 2m
@@ -159,6 +170,7 @@
       labels:
         rulesgroup: cluster-api
         severity: warning
+        group: ClusterApiMachineConditionNotTrue
       expr: |
         sum((capi_machine_status_condition{status!="True"}) * on (name) group_left(node_name) sum(capi_machine_status_noderef) by (name, node_name)) by (cluster_name, node_name, type, status) > 0
       for: 15m

--- a/helmfile.d/charts/prometheus-alerts/files/cluster-autoscaler.yaml
+++ b/helmfile.d/charts/prometheus-alerts/files/cluster-autoscaler.yaml
@@ -5,6 +5,7 @@
       for: 15m
       labels:
         severity: critical
+        group: ClusterAutoscaler
       annotations:
         summary: "Autoscaling is not safe"
         description: "Cluster Autoscaler for cluster {{"`{{ $labels.cluster }}`"}} has deemed it unsafe to autoscale for 15 minutes. This is primarily triggered when the number of unready nodes pass a configured threshold. It can also be triggered when the cluster is empty and scaling from zero nodes is not allowed."
@@ -15,6 +16,7 @@
       for: 1m
       labels:
         severity: high
+        group: ClusterAutoscaler
       annotations:
         summary: "No Cluster Autoscaler main loop activity"
         description: "The main loop of the Cluster Autoscaler for cluster {{"`{{ $labels.cluster }}`"}} has not updated its last activity in over 5 minutes which means it might be stuck or not running."
@@ -25,6 +27,7 @@
       for: 1m
       labels:
         severity: critical
+        group: ClusterAutoscaler
       annotations:
         summary: "No Cluster Autoscaler main loop activity for a long time"
         description: "The main loop of the Cluster Autoscaler for cluster {{"`{{ $labels.cluster }}`"}} has not updated its last activity in over 1 hour which means it might be stuck or not running."
@@ -35,6 +38,7 @@
       for: 30m
       labels:
         severity: warning
+        group: ClusterAutoscaler
       annotations:
         summary: "Pods are currently unschedulable"
         description: "There are unschedulable pods in the cluster {{"`{{ $labels.cluster }}`"}}. The Cluster Autoscaler should address this by scaling up, if possible."
@@ -45,6 +49,7 @@
       for: 1m
       labels:
         severity: critical
+        group: ClusterAutoscaler
       annotations:
         summary: "Cluster Autoscaler failed to scale up"
         description: "The Cluster Autoscaler for cluster {{"`{{ $labels.cluster }}`"}} encountered an error while attempting to scale up new nodes. Reason: {{"{{ $labels.reason }}"}}"
@@ -55,6 +60,7 @@
       for: 1m
       labels:
         severity: critical
+        group: ClusterAutoscaler
       annotations:
         summary: "Cluster Autoscaler failed to scale up GPU nodes"
         description: "The Cluster Autoscaler for cluster {{"`{{ $labels.cluster }}`"}} encountered an error while attempting to scale up GPU nodes. Reason: {{"{{ $labels.reason }}"}}, GPU Resource: {{"{{ $labels.gpu_resource_name }}"}}, GPU Name: {{"{{ $labels.gpu_name }}"}}"
@@ -65,6 +71,7 @@
       for: 10m
       labels:
         severity: warning
+        group: ClusterAutoscaler
       annotations:
         summary: "Unhealthy node group"
         description: "The node group {{"{{ $labels.node_group }}"}} in cluster {{"`{{ $labels.cluster }}`"}} is reporting as unhealthy which might prevent autoscaling operations for this group."
@@ -75,6 +82,7 @@
       for: 5m
       labels:
         severity: warning
+        group: ClusterAutoscaler
       annotations:
         summary: "A node group is in backoff state"
         description: "The node group {{"{{ $labels.node_group }}"}} in cluster {{"`{{ $labels.cluster }}`"}} is currently in a backoff state due to reason: {{"{{ $labels.reason }}"}}. This means that the Cluster Autoscaler will not try to scale it up."
@@ -85,6 +93,7 @@
       for: 6h
       labels:
         severity: warning
+        group: ClusterAutoscaler
       annotations:
         summary: "Cluster Autoscaler reports unneeded nodes that are not being scaled down"
         description: "There are {{"{{ $value }}"}} nodes in cluster {{"`{{ $labels.cluster }}`"}} identified as unneeded by the Cluster Autoscaler, but they have not been scaled down for 24 hours."
@@ -106,6 +115,7 @@
       for: 1m
       labels:
         severity: high
+        group: ClusterAutoscaler
       annotations:
         summary: "Cluster Autoscaler is reporting errors"
         description: "The Cluster Autoscaler for cluster {{"`{{ $labels.cluster }}`"}} is experiencing errors of type {{"{{ $labels.type }}"}}."
@@ -116,6 +126,7 @@
       for: 30m
       labels:
         severity: warning
+        group: ClusterAutoscaler
       annotations:
         summary: "Nodes are stuck in pending deletion state"
         description: "There are {{"{{ $value }}"}} nodes in cluster {{"`{{ $labels.cluster }}`"}} that have completed scale-down but are still pending deletion."
@@ -126,6 +137,7 @@
       for: 5m
       labels:
         severity: warning
+        group: ClusterAutoscaler
       annotations:
         summary: "Cluster Autoscaler scale up function is taking too long"
         description: "The 99th percentile of the {{"`{{ $labels.cluster }}`"}} Cluster Autoscaler's scaleUp function duration has exceeded 60 seconds."
@@ -136,6 +148,7 @@
       for: 5m
       labels:
         severity: warning
+        group: ClusterAutoscaler
       annotations:
         summary: "Cluster Autoscaler scale down function is taking too long"
         description: "The 99th percentile of the {{"`{{ $labels.cluster }}`"}} Cluster Autoscaler's scaleDown function duration has exceeded 60 seconds."
@@ -146,6 +159,7 @@
       for: 5m
       labels:
         severity: high
+        group: ClusterAutoscaler
       annotations:
         summary: "Cluster Autoscaler main loop is taking too long"
         description: "The 99th percentile of the {{"`{{ $labels.cluster }}`"}} Cluster Autoscaler's main loop duration has exceeded 120 seconds."

--- a/helmfile.d/charts/prometheus-alerts/files/hnc.yaml
+++ b/helmfile.d/charts/prometheus-alerts/files/hnc.yaml
@@ -10,6 +10,7 @@
       labels:
         rulesgroup: hnc
         severity: warning
+        group: HierarchicalNamespaceControllerNamespaceCondition
       expr: |
         hnc_namespace_conditions > 0
       for: 1m

--- a/helmfile.d/charts/prometheus-alerts/files/missing-metrics-alerts.yaml
+++ b/helmfile.d/charts/prometheus-alerts/files/missing-metrics-alerts.yaml
@@ -5,6 +5,7 @@
       description: Metrics from the worker cluster is missing
       summary: Metrics from the worker cluster is not being received.
       runbook_url: {{ .Values.runbookUrls.missingMetrics.MetricsFromWcClusterIsMissing }}
+      group: MetricsFromWcClusterIsMissing
     expr: |
       absent(prometheus_tsdb_head_series{job="kube-prometheus-stack-prometheus",tenant_id!~".*-sc"}) > 0 or prometheus_tsdb_head_series{job="kube-prometheus-stack-prometheus",tenant_id!~".*-sc"} == 0
     for: 5m
@@ -15,6 +16,7 @@
       description: Metrics from the service cluster is missing
       summary: Metrics from the service cluster is not being received.
       runbook_url: {{ .Values.runbookUrls.missingMetrics.MetricsFromScClusterIsMissing }}
+      group: MetricsFromScClusterIsMissing
     expr: |
       absent(prometheus_tsdb_head_series{job="kube-prometheus-stack-prometheus",tenant_id!~".*-wc"}) > 0 or prometheus_tsdb_head_series{job="kube-prometheus-stack-prometheus",tenant_id!~".*-wc"} == 0
     for: 15m

--- a/helmfile.d/charts/prometheus-alerts/files/rook-alerts.yaml
+++ b/helmfile.d/charts/prometheus-alerts/files/rook-alerts.yaml
@@ -13,6 +13,7 @@ groups:
         for: 5s
         labels:
           severity: warning
+          group: PersistentVolumeUsageNearFull
       - alert: PersistentVolumeUsageCritical
         annotations:
           description: PVC {{ $labels.persistentvolumeclaim }} utilization has crossed 85%. Free up some space or expand the PVC immediately.
@@ -24,6 +25,7 @@ groups:
         for: 5s
         labels:
           severity: critical
+          group: PersistentVolumeUsageCritical
   # Taken from https://github.com/rook/rook/blob/v1.10.5/deploy/charts/rook-ceph-cluster/prometheus/localrules.yaml
   #
   # Note: CephNodeInconsistentMTU has been removed as it would be constantly firing.
@@ -38,6 +40,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.2.1
+          group: CephHealthError
         annotations:
           summary: Cluster is in the ERROR state
           description: >
@@ -50,6 +53,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephHealthWarning
         annotations:
           summary: Cluster is in the WARNING state
           description: >
@@ -65,6 +69,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.3.1
+          group: CephMonDownQuorumAtRisk
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down
           summary: Monitor quorum is at risk
@@ -82,6 +87,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephMonDown
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down
           summary: One or more monitors down
@@ -100,6 +106,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.3.2
+          group: CephMonDiskspaceCritical
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-crit
           summary: Filesystem space on at least one monitor is critically low
@@ -121,6 +128,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephMonDiskspaceLow
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-low
           summary: Disk space on at least one monitor is approaching full
@@ -142,6 +150,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephMonClockSkew
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-clock-skew
           summary: Clock skew detected among monitors
@@ -162,6 +171,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.4.1
+          group: CephOSDDownHigh
         annotations:
           summary: More than 10% of OSDs are down
           description: |
@@ -178,6 +188,7 @@ groups:
           severity: warning
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.4.8
+          group: CephOSDHostDown
         annotations:
           summary: An OSD host is offline
           description: |
@@ -192,6 +203,7 @@ groups:
           severity: warning
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.4.2
+          group: CephOSDDown
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-down
           summary: An OSD has been marked down
@@ -210,6 +222,7 @@ groups:
           severity: warning
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.4.3
+          group: CephOSDNearFull
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-nearfull
           summary: OSD(s) running low on free space (NEARFULL)
@@ -225,6 +238,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.4.6
+          group: CephOSDFull
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-full
           summary: OSD full, writes blocked
@@ -240,6 +254,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephOSDBackfillFull
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-backfillfull
           summary: OSD(s) too full for backfill operations
@@ -255,6 +270,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephOSDTooManyRepairs
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-too-many-repairs
           summary: OSD reports a high number of read errors
@@ -267,6 +283,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephOSDTimeoutsPublicNetwork
         annotations:
           summary: Network issues delaying OSD heartbeats (public network)
           description: |
@@ -278,6 +295,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephOSDTimeoutsClusterNetwork
         annotations:
           summary: Network issues delaying OSD heartbeats (cluster network)
           description: |
@@ -289,6 +307,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephOSDInternalDiskSizeMismatch
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-disk-size-mismatch
           summary: OSD size inconsistency error
@@ -301,6 +320,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephDeviceFailurePredicted
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#id2
           summary: Device(s) predicted to fail soon
@@ -318,6 +338,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.4.7
+          group: CephDeviceFailurePredictionTooHigh
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-toomany
           summary: Too many devices are predicted to fail, unable to resolve
@@ -332,6 +353,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephDeviceFailureRelocationIncomplete
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-in-use
           summary: Device failure is predicted, but unable to relocate data
@@ -354,6 +376,7 @@ groups:
           severity: warning
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.4.4
+          group: CephOSDFlapping
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-osd#flapping-osds
           summary: Network issues are causing OSDs to flap (mark each other down)
@@ -370,6 +393,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephOSDReadErrors
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-spurious-read-errors
           summary: Device read errors detected
@@ -389,6 +413,7 @@ groups:
           severity: warning
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.4.5
+          group: CephPGImbalance
         annotations:
           summary: PGs are not balanced across OSDs
           description: >
@@ -405,6 +430,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.5.1
+          group: CephFilesystemDamaged
         annotations:
           documentation: https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages
           summary: CephFS filesystem is damaged.
@@ -419,6 +445,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.5.3
+          group: CephFilesystemOffline
         annotations:
           documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-all-down
           summary: CephFS filesystem is offline
@@ -432,6 +459,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.5.4
+          group: CephFilesystemDegraded
         annotations:
           documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-degraded
           summary: CephFS filesystem is degraded
@@ -445,6 +473,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephFilesystemMDSRanksLow
         annotations:
           documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-up-less-than-max
           summary: MDS daemon count is lower than configured
@@ -458,6 +487,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephFilesystemInsufficientStandby
         annotations:
           documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-insufficient-standby
           summary: Ceph filesystem standby daemons too few
@@ -472,6 +502,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.5.5
+          group: CephFilesystemFailureNoStandby
         annotations:
           documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-with-failed-mds
           summary: MDS daemon failed, no further standby available
@@ -486,6 +517,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.5.2
+          group: CephFilesystemReadOnly
         annotations:
           documentation: https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages
           summary: CephFS filesystem in read only mode due to write error(s)
@@ -505,6 +537,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.6.1
+          group: CephMgrModuleCrash
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#recent-mgr-module-crash
           summary: A manager module has recently crashed
@@ -519,6 +552,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.6.2
+          group: CephMgrPrometheusModuleInactive
         annotations:
           summary: The mgr/prometheus module is not available
           description: >
@@ -540,6 +574,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.7.1
+          group: CephPGsInactive
         annotations:
           summary: One or more placement groups are inactive
           description: >
@@ -552,6 +587,7 @@ groups:
           severity: warning
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.7.2
+          group: CephPGsUnclean
         annotations:
           summary: One or more placement groups are marked unclean
           description: >
@@ -564,6 +600,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.7.4
+          group: CephPGsDamaged
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-damaged
           summary: Placement group damaged; manual intervention needed
@@ -580,6 +617,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.7.5
+          group: CephPGRecoveryAtRisk
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-recovery-full
           summary: OSDs are too full for recovery
@@ -594,6 +632,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.7.3
+          group: CephPGUnavailableBlockingIO
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-availability
           summary: PG is unavailable, blocking I/O
@@ -607,6 +646,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.7.6
+          group: CephPGBackfillAtRisk
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-backfill-full
           summary: Backfill operations are blocked due to lack of free space
@@ -619,6 +659,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephPGNotScrubbed
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-scrubbed
           summary: Placement group(s) have not been scrubbed
@@ -636,6 +677,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephPGsHighPerOSD
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#too-many-pgs
           summary: Placement groups per OSD is too high
@@ -653,6 +695,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephPGNotDeepScrubbed
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-deep-scrubbed
           summary: Placement group(s) have not been deep scrubbed
@@ -674,6 +717,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.8.1
+          group: CephNodeRootFilesystemFull
         annotations:
           summary: Root filesystem is dangerously full
           description: >
@@ -697,6 +741,7 @@ groups:
           severity: warning
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.8.3
+          group: CephNodeNetworkPacketErrors
         annotations:
           summary: One or more NICs reports packet errors
           description: >
@@ -713,6 +758,7 @@ groups:
           severity: warning
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.8.4
+          group: CephNodeDiskspaceWarning
         annotations:
           summary: Host filesystem free space is low
           description: >
@@ -730,6 +776,7 @@ groups:
           severity: warning
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.9.2
+          group: CephPoolGrowthWarning
         annotations:
           summary: Pool growth rate may soon exceed capacity
           description: >
@@ -740,6 +787,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephPoolBackfillFull
         annotations:
           summary: Free space in a pool is too low for recovery/backfill
           description: >
@@ -753,6 +801,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.9.1
+          group: CephPoolFull
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pool-full
           summary: Pool is full - writes are blocked
@@ -772,6 +821,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephPoolNearFull
         annotations:
           summary: One or more Ceph pools are nearly full
           description: |
@@ -793,6 +843,7 @@ groups:
         labels:
           severity: warning
           type: ceph_default
+          group: CephSlowOps
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#slow-ops
           summary: OSD operations are slow to complete
@@ -809,6 +860,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.10.1
+          group: CephObjectMissing
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#object-unfound
           summary: Object(s) marked UNFOUND
@@ -826,6 +878,7 @@ groups:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.1.2.1.1.2
+          group: CephDaemonCrash
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#recent-crash
           summary: One or more Ceph daemons have crashed, and are pending acknowledgement

--- a/helmfile.d/charts/prometheus-alerts/files/thanos-ruler.yaml
+++ b/helmfile.d/charts/prometheus-alerts/files/thanos-ruler.yaml
@@ -14,6 +14,7 @@ groups:
     for: 5m
     labels:
       severity: critical
+      group: Thanos
   - alert: ThanosRuleQueueIsDroppingAlerts
     annotations:
       description: Thanos Rule {{`{{$labels.instance}}`}} is failing to queue alerts.
@@ -24,6 +25,7 @@ groups:
     for: 5m
     labels:
       severity: critical
+      group: Thanos
   - alert: ThanosRuleSenderIsFailingAlerts
     annotations:
       description: Thanos Rule {{`{{$labels.instance}}`}} is failing to send alerts to alertmanager.
@@ -34,6 +36,7 @@ groups:
     for: 5m
     labels:
       severity: critical
+      group: Thanos
   - alert: ThanosRuleHighRuleEvaluationFailures
     annotations:
       description: Thanos Rule {{`{{$labels.instance}}`}} is failing to evaluate rules.
@@ -49,6 +52,7 @@ groups:
     for: 5m
     labels:
       severity: critical
+      group: Thanos
   - alert: ThanosRuleHighRuleEvaluationWarnings
     annotations:
       description: Thanos Rule {{`{{$labels.instance}}`}} has high number of evaluation
@@ -60,6 +64,7 @@ groups:
     for: 15m
     labels:
       severity: info
+      group: Thanos
   - alert: ThanosRuleRuleEvaluationLatencyHigh
     annotations:
       description: Thanos Rule {{`{{$labels.instance}}`}} has higher evaluation latency
@@ -75,6 +80,7 @@ groups:
     for: 5m
     labels:
       severity: warning
+      group: Thanos
   - alert: ThanosRuleGrpcErrorRate
     annotations:
       description: Thanos Rule {{`{{$labels.job}}`}} is failing to handle {{`{{$value | humanize}}`}}%
@@ -91,6 +97,7 @@ groups:
     for: 5m
     labels:
       severity: warning
+      group: Thanos
   - alert: ThanosRuleConfigReloadFailure
     annotations:
       description: Thanos Rule {{`{{$labels.job}}`}} has not been able to reload its configuration.
@@ -101,6 +108,7 @@ groups:
     for: 5m
     labels:
       severity: info
+      group: Thanos
   - alert: ThanosRuleQueryHighDNSFailures
     annotations:
       description: Thanos Rule {{`{{$labels.job}}`}} has {{`{{$value | humanize}}`}}% of failing
@@ -117,6 +125,7 @@ groups:
     for: 15m
     labels:
       severity: warning
+      group: Thanos
   - alert: ThanosRuleAlertmanagerHighDNSFailures
     annotations:
       description: Thanos Rule {{`{{$labels.instance}}`}} has {{`{{$value | humanize}}`}}% of
@@ -133,6 +142,7 @@ groups:
     for: 15m
     labels:
       severity: warning
+      group: Thanos
   - alert: ThanosRuleNoEvaluationFor10Intervals
     annotations:
       description: Thanos Rule {{`{{$labels.job}}`}} has {{`{{$value | humanize}}`}}% rule groups
@@ -146,6 +156,7 @@ groups:
     for: 5m
     labels:
       severity: info
+      group: Thanos
   - alert: ThanosNoRuleEvaluations
     annotations:
       description: Thanos Rule {{`{{$labels.instance}}`}} did not perform any rule evaluations
@@ -159,3 +170,4 @@ groups:
     for: 5m
     labels:
       severity: critical
+      group: Thanos

--- a/helmfile.d/charts/prometheus-alerts/files/thanos.yaml
+++ b/helmfile.d/charts/prometheus-alerts/files/thanos.yaml
@@ -13,6 +13,7 @@ groups:
     for: 5m
     labels:
       severity: warning
+      group: Thanos
   - alert: ThanosCompactHalted
     annotations:
       description: Thanos Compact {{`{{$labels.job}}`}} has failed to run and now is halted.
@@ -22,6 +23,7 @@ groups:
     for: 5m
     labels:
       severity: warning
+      group: Thanos
   - alert: ThanosCompactHighCompactionFailures
     annotations:
       description: Thanos Compact {{`{{$labels.job}}`}} is failing to execute {{`{{$value | humanize}}`}}% of compactions.
@@ -37,6 +39,7 @@ groups:
     for: 15m
     labels:
       severity: warning
+      group: Thanos
   - alert: ThanosCompactBucketHighOperationFailures
     annotations:
       description: Thanos Compact {{`{{$labels.job}}`}} Bucket is failing to execute {{`{{$value | humanize}}`}}% of operations.
@@ -52,6 +55,7 @@ groups:
     for: 15m
     labels:
       severity: warning
+      group: Thanos
   - alert: ThanosCompactHasNotRun
     annotations:
       description: Thanos Compact {{`{{$labels.job}}`}} has not uploaded anything for 24
@@ -62,6 +66,7 @@ groups:
       / 60 / 60 > 24
     labels:
       severity: warning
+      group: Thanos
 - name: thanos-query
   rules:
   - alert: ThanosQueryHttpRequestQueryErrorRateHigh
@@ -79,6 +84,7 @@ groups:
     for: 5m
     labels:
       severity: critical
+      group: Thanos
   - alert: ThanosQueryHttpRequestQueryRangeErrorRateHigh
     annotations:
       description: Thanos Query {{`{{$labels.job}}`}} is failing to handle {{`{{$value | humanize}}`}}%
@@ -94,6 +100,7 @@ groups:
     for: 5m
     labels:
       severity: critical
+      group: Thanos
   - alert: ThanosQueryGrpcServerErrorRate
     annotations:
       description: Thanos Query {{`{{$labels.job}}`}} is failing to handle {{`{{$value | humanize}}`}}%
@@ -110,6 +117,7 @@ groups:
     for: 5m
     labels:
       severity: warning
+      group: Thanos
   - alert: ThanosQueryGrpcClientErrorRate
     annotations:
       description: Thanos Query {{`{{$labels.job}}`}} is failing to send {{`{{$value | humanize}}`}}%
@@ -125,6 +133,7 @@ groups:
     for: 5m
     labels:
       severity: warning
+      group: Thanos
   - alert: ThanosQueryHighDNSFailures
     annotations:
       description: Thanos Query {{`{{$labels.job}}`}} have {{`{{$value | humanize}}`}}% of failing
@@ -140,6 +149,7 @@ groups:
     for: 15m
     labels:
       severity: warning
+      group: Thanos
   - alert: ThanosQueryInstantLatencyHigh
     annotations:
       description: Thanos Query {{`{{$labels.job}}`}} has a 99th percentile latency of {{`{{$value}}`}}
@@ -155,6 +165,7 @@ groups:
     for: 10m
     labels:
       severity: critical
+      group: Thanos
   - alert: ThanosQueryRangeLatencyHigh
     annotations:
       description: Thanos Query {{`{{$labels.job}}`}} has a 99th percentile latency of {{`{{$value}}`}}
@@ -170,6 +181,7 @@ groups:
     for: 10m
     labels:
       severity: critical
+      group: Thanos
 - name: thanos-receive
   rules:
   - alert: ThanosReceiveHttpRequestErrorRateHigh
@@ -186,6 +198,7 @@ groups:
     for: 20m
     labels:
       severity: critical
+      group: Thanos
   - alert: ThanosReceiveHttpRequestLatencyHigh
     annotations:
       description: Thanos Receive {{`{{$labels.job}}`}} has a 99th percentile latency of
@@ -201,6 +214,7 @@ groups:
     for: 10m
     labels:
       severity: critical
+      group: Thanos
   - alert: ThanosReceiveHighReplicationFailures
     annotations:
       description: Thanos Receive {{`{{$labels.job}}`}} is failing to replicate {{`{{$value | humanize}}`}}% of requests.
@@ -225,6 +239,7 @@ groups:
     for: 5m
     labels:
       severity: warning
+      group: Thanos
   - alert: ThanosReceiveHighForwardRequestFailures
     annotations:
       description: Thanos Receive {{`{{$labels.job}}`}} is failing to forward {{`{{$value | humanize}}`}}% of requests.
@@ -239,6 +254,7 @@ groups:
     for: 5m
     labels:
       severity: info
+      group: Thanos
   - alert: ThanosReceiveHighHashringFileRefreshFailures
     annotations:
       description: Thanos Receive {{`{{$labels.job}}`}} is failing to refresh hashring file,
@@ -255,6 +271,7 @@ groups:
     for: 15m
     labels:
       severity: warning
+      group: Thanos
   - alert: ThanosReceiveConfigReloadFailure
     annotations:
       description: Thanos Receive {{`{{$labels.job}}`}} has not been able to reload hashring
@@ -266,6 +283,7 @@ groups:
     for: 5m
     labels:
       severity: warning
+      group: Thanos
   - alert: ThanosReceiveNoUpload
     annotations:
       description: Thanos Receive {{`{{$labels.instance}}`}} has not uploaded latest data
@@ -279,6 +297,7 @@ groups:
     for: 3h
     labels:
       severity: critical
+      group: Thanos
   - alert: ThanosReceiveTrafficBelowThreshold
     annotations:
       description: At Thanos Receive {{`{{$labels.job}}`}} in {{`{{$labels.namespace}}`}} , the
@@ -296,6 +315,7 @@ groups:
     for: 1h
     labels:
       severity: warning
+      group: Thanos
 - name: thanos-store
   rules:
   - alert: ThanosStoreGrpcErrorRate
@@ -314,6 +334,7 @@ groups:
     for: 5m
     labels:
       severity: warning
+      group: Thanos
   - alert: ThanosStoreSeriesGateLatencyHigh
     annotations:
       description: Thanos Store {{`{{$labels.job}}`}} has a 99th percentile latency of {{`{{$value}}`}}
@@ -329,6 +350,7 @@ groups:
     for: 10m
     labels:
       severity: warning
+      group: Thanos
   - alert: ThanosStoreBucketHighOperationFailures
     annotations:
       description: Thanos Store {{`{{$labels.job}}`}} Bucket is failing to execute {{`{{$value | humanize}}`}}% of operations.
@@ -344,6 +366,7 @@ groups:
     for: 15m
     labels:
       severity: warning
+      group: Thanos
   - alert: ThanosStoreObjstoreOperationLatencyHigh
     annotations:
       description: Thanos Store {{`{{$labels.job}}`}} Bucket has a 99th percentile latency
@@ -359,6 +382,7 @@ groups:
     for: 10m
     labels:
       severity: warning
+      group: Thanos
 - name: thanos-bucket-replicate
   rules:
   - alert: ThanosBucketReplicateErrorRate
@@ -376,6 +400,7 @@ groups:
     for: 5m
     labels:
       severity: critical
+      group: Thanos
   - alert: ThanosBucketReplicateRunLatency
     annotations:
       description: Thanos Replicate {{`{{$labels.job}}`}} has a 99th percentile latency
@@ -391,6 +416,7 @@ groups:
     for: 5m
     labels:
       severity: critical
+      group: Thanos
 - name: thanos-component-absent
   rules:
   - alert: ThanosCompactIsDown
@@ -404,6 +430,7 @@ groups:
     for: 5m
     labels:
       severity: critical
+      group: Thanos
   - alert: ThanosQueryIsDown
     annotations:
       description: ThanosQuery has disappeared. Prometheus target for the component
@@ -415,6 +442,7 @@ groups:
     for: 5m
     labels:
       severity: critical
+      group: Thanos
   - alert: ThanosReceiveIsDown
     annotations:
       description: ThanosReceive has disappeared. Prometheus target for the component
@@ -426,6 +454,7 @@ groups:
     for: 5m
     labels:
       severity: critical
+      group: Thanos
   - alert: ThanosStoreIsDown
     annotations:
       description: ThanosStore has disappeared. Prometheus target for the component
@@ -437,3 +466,4 @@ groups:
     for: 5m
     labels:
       severity: critical
+      group: Thanos

--- a/helmfile.d/charts/prometheus-alerts/files/webhooks.yaml
+++ b/helmfile.d/charts/prometheus-alerts/files/webhooks.yaml
@@ -9,3 +9,4 @@
     for: 10m
     labels:
       severity: warning
+      group: WebhookFailing

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/alertmanager.rules.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/alertmanager.rules.yaml
@@ -38,6 +38,7 @@ spec:
       for: 20m
       labels:
         severity: critical
+        group: Alertmanager
     - alert: AlertmanagerFailedReload
       annotations:
         description: Configuration has failed to load for {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod{{`}}`}}.
@@ -50,6 +51,7 @@ spec:
       for: 10m
       labels:
         severity: critical
+        group: Alertmanager
     - alert: AlertmanagerMembersInconsistent
       annotations:
         description: Alertmanager {{`{{`}} $labels.namespace {{`}}`}}/{{`{{`}} $labels.pod{{`}}`}} has only found {{`{{`}} $value {{`}}`}} members of the {{`{{`}}$labels.job{{`}}`}} cluster.
@@ -64,4 +66,5 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: Alertmanager
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/backup-status.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/backup-status.yaml
@@ -29,6 +29,7 @@ spec:
       for: 1h
       labels:
         severity: warning
+        group: HarborBackupHaveFailed
     - alert: HarborBackupHaveFailed48Hours
       annotations:
         description: The job daily backup job harbor-backup have failed over 48 hours.
@@ -41,6 +42,7 @@ spec:
       for: 1h
       labels:
         severity: warning
+        group: HarborBackupHaveFailed
     - alert: VeleroBackupHaveFailed24Hours
       annotations:
         description: The job daily backup job velero-backup have failed over 24 hours.
@@ -53,6 +55,7 @@ spec:
       for: 1h
       labels:
         severity: warning
+        group: VeleroBackupHaveFailed
     - alert: VeleroBackupHaveFailed48Hours
       annotations:
         description: The job daily backup job velero-backup have failed over 48 hours.
@@ -65,6 +68,7 @@ spec:
       for: 1h
       labels:
         severity: warning
+        group: VeleroBackupHaveFailed
     - alert: OpenSearchSnapshotHaveFailed24Hours
       annotations:
         description: There have been no successful OpenSearch snapshots for over 24 hours.
@@ -79,6 +83,7 @@ spec:
       for: 1h
       labels:
         severity: warning
+        group: OpenSearchSnapshotHaveFailed
     - alert: OpenSearchSnapshotHaveFailed48Hours
       annotations:
         description: There have been no successful OpenSearch snapshots for over 48 hours.
@@ -93,4 +98,5 @@ spec:
       for: 1h
       labels:
         severity: warning
+        group: OpenSearchSnapshotHaveFailed
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/blackbox.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/blackbox.yaml
@@ -22,6 +22,7 @@ spec:
           for: 60s
           labels:
             severity: "critical"
+            group: EndpointDown
           annotations:
             summary: "Endpoint {{`{{ $labels.target }}`}} at {{`{{ $labels.instance }}`}} down"
             runbook_url: {{ .Values.runbookUrls.blackbox.EndpointDown }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/cert-manager-alerts.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/cert-manager-alerts.yaml
@@ -27,6 +27,7 @@ spec:
       for: 10m
       labels:
         severity: low
+        group: CertificateExpiringSoon
     - alert: CertificateNotReady
       annotations:
         message: The Certificate {{`{{$labels.name}}`}} is not ready!
@@ -36,4 +37,5 @@ spec:
       for: 10m
       labels:
         severity: critical
+        group: CertificateNotReady
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/cluster-capacity-management-alerts.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/cluster-capacity-management-alerts.yaml
@@ -33,6 +33,7 @@ spec:
       for: 1h
       labels:
         severity: warning
+        group: NodeFilesystemSpaceFillingUp
     {{- if .Values.capacityManagementAlertsPersistentVolumeEnabled }}
     - alert: PersistentVolume{{.Values.capacityManagementAlertsPersistentVolumeLimit}}PercentInThreeDays
       annotations:
@@ -42,6 +43,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: ClusterCapacityPersistentVolumePercent
     {{- end }}
     {{- if .Values.capacityManagementAlertsPredictUsage}}
     - alert: Memory{{.Values.capacityManagementAlertsUsageLimit}}PercentInThreeDays
@@ -52,6 +54,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: ClusterCapacityMemoryPercent
     {{- end }}
     - alert: NodeGroupCPU{{.Values.capacityManagementAlertsNodeGroupCpuLimit24h}}PercentOver24h
       annotations:
@@ -61,6 +64,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: ClusterCapacityManagement
     - alert: NodeGroupCPU{{.Values.capacityManagementAlertsNodeGroupCpuLimit1h}}PercentOver1h
       annotations:
         message: CPU usage has been over {{.Values.capacityManagementAlertsNodeGroupCpuLimit1h}}% on average over the span of 1h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
@@ -69,6 +73,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: ClusterCapacityManagement
     - alert: NodeGroupMemory{{.Values.capacityManagementAlertsNodeGroupMemoryLimit24h}}PercentOver24h
       annotations:
         message: Memory usage has been over {{.Values.capacityManagementAlertsNodeGroupMemoryLimit24h}}% on average over the span of 24h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
@@ -77,6 +82,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: ClusterCapacityManagement
     - alert: NodeGroupMemory{{.Values.capacityManagementAlertsNodeGroupMemoryLimit1h}}PercentOver1h
       annotations:
         message: Memory usage has been over {{.Values.capacityManagementAlertsNodeGroupMemoryLimit1h}}% on average over the span of 1h in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
@@ -85,6 +91,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: ClusterCapacityManagement
     - alert: NodeCPU{{.Values.capacityManagementAlertsNodeCpuLimit1h}}PercentOver1h
       annotations:
         message: CPU usage has been over {{.Values.capacityManagementAlertsNodeCpuLimit1h}}% on average over the span of 1h for the node {{`{{ $labels.instance }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
@@ -93,6 +100,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: ClusterCapacityManagement
     - alert: NodeMemory{{.Values.capacityManagementAlertsNodeMemoryLimit1h}}PercentOver1h
       annotations:
         message: Memory usage has been over {{.Values.capacityManagementAlertsNodeMemoryLimit1h}}% on average over the span of 1h for the Node {{`{{ $labels.instance }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
@@ -105,6 +113,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: ClusterCapacityManagement
     - alert: NodeGroupCpuRequest{{ .Values.capacityManagementAlertsCpuRequestLimit }}Percent
       annotations:
         message: Average CPU requests is over {{ .Values.capacityManagementAlertsCpuRequestLimit }}% in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
@@ -121,6 +130,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: ClusterCapacityManagement
     - alert: NodeGroupMemoryRequest{{ .Values.capacityManagementAlertsMemoryRequestLimit }}Percent
       annotations:
         message: Average memory requests is over {{ .Values.capacityManagementAlertsMemoryRequestLimit }}% in the Node Group {{`{{ $labels.label_elastisys_io_node_group }}`}} in Cluster {{`{{ $labels.cluster }}`}}.
@@ -137,6 +147,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: ClusterCapacityManagement
     - alert: NodeMissingElastisysNodeGroupLabel
       annotations:
         description: "The node {{`{{`}} $labels.node {{`}}`}} in {{`{{`}} $labels.cluster {{`}}`}}  is missing the 'elastisys.io/node-group' label. This might affect capacity management monitoring."
@@ -146,4 +157,5 @@ spec:
       for: 60m
       labels:
         severity: warning
+        group: ClusterCapacityManagement
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/config-reloaders.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/config-reloaders.yaml
@@ -27,6 +27,7 @@ spec:
       for: 10m
       labels:
         severity: warning
+        group: ConfigReloaderSidecarErrors
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/coredns.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/coredns.yaml
@@ -27,6 +27,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: {{ . | title }}
     - alert: {{ . | title }}LatencyHigh
       annotations:
         description: {{ . | title }} has 99th percentile latency of {{`{{`}} $value {{`}}`}} seconds for server  {{`{{`}} $labels.server {{`}}`}} zone  {{`{{`}} $labels.zone {{`}}`}}.
@@ -37,6 +38,7 @@ spec:
       for: 10m
       labels:
         severity: medium
+        group: {{ . | title }}
     - alert: {{ . | title }}ErrorsHigh
       annotations:
         description: {{ . | title }} is returning SERVFAIL for {{`{{`}} $value | humanizePercentage {{`}}`}} of requests.
@@ -49,6 +51,7 @@ spec:
       for: 10m
       labels:
         severity: medium
+        group: {{ . | title }}
     - alert: {{ . | title }}ErrorsHigh
       annotations:
         description: {{ . | title }} is returning SERVFAIL for {{`{{`}} $value | humanizePercentage {{`}}`}} of requests.
@@ -61,6 +64,7 @@ spec:
       for: 10m
       labels:
         severity: low
+        group: {{ . | title }}
     - alert: {{ . | title }}ForwardLatencyHigh
       annotations:
         description: {{ . | title }} has 99th percentile latency of {{`{{`}} $value {{`}}`}} seconds forwarding requests to  {{`{{`}} $labels.to {{`}}`}}.
@@ -71,6 +75,7 @@ spec:
       for: 10m
       labels:
         severity: medium
+        group: {{ . | title }}
     - alert: {{ . | title }}ForwardErrorsHigh
       annotations:
         description: {{ . | title }} is returning SERVFAIL for {{`{{`}} $value | humanizePercentage {{`}}`}} of forward requests to  {{`{{`}} $labels.to {{`}}`}}.
@@ -83,6 +88,7 @@ spec:
       for: 10m
       labels:
         severity: medium
+        group: {{ . | title }}
     - alert: {{ . | title }}ForwardErrorsHigh
       annotations:
         description: {{ . | title }} is returning SERVFAIL for {{`{{`}} $value | humanizePercentage {{`}}`}} of forward requests to  {{`{{`}} $labels.to {{`}}`}}.
@@ -95,6 +101,7 @@ spec:
       for: 10m
       labels:
         severity: low
+        group: {{ . | title }}
     - alert: {{ . | title }}ForwardHealthcheckFailureCount
       annotations:
         description: {{ . | title }} health checks have failed to upstream server  {{`{{`}} $labels.to {{`}}`}}.
@@ -105,6 +112,7 @@ spec:
       for: 10m
       labels:
         severity: low
+        group: {{ . | title }}
     - alert: {{ . | title }}ForwardHealthcheckBrokenCount
       annotations:
         description: {{ . | title }} health checks have failed for all upstream servers.
@@ -115,6 +123,7 @@ spec:
       for: 10m
       labels:
         severity: low
+        group: {{ . | title }}
     - alert: {{ . | title }}PanicCount
       annotations:
         description: "Number of {{ . | title }} panics encountered VALUE = {{`{{`}} $value {{`}}`}}  LABELS = {{`{{`}} $labels {{`}}`}}"
@@ -124,6 +133,7 @@ spec:
       for: 1m
       labels:
         severity: low
+        group: {{ . | title }}
     {{- end }}
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/daily-checks.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/daily-checks.yaml
@@ -37,6 +37,7 @@ spec:
       for: 1h
       labels:
         severity: warning
+        group: S3BucketSizeOverPercent
     {{- end }}
     {{- if .objects.enabled }}
     - alert: S3BucketObjectsOver{{.objects.percent}}Percent-{{ .name }}
@@ -50,6 +51,7 @@ spec:
       for: 2h
       labels:
         severity: warning
+        group: S3BucketObjectsOverPercent
     {{- end }}
   {{- end }}
 {{- end }}
@@ -65,6 +67,7 @@ spec:
       for: 1h
       labels:
         severity: warning
+        group: S3BucketSizeOverPercent
 {{- end }}
 {{- if .Values.s3BucketAlerts.totalSize.enabled }}
     - alert: S3BucketsTotalSizeOver{{.Values.s3BucketAlerts.totalSize.percent}}Percent
@@ -78,6 +81,7 @@ spec:
       for: 1h
       labels:
         severity: warning
+        group: S3BucketSizeOverPercent
 {{- end }}
 {{- if .Values.s3BucketAlerts.objects.enabled }}
     - alert: S3BucketObjectsOver{{.Values.s3BucketAlerts.objects.percent}}Percent
@@ -91,6 +95,7 @@ spec:
       for: 2h
       labels:
         severity: warning
+        group: S3BucketObjectsOverPercent
 {{- end }}
     - alert: Bucket36hActivityCheck
       annotations:
@@ -103,4 +108,5 @@ spec:
       for: 1h
       labels:
         severity: warning
+        group: Bucket36hActivityCheck
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/disk-perf.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/disk-perf.yaml
@@ -38,6 +38,7 @@ spec:
           for: 10m
           labels:
             severity: warning
+            group: DiskPerformance
         - alert: DiskWriteWaitTimeHigh
           annotations:
             description: Disk {{`{{`}} $labels.device {{`}}`}} Wait Time on {{`{{`}} $labels.instance {{`}}`}} is {{`{{`}} $value {{`}}`}}, check the workload
@@ -54,6 +55,7 @@ spec:
           for: 10m
           labels:
             severity: warning
+            group: DiskPerformance
         - alert: DiskQueueSizeHigh
           annotations:
             description: Disk {{`{{`}} $labels.device {{`}}`}} Queue Size on {{`{{`}} $labels.instance {{`}}`}} is {{`{{`}} $value {{`}}`}}, check the workload
@@ -68,4 +70,5 @@ spec:
           for: 10m
           labels:
             severity: warning
+            group: DiskPerformance
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/falco-alerts.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/falco-alerts.yaml
@@ -25,4 +25,5 @@ spec:
         falcosecurity_falcosidekick_falco_events_total != 0
       labels:
         severity: warning
+        group: FalcoAlert
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/fluentd.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/fluentd.yaml
@@ -23,6 +23,7 @@ spec:
       labels:
         service: fluentd
         severity: warning
+        group: Fluentd
       annotations:
         summary: fluentd cannot be scraped
         description: Prometheus could not scrape {{ "{{ $labels.job }}" }} for more than 10 minutes
@@ -33,6 +34,7 @@ spec:
       labels:
         service: fluentd
         severity: critical
+        group: Fluentd
       annotations:
         summary: fluentd cannot be scraped
         description: Prometheus could not scrape {{ "{{ $labels.job }}" }} for more than 30 minutes
@@ -43,6 +45,7 @@ spec:
       labels:
         service: fluentd
         severity: warning
+        group: Fluentd
       annotations:
         summary: fluentd node are failing
         description: In the last 15 minutes, fluentd queues increased 30%. Current value is {{ "{{ $value }}" }}
@@ -53,6 +56,7 @@ spec:
       labels:
         service: fluentd
         severity: critical
+        group: Fluentd
       annotations:
         summary: fluentd node are critical
         description: In the last 5 minutes, fluentd queues increased 50%. Current value is {{ "{{ $value }}" }}
@@ -63,6 +67,7 @@ spec:
       labels:
         service: fluentd
         severity: warning
+        group: Fluentd
       annotations:
         summary: fluentd available space in buffer is less than 50%
         description: For the last 5 minutes, the available buffer space for pod {{ "{{ $labels.pod }}" }}, plugin-id {{  "{{ $labels.plugin_id }}" }} in cluster {{ "{{ $labels.cluster }}" }} is below 50%. Current value is {{ "{{ $value }}" }}
@@ -73,6 +78,7 @@ spec:
       labels:
         service: fluentd
         severity: critical
+        group: Fluentd
       annotations:
         summary: fluentd available space in buffer is less than 90%
         description: For the last 5 minutes, the available buffer space for pod {{ "{{ $labels.pod }}" }}, plugin-id {{  "{{ $labels.plugin_id }}" }} in cluster {{ "{{ $labels.cluster }}" }} is below 10%. Current value is {{ "{{ $value }}" }}
@@ -86,6 +92,7 @@ spec:
       labels:
         service: fluentd
         severity: warning
+        group: Fluentd
       annotations:
         summary: fluentd records count are critical
         description: In the last 5m, records counts increased 3 times, comparing to the latest 15 min.
@@ -96,6 +103,7 @@ spec:
       labels:
         service: fluentd
         severity: warning
+        group: Fluentd
       annotations:
         description: Fluentd retry count has been  {{ "{{ $value }}" }} for the last 10 minutes
         summary: Fluentd retry count has been  {{ "{{ $value }}" }} for the last 10 minutes
@@ -106,6 +114,7 @@ spec:
       labels:
         service: fluentd
         severity: warning
+        group: Fluentd
       annotations:
         description: Fluentd output error count is {{ "{{ $value }}" }} for the last 10 minutes
         summary: There have been Fluentd output error(s) for the last 10 minutes

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/general.rules.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/general.rules.yaml
@@ -26,6 +26,7 @@ spec:
       for: 10m
       labels:
         severity: warning
+        group: TargetDown
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -47,6 +48,7 @@ spec:
       expr: vector(1)
       labels:
         severity: none
+        group: Watchdog
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/harbor.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/harbor.yaml
@@ -23,6 +23,7 @@ spec:
       for: 5m
       labels:
         severity: critical
+        group: Harbor
       annotations:
         description: Harbor Core Is Down
         runbook_url: {{ .Values.runbookUrls.harbor.HarborCoreDown }}
@@ -33,6 +34,7 @@ spec:
       for: 5m
       labels:
         severity: critical
+        group: Harbor
       annotations:
         description: Harbor Database Is Down
         runbook_url: {{ .Values.runbookUrls.harbor.HarborDatabaseDown }}
@@ -43,6 +45,7 @@ spec:
       for: 5m
       labels:
         severity: critical
+        group: Harbor
       annotations:
         description: Harbor Registry Is Down
         runbook_url: {{ .Values.runbookUrls.harbor.HarborRegistryDown }}
@@ -53,6 +56,7 @@ spec:
       for: 5m
       labels:
         severity: critical
+        group: Harbor
       annotations:
         description: Harbor Redis Is Down
         runbook_url: {{ .Values.runbookUrls.harbor.HarborRedisDown }}
@@ -63,6 +67,7 @@ spec:
       for: 5m
       labels:
         severity: critical
+        group: Harbor
       annotations:
         description: Harbor Trivy Is Down
         runbook_url: {{ .Values.runbookUrls.harbor.HarborTrivyDown }}
@@ -72,6 +77,7 @@ spec:
       for: 5m
       labels:
         severity: critical
+        group: Harbor
       annotations:
         description: Harbor JobService Is Down
         runbook_url: {{ .Values.runbookUrls.harbor.HarborJobServiceDown }}
@@ -81,6 +87,7 @@ spec:
       for: 5m
       labels:
         severity: medium
+        group: Harbor
       annotations:
         description: Total used storage for Harbor is high (above the threshold of {{ .Values.harbor.alerts.maxTotalStorageUsedGB }}GB). This indicates that users have not set up artifact retention. If the total size of artifacts continues to grow, then Harbor will likely consume more resources and slow down. This might also cause issues with object storage quota at the infrastructure provider.
         runbook_url: {{ .Values.runbookUrls.harbor.HarborStorageUsageAboveThreshold }}
@@ -90,6 +97,7 @@ spec:
       for: 5m
       labels:
         severity: low
+        group: Harbor
       annotations:
         description: Harbor p99 latency is higher than 10 seconds
         runbook_url: {{ .Values.runbookUrls.harbor.HarborP99LatencyHigherThan10Seconds }}
@@ -99,6 +107,7 @@ spec:
       for: 5m
       labels:
         severity: low
+        group: Harbor
       annotations:
         description: Harbor Error Rate is High
         runbook_url: {{ .Values.runbookUrls.harbor.HarborErrorRateHigh }}
@@ -108,6 +117,7 @@ spec:
       for: 5m
       labels:
         severity: low
+        group: Harbor
       annotations:
         description: Total number of artifacts is high (above alert threshold of {{ .Values.harbor.alerts.maxTotalArtifacts }}). This indicates that users have not set up artifact retention. If the number of artifacts continues to grow, then Harbor will likely consume more resources and slow down.
         runbook_url: {{ .Values.runbookUrls.harbor.HarborTotalNumberOfArtifactsAboveThreshold }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kube-state-metrics.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kube-state-metrics.yaml
@@ -30,6 +30,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: KubeStateMetrics
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -46,6 +47,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: KubeStateMetrics
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -58,6 +60,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: KubeStateMetrics
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -74,6 +77,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: KubeStateMetrics
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-apps.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-apps.yaml
@@ -27,6 +27,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubernetesApps
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -46,6 +47,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubernetesApps
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -58,6 +60,7 @@ spec:
       for: 0m
       labels:
         severity: warning
+        group: KubernetesApps
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -73,6 +76,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubeDeploymentGenerationMismatch
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -94,6 +98,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubernetesApps
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -115,6 +120,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubernetesApps
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -130,6 +136,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubernetesApps
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -159,6 +166,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubernetesApps
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -194,6 +202,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubernetesApps
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -206,6 +215,7 @@ spec:
       for: 1h
       labels:
         severity: warning
+        group: KubernetesApps
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -221,6 +231,7 @@ spec:
       for: 10m
       labels:
         severity: warning
+        group: KubernetesApps
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -233,6 +244,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubernetesApps
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -247,6 +259,7 @@ spec:
         kube_job_status_active{job="kube-state-metrics", namespace=~"{{ $targetNamespace }}"} > 0) > 43200
       labels:
         severity: warning
+        group: KubeJob
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -259,6 +272,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubeJob
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -271,6 +285,7 @@ spec:
       for: 10m
       labels:
         severity: warning
+        group: KubeFailedEvictedPods
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-resources.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-resources.yaml
@@ -29,6 +29,7 @@ spec:
       for: 10m
       labels:
         severity: warning
+        group: KubernetesResources
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -44,6 +45,7 @@ spec:
       for: 10m
       labels:
         severity: warning
+        group: KubernetesResources
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -60,6 +62,7 @@ spec:
       for: 15m
       labels:
         severity: info
+        group: KubernetesResources
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-storage.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-storage.yaml
@@ -34,6 +34,7 @@ spec:
       for: 1m
       labels:
         severity: critical
+        group: KubernetesStorage
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -55,6 +56,7 @@ spec:
       for: 1h
       labels:
         severity: warning
+        group: KubernetesStorage
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -67,6 +69,7 @@ spec:
       for: 5m
       labels:
         severity: critical
+        group: KubernetesStorage
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system-apiserver.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system-apiserver.yaml
@@ -25,6 +25,7 @@ spec:
       expr: apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
       labels:
         severity: warning
+        group: KubernetesAPIServer
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -36,6 +37,7 @@ spec:
       expr: apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
       labels:
         severity: critical
+        group: KubernetesAPIServer
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -47,6 +49,7 @@ spec:
       expr: sum by(cluster, name, namespace)(increase(aggregator_unavailable_apiservice_total[10m])) > 4
       labels:
         severity: warning
+        group: KubernetesAPIServer
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -59,6 +62,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: KubernetesAPIServer
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -71,6 +75,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: KubernetesAPIServer
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -83,6 +88,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: KubernetesAPIServer
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system-kube-proxy.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system-kube-proxy.yaml
@@ -26,4 +26,5 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: KubeProxyDown
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system-kubelet.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system-kubelet.yaml
@@ -26,6 +26,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -38,6 +39,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -57,6 +59,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -69,6 +72,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -81,6 +85,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -93,6 +98,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -104,6 +110,7 @@ spec:
       expr: kubelet_certificate_manager_client_ttl_seconds < 604800
       labels:
         severity: warning
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -115,6 +122,7 @@ spec:
       expr: kubelet_certificate_manager_client_ttl_seconds < 86400
       labels:
         severity: critical
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -126,6 +134,7 @@ spec:
       expr: kubelet_certificate_manager_server_ttl_seconds < 604800
       labels:
         severity: warning
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -137,6 +146,7 @@ spec:
       expr: kubelet_certificate_manager_server_ttl_seconds < 86400
       labels:
         severity: critical
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -149,6 +159,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -161,6 +172,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -173,6 +185,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -189,6 +202,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -204,6 +218,7 @@ spec:
       for: 30m
       labels:
         severity: critical
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -219,6 +234,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -234,6 +250,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -247,6 +264,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -259,6 +277,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: KubernetesKubelet
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-system.yaml
@@ -26,6 +26,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: Kubernetes
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -42,6 +43,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: Kubernetes
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kured.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kured.yaml
@@ -23,6 +23,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: KuredFailedNodeReboot
       annotations:
         description: "Kured has failed with required reboot of node {{`{{ $labels.node }}`}} over 30 days."
         runbook_url: {{ .Values.runbookUrls.kured.KuredFailedNodeReboot }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/node-exporter.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/node-exporter.yaml
@@ -32,6 +32,7 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
+        group: NodeFilesystem
   {{- if $.Values.defaultRules.additionalRuleLabels }}
   {{ toYaml $.Values.defaultRules.additionalRuleLabels | indent 8 }}
   {{- end }}
@@ -53,6 +54,7 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
+        group: NodeFilesystem
   {{- if $.Values.defaultRules.additionalRuleLabels }}
   {{ toYaml $.Values.defaultRules.additionalRuleLabels | indent 8 }}
   {{- end }}
@@ -72,6 +74,7 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
+        group: NodeFilesystem
   {{- if $.Values.defaultRules.additionalRuleLabels }}
   {{ toYaml $.Values.defaultRules.additionalRuleLabels | indent 8 }}
   {{- end }}
@@ -93,6 +96,7 @@ spec:
       for: {{ .for }}
       labels:
         severity: {{ .severity }}
+        group: NodeFilesystem
   {{- if $.Values.defaultRules.additionalRuleLabels }}
   {{ toYaml $.Values.defaultRules.additionalRuleLabels | indent 8 }}
   {{- end }}
@@ -106,6 +110,7 @@ spec:
       for: 1h
       labels:
         severity: warning
+        group: NodeNetwork
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -118,6 +123,7 @@ spec:
       for: 1h
       labels:
         severity: warning
+        group: NodeNetwork
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -129,6 +135,7 @@ spec:
       expr: (node_nf_conntrack_entries / node_nf_conntrack_entries_limit) > 0.75
       labels:
         severity: warning
+        group: Node
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -140,6 +147,7 @@ spec:
       expr: node_textfile_scrape_error{job="node-exporter"} == 1
       labels:
         severity: warning
+        group: Node
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -163,6 +171,7 @@ spec:
       for: 10m
       labels:
         severity: warning
+        group: Node
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -178,6 +187,7 @@ spec:
       for: 10m
       labels:
         severity: warning
+        group: Node
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -193,6 +203,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: Node
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -208,6 +219,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: Node
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/node-network.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/node-network.yaml
@@ -26,6 +26,7 @@ spec:
       for: 2m
       labels:
         severity: warning
+        group: Node
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/opensearch.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/opensearch.yaml
@@ -22,6 +22,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: Opensearch
       annotations:
         description: There are only {{`{{ $value }}`}}  OpenSearch nodes running
         summary: OpenSearch running on less than {{ .Values.osNodeCount }} nodes
@@ -31,6 +32,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: Opensearch
       annotations:
         description: The heap usage is over 90% for 15m
         summary: OpenSearch node {{`{{ $labels.node}}`}} heap usage is high
@@ -40,6 +42,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: Opensearch
       annotations:
         description: Index {{`{{ $labels.index }}`}} is using {{`{{ $value }}`}} percent of max field limit
         summary: Index {{`{{ $labels.index }}`}} is using {{`{{ $value }}`}} percent of max field limit
@@ -49,6 +52,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: Opensearch
       annotations:
         description: Index {{`{{ $labels.index }}`}} is using {{`{{ $value }}`}} percent of max field limit
         summary: Index {{`{{ $labels.index }}`}} is using {{`{{ $value }}`}} percent of max field limit
@@ -58,6 +62,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: Opensearch
       annotations:
         summary: Opensearch Cluster Yellow (instance {{`{{ $labels.instance }}`}})
         description: Opensearch Cluster is in a Yellow status VALUE = {{`{{ $value }}`}}  LABELS = {{`{{ $labels }}`}}
@@ -67,6 +72,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: Opensearch
       annotations:
         summary: Opensearch Cluster Red (instance {{`{{ $labels.instance }}`}})
         description: Opensearch Cluster is in a Red status VALUE = {{`{{ $value }}`}}  LABELS = {{`{{ $labels }}`}}
@@ -77,6 +83,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: Opensearch
       annotations:
         message: Active primary shard size for index {{`{{ $labels.index }}`}} has increased over the limit of {{ $prefixes.alertSizeMB }}MB, current size is {{`{{ $value | printf "%.0f" }}`}}MB
         description: This indicates a problem with index state management preventing the alias to roll over to a new index.

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/openstack.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/openstack.yaml
@@ -25,6 +25,7 @@ spec:
       for: 10m
       labels:
         severity: critical
+        group: Openstack
     - alert: OpenStackApiRequestFailed
       annotations:
         summary: Failed OpenStack API call.
@@ -33,6 +34,7 @@ spec:
       for: 5m
       labels:
         severity: high
+        group: Openstack
     - alert: OpenStackApiRequestDuration
       annotations:
         summary: OpenStack API has taken longer than 15 seconds.
@@ -41,6 +43,7 @@ spec:
       for: 5m
       labels:
         severity: high
+        group: Openstack
     - alert: OpenStackApiRequestTotal
       annotations:
         summary: Too high amount of OpenStack API calls.
@@ -49,6 +52,7 @@ spec:
       for: 5m
       labels:
         severity: high
+        group: Openstack
     - alert: OpenStackReconcileFailed
       annotations:
         summary: Increased reconciliation errors.
@@ -57,6 +61,7 @@ spec:
       for: 10m
       labels:
         severity: high
+        group: Openstack
     - alert: OpenStackReconcileDuration
       annotations:
         summary: Reconciliation has taken longer than 10 minutes.
@@ -65,4 +70,5 @@ spec:
       for: 10m
       labels:
         severity: high
+        group: Openstack
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/packets-dropped.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/packets-dropped.yaml
@@ -27,6 +27,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: PacketsDropped
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -40,6 +41,7 @@ spec:
       for: 6h
       labels:
         severity: info
+        group: PacketsDropped
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -53,6 +55,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: PacketsDropped
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -66,6 +69,7 @@ spec:
       for: 6h
       labels:
         severity: info
+        group: PacketsDropped
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/prometheus-operator.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/prometheus-operator.yaml
@@ -28,6 +28,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -40,6 +41,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -52,6 +54,7 @@ spec:
       for: 10m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -64,6 +67,7 @@ spec:
       for: 10m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -76,6 +80,7 @@ spec:
       for: 10m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -88,6 +93,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -100,6 +106,7 @@ spec:
       for: 5m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/prometheus.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/prometheus.yaml
@@ -32,6 +32,7 @@ spec:
       for: 10m
       labels:
         severity: critical
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -51,6 +52,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -70,6 +72,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -85,6 +88,7 @@ spec:
       for: 10m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -97,6 +101,7 @@ spec:
       for: 4h
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -109,6 +114,7 @@ spec:
       for: 4h
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -130,6 +136,7 @@ spec:
       for: 10m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -142,6 +149,7 @@ spec:
       for: 10m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -154,6 +162,7 @@ spec:
       for: 10m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -177,6 +186,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -197,6 +207,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -216,6 +227,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -228,6 +240,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -240,6 +253,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -252,6 +266,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -264,6 +279,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -276,6 +292,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -288,6 +305,7 @@ spec:
       for: 15m
       labels:
         severity: warning
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -300,6 +318,7 @@ spec:
       for: 5m
       labels:
         severity: critical
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
@@ -319,6 +338,7 @@ spec:
       for: 15m
       labels:
         severity: critical
+        group: Prometheus
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}

--- a/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
+++ b/helmfile.d/values/kube-prometheus-stack-sc.yaml.gotmpl
@@ -205,6 +205,7 @@ alertmanager:
           api_url: {{ .Values.alerts.opsGenie.apiUrl }}
           source: {{ .Values.grafana.user.subdomain }}.{{ .Values.global.opsDomain }}
           priority: {{`'{{ if eq .GroupLabels.severity "critical"}}P1{{else if or (eq .GroupLabels.severity "warning") (eq .GroupLabels.severity "high")}}P2{{else if eq .GroupLabels.severity "medium"}}P3{{else if eq .GroupLabels.severity "low"}}P4{{else}}P5{{end}}'`}}
+          update_alerts: {{ .Values.alerts.opsGenie.updateAlerts }}
       {{ end }}
     {{- with .Values.alerts.customReceivers }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->


### Platform Administrator notice
New alerts must now include a group label.


<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Added possibility and instructions on how to use grouped alerts
Added group label for all Welkin alerts

In order for grouping to work all alerts must have a group label, or all alerts with missing group label will be grouped together.
Grouping is disabled by default, keeping the previous behavior.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2634

#### Information to reviewers

Advise on grouping would be appreciated, a lot of alerts have the same group name as the alert name.

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [x] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [x] The metrics are still exposed and present in Grafana after the change
    - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [x] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
