### PR TITLE
fix integration test runs

### DIFF
--- a/tests/cypress.config.cjs
+++ b/tests/cypress.config.cjs
@@ -1,14 +1,12 @@
-import { defineConfig } from 'cypress'
-
-import { spawn } from 'node:child_process'
-
-import path from 'node:path'
+const { defineConfig } = require('cypress')
+const { spawn } = require('node:child_process')
+const path = require('node:path')
 
 const PROXY_READY_MARKER = '%%PROXY_READY%%'
 const PROXY_WAITING_FOR_DEX_MARKER = '%%PROXY_WAITING_FOR_DEX%%'
 const DEFAULT_TIMEOUT = 60 * 1000
 
-export default defineConfig({
+module.exports = defineConfig({
   env: process.env,
   e2e: {
     setupNodeEvents(on, config) {
@@ -29,14 +27,9 @@ export default defineConfig({
         wrapProxy(kubeconfig) {
           process.env.KUBECONFIG = kubeconfig
           const batsFile = /** @type {string} */ (process.env.BATS_TEST_FILENAME)
-          const wrapperPath = path.resolve(
-            path.dirname(batsFile) + '/../../../scripts/kubeproxy-wrapper.sh'
-          )
+          const wrapperPath = path.resolve(path.dirname(batsFile) + '/../../../scripts/kubeproxy-wrapper.sh')
 
-          const proxy = spawn(wrapperPath, [], {
-            detached: true,
-            stdio: ['ignore', 'pipe', 'pipe'],
-          })
+          const proxy = spawn(wrapperPath, [], { detached: true, stdio: ['ignore', 'pipe', 'pipe'] })
           return new Promise((resolve) => {
             proxy.stdout.on('data', (data) => {
               if (data.includes(PROXY_WAITING_FOR_DEX_MARKER)) {

--- a/tests/eslint.config.js
+++ b/tests/eslint.config.js
@@ -52,7 +52,7 @@ export default tseslint.config([
 
   { ignores: ['node_modules/**'] },
 
-  { files: ['**/*.js'], rules: rules },
+  { files: ['**/*.js', '**/*.cjs'], rules: rules },
 
   { files: ['**/*.ts'], rules: { ...rules, 'no-unused-vars': 'off' } },
 ])

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -11,5 +11,5 @@
     "esModuleInterop": true,
     "moduleResolution": "nodenext"
   },
-  "include": ["**/*.js", "**/*.d.ts"]
+  "include": ["**/*.js", "**/*.d.ts", "**/*.cjs"]
 }


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

The Harbor integration test suite, which uses Cypress, started failing on `main`.

Traced it down to Cypress not liking the "module" style configuration file at all and had no choice but to revert it to a CommonJS style.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
