### PR TITLE
scripts: added backup and restore script for QA

### DIFF
--- a/scripts/backup-restore.sh
+++ b/scripts/backup-restore.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z "$CK8S_CONFIG_PATH" ]; then
+  log "ERROR: CK8S_CONFIG_PATH is not set."
+  log "Please set and export the variable before running the script."
+  exit 1
+fi
+
+usage() {
+  echo "Usage: $0 <action> <target>"
+  echo "Actions: backup | restore"
+  echo "Targets: opensearch | harbor | rclone | velero"
+  exit 1
+}
+
+# Sets a timestamp log before every message, also colors it purple to make it easier to distinct from rest of the text because why not
+PURPLE='\033[0;35m'
+NOCOLOR='\033[0m'
+log() {
+  echo -e "[${PURPLE}$(date +'%Y-%m-%d %H:%M:%S')${NOCOLOR}]: $1"
+}
+
+# allows the script to be run from anywhere
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$(realpath "$SCRIPT_DIR/..")
+CK8S_CMD="$REPO_ROOT/bin/ck8s"
+
+if [ "$#" -ne 2 ]; then
+  usage
+fi
+
+ACTION="$1"
+TARGET="$2"
+
+run_backup() {
+  case "$1" in
+    opensearch)
+      log "Starting OpenSearch backup..."
+
+      local user="admin"
+      local password
+      password=$(sops -d "${CK8S_CONFIG_PATH}/secrets.yaml" | yq '.opensearch.adminPassword')
+      local os_url="https://opensearch.$(yq '.global.opsDomain' "${CK8S_CONFIG_PATH}/common-config.yaml")"
+      log "OpenSearch URL: ${os_url}"
+
+      log "Discovering snapshot repository name..."
+      local snapshot_repo
+      snapshot_repo=$(curl -kL -s -u "${user}:${password}" "${os_url}/_cat/repositories?v" | awk 'NR==2 {print $1}')
+      if [ -z "$snapshot_repo" ]; then
+        log "ERROR: Could not find OpenSearch snapshot repository."
+        exit 1
+      fi
+      log "Found snapshot repository: ${snapshot_repo}"
+
+      local snapshot_name="manual-snapshot-$(date +%Y%m%d%H%M%S)"
+      log "Taking snapshot: ${snapshot_name}"
+      curl -kL -u "${user}:${password}" -X PUT "${os_url}/_snapshot/${snapshot_repo}/${snapshot_name}" -H 'Content-Type: application/json' -d'
+      {
+        "indices": "*,-.opendistro_security",
+        "include_global_state": false
+      }
+      '
+
+      log "Waiting for snapshot to complete..."
+      local status=""
+      local retries=60 # 30 min timeout
+      while [ $retries -gt 0 ]; do
+        status=$(curl -kL -s -u "${user}:${password}" "${os_url}/_snapshot/${snapshot_repo}/${snapshot_name}" | jq -r '.snapshots[0].state')
+        log "Current snapshot status: ${status}"
+
+        if [ "$status" = "SUCCESS" ]; then
+          log "OpenSearch backup successfully completed."
+          return
+        elif [ "$status" = "FAILED" ] || [ "$status" = "PARTIAL" ]; then
+          log "ERROR: OpenSearch snapshot failed with status: ${status}"
+          exit 1
+        fi
+
+        sleep 30
+        retries=$((retries - 1))
+      done
+
+      log "ERROR: Timeout waiting for OpenSearch snapshot to complete."
+      exit 1
+      ;;
+    harbor)
+      log "Starting Harbor backup..."
+      local backup_job_name="harbor-backup-manual-$(date +%Y%m%d%H%M%S)"
+      log "Creating on-demand backup job: $backup_job_name"
+
+      "$CK8S_CMD" ops kubectl sc -n harbor create job "$backup_job_name" --from=cronjob/harbor-backup-cronjob
+
+      log "Waiting for backup job to complete..."
+      "$CK8S_CMD" ops kubectl sc -n harbor wait --for=condition=complete "job/$backup_job_name" --timeout=30m
+
+      log "Backup complete. Deleting job: $backup_job_name"
+      "$CK8S_CMD" ops kubectl sc -n harbor delete job "$backup_job_name"
+
+      log "Harbor backup successfully completed."
+      ;;
+    rclone)
+      log "Starting Rclone backup..."
+
+      # Check if rclone-sync is enabled before continuing
+      log "Checking for rclone-sync cronjobs"
+      local cronjob_list
+      cronjob_list=$("$CK8S_CMD" ops kubectl sc -n rclone get cronjobs -lapp.kubernetes.io/instance=rclone-sync -oname)
+
+      if [ -z "$cronjob_list" ]; then
+        log "ERROR: No rclone-sync cronjobs found."
+        log "Please ensure rclone sync is enabled in your configuration and has been applied."
+        exit 1
+      fi
+      local total_jobs
+      total_jobs=$(echo "$cronjob_list" | wc -w)
+      log "Found ${total_jobs} cronjobs."
+
+      # Create jobs from cronjobs
+      for cronjob in $cronjob_list; do
+        "$CK8S_CMD" ops kubectl sc -n rclone create job --from "${cronjob}" "${cronjob/#cronjob.batch\/}"
+        local job_name=${cronjob/#cronjob.batch\/}
+        log "Creating job '${job_name}' from '${cronjob}' cronjob..."
+      done
+
+      job_list=$("$CK8S_CMD" ops kubectl sc -n rclone get jobs -lapp.kubernetes.io/instance=rclone-sync -oname)
+
+      log "Waiting for all ${total_jobs} rclone jobs to complete..."
+      local retries=480 # these can take a really long time depending on content, so the timeout is set to 4 hours
+      while [ $retries -gt 0 ]; do
+        
+        local job_statuses
+        job_statuses=$("$CK8S_CMD" ops kubectl sc -n rclone get jobs -lapp.kubernetes.io/instance=rclone-sync -o json)
+        
+        local succeeded
+        succeeded=$(echo "$job_statuses" | jq '[.items[] | select(.status.succeeded == 1)] | length')
+        local failed
+        failed=$(echo "$job_statuses" | jq '[.items[] | select(.status.failed > 0)] | length')
+        local active
+        active=$(echo "$job_statuses" | jq '[.items[] | select(.status.active == 1)] | length')
+
+        log "Job Status -> Total: ${total_jobs} | Succeeded: ${succeeded} | Failed: ${failed} | Active: ${active}"
+
+        if [ "$active" -eq 0 ]; then
+          break
+        fi
+
+        sleep 30
+        retries=$((retries - 1))
+      done
+
+      # check if all jobs succeeded or not
+      if [ "$(echo "$job_statuses" | jq '[.items[] | select(.status.succeeded == 1)] | length')" -ne "$total_jobs" ]; then
+        log "ERROR: Not all rclone jobs succeeded. Please check the logs for failed jobs."
+        exit 1
+      fi
+
+      log "Cleaning up..."
+      for job in $job_list; do
+        "$CK8S_CMD" ops kubectl sc -n rclone delete "$job" --ignore-not-found=true
+      done
+
+      log "Rclone backup successfully completed."
+      ;;
+    velero)
+      log "Starting Velero backup..."
+
+      local backup_name="manual-backup-$(date +%Y%m%d%H%M%S)"
+      log "Creating Velero backup: ${backup_name}"
+
+      "$CK8S_CMD" ops velero wc backup create "$backup_name" --from-schedule velero-daily-backup
+
+      log "Waiting for backup to complete..."
+      local phase=""
+      local retries=90
+      while [ $retries -gt 0 ]; do
+        phase=$( "$CK8S_CMD" ops velero wc backup describe "$backup_name" -o json | jq -r .phase )
+        log "Current backup phase: ${phase}"
+
+        if [ "$phase" = "Completed" ]; then
+          log "Velero backup successfully completed."
+          return
+        elif [[ "$phase" =~ Failed|PartiallyFailed|Deleting ]]; then
+          log "ERROR: Velero backup failed or was deleted with phase: ${phase}"
+          exit 1
+        fi
+
+        sleep 30
+        retries=$((retries - 1))
+      done
+
+      log "ERROR: Timeout waiting for Velero backup to complete."
+      exit 1
+      ;;
+    *)
+      log "Error: Invalid backup target '$1'."
+      usage
+      ;;
+  esac
+}
+
+run_restore() {
+  case "$1" in
+    opensearch)
+      log "Starting OpenSearch restore..."
+      
+      local user="admin"
+      local password
+      password=$(sops -d "${CK8S_CONFIG_PATH}/secrets.yaml" | yq '.opensearch.adminPassword')
+      local os_url="https://opensearch.$(yq '.global.opsDomain' "${CK8S_CONFIG_PATH}/common-config.yaml")"
+      log "OpenSearch URL: ${os_url}"
+
+      log "Discovering snapshot repository name..."
+      local snapshot_repo
+      snapshot_repo=$(curl -kL -s -u "${user}:${password}" "${os_url}/_cat/repositories?v" | awk 'NR==2 {print $1}')
+      if [ -z "$snapshot_repo" ]; then
+        log "ERROR: Could not find OpenSearch snapshot repository."
+        exit 1
+      fi
+      log "Found snapshot repository: ${snapshot_repo}"
+
+      log "Finding latest successful snapshot..."
+      local latest_snapshot
+      latest_snapshot=$(curl -kL -s -u "${user}:${password}" -X GET "${os_url}/_snapshot/${snapshot_repo}/_all" | jq -r '.snapshots | map(select(.state == "SUCCESS")) | sort_by(.start_time_in_millis) | .[-1].snapshot')
+      if [ -z "$latest_snapshot" ] || [ "$latest_snapshot" = "null" ]; then
+          log "ERROR: No successful snapshots found to restore."
+          exit 1
+      fi
+      log "Found latest snapshot to restore: ${latest_snapshot}"
+
+      local indices_to_restore="kubernetes-*,kubeaudit-*,other-*,authlog-*"
+      log "Will restore indices matching pattern: ${indices_to_restore}"
+
+      log "Closing existing indices matching the restore pattern..."
+      curl -kL -s -u "${user}:${password}" -X POST "${os_url}/${indices_to_restore}/_close?pretty"
+
+      log "Starting restore from snapshot ${latest_snapshot}..."
+      curl -kL -s -u "${user}:${password}" -X POST "${os_url}/_snapshot/${snapshot_repo}/${latest_snapshot}/_restore?pretty" -H 'Content-Type: application/json' -d'
+      {
+        "indices": "'"${indices_to_restore}"'"
+      }
+      '
+
+      log "Waiting for cluster health to become green..."
+      local status=""
+      local retries=60 # 30 min timeout
+      while [ $retries -gt 0 ]; do
+        status=$(curl -kL -s -u "${user}:${password}" "${os_url}/_cluster/health" | jq -r '.status')
+        log "Current cluster status: ${status}"
+
+        if [ "$status" = "green" ]; then
+          log "OpenSearch restore complete and cluster is healthy."
+          return
+        fi
+
+        sleep 30
+        retries=$((retries - 1))
+      done
+
+      log "ERROR: Timeout waiting for OpenSearch cluster to become healthy after restore."
+      exit 1
+      ;;
+    harbor)
+      log "Starting Harbor restore..."
+
+      "$CK8S_CMD" harbor-restore
+
+      log "Harbor restore successfully completed."
+      ;;
+    rclone)
+      log "Starting Rclone restore..."
+
+      # Check if rclone-restore is enabled before continuing
+      log "Checking for rclone-restore cronjobs"
+      local cronjob_list
+      cronjob_list=$("$CK8S_CMD" ops kubectl sc -n rclone get cronjobs -lapp.kubernetes.io/instance=rclone-restore -oname)
+
+      if [ -z "$cronjob_list" ]; then
+        log "ERROR: No rclone-restore cronjobs found."
+        log "Please ensure rclone restore is enabled in your configuration and has been applied."
+        exit 1
+      fi
+      local total_jobs
+      total_jobs=$(echo "$cronjob_list" | wc -w)
+      log "Found ${total_jobs} cronjobs."
+
+      # Create jobs from cronjobs
+      for cronjob in $cronjob_list; do
+        "$CK8S_CMD" ops kubectl sc -n rclone create job --from "${cronjob}" "${cronjob/#cronjob.batch\/}"
+        local job_name=${cronjob/#cronjob.batch\/}
+        log "Creating job '${job_name}' from '${cronjob}' cronjob..."
+      done
+
+      local job_list
+      job_list=$("$CK8S_CMD" ops kubectl sc -n rclone get jobs -lapp.kubernetes.io/instance=rclone-restore -oname)
+
+      log "Waiting for all ${total_jobs} rclone jobs to complete..."
+      local retries=480 # 4 hour timeout
+      while [ $retries -gt 0 ]; do
+        
+        local job_statuses
+        job_statuses=$("$CK8S_CMD" ops kubectl sc -n rclone get jobs -lapp.kubernetes.io/instance=rclone-restore -o json)
+        
+        local succeeded
+        succeeded=$(echo "$job_statuses" | jq '[.items[] | select(.status.succeeded == 1)] | length')
+        local failed
+        failed=$(echo "$job_statuses" | jq '[.items[] | select(.status.failed > 0)] | length')
+        local active
+        active=$(echo "$job_statuses" | jq '[.items[] | select(.status.active == 1)] | length')
+
+        log "Job Status -> Total: ${total_jobs} | Succeeded: ${succeeded} | Failed: ${failed} | Active: ${active}"
+
+        if [ "$active" -eq 0 ]; then
+          break
+        fi
+
+        sleep 30
+        retries=$((retries - 1))
+      done
+
+      # Check if all jobs succeeded
+      if [ "$(echo "$job_statuses" | jq '[.items[] | select(.status.succeeded == 1)] | length')" -ne "$total_jobs" ]; then
+        log "ERROR: Not all rclone jobs succeeded. Please check the logs for failed jobs."
+        exit 1
+      fi
+
+      log "Cleaning up..."
+      for job in $job_list; do
+        "$CK8S_CMD" ops kubectl sc -n rclone delete "$job" --ignore-not-found=true
+      done
+
+      log "Rclone restore successfully completed."
+      ;;
+    velero)
+      log "Starting Velero restore..."
+
+      log "Finding latest completed Velero backup..."
+      local latest_backup
+      latest_backup=$( "$CK8S_CMD" ops velero wc backup get -o json | jq -r '.items | map(select(.status.phase == "Completed")) | sort_by(.metadata.creationTimestamp) | .[-1].metadata.name' )
+
+      if [ -z "$latest_backup" ] || [ "$latest_backup" = "null" ]; then
+        log "ERROR: No completed Velero backups found to restore from."
+        exit 1
+      fi
+      log "Found latest backup to restore: ${latest_backup}"
+
+      log "Deleting Alertmanager secret..."
+      "$CK8S_CMD" ops kubectl wc delete secret -n alertmanager alertmanager-kube-prometheus-stack-alertmanager --ignore-not-found=true
+
+      local restore_name="restore-$(date +%Y%m%d%H%M%S)"
+      log "Creating restore '${restore_name}' from backup '${latest_backup}'"
+      "$CK8S_CMD" ops velero wc restore create "$restore_name" --from-backup "$latest_backup"
+
+      log "Waiting for restore to complete..."
+      local phase=""
+      local retries=60 # 30 min timeout
+      while [ $retries -gt 0 ]; do
+        phase=$( "$CK8S_CMD" ops velero wc restore get "$restore_name" -o json | jq -r .status.phase )
+        log "Current restore phase: ${phase}"
+
+        if [ "$phase" = "Completed" ]; then
+          log "Velero restore successfully completed."
+          return
+        elif [[ "$phase" =~ Failed|PartiallyFailed ]]; then
+          log "ERROR: Velero restore failed with phase: ${phase}"
+          exit 1
+        fi
+
+        sleep 30
+        retries=$((retries - 1))
+      done
+      
+      log "ERROR: Timeout waiting for Velero restore to complete."
+      exit 1
+      ;;
+    *)
+      log "Error: Invalid restore target '$1'."
+      usage
+      ;;
+  esac
+}
+
+case "$ACTION" in
+  backup)
+    run_backup "$TARGET"
+    ;;
+  restore)
+    run_restore "$TARGET"
+    ;;
+  *)
+    log "Error: Invalid action '$ACTION'."
+    usage
+    ;;
+esac

--- a/scripts/backup-restore.sh
+++ b/scripts/backup-restore.sh
@@ -53,7 +53,7 @@ run_backup() {
     log "Found snapshot repository: ${snapshot_repo}"
 
     local snapshot_name
-    snapshot_name="manual-snapshot-$(date --utc +%Y%m%d%H%M%S)Z"
+    snapshot_name="manual-snapshot-$(date --utc +%Y%m%d%H%M%S)z"
     log "Taking snapshot: ${snapshot_name}"
     curl -kL -u "${user}:${password}" -X PUT "${os_url}/_snapshot/${snapshot_repo}/${snapshot_name}" -H 'Content-Type: application/json' -d'
       {
@@ -87,7 +87,7 @@ run_backup() {
   harbor)
     log "Starting Harbor backup..."
     local backup_job_name
-    backup_job_name="harbor-backup-manual-$(date --utc +%Y%m%d%H%M%S)Z"
+    backup_job_name="harbor-backup-manual-$(date --utc +%Y%m%d%H%M%S)z"
     log "Creating on-demand backup job: $backup_job_name"
 
     "$CK8S_CMD" ops kubectl sc -n harbor create job "$backup_job_name" --from=cronjob/harbor-backup-cronjob
@@ -170,7 +170,7 @@ run_backup() {
     log "Starting Velero backup..."
 
     local backup_name
-    backup_name="manual-backup-$(date --utc +%Y%m%d%H%M%S)Z"
+    backup_name="manual-backup-$(date --utc +%Y%m%d%H%M%S)z"
     log "Creating Velero backup: ${backup_name}"
 
     "$CK8S_CMD" ops velero wc backup create "$backup_name" --from-schedule velero-daily-backup
@@ -367,7 +367,7 @@ run_restore() {
     "$CK8S_CMD" ops kubectl wc delete secret -n alertmanager alertmanager-kube-prometheus-stack-alertmanager --ignore-not-found=true
 
     local restore_name
-    restore_name="restore-$(date --utc +%Y%m%d%H%M%S)Z"
+    restore_name="restore-$(date --utc +%Y%m%d%H%M%S)z"
     log "Creating restore '${restore_name}' from backup '${latest_backup}'"
     "$CK8S_CMD" ops velero wc restore create "$restore_name" --from-backup "$latest_backup"
 

--- a/scripts/backup-restore.sh
+++ b/scripts/backup-restore.sh
@@ -166,7 +166,7 @@ run_backup() {
     fi
 
     log "Cleaning up..."
-    "$CK8S_CMD" ops kubectl sc -n rclone delete "${job_names[@]}" --ignore-not-found=true
+    "$CK8S_CMD" ops kubectl sc -n rclone delete jobs "${job_names[@]}" --ignore-not-found=true
 
     log "Rclone backup successfully completed."
     ;;
@@ -362,7 +362,7 @@ run_restore() {
     fi
 
     log "Cleaning up..."
-    "$CK8S_CMD" ops kubectl sc -n rclone delete "${job_names[@]}" --ignore-not-found=true
+    "$CK8S_CMD" ops kubectl sc -n rclone delete jobs "${job_names[@]}" --ignore-not-found=true
 
     log "Rclone restore successfully completed."
     ;;

--- a/scripts/backup-restore.sh
+++ b/scripts/backup-restore.sh
@@ -122,8 +122,8 @@ run_backup() {
 
     # Create jobs from cronjobs
     for cronjob in $cronjob_list; do
-      "$CK8S_CMD" ops kubectl sc -n rclone create job --from "${cronjob}" "${cronjob/#cronjob.batch\//}"
       local job_name=${cronjob/#cronjob.batch\//}
+      "$CK8S_CMD" ops kubectl sc -n rclone create job --from "${cronjob}" "${job_name}"
       log "Created job '${job_name}' from '${cronjob}' cronjob..."
     done
 
@@ -305,8 +305,8 @@ run_restore() {
 
     # Create jobs from cronjobs
     for cronjob in $cronjob_list; do
-      "$CK8S_CMD" ops kubectl sc -n rclone create job --from "${cronjob}" "${cronjob/#cronjob.batch\//}"
       local job_name=${cronjob/#cronjob.batch\//}
+      "$CK8S_CMD" ops kubectl sc -n rclone create job --from "${cronjob}" "${job_name}"
       log "Created job '${job_name}' from '${cronjob}' cronjob..."
     done
 

--- a/scripts/backup-restore.sh
+++ b/scripts/backup-restore.sh
@@ -23,7 +23,7 @@ log() {
 }
 
 # allows the script to be run from anywhere
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 REPO_ROOT=$(realpath "$SCRIPT_DIR/..")
 CK8S_CMD="$REPO_ROOT/bin/ck8s"
 
@@ -36,360 +36,366 @@ TARGET="$2"
 
 run_backup() {
   case "$1" in
-    opensearch)
-      log "Starting OpenSearch backup..."
+  opensearch)
+    log "Starting OpenSearch backup..."
 
-      local user="admin"
-      local password
-      password=$(sops -d "${CK8S_CONFIG_PATH}/secrets.yaml" | yq '.opensearch.adminPassword')
-      local os_url="https://opensearch.$(yq '.global.opsDomain' "${CK8S_CONFIG_PATH}/common-config.yaml")"
-      log "OpenSearch URL: ${os_url}"
+    local user="admin"
+    local password
+    password=$(sops -d "${CK8S_CONFIG_PATH}/secrets.yaml" | yq '.opensearch.adminPassword')
+    local os_url
+    os_url="https://opensearch.$(yq '.global.opsDomain' "${CK8S_CONFIG_PATH}/common-config.yaml")"
+    log "OpenSearch URL: ${os_url}"
 
-      log "Discovering snapshot repository name..."
-      local snapshot_repo
-      snapshot_repo=$(curl -kL -s -u "${user}:${password}" "${os_url}/_cat/repositories?v" | awk 'NR==2 {print $1}')
-      if [ -z "$snapshot_repo" ]; then
-        log "ERROR: Could not find OpenSearch snapshot repository."
-        exit 1
-      fi
-      log "Found snapshot repository: ${snapshot_repo}"
+    log "Discovering snapshot repository name..."
+    local snapshot_repo
+    snapshot_repo=$(curl -kL -s -u "${user}:${password}" "${os_url}/_cat/repositories?v" | awk 'NR==2 {print $1}')
+    if [ -z "$snapshot_repo" ]; then
+      log "ERROR: Could not find OpenSearch snapshot repository."
+      exit 1
+    fi
+    log "Found snapshot repository: ${snapshot_repo}"
 
-      local snapshot_name="manual-snapshot-$(date +%Y%m%d%H%M%S)"
-      log "Taking snapshot: ${snapshot_name}"
-      curl -kL -u "${user}:${password}" -X PUT "${os_url}/_snapshot/${snapshot_repo}/${snapshot_name}" -H 'Content-Type: application/json' -d'
+    local snapshot_name
+    snapshot_name="manual-snapshot-$(date +%Y%m%d%H%M%S)"
+    log "Taking snapshot: ${snapshot_name}"
+    curl -kL -u "${user}:${password}" -X PUT "${os_url}/_snapshot/${snapshot_repo}/${snapshot_name}" -H 'Content-Type: application/json' -d'
       {
         "indices": "*,-.opendistro_security",
         "include_global_state": false
       }
       '
 
-      log "Waiting for snapshot to complete..."
-      local status=""
-      local retries=60 # 30 min timeout
-      while [ $retries -gt 0 ]; do
-        status=$(curl -kL -s -u "${user}:${password}" "${os_url}/_snapshot/${snapshot_repo}/${snapshot_name}" | jq -r '.snapshots[0].state')
-        log "Current snapshot status: ${status}"
+    log "Waiting for snapshot to complete..."
+    local status=""
+    local retries=60 # 30 min timeout
+    while [ $retries -gt 0 ]; do
+      status=$(curl -kL -s -u "${user}:${password}" "${os_url}/_snapshot/${snapshot_repo}/${snapshot_name}" | jq -r '.snapshots[0].state')
+      log "Current snapshot status: ${status}"
 
-        if [ "$status" = "SUCCESS" ]; then
-          log "OpenSearch backup successfully completed."
-          return
-        elif [ "$status" = "FAILED" ] || [ "$status" = "PARTIAL" ]; then
-          log "ERROR: OpenSearch snapshot failed with status: ${status}"
-          exit 1
-        fi
-
-        sleep 30
-        retries=$((retries - 1))
-      done
-
-      log "ERROR: Timeout waiting for OpenSearch snapshot to complete."
-      exit 1
-      ;;
-    harbor)
-      log "Starting Harbor backup..."
-      local backup_job_name="harbor-backup-manual-$(date +%Y%m%d%H%M%S)"
-      log "Creating on-demand backup job: $backup_job_name"
-
-      "$CK8S_CMD" ops kubectl sc -n harbor create job "$backup_job_name" --from=cronjob/harbor-backup-cronjob
-
-      log "Waiting for backup job to complete..."
-      "$CK8S_CMD" ops kubectl sc -n harbor wait --for=condition=complete "job/$backup_job_name" --timeout=30m
-
-      log "Backup complete. Deleting job: $backup_job_name"
-      "$CK8S_CMD" ops kubectl sc -n harbor delete job "$backup_job_name"
-
-      log "Harbor backup successfully completed."
-      ;;
-    rclone)
-      log "Starting Rclone backup..."
-
-      # Check if rclone-sync is enabled before continuing
-      log "Checking for rclone-sync cronjobs"
-      local cronjob_list
-      cronjob_list=$("$CK8S_CMD" ops kubectl sc -n rclone get cronjobs -lapp.kubernetes.io/instance=rclone-sync -oname)
-
-      if [ -z "$cronjob_list" ]; then
-        log "ERROR: No rclone-sync cronjobs found."
-        log "Please ensure rclone sync is enabled in your configuration and has been applied."
-        exit 1
-      fi
-      local total_jobs
-      total_jobs=$(echo "$cronjob_list" | wc -w)
-      log "Found ${total_jobs} cronjobs."
-
-      # Create jobs from cronjobs
-      for cronjob in $cronjob_list; do
-        "$CK8S_CMD" ops kubectl sc -n rclone create job --from "${cronjob}" "${cronjob/#cronjob.batch\/}"
-        local job_name=${cronjob/#cronjob.batch\/}
-        log "Creating job '${job_name}' from '${cronjob}' cronjob..."
-      done
-
-      job_list=$("$CK8S_CMD" ops kubectl sc -n rclone get jobs -lapp.kubernetes.io/instance=rclone-sync -oname)
-
-      log "Waiting for all ${total_jobs} rclone jobs to complete..."
-      local retries=480 # these can take a really long time depending on content, so the timeout is set to 4 hours
-      while [ $retries -gt 0 ]; do
-        
-        local job_statuses
-        job_statuses=$("$CK8S_CMD" ops kubectl sc -n rclone get jobs -lapp.kubernetes.io/instance=rclone-sync -o json)
-        
-        local succeeded
-        succeeded=$(echo "$job_statuses" | jq '[.items[] | select(.status.succeeded == 1)] | length')
-        local failed
-        failed=$(echo "$job_statuses" | jq '[.items[] | select(.status.failed > 0)] | length')
-        local active
-        active=$(echo "$job_statuses" | jq '[.items[] | select(.status.active == 1)] | length')
-
-        log "Job Status -> Total: ${total_jobs} | Succeeded: ${succeeded} | Failed: ${failed} | Active: ${active}"
-
-        if [ "$active" -eq 0 ]; then
-          break
-        fi
-
-        sleep 30
-        retries=$((retries - 1))
-      done
-
-      # check if all jobs succeeded or not
-      if [ "$(echo "$job_statuses" | jq '[.items[] | select(.status.succeeded == 1)] | length')" -ne "$total_jobs" ]; then
-        log "ERROR: Not all rclone jobs succeeded. Please check the logs for failed jobs."
+      if [ "$status" = "SUCCESS" ]; then
+        log "OpenSearch backup successfully completed."
+        return
+      elif [ "$status" = "FAILED" ] || [ "$status" = "PARTIAL" ]; then
+        log "ERROR: OpenSearch snapshot failed with status: ${status}"
         exit 1
       fi
 
-      log "Cleaning up..."
-      for job in $job_list; do
-        "$CK8S_CMD" ops kubectl sc -n rclone delete "$job" --ignore-not-found=true
-      done
+      sleep 30
+      retries=$((retries - 1))
+    done
 
-      log "Rclone backup successfully completed."
-      ;;
-    velero)
-      log "Starting Velero backup..."
+    log "ERROR: Timeout waiting for OpenSearch snapshot to complete."
+    exit 1
+    ;;
+  harbor)
+    log "Starting Harbor backup..."
+    local backup_job_name
+    backup_job_name="harbor-backup-manual-$(date +%Y%m%d%H%M%S)"
+    log "Creating on-demand backup job: $backup_job_name"
 
-      local backup_name="manual-backup-$(date +%Y%m%d%H%M%S)"
-      log "Creating Velero backup: ${backup_name}"
+    "$CK8S_CMD" ops kubectl sc -n harbor create job "$backup_job_name" --from=cronjob/harbor-backup-cronjob
 
-      "$CK8S_CMD" ops velero wc backup create "$backup_name" --from-schedule velero-daily-backup
+    log "Waiting for backup job to complete..."
+    "$CK8S_CMD" ops kubectl sc -n harbor wait --for=condition=complete "job/$backup_job_name" --timeout=30m
 
-      log "Waiting for backup to complete..."
-      local phase=""
-      local retries=90
-      while [ $retries -gt 0 ]; do
-        phase=$( "$CK8S_CMD" ops velero wc backup describe "$backup_name" -o json | jq -r .phase )
-        log "Current backup phase: ${phase}"
+    log "Backup complete. Deleting job: $backup_job_name"
+    "$CK8S_CMD" ops kubectl sc -n harbor delete job "$backup_job_name"
 
-        if [ "$phase" = "Completed" ]; then
-          log "Velero backup successfully completed."
-          return
-        elif [[ "$phase" =~ Failed|PartiallyFailed|Deleting ]]; then
-          log "ERROR: Velero backup failed or was deleted with phase: ${phase}"
-          exit 1
-        fi
+    log "Harbor backup successfully completed."
+    ;;
+  rclone)
+    log "Starting Rclone backup..."
 
-        sleep 30
-        retries=$((retries - 1))
-      done
+    # Check if rclone-sync is enabled before continuing
+    log "Checking for rclone-sync cronjobs"
+    local cronjob_list
+    cronjob_list=$("$CK8S_CMD" ops kubectl sc -n rclone get cronjobs -lapp.kubernetes.io/instance=rclone-sync -oname)
 
-      log "ERROR: Timeout waiting for Velero backup to complete."
+    if [ -z "$cronjob_list" ]; then
+      log "ERROR: No rclone-sync cronjobs found."
+      log "Please ensure rclone sync is enabled in your configuration and has been applied."
       exit 1
-      ;;
-    *)
-      log "Error: Invalid backup target '$1'."
-      usage
-      ;;
+    fi
+    local total_jobs
+    total_jobs=$(echo "$cronjob_list" | wc -w)
+    log "Found ${total_jobs} cronjobs."
+
+    # Create jobs from cronjobs
+    for cronjob in $cronjob_list; do
+      "$CK8S_CMD" ops kubectl sc -n rclone create job --from "${cronjob}" "${cronjob/#cronjob.batch\//}"
+      local job_name=${cronjob/#cronjob.batch\//}
+      log "Creating job '${job_name}' from '${cronjob}' cronjob..."
+    done
+
+    job_list=$("$CK8S_CMD" ops kubectl sc -n rclone get jobs -lapp.kubernetes.io/instance=rclone-sync -oname)
+
+    log "Waiting for all ${total_jobs} rclone jobs to complete..."
+    local retries=480 # these can take a really long time depending on content, so the timeout is set to 4 hours
+    while [ $retries -gt 0 ]; do
+
+      local job_statuses
+      job_statuses=$("$CK8S_CMD" ops kubectl sc -n rclone get jobs -lapp.kubernetes.io/instance=rclone-sync -o json)
+
+      local succeeded
+      succeeded=$(echo "$job_statuses" | jq '[.items[] | select(.status.succeeded == 1)] | length')
+      local failed
+      failed=$(echo "$job_statuses" | jq '[.items[] | select(.status.failed > 0)] | length')
+      local active
+      active=$(echo "$job_statuses" | jq '[.items[] | select(.status.active == 1)] | length')
+
+      log "Job Status -> Total: ${total_jobs} | Succeeded: ${succeeded} | Failed: ${failed} | Active: ${active}"
+
+      if [ "$active" -eq 0 ]; then
+        break
+      fi
+
+      sleep 30
+      retries=$((retries - 1))
+    done
+
+    # check if all jobs succeeded or not
+    if [ "$(echo "$job_statuses" | jq '[.items[] | select(.status.succeeded == 1)] | length')" -ne "$total_jobs" ]; then
+      log "ERROR: Not all rclone jobs succeeded. Please check the logs for failed jobs."
+      exit 1
+    fi
+
+    log "Cleaning up..."
+    for job in $job_list; do
+      "$CK8S_CMD" ops kubectl sc -n rclone delete "$job" --ignore-not-found=true
+    done
+
+    log "Rclone backup successfully completed."
+    ;;
+  velero)
+    log "Starting Velero backup..."
+
+    local backup_name
+    backup_name="manual-backup-$(date +%Y%m%d%H%M%S)"
+    log "Creating Velero backup: ${backup_name}"
+
+    "$CK8S_CMD" ops velero wc backup create "$backup_name" --from-schedule velero-daily-backup
+
+    log "Waiting for backup to complete..."
+    local phase=""
+    local retries=90
+    while [ $retries -gt 0 ]; do
+      phase=$("$CK8S_CMD" ops velero wc backup describe "$backup_name" -o json | jq -r .phase)
+      log "Current backup phase: ${phase}"
+
+      if [ "$phase" = "Completed" ]; then
+        log "Velero backup successfully completed."
+        return
+      elif [[ "$phase" =~ Failed|PartiallyFailed|Deleting ]]; then
+        log "ERROR: Velero backup failed or was deleted with phase: ${phase}"
+        exit 1
+      fi
+
+      sleep 30
+      retries=$((retries - 1))
+    done
+
+    log "ERROR: Timeout waiting for Velero backup to complete."
+    exit 1
+    ;;
+  *)
+    log "Error: Invalid backup target '$1'."
+    usage
+    ;;
   esac
 }
 
 run_restore() {
   case "$1" in
-    opensearch)
-      log "Starting OpenSearch restore..."
-      
-      local user="admin"
-      local password
-      password=$(sops -d "${CK8S_CONFIG_PATH}/secrets.yaml" | yq '.opensearch.adminPassword')
-      local os_url="https://opensearch.$(yq '.global.opsDomain' "${CK8S_CONFIG_PATH}/common-config.yaml")"
-      log "OpenSearch URL: ${os_url}"
+  opensearch)
+    log "Starting OpenSearch restore..."
 
-      log "Discovering snapshot repository name..."
-      local snapshot_repo
-      snapshot_repo=$(curl -kL -s -u "${user}:${password}" "${os_url}/_cat/repositories?v" | awk 'NR==2 {print $1}')
-      if [ -z "$snapshot_repo" ]; then
-        log "ERROR: Could not find OpenSearch snapshot repository."
-        exit 1
-      fi
-      log "Found snapshot repository: ${snapshot_repo}"
+    local user="admin"
+    local password
+    password=$(sops -d "${CK8S_CONFIG_PATH}/secrets.yaml" | yq '.opensearch.adminPassword')
+    local os_url
+    os_url="https://opensearch.$(yq '.global.opsDomain' "${CK8S_CONFIG_PATH}/common-config.yaml")"
+    log "OpenSearch URL: ${os_url}"
 
-      log "Finding latest successful snapshot..."
-      local latest_snapshot
-      latest_snapshot=$(curl -kL -s -u "${user}:${password}" -X GET "${os_url}/_snapshot/${snapshot_repo}/_all" | jq -r '.snapshots | map(select(.state == "SUCCESS")) | sort_by(.start_time_in_millis) | .[-1].snapshot')
-      if [ -z "$latest_snapshot" ] || [ "$latest_snapshot" = "null" ]; then
-          log "ERROR: No successful snapshots found to restore."
-          exit 1
-      fi
-      log "Found latest snapshot to restore: ${latest_snapshot}"
+    log "Discovering snapshot repository name..."
+    local snapshot_repo
+    snapshot_repo=$(curl -kL -s -u "${user}:${password}" "${os_url}/_cat/repositories?v" | awk 'NR==2 {print $1}')
+    if [ -z "$snapshot_repo" ]; then
+      log "ERROR: Could not find OpenSearch snapshot repository."
+      exit 1
+    fi
+    log "Found snapshot repository: ${snapshot_repo}"
 
-      local indices_to_restore="kubernetes-*,kubeaudit-*,other-*,authlog-*"
-      log "Will restore indices matching pattern: ${indices_to_restore}"
+    log "Finding latest successful snapshot..."
+    local latest_snapshot
+    latest_snapshot=$(curl -kL -s -u "${user}:${password}" -X GET "${os_url}/_snapshot/${snapshot_repo}/_all" | jq -r '.snapshots | map(select(.state == "SUCCESS")) | sort_by(.start_time_in_millis) | .[-1].snapshot')
+    if [ -z "$latest_snapshot" ] || [ "$latest_snapshot" = "null" ]; then
+      log "ERROR: No successful snapshots found to restore."
+      exit 1
+    fi
+    log "Found latest snapshot to restore: ${latest_snapshot}"
 
-      log "Closing existing indices matching the restore pattern..."
-      curl -kL -s -u "${user}:${password}" -X POST "${os_url}/${indices_to_restore}/_close?pretty"
+    local indices_to_restore="kubernetes-*,kubeaudit-*,other-*,authlog-*"
+    log "Will restore indices matching pattern: ${indices_to_restore}"
 
-      log "Starting restore from snapshot ${latest_snapshot}..."
-      curl -kL -s -u "${user}:${password}" -X POST "${os_url}/_snapshot/${snapshot_repo}/${latest_snapshot}/_restore?pretty" -H 'Content-Type: application/json' -d'
+    log "Closing existing indices matching the restore pattern..."
+    curl -kL -s -u "${user}:${password}" -X POST "${os_url}/${indices_to_restore}/_close?pretty"
+
+    log "Starting restore from snapshot ${latest_snapshot}..."
+    curl -kL -s -u "${user}:${password}" -X POST "${os_url}/_snapshot/${snapshot_repo}/${latest_snapshot}/_restore?pretty" -H 'Content-Type: application/json' -d'
       {
         "indices": "'"${indices_to_restore}"'"
       }
       '
 
-      log "Waiting for cluster health to become green..."
-      local status=""
-      local retries=60 # 30 min timeout
-      while [ $retries -gt 0 ]; do
-        status=$(curl -kL -s -u "${user}:${password}" "${os_url}/_cluster/health" | jq -r '.status')
-        log "Current cluster status: ${status}"
+    log "Waiting for cluster health to become green..."
+    local status=""
+    local retries=60 # 30 min timeout
+    while [ $retries -gt 0 ]; do
+      status=$(curl -kL -s -u "${user}:${password}" "${os_url}/_cluster/health" | jq -r '.status')
+      log "Current cluster status: ${status}"
 
-        if [ "$status" = "green" ]; then
-          log "OpenSearch restore complete and cluster is healthy."
-          return
-        fi
+      if [ "$status" = "green" ]; then
+        log "OpenSearch restore complete and cluster is healthy."
+        return
+      fi
 
-        sleep 30
-        retries=$((retries - 1))
-      done
+      sleep 30
+      retries=$((retries - 1))
+    done
 
-      log "ERROR: Timeout waiting for OpenSearch cluster to become healthy after restore."
+    log "ERROR: Timeout waiting for OpenSearch cluster to become healthy after restore."
+    exit 1
+    ;;
+  harbor)
+    log "Starting Harbor restore..."
+
+    "$CK8S_CMD" harbor-restore
+
+    log "Harbor restore successfully completed."
+    ;;
+  rclone)
+    log "Starting Rclone restore..."
+
+    # Check if rclone-restore is enabled before continuing
+    log "Checking for rclone-restore cronjobs"
+    local cronjob_list
+    cronjob_list=$("$CK8S_CMD" ops kubectl sc -n rclone get cronjobs -lapp.kubernetes.io/instance=rclone-restore -oname)
+
+    if [ -z "$cronjob_list" ]; then
+      log "ERROR: No rclone-restore cronjobs found."
+      log "Please ensure rclone restore is enabled in your configuration and has been applied."
       exit 1
-      ;;
-    harbor)
-      log "Starting Harbor restore..."
+    fi
+    local total_jobs
+    total_jobs=$(echo "$cronjob_list" | wc -w)
+    log "Found ${total_jobs} cronjobs."
 
-      "$CK8S_CMD" harbor-restore
+    # Create jobs from cronjobs
+    for cronjob in $cronjob_list; do
+      "$CK8S_CMD" ops kubectl sc -n rclone create job --from "${cronjob}" "${cronjob/#cronjob.batch\//}"
+      local job_name=${cronjob/#cronjob.batch\//}
+      log "Creating job '${job_name}' from '${cronjob}' cronjob..."
+    done
 
-      log "Harbor restore successfully completed."
-      ;;
-    rclone)
-      log "Starting Rclone restore..."
+    local job_list
+    job_list=$("$CK8S_CMD" ops kubectl sc -n rclone get jobs -lapp.kubernetes.io/instance=rclone-restore -oname)
 
-      # Check if rclone-restore is enabled before continuing
-      log "Checking for rclone-restore cronjobs"
-      local cronjob_list
-      cronjob_list=$("$CK8S_CMD" ops kubectl sc -n rclone get cronjobs -lapp.kubernetes.io/instance=rclone-restore -oname)
+    log "Waiting for all ${total_jobs} rclone jobs to complete..."
+    local retries=480 # 4 hour timeout
+    while [ $retries -gt 0 ]; do
 
-      if [ -z "$cronjob_list" ]; then
-        log "ERROR: No rclone-restore cronjobs found."
-        log "Please ensure rclone restore is enabled in your configuration and has been applied."
-        exit 1
-      fi
-      local total_jobs
-      total_jobs=$(echo "$cronjob_list" | wc -w)
-      log "Found ${total_jobs} cronjobs."
+      local job_statuses
+      job_statuses=$("$CK8S_CMD" ops kubectl sc -n rclone get jobs -lapp.kubernetes.io/instance=rclone-restore -o json)
 
-      # Create jobs from cronjobs
-      for cronjob in $cronjob_list; do
-        "$CK8S_CMD" ops kubectl sc -n rclone create job --from "${cronjob}" "${cronjob/#cronjob.batch\/}"
-        local job_name=${cronjob/#cronjob.batch\/}
-        log "Creating job '${job_name}' from '${cronjob}' cronjob..."
-      done
+      local succeeded
+      succeeded=$(echo "$job_statuses" | jq '[.items[] | select(.status.succeeded == 1)] | length')
+      local failed
+      failed=$(echo "$job_statuses" | jq '[.items[] | select(.status.failed > 0)] | length')
+      local active
+      active=$(echo "$job_statuses" | jq '[.items[] | select(.status.active == 1)] | length')
 
-      local job_list
-      job_list=$("$CK8S_CMD" ops kubectl sc -n rclone get jobs -lapp.kubernetes.io/instance=rclone-restore -oname)
+      log "Job Status -> Total: ${total_jobs} | Succeeded: ${succeeded} | Failed: ${failed} | Active: ${active}"
 
-      log "Waiting for all ${total_jobs} rclone jobs to complete..."
-      local retries=480 # 4 hour timeout
-      while [ $retries -gt 0 ]; do
-        
-        local job_statuses
-        job_statuses=$("$CK8S_CMD" ops kubectl sc -n rclone get jobs -lapp.kubernetes.io/instance=rclone-restore -o json)
-        
-        local succeeded
-        succeeded=$(echo "$job_statuses" | jq '[.items[] | select(.status.succeeded == 1)] | length')
-        local failed
-        failed=$(echo "$job_statuses" | jq '[.items[] | select(.status.failed > 0)] | length')
-        local active
-        active=$(echo "$job_statuses" | jq '[.items[] | select(.status.active == 1)] | length')
-
-        log "Job Status -> Total: ${total_jobs} | Succeeded: ${succeeded} | Failed: ${failed} | Active: ${active}"
-
-        if [ "$active" -eq 0 ]; then
-          break
-        fi
-
-        sleep 30
-        retries=$((retries - 1))
-      done
-
-      # Check if all jobs succeeded
-      if [ "$(echo "$job_statuses" | jq '[.items[] | select(.status.succeeded == 1)] | length')" -ne "$total_jobs" ]; then
-        log "ERROR: Not all rclone jobs succeeded. Please check the logs for failed jobs."
-        exit 1
+      if [ "$active" -eq 0 ]; then
+        break
       fi
 
-      log "Cleaning up..."
-      for job in $job_list; do
-        "$CK8S_CMD" ops kubectl sc -n rclone delete "$job" --ignore-not-found=true
-      done
+      sleep 30
+      retries=$((retries - 1))
+    done
 
-      log "Rclone restore successfully completed."
-      ;;
-    velero)
-      log "Starting Velero restore..."
-
-      log "Finding latest completed Velero backup..."
-      local latest_backup
-      latest_backup=$( "$CK8S_CMD" ops velero wc backup get -o json | jq -r '.items | map(select(.status.phase == "Completed")) | sort_by(.metadata.creationTimestamp) | .[-1].metadata.name' )
-
-      if [ -z "$latest_backup" ] || [ "$latest_backup" = "null" ]; then
-        log "ERROR: No completed Velero backups found to restore from."
-        exit 1
-      fi
-      log "Found latest backup to restore: ${latest_backup}"
-
-      log "Deleting Alertmanager secret..."
-      "$CK8S_CMD" ops kubectl wc delete secret -n alertmanager alertmanager-kube-prometheus-stack-alertmanager --ignore-not-found=true
-
-      local restore_name="restore-$(date +%Y%m%d%H%M%S)"
-      log "Creating restore '${restore_name}' from backup '${latest_backup}'"
-      "$CK8S_CMD" ops velero wc restore create "$restore_name" --from-backup "$latest_backup"
-
-      log "Waiting for restore to complete..."
-      local phase=""
-      local retries=60 # 30 min timeout
-      while [ $retries -gt 0 ]; do
-        phase=$( "$CK8S_CMD" ops velero wc restore get "$restore_name" -o json | jq -r .status.phase )
-        log "Current restore phase: ${phase}"
-
-        if [ "$phase" = "Completed" ]; then
-          log "Velero restore successfully completed."
-          return
-        elif [[ "$phase" =~ Failed|PartiallyFailed ]]; then
-          log "ERROR: Velero restore failed with phase: ${phase}"
-          exit 1
-        fi
-
-        sleep 30
-        retries=$((retries - 1))
-      done
-      
-      log "ERROR: Timeout waiting for Velero restore to complete."
+    # Check if all jobs succeeded
+    if [ "$(echo "$job_statuses" | jq '[.items[] | select(.status.succeeded == 1)] | length')" -ne "$total_jobs" ]; then
+      log "ERROR: Not all rclone jobs succeeded. Please check the logs for failed jobs."
       exit 1
-      ;;
-    *)
-      log "Error: Invalid restore target '$1'."
-      usage
-      ;;
+    fi
+
+    log "Cleaning up..."
+    for job in $job_list; do
+      "$CK8S_CMD" ops kubectl sc -n rclone delete "$job" --ignore-not-found=true
+    done
+
+    log "Rclone restore successfully completed."
+    ;;
+  velero)
+    log "Starting Velero restore..."
+
+    log "Finding latest completed Velero backup..."
+    local latest_backup
+    latest_backup=$("$CK8S_CMD" ops velero wc backup get -o json | jq -r '.items | map(select(.status.phase == "Completed")) | sort_by(.metadata.creationTimestamp) | .[-1].metadata.name')
+
+    if [ -z "$latest_backup" ] || [ "$latest_backup" = "null" ]; then
+      log "ERROR: No completed Velero backups found to restore from."
+      exit 1
+    fi
+    log "Found latest backup to restore: ${latest_backup}"
+
+    log "Deleting Alertmanager secret..."
+    "$CK8S_CMD" ops kubectl wc delete secret -n alertmanager alertmanager-kube-prometheus-stack-alertmanager --ignore-not-found=true
+
+    local restore_name
+    restore_name="restore-$(date +%Y%m%d%H%M%S)"
+    log "Creating restore '${restore_name}' from backup '${latest_backup}'"
+    "$CK8S_CMD" ops velero wc restore create "$restore_name" --from-backup "$latest_backup"
+
+    log "Waiting for restore to complete..."
+    local phase=""
+    local retries=60 # 30 min timeout
+    while [ $retries -gt 0 ]; do
+      phase=$("$CK8S_CMD" ops velero wc restore get "$restore_name" -o json | jq -r .status.phase)
+      log "Current restore phase: ${phase}"
+
+      if [ "$phase" = "Completed" ]; then
+        log "Velero restore successfully completed."
+        return
+      elif [[ "$phase" =~ Failed|PartiallyFailed ]]; then
+        log "ERROR: Velero restore failed with phase: ${phase}"
+        exit 1
+      fi
+
+      sleep 30
+      retries=$((retries - 1))
+    done
+
+    log "ERROR: Timeout waiting for Velero restore to complete."
+    exit 1
+    ;;
+  *)
+    log "Error: Invalid restore target '$1'."
+    usage
+    ;;
   esac
 }
 
 case "$ACTION" in
-  backup)
-    run_backup "$TARGET"
-    ;;
-  restore)
-    run_restore "$TARGET"
-    ;;
-  *)
-    log "Error: Invalid action '$ACTION'."
-    usage
-    ;;
+backup)
+  run_backup "$TARGET"
+  ;;
+restore)
+  run_restore "$TARGET"
+  ;;
+*)
+  log "Error: Invalid action '$ACTION'."
+  usage
+  ;;
 esac


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [x] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Adds a backup and restore script that can target harbor, velero, opensearch and rclone to automatically perform QA steps of taking and restoring backups.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes https://github.com/elastisys/ck8s-issue-tracker/issues/448

#### Information to reviewers

Tested all backups and restores on cluster running v0.48 with s3 object storage as both backup and restore target.

Have not tested the script with Azure or Swift.

Note that rclone requires user to manually apply sync or restore before running the script since I didn't want this script to interfere with peoples configs and apply changes to a cluster automatically. I am open to opinions on this though.

To run the script simply run `/backup-restore.sh <backup | restore> <opensearch | velero | rclone | harbor>`
It can be run from anywhere.
<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
