### PR TITLE
bin: Do not block apply when version set to 'any' or git commit

### DIFF
--- a/bin/common.bash
+++ b/bin/common.bash
@@ -347,8 +347,9 @@ validate_version() {
     log_error "Welkin Apps repository version: ${version}"
     exit 1
   fi
-  if [[ -z "${cluster_version}" ]]; then
-    log_warning "Welkin Apps cluster version:    Unknown"
+
+  if [[ -z "${cluster_version}" ]] || [[ "${ck8s_version}" == "any" ]] || [[ "${ck8s_version}" =~ ^[0-9a-f]{40}$ ]]; then
+    log_warning "Welkin Apps cluster version:    ${cluster_version:-Unknown}"
     log_warning "Welkin Apps config version:     ${ck8s_version}"
     log_warning "Welkin Apps repository version: ${version}"
   elif [[ "${cluster_version}" != "${version%.*}" ]]; then


### PR DESCRIPTION
When the 'welkin-apps-meta' configmap exists, a stricter version check was enabled which prevented running 'apply' when
running on the main branch or any untagged git commit.

This bypasses the checks if .global.ck8sVersion is set to 'any' or a random untagged git commit has been checked out IFF
`ck8s init` has been run to explicitly mark that as the current version.

<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
When the 'welkin-apps-meta' configmap exists, a stricter version check was enabled which prevented running 'apply' when running on the main branch or any untagged git commit.

This bypasses the checks if .global.ck8sVersion is set to 'any' or a random untagged git commit has been checked out IFF `ck8s init` has been run to explicitly mark that as the current version.

#### Information to reviewers


If you don't already have the version recorded in your cluster, you can create it with this command:
```bash
ck8s ops kubectl sc create configmap -n kube-system welkin-apps-meta --from-literal version=v0.47
```

Before the change, this command would report verions gathered from cluster, config and git repo and then exit with an error:

```console
$ ck8s apply sc
```

After the change, this should be reduced to a warning to highlight that you are running a development or otherwise untagged version, letting you continue.

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
