### PR TITLE
apps: make namespace label in metric refer to resource, not exporter

### DIFF
--- a/helmfile.d/charts/calico-accountant/templates/service.yaml
+++ b/helmfile.d/charts/calico-accountant/templates/service.yaml
@@ -8,6 +8,11 @@ metadata:
 spec:
   endpoints:
   - port: metrics
+    metricRelabelings:
+    - action: replace
+      sourceLabels:
+      - pod_namespace
+      targetLabel: namespace
   selector:
     matchLabels:
       app: "calico-accountant"

--- a/helmfile.d/charts/grafana-dashboards/dashboards/README.md
+++ b/helmfile.d/charts/grafana-dashboards/dashboards/README.md
@@ -5,3 +5,5 @@ The Rook/Ceph dashboards were found through [this page](https://rook.io/docs/roo
 - Ceph cluster: https://grafana.com/dashboards/2842
 - Ceph OSD (Single): https://grafana.com/dashboards/5336 (fixed bug in this where "osd.0" should be "$osd" in a few places)
 - Ceph pools: https://grafana.com/dashboards/5342
+
+The Ingress nginx dashboard was likely found through [this page](https://grafana.com/grafana/dashboards/16677-ingress-nginx-overview/). It has at least been altered to work with `honorLabels` in the servicemonitor, i.e. when the `namespace` label points to the ingress namespace instead of the controller namespace.

--- a/helmfile.d/charts/grafana-dashboards/dashboards/cert-manager-mixin/cert-manager-dashboard.json
+++ b/helmfile.d/charts/grafana-dashboards/dashboards/cert-manager-mixin/cert-manager-dashboard.json
@@ -267,7 +267,7 @@
          "pluginVersion": "7.4.5",
          "targets": [
             {
-               "expr": "label_join(avg by (name, namespace, condition, exported_namespace) (certmanager_certificate_ready_status == 1), \"namespaced_name\", \"-\", \"namespace\", \"exported_namespace\", \"name\")",
+               "expr": "label_join(avg by (name, namespace, condition) (certmanager_certificate_ready_status == 1), \"namespaced_name\", \"-\", \"namespace\", \"name\")",
                "format": "table",
                "instant": true,
                "interval": "",
@@ -275,7 +275,7 @@
                "refId": "A"
             },
             {
-               "expr": "label_join(avg by (name, namespace, exported_namespace) (certmanager_certificate_expiration_timestamp_seconds) * 1000, \"namespaced_name\", \"-\", \"namespace\", \"exported_namespace\", \"name\")",
+               "expr": "label_join(avg by (name, namespace) (certmanager_certificate_expiration_timestamp_seconds) * 1000, \"namespaced_name\", \"-\", \"namespace\", \"name\")",
                "format": "table",
                "instant": true,
                "interval": "",
@@ -301,9 +301,6 @@
                      "Time 1": true,
                      "Time 2": true,
                      "Value #A": true,
-                     "exported_namespace": false,
-                     "exported_namespace 1": false,
-                     "exported_namespace 2": true,
                      "name 1": true,
                      "namespace 2": true,
                      "namespaced_name": true
@@ -314,8 +311,6 @@
                      "Value #A": 6,
                      "Value #B": 5,
                      "condition": 4,
-                     "exported_namespace 1": 1,
-                     "exported_namespace 2": 11,
                      "name 1": 9,
                      "name 2": 3,
                      "namespace": 0,
@@ -326,9 +321,6 @@
                      "Time 1": "",
                      "Value #B": "Valid Until",
                      "condition": "Ready Status",
-                     "exported_namespace": "Certificate Namespace",
-                     "exported_namespace 1": "Certificate Namespace",
-                     "exported_namespace 2": "",
                      "name": "Certificate",
                      "name 2": "Certificate",
                      "namespace": "Namespace",

--- a/helmfile.d/charts/grafana-dashboards/dashboards/nginx-dashboard.json
+++ b/helmfile.d/charts/grafana-dashboards/dashboards/nginx-dashboard.json
@@ -18,7 +18,7 @@
           "uid": "$datasource"
         },
         "enable": true,
-        "expr": "sum(changes(nginx_ingress_controller_config_last_reload_successful_timestamp_seconds{instance!=\"unknown\",controller_class=~\"$controller_class\",namespace=~\"$namespace\"}[30s])) by (controller_class)",
+        "expr": "sum(changes(nginx_ingress_controller_config_last_reload_successful_timestamp_seconds{instance!=\"unknown\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\"}[30s])) by (controller_class)",
         "hide": false,
         "iconColor": "rgba(255, 96, 96, 1)",
         "limit": 100,
@@ -103,7 +103,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "round(sum(irate(nginx_ingress_controller_requests{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\"}[2m])), 0.001)",
+          "expr": "round(sum(irate(nginx_ingress_controller_requests{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\"}[2m])), 0.001)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -183,7 +183,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(avg_over_time(nginx_ingress_controller_nginx_process_connections{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"}[2m]))",
+          "expr": "sum(avg_over_time(nginx_ingress_controller_nginx_process_connections{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\"}[2m]))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -268,7 +268,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(rate(nginx_ingress_controller_requests{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\",status!~\"[4-5].*\"}[2m])) / sum(rate(nginx_ingress_controller_requests{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\"}[2m]))",
+          "expr": "sum(rate(nginx_ingress_controller_requests{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\",status!~\"[4-5].*\"}[2m])) / sum(rate(nginx_ingress_controller_requests{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\"}[2m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -349,7 +349,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg(nginx_ingress_controller_success{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"})",
+          "expr": "avg(nginx_ingress_controller_success{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\"})",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -431,7 +431,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "count(nginx_ingress_controller_config_last_reload_successful{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_namespace=~\"$namespace\"} == 0)",
+          "expr": "count(nginx_ingress_controller_config_last_reload_successful{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_namespace=~\"$controller_namespace\"} == 0)",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -554,7 +554,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "round(sum(irate(nginx_ingress_controller_requests{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (ingress,cluster), 0.001)",
+          "expr": "round(sum(irate(nginx_ingress_controller_requests{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\",ingress=~\"$ingress\"}[2m])) by (ingress,cluster), 0.001)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -724,7 +724,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(rate(nginx_ingress_controller_requests{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\",ingress=~\"$ingress\",status!~\"[4-5].*\"}[2m])) by (ingress,cluster) / sum(rate(nginx_ingress_controller_requests{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (ingress,cluster)",
+          "expr": "sum(rate(nginx_ingress_controller_requests{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\",ingress=~\"$ingress\",status!~\"[4-5].*\"}[2m])) by (ingress,cluster) / sum(rate(nginx_ingress_controller_requests{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\",ingress=~\"$ingress\"}[2m])) by (ingress,cluster)",
           "format": "time_series",
           "instant": false,
           "interval": "10s",
@@ -827,7 +827,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum (irate (nginx_ingress_controller_request_size_sum{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"}[2m])) by (cluster)",
+          "expr": "sum (irate (nginx_ingress_controller_request_size_sum{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\"}[2m])) by (cluster)",
           "format": "time_series",
           "instant": false,
           "interval": "10s",
@@ -841,7 +841,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "- sum (irate (nginx_ingress_controller_response_size_sum{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"}[2m])) by (cluster)",
+          "expr": "- sum (irate (nginx_ingress_controller_response_size_sum{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\"}[2m])) by (cluster)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -991,7 +991,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg(nginx_ingress_controller_nginx_process_resident_memory_bytes{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"}) by (cluster)",
+          "expr": "avg(nginx_ingress_controller_nginx_process_resident_memory_bytes{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\"}) by (cluster)",
           "format": "time_series",
           "instant": false,
           "interval": "10s",
@@ -1089,7 +1089,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum (rate (nginx_ingress_controller_nginx_process_cpu_seconds_total{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"}[2m])) by (cluster)",
+          "expr": "sum (rate (nginx_ingress_controller_nginx_process_cpu_seconds_total{cluster=~\"$cluster\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\"}[2m])) by (cluster)",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -1317,7 +1317,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{cluster=~\"$cluster\",ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (le, ingress, cluster))",
+          "expr": "histogram_quantile(0.50, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{cluster=~\"$cluster\",ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\",ingress=~\"$ingress\"}[2m])) by (le, ingress, cluster))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1330,7 +1330,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "histogram_quantile(0.90, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{cluster=~\"$cluster\",ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (le, ingress, cluster))",
+          "expr": "histogram_quantile(0.90, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{cluster=~\"$cluster\",ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\",ingress=~\"$ingress\"}[2m])) by (le, ingress, cluster))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1343,7 +1343,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{cluster=~\"$cluster\",ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (le, ingress, cluster))",
+          "expr": "histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{cluster=~\"$cluster\",ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\",ingress=~\"$ingress\"}[2m])) by (le, ingress, cluster))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1356,7 +1356,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(irate(nginx_ingress_controller_request_size_sum{cluster=~\"$cluster\",ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (ingress,cluster)",
+          "expr": "sum(irate(nginx_ingress_controller_request_size_sum{cluster=~\"$cluster\",ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\",ingress=~\"$ingress\"}[2m])) by (ingress,cluster)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1369,7 +1369,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(irate(nginx_ingress_controller_response_size_sum{cluster=~\"$cluster\",ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (ingress,cluster)",
+          "expr": "sum(irate(nginx_ingress_controller_response_size_sum{cluster=~\"$cluster\",ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$controller_namespace\",ingress=~\"$ingress\"}[2m])) by (ingress,cluster)",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -1488,7 +1488,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg(nginx_ingress_controller_ssl_expire_time_seconds{cluster=~\"$cluster\",kubernetes_pod_name=~\"$controller\",namespace=~\"$namespace\",ingress=~\"$ingress\"}) by (host, cluster) - time()",
+          "expr": "avg(nginx_ingress_controller_ssl_expire_time_seconds{cluster=~\"$cluster\",kubernetes_pod_name=~\"$controller\",controller_namespace=~\"$controller_namespace\",ingress=~\"$ingress\"}) by (host, cluster) - time()",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -1584,9 +1584,9 @@
         "definition": "label_values(nginx_ingress_controller_config_hash{cluster=~\"$cluster\"}, controller_namespace)",
         "hide": 0,
         "includeAll": true,
-        "label": "Namespace",
+        "label": "Controller Namespace",
         "multi": false,
-        "name": "namespace",
+        "name": "controller_namespace",
         "options": [],
         "query": "label_values(nginx_ingress_controller_config_hash{cluster=~\"$cluster\"}, controller_namespace)",
         "refresh": 1,
@@ -1609,14 +1609,14 @@
           "type": "prometheus",
           "uid": "$datasource"
         },
-        "definition": "label_values(nginx_ingress_controller_config_hash{cluster=~\"$cluster\",namespace=~\"$namespace\"}, controller_class)",
+        "definition": "label_values(nginx_ingress_controller_config_hash{cluster=~\"$cluster\",controller_namespace=~\"$controller_namespace\"}, controller_class)",
         "hide": 0,
         "includeAll": true,
         "label": "Controller Class",
         "multi": false,
         "name": "controller_class",
         "options": [],
-        "query": "label_values(nginx_ingress_controller_config_hash{cluster=~\"$cluster\",namespace=~\"$namespace\"}, controller_class)",
+        "query": "label_values(nginx_ingress_controller_config_hash{cluster=~\"$cluster\",controller_namespace=~\"$controller_namespace\"}, controller_class)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1637,14 +1637,14 @@
           "type": "prometheus",
           "uid": "$datasource"
         },
-        "definition": "label_values(nginx_ingress_controller_config_hash{cluster=~\"$cluster\",namespace=~\"$namespace\",controller_class=~\"$controller_class\"}, controller_pod) ",
+        "definition": "label_values(nginx_ingress_controller_config_hash{cluster=~\"$cluster\",controller_namespace=~\"$controller_namespace\",controller_class=~\"$controller_class\"}, controller_pod) ",
         "hide": 0,
         "includeAll": true,
         "label": "Controller",
         "multi": false,
         "name": "controller",
         "options": [],
-        "query": "label_values(nginx_ingress_controller_config_hash{cluster=~\"$cluster\",namespace=~\"$namespace\",controller_class=~\"$controller_class\"}, controller_pod) ",
+        "query": "label_values(nginx_ingress_controller_config_hash{cluster=~\"$cluster\",controller_namespace=~\"$controller_namespace\",controller_class=~\"$controller_class\"}, controller_pod) ",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1665,14 +1665,14 @@
           "type": "prometheus",
           "uid": "$datasource"
         },
-        "definition": "label_values(nginx_ingress_controller_requests{cluster=~\"$cluster\",namespace=~\"$namespace\",controller_class=~\"$controller_class\",controller=~\"$controller\"}, ingress) ",
+        "definition": "label_values(nginx_ingress_controller_requests{cluster=~\"$cluster\",controller_namespace=~\"$controller_namespace\",controller_class=~\"$controller_class\",controller=~\"$controller\"}, ingress) ",
         "hide": 0,
         "includeAll": true,
         "label": "Ingress",
         "multi": false,
         "name": "ingress",
         "options": [],
-        "query": "label_values(nginx_ingress_controller_requests{cluster=~\"$cluster\",namespace=~\"$namespace\",controller_class=~\"$controller_class\",controller=~\"$controller\"}, ingress) ",
+        "query": "label_values(nginx_ingress_controller_requests{cluster=~\"$cluster\",controller_namespace=~\"$controller_namespace\",controller_class=~\"$controller_class\",controller=~\"$controller\"}, ingress) ",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/helmfile.d/charts/tekton-pipelines/templates/controller/service-monitor.yaml
+++ b/helmfile.d/charts/tekton-pipelines/templates/controller/service-monitor.yaml
@@ -17,3 +17,10 @@ spec:
   - port: http-metrics
     path: /metrics
     interval: 30s
+    honorLabels: true
+    metricRelabelings:
+      # The exported_namespace label is deprecated for these metrics and will be removed in three minor releases, likely v0.52
+    - action: replace
+      sourceLabels:
+      - namespace
+      targetLabel: exported_namespace

--- a/helmfile.d/values/cert-manager.yaml.gotmpl
+++ b/helmfile.d/values/cert-manager.yaml.gotmpl
@@ -77,3 +77,11 @@ crds:
 prometheus:
   servicemonitor:
     enabled: true
+    honorLabels: true
+    endpointAdditionalProperties:
+      metricRelabelings:
+      # The exported_namespace label is deprecated for these metrics and will be removed in three minor releases, likely v0.52
+      - action: replace
+        sourceLabels:
+        - namespace
+        targetLabel: exported_namespace

--- a/helmfile.d/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile.d/values/ingress-nginx.yaml.gotmpl
@@ -154,6 +154,13 @@ controller:
 
     serviceMonitor:
       enabled: true
+      honorLabels: true
+      metricRelabelings:
+      # The exported_namespace label is deprecated for these metrics and will be removed in three minor releases, likely v0.52
+      - action: replace
+        sourceLabels:
+        - namespace
+        targetLabel: exported_namespace
 
 {{- $global := dict
   "registry" (ternary (dig "uri" "" .Values.images.global.registry) "" .Values.images.global.registry.enabled)

--- a/scripts/grafana-dashboards/configs/cert-manager-mixin/dashboards.jsonnet
+++ b/scripts/grafana-dashboards/configs/cert-manager-mixin/dashboards.jsonnet
@@ -5,24 +5,55 @@ local dashboards = (
 local replaceContainerExpr(expr) =
   std.strReplace(expr, 'container="cert-manager"', 'container="cert-manager-controller"');
 
+local removeExportedNamespaceExpr(expr) =
+  local removedWithQuotes = std.strReplace(expr, ', "exported_namespace"', '');
+  std.strReplace(removedWithQuotes, ', exported_namespace', '');
+
+local removeExportedNamespaceObj(obj) =
+  local removedWithoutNumber = std.objectRemoveKey(obj, "exported_namespace");
+  local removedWithoutNumberAndOne = std.objectRemoveKey(removedWithoutNumber, "exported_namespace 1");
+  std.objectRemoveKey(removedWithoutNumberAndOne, "exported_namespace 2");
+
 local updateTargets(targets) =
   std.map(
     function(target)
       if std.objectHas(target, "expr") then
-        target + { expr: replaceContainerExpr(target.expr) }
+        target + { expr: removeExportedNamespaceExpr(replaceContainerExpr(target.expr)) }
       else
         target,
     targets
   );
 
-local updatePanels(panels) =
+local updateTransformations(transformations) =
   std.map(
+    function(transformation)
+      if transformation.id == "organize" then
+        transformation + { options: transformation.options + {
+            excludeByName: removeExportedNamespaceObj(transformation.options.excludeByName),
+            indexByName: removeExportedNamespaceObj(transformation.options.indexByName),
+            renameByName: removeExportedNamespaceObj(transformation.options.renameByName)
+          }}
+      else
+        transformation,
+    transformations
+  );
+
+local updatePanels(panels) =
+  local panelsUpdatedTargets = std.map(
     function(panel)
       if std.objectHas(panel, "targets") then
         panel + { targets: updateTargets(panel.targets) }
       else
         panel,
     panels
+  );
+  std.map(
+    function(panel)
+      if std.objectHas(panel, "transformations") then
+        panel + { transformations: updateTransformations(panel.transformations) }
+      else
+        panel,
+    panelsUpdatedTargets
   );
 
 {


### PR DESCRIPTION
The exported_namespace that was added by prometheus is kept for now But it is deprecated and will likely be removed in v0.52

<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [x] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->


### Platform Administrator notice

Prometheus by default overwrites the namespace label for metrics that already has a namespace label, to the namespace of the pod that was scraped for metrics. This is now changed for the instances that were currently affected. The namespace label will now keep the original information, usually the namespace of the object it is referring to, e.g. for cert-manager this is usually the namespace where a certificate exists instead of the cert-manager namespace.
Prometheus added a exported_namespace label when it was overwriting the namespace label, with the original value of the namespace label. This is kept for now, but it is deprecated and will be removed in a later version, likely v0.52.

### Application Developer notice


Prometheus by default overwrites the namespace label for metrics that already has a namespace label, to the namespace of the pod that was scraped for metrics. This is now changed for the instances that were currently affected. The namespace label will now keep the original information, usually the namespace of the object it is referring to, e.g. for cert-manager this is usually the namespace where a certificate exists instead of the cert-manager namespace.
Prometheus added a exported_namespace label when it was overwriting the namespace label, with the original value of the namespace label. This is kept for now, but it is deprecated and will be removed in a later version, likely v0.52.

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->

We wanted to have the namespace label in metrics to refer to the namespace of the resource the metric was referring to, instead of the namespace of the metric exporter. So this primarily stops prometheus from changing the namespace of metrics that already had a namespace label.

There were changes done to nginx, cert-mananger, calico-accountant, and tekton.

This also updates some dashboards that are using these metrics.

- Fixes #1798 

#### Information to reviewers

To me it seemed like there were no changes needed to any of the alerting. But let me know if I'm wrong about that.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
