### PR TITLE
Re-run Harbor init job after restore to ensure OIDC secrets synced

### DIFF
--- a/bin/harbor-restore.sh
+++ b/bin/harbor-restore.sh
@@ -165,7 +165,13 @@ log_info "Cleaning up restore artifacts..."
 "${root_path}/bin/ck8s" ops kubectl sc delete -n harbor -f "${TMP_JOB_FILE}"
 "${root_path}/bin/ck8s" ops kubectl sc delete configmap -n harbor restore-harbor
 
+# Reinitialize
+log_info "Re-initializing..."
+"${root_path}/bin/ck8s" ops kubectl sc delete --ignore-not-found job -n harbor init-harbor-job
+"${root_path}/bin/ck8s" ops helmfile sc sync -l app=harbor
+"${root_path}/bin/ck8s" ops kubectl sc wait --for=condition=complete job -n harbor init-harbor-job --timeout=5m ||
+  log_fatal "Harbor initialization job has not completed, please check 'ck8s ops kubectl sc logs -n harbor job/init-harbor-job'"
+
 log_info "Harbor restore from ${STORAGE_TYPE} completed successfully."
 log_info "Post-restore steps from documentation (manual intervention may be required):"
-log_info "- If restoring to a different domain, re-run the init job (see docs)."
 log_info "- If restoring between Swift and S3/Azure, manual object storage modifications may be needed (see docs)."

--- a/helmfile.d/charts/harbor/harbor-backup/scripts/harbor-backup.sh
+++ b/helmfile.d/charts/harbor/harbor-backup/scripts/harbor-backup.sh
@@ -21,7 +21,7 @@ wait_for_db_ready() {
     sleep 5
   done
   if [ $TIMEOUT -eq 0 ]; then
-    echo "Harbor DB cannot reach within one minute."
+    echo "Harbor DB cannot be reached within one minute."
     exit 1
   fi
 }

--- a/restore/harbor/README.md
+++ b/restore/harbor/README.md
@@ -11,6 +11,7 @@ It can be installed normally.
 
 - Ensure `yq`, `sops`, `envsubst`and `kubectl` are installed and configured.
 - Ensure `CK8S_CONFIG_PATH` is set correctly.
+- Ensure the Harbor admin password is the same as in the old environment (needed by the init job).
 
 ## Usage
 
@@ -85,20 +86,6 @@ The script will provide reminders for these, but refer to the sections below if 
 
 <details>
     <summary>Restore to a different domain</summary>
-
-If you are restoring harbor to a new environment with a different domain, you need to re-run the init job. First, make sure the harbor admin password is the same as in the old environment:
-
-```bash
-# Edit harbor.password
-sops ${CK8S_CONFIG_PATH}/secrets.yaml
-```
-
-Then, re-run the init job:
-
-```bash
-./bin/ck8s ops kubectl sc delete job -n harbor init-harbor-job
-./bin/ck8s ops helmfile sc -l app=harbor sync
-```
 
 If the new harbor is using a dex instance with a different domain compared to the dex the old harbor was using, then when users login via dex harbor will not recognize them as the same user. Harbor will have the old OIDC users in the database, but when the new ones are created at first login they will conflict with the old ones and you will get a error like `failed to create user record: user <user> or email <email> already exists`.
 

--- a/restore/harbor/restore-harbor.sh
+++ b/restore/harbor/restore-harbor.sh
@@ -42,7 +42,7 @@ wait_for_db_ready() {
     sleep 5
   done
   if [ $TIMEOUT -eq 0 ]; then
-    echo "Harbor DB cannot reach within one minute."
+    echo "Harbor DB cannot be reached within one minute."
     exit 1
   fi
 }


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Harbor stores some configuration in its database.
When restoring from backups, that configuration is included.
This includes OIDC parameters.

This PR makes the Harbor restore script re-run the init job in case the OIDC secrets has been regenerated as part of disaster recovery.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2655

#### Information to reviewers

The last two commits changes from documenting the need to re-run the init job to always running the init job from the restore script.
If there's any reason not to always re-run the init job, those commits can easily be reverted.


#### How to test

1. Deploy at least Harbor and Dex to a service cluster
1. Wait for, or manually trigger a backup job
1. Change `.harbor.clientSecret` in `secrets.yaml` to a new random value
1. Apply change to Dex and Harbor
1. Follow [Harbor restore instructions](restore/harbor/README.md)
1. Try to login to Harbor

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates - (relevant documentation is in **this** repository, and updated herein)
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [x] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
