### PR TITLE
Velero: set assertions for excluded namespaces

### DIFF
--- a/tests/end-to-end/velero/backup-restore-sc.gen.bats
+++ b/tests/end-to-end/velero/backup-restore-sc.gen.bats
@@ -11,7 +11,14 @@ setup() {
 @test "velero backup spec sc" {
   run velero_backups_spec sc
   assert_success
-  assert_output "$(cat "${BATS_TEST_DIRNAME}/resources/backup-spec-sc.yaml")"
+  assert_output "$(velero_expected_spec sc)"
+
+  # Expect the spec to contain _at least_ the namespaces specified by the fixture
+  # (but we don't mind if we find more)
+  run comm -13 \
+    <(velero_backups_excluded_ns sc | sort) \
+    <(velero_expected_excluded_ns sc | sort)
+  refute_output
 }
 
 @test "velero backup and restore sc" {

--- a/tests/end-to-end/velero/backup-restore-sc.gen.bats
+++ b/tests/end-to-end/velero/backup-restore-sc.gen.bats
@@ -9,15 +9,15 @@ setup() {
 }
 
 @test "velero backup spec sc" {
-  run velero_backups_spec sc
+  run velero_backups_spec_without_excluded_namespaces sc
   assert_success
-  assert_output "$(velero_expected_spec sc)"
+  assert_output "$(velero_expected_spec_without_excluded_namespaces sc)"
 
   # Expect the spec to contain _at least_ the namespaces specified by the fixture
   # (but we don't mind if we find more)
   run comm -13 \
-    <(velero_backups_excluded_ns sc | sort) \
-    <(velero_expected_excluded_ns sc | sort)
+    <(velero_backups_excluded_namespaces sc | sort) \
+    <(velero_expected_excluded_namespaces sc | sort)
   refute_output
 }
 

--- a/tests/end-to-end/velero/backup-restore-wc.gen.bats
+++ b/tests/end-to-end/velero/backup-restore-wc.gen.bats
@@ -11,7 +11,14 @@ setup() {
 @test "velero backup spec wc" {
   run velero_backups_spec wc
   assert_success
-  assert_output "$(cat "${BATS_TEST_DIRNAME}/resources/backup-spec-wc.yaml")"
+  assert_output "$(velero_expected_spec wc)"
+
+  # Expect the spec to contain _at least_ the namespaces specified by the fixture
+  # (but we don't mind if we find more)
+  run comm -13 \
+    <(velero_backups_excluded_ns wc | sort) \
+    <(velero_expected_excluded_ns wc | sort)
+  refute_output
 }
 
 @test "velero backup and restore wc" {

--- a/tests/end-to-end/velero/backup-restore-wc.gen.bats
+++ b/tests/end-to-end/velero/backup-restore-wc.gen.bats
@@ -9,15 +9,15 @@ setup() {
 }
 
 @test "velero backup spec wc" {
-  run velero_backups_spec wc
+  run velero_backups_spec_without_excluded_namespaces wc
   assert_success
-  assert_output "$(velero_expected_spec wc)"
+  assert_output "$(velero_expected_spec_without_excluded_namespaces wc)"
 
   # Expect the spec to contain _at least_ the namespaces specified by the fixture
   # (but we don't mind if we find more)
   run comm -13 \
-    <(velero_backups_excluded_ns wc | sort) \
-    <(velero_expected_excluded_ns wc | sort)
+    <(velero_backups_excluded_namespaces wc | sort) \
+    <(velero_expected_excluded_namespaces wc | sort)
   refute_output
 }
 

--- a/tests/end-to-end/velero/backup-restore.bats.gotmpl
+++ b/tests/end-to-end/velero/backup-restore.bats.gotmpl
@@ -14,7 +14,14 @@ setup() {
 @test "velero backup spec {{ .cluster }}" {
   run velero_backups_spec {{ .cluster }}
   assert_success
-  assert_output "$(cat "${BATS_TEST_DIRNAME}/resources/backup-spec-{{ .cluster }}.yaml")"
+  assert_output "$(velero_expected_spec {{ .cluster }})"
+
+  # Expect the spec to contain _at least_ the namespaces specified by the fixture
+  # (but we don't mind if we find more)
+  run comm -13 \
+    <(velero_backups_excluded_ns {{ .cluster }} | sort) \
+    <(velero_expected_excluded_ns {{ .cluster }} | sort)
+  refute_output
 }
 
 @test "velero backup and restore {{ .cluster }}" {

--- a/tests/end-to-end/velero/backup-restore.bats.gotmpl
+++ b/tests/end-to-end/velero/backup-restore.bats.gotmpl
@@ -12,15 +12,15 @@ setup() {
 }
 
 @test "velero backup spec {{ .cluster }}" {
-  run velero_backups_spec {{ .cluster }}
+  run velero_backups_spec_without_excluded_namespaces {{ .cluster }}
   assert_success
-  assert_output "$(velero_expected_spec {{ .cluster }})"
+  assert_output "$(velero_expected_spec_without_excluded_namespaces {{ .cluster }})"
 
   # Expect the spec to contain _at least_ the namespaces specified by the fixture
   # (but we don't mind if we find more)
   run comm -13 \
-    <(velero_backups_excluded_ns {{ .cluster }} | sort) \
-    <(velero_expected_excluded_ns {{ .cluster }} | sort)
+    <(velero_backups_excluded_namespaces {{ .cluster }} | sort) \
+    <(velero_expected_excluded_namespaces {{ .cluster }} | sort)
   refute_output
 }
 

--- a/tests/end-to-end/velero/common.bash
+++ b/tests/end-to-end/velero/common.bash
@@ -1,31 +1,39 @@
+# Usage: velero_backups_spec <cluster>
 velero_backups_spec() {
   ck8s ops velero "${1}" backup create --from-schedule velero-daily-backup -o yaml 2>/dev/null | yq '.spec | del(.excludedNamespaces)'
 }
 
+# Usage: velero_backups_excluded_ns <cluster>
 velero_backups_excluded_ns() {
   ck8s ops velero "${1}" backup create --from-schedule velero-daily-backup -o yaml 2>/dev/null | yq '.spec.excludedNamespaces'
 }
 
+# Usage: velero_expected_spec <cluster>
 velero_expected_spec() {
   yq 'del(.excludedNamespaces)' <"${BATS_TEST_DIRNAME}/resources/backup-spec-${1}.yaml"
 }
 
+# Usage: velero_expected_excluded_ns <cluster>
 velero_expected_excluded_ns() {
   yq '.excludedNamespaces' <"${BATS_TEST_DIRNAME}/resources/backup-spec-${1}.yaml"
 }
 
+# Usage: velero_backup_create <cluster> <backup_name>
 velero_backup_create() {
   ck8s ops velero "${1}" backup create "${2}" --from-schedule velero-daily-backup --wait
 }
 
+# Usage: velero_backup_get_phase <cluster> <backup_name>
 velero_backup_get_phase() {
   ck8s ops velero "${1}" backup get "${2}" -o json 2>/dev/null | jq -r .status.phase
 }
 
+# Usage: velero_restore_create <cluster> <backup_name>
 velero_restore_create() {
   ck8s ops velero "${1}" restore create "${2}" --from-backup "${3}" --wait
 }
 
+# Usage: velero_restore_get_phase <cluster> <backup_name>
 velero_restore_get_phase() {
   ck8s ops velero "${1}" restore get "${2}" -o json 2>/dev/null | jq -r .status.phase
 }

--- a/tests/end-to-end/velero/common.bash
+++ b/tests/end-to-end/velero/common.bash
@@ -1,5 +1,17 @@
 velero_backups_spec() {
-  ck8s ops velero "${1}" backup create --from-schedule velero-daily-backup -o yaml 2>/dev/null | yq .spec
+  ck8s ops velero "${1}" backup create --from-schedule velero-daily-backup -o yaml 2>/dev/null | yq '.spec | del(.excludedNamespaces)'
+}
+
+velero_backups_excluded_ns() {
+  ck8s ops velero "${1}" backup create --from-schedule velero-daily-backup -o yaml 2>/dev/null | yq '.spec.excludedNamespaces'
+}
+
+velero_expected_spec() {
+  yq 'del(.excludedNamespaces)' <"${BATS_TEST_DIRNAME}/resources/backup-spec-${1}.yaml"
+}
+
+velero_expected_excluded_ns() {
+  yq '.excludedNamespaces' <"${BATS_TEST_DIRNAME}/resources/backup-spec-${1}.yaml"
 }
 
 velero_backup_create() {

--- a/tests/end-to-end/velero/common.bash
+++ b/tests/end-to-end/velero/common.bash
@@ -1,20 +1,20 @@
-# Usage: velero_backups_spec <cluster>
-velero_backups_spec() {
+# Usage: velero_backups_spec_without_excluded_namespaces <cluster>
+velero_backups_spec_without_excluded_namespaces() {
   ck8s ops velero "${1}" backup create --from-schedule velero-daily-backup -o yaml 2>/dev/null | yq '.spec | del(.excludedNamespaces)'
 }
 
-# Usage: velero_backups_excluded_ns <cluster>
-velero_backups_excluded_ns() {
+# Usage: velero_backups_excluded_namespaces <cluster>
+velero_backups_excluded_namespaces() {
   ck8s ops velero "${1}" backup create --from-schedule velero-daily-backup -o yaml 2>/dev/null | yq '.spec.excludedNamespaces'
 }
 
-# Usage: velero_expected_spec <cluster>
-velero_expected_spec() {
+# Usage: velero_expected_spec_without_excluded_namespaces <cluster>
+velero_expected_spec_without_excluded_namespaces() {
   yq 'del(.excludedNamespaces)' <"${BATS_TEST_DIRNAME}/resources/backup-spec-${1}.yaml"
 }
 
-# Usage: velero_expected_excluded_ns <cluster>
-velero_expected_excluded_ns() {
+# Usage: velero_expected_excluded_namespaces <cluster>
+velero_expected_excluded_namespaces() {
   yq '.excludedNamespaces' <"${BATS_TEST_DIRNAME}/resources/backup-spec-${1}.yaml"
 }
 

--- a/tests/end-to-end/velero/resources/backup-spec-wc.yaml
+++ b/tests/end-to-end/velero/resources/backup-spec-wc.yaml
@@ -19,10 +19,6 @@ excludedNamespaces:
   - openstack-system
   - rook-ceph
   - velero
-  - jaeger-system
-  - postgres-system
-  - rabbitmq-system
-  - redis-system
 excludedResources:
   - clustercompliancereports.aquasecurity.github.io
   - clusterconfigauditreports.aquasecurity.github.io


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Decouples the `velero` end-to-end test suite assertions from "knowledge" that's specific to Devbox-based clusters. 

Let me explain: when making a cluster with Devbox, we add a few excluded namespaces to Velero's backup spec in the WC. These have leaked into the the velero test fixture, so that now, even on vanilla clusters (that haven't been installed with Devbox), we expect to find those namespaces in the spec. This is wrong.

What we propose here instead is that the test checks that the set of excluded namespaces does include _at least_ all the namespaces in the fixture, but we won't fail if we find more. The Devbox-specific namespaces have been removed from the fixture.

#### Information to reviewers

```
make -C tests run-end-to-end/velero
```

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
