### PR TITLE
Add fluentd client error metric and alert

### DIFF
--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/fluentd.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/fluentd.yaml
@@ -110,4 +110,15 @@ spec:
         description: Fluentd output error count is {{ "{{ $value }}" }} for the last 10 minutes
         summary: There have been Fluentd output error(s) for the last 10 minutes
         runbook_url: {{ .Values.runbookUrls.fluentd.FluentdOutputError }}
+    - alert: FluentdOutputClientError
+      expr: sum(increase(fluentd_output_status_num_client_errors[10m])) by (pod, cluster, service) > 0
+      for: 1m
+      labels:
+        service: fluentd
+        severity: warning
+        group: Fluentd
+      annotations:
+        description: Fluentd output client error count is {{ "{{ $value }}" }} for the last 10 minutes
+        summary: There have been Fluentd output client error(s) for the last 10 minutes
+        runbook_url: {{ .Values.runbookUrls.fluentd.FluentdOutputClientError }}
 {{- end }}

--- a/helmfile.d/values/fluentd/forwarder-common.yaml.gotmpl
+++ b/helmfile.d/values/fluentd/forwarder-common.yaml.gotmpl
@@ -278,6 +278,17 @@ extraConfigMaps:
       </metric>
     </filter>
 
+    <label @ERROR>
+      <match **>
+        @type prometheus
+        <metric>
+          name fluentd_output_status_num_client_errors
+          type counter
+          desc The total number of errors from kubernetes containers output
+        </metric>
+      </match>
+    </label>
+
 # Liveliness probe reverted from upstream changes to prevent that it fails if just one buffer is inactive.
 # E.g. the authlog buffer will often be inactive, so it would make the probe fail.
 livenessProbe:

--- a/helmfile.d/values/prometheus-alerts-runbook-urls.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-alerts-runbook-urls.yaml.gotmpl
@@ -104,6 +104,7 @@ runbookUrls:
     {{- dict "name" "FluentdRecordsCountsHigh" "config" .fluentd | include "tpl.missing-runbook" }}
     {{- dict "name" "FluentdRetry" "config" .fluentd | include "tpl.missing-runbook" }}
     {{- dict "name" "FluentdOutputError" "config" .fluentd | include "tpl.missing-runbook" }}
+    {{- dict "name" "FluentdOutputClientError" "config" .fluentd | include "tpl.missing-runbook" }}
   general:
     {{- dict "name" "TargetDown" "subpath" "general" "config" .general | include "tpl.prometheus-operator" }}
     {{- dict "name" "Watchdog" "subpath" "general" "config" .general | include "tpl.prometheus-operator" }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Added a new metric and alert for fluentd client errors

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

The default `fluentd_output_status_num_errors` that we use for alerts doesn't include code 400 errors, as they are considered client errors. As a result, mapping conflicts can go unnoticed, which in turn leads to logs being rejected by OpenSearch and subsequently dropped. This new metric and alert catches these errors.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
