### PR TITLE
Test suite love (pt. 2)

### DIFF
--- a/helmfile.d/charts/grafana-dashboards/dashboards/nginx-dashboard.json
+++ b/helmfile.d/charts/grafana-dashboards/dashboards/nginx-dashboard.json
@@ -612,6 +612,7 @@
           },
           "links": [],
           "mappings": [],
+          "noValue": "missing",
           "thresholds": {
             "mode": "absolute",
             "steps": [

--- a/tests/common/cypress/grafana.js
+++ b/tests/common/cypress/grafana.js
@@ -60,7 +60,7 @@ Cypress.Commands.add('grafanaDexStaticLogin', (ingress, cacheSession = true) => 
 
     cy.dexStaticLogin()
 
-    cy.getCookie('grafana_session_expiry').should('exist')
+    return cy.getCookie('grafana_session_expiry').should('exist')
   }
 
   if (cacheSession) {
@@ -69,6 +69,7 @@ Cypress.Commands.add('grafanaDexStaticLogin', (ingress, cacheSession = true) => 
   } else {
     login()
   }
+  return cy.wrap(true)
 })
 
 // Available as cy.grafanaDexStaticLogin("grafana.example.com", "dev@example.com")
@@ -80,21 +81,28 @@ Cypress.Commands.add('grafanaDexExtraStaticLogin', (ingress, staticUser) => {
   cy.dexExtraStaticLogin(staticUser)
 
   cy.getCookie('grafana_session_expiry').should('exist')
+
+  return cy.wrap(true)
 })
 
 // Available as cy.grafanaSetRole(ingress, '.user.grafanaPassword', 'dev@example.com', 'Viewer')
 Cypress.Commands.add('grafanaSetRole', (ingress, adminPasswordKey, user, role) => {
   // Log in as the grafana admin and change the role
-  cy.visit(`https://${ingress}/admin/users`)
+  cy.session([`${ingress}/admin/users`], function () {
+    cy.visit(`https://${ingress}`)
 
-  cy.yqSecrets(adminPasswordKey).then((password) => {
-    cy.get('input[placeholder*="username"]').type('admin', { log: false })
+    cy.yqSecrets(adminPasswordKey).then((password) => {
+      cy.get('input[placeholder*="username"]').type('admin', { log: false })
 
-    cy.get('input[placeholder*="password"]').type(password, { log: false })
+      cy.get('input[placeholder*="password"]').type(password, { log: false })
 
-    cy.get('button').contains('Log in').click()
+      cy.get('button').contains('Log in').click()
+    })
+
+    cy.visit(`https://${ingress}/admin/users`)
   })
 
+  cy.visit(`https://${ingress}/admin/users`)
   cy.contains('Organization users').should('be.visible').click()
 
   // remove TLD, form doesn't seem to like it
@@ -106,7 +114,7 @@ Cypress.Commands.add('grafanaSetRole', (ingress, adminPasswordKey, user, role) =
   cy.get('[aria-label="Role"]').as('role').focus()
   cy.get('@role').should('not.be.disabled').type(`${role}{enter}`, { force: true })
 
-  cy.contains('Organization user updated').should('be.visible')
+  return cy.contains('Organization user updated').should('be.visible')
 })
 
 // Available as cy.grafanaCheckRole(ingress, 'dev@example.com', 'Admin')
@@ -121,5 +129,5 @@ Cypress.Commands.add('grafanaCheckRole', (ingress, user, role) => {
 
   cy.wait(['@userOrgs'])
 
-  cy.get('[data-testid="data-testid-user-orgs-table"]').contains(role).should('exist')
+  return cy.get('[data-testid="data-testid-user-orgs-table"]').contains(role).should('exist')
 })

--- a/tests/common/cypress/support.js
+++ b/tests/common/cypress/support.js
@@ -94,7 +94,9 @@ Cypress.Commands.add('retryRequest', (options) => {
 // Available as cy.dexStaticLogin()
 Cypress.Commands.add('dexStaticLogin', () => {
   // Requires dex static login to be enabled
-  cy.yqDig('sc', '.dex.enableStaticLogin').should('equal', 'true')
+  cy.yqDig('sc', '.dex.enableStaticLogin').then((value) => {
+    assert(value === 'true', ".dex.enableStaticLogin in sc config must be 'true'")
+  })
 
   // Conditionally skip connector selection
   cy.yqSecrets('.dex.connectors | length').then((connectors) => {

--- a/tests/common/exec.bash
+++ b/tests/common/exec.bash
@@ -146,6 +146,7 @@ end_to_end.socat_up() {
   if ! command -v socat >/dev/null; then
     echo "error: the end-to-end suites require the socat binary be present on your system" >&2
     echo "tip: run './bin/ck8s install-requirements' to update your requirements" >&2
+    return 1
   fi
 
   mkdir -p "${tests}/end-to-end/.run"

--- a/tests/end-to-end/grafana/admin-promotion-ops.cy.js
+++ b/tests/end-to-end/grafana/admin-promotion-ops.cy.js
@@ -9,12 +9,12 @@ describe('ops grafana user promotion', function () {
       .as('ingress')
 
     // Cypress does not like trailing dots
-    cy.yqDig('sc', '.grafana.ops.trailingDots').should((value) =>
+    cy.yqDig('sc', '.grafana.ops.trailingDots').then((value) =>
       assert(value !== 'true', ".grafana.ops.trailingDots in sc config must not be 'true'")
     )
 
     // skipRoleSync must be true
-    cy.yqDig('sc', '.grafana.ops.oidc.skipRoleSync').should((value) =>
+    cy.yqDig('sc', '.grafana.ops.oidc.skipRoleSync').then((value) =>
       assert(value === 'true', ".grafana.ops.oidc.skipRoleSync in sc config must be 'true'")
     )
 

--- a/tests/end-to-end/grafana/admin-promotion-ops.cy.js
+++ b/tests/end-to-end/grafana/admin-promotion-ops.cy.js
@@ -1,5 +1,7 @@
 import '../../common/cypress/grafana.js'
 
+const ADMIN_USER = 'admin@example.com'
+
 describe('ops grafana user promotion', function () {
   before(function () {
     cy.yq('sc', '.grafana.ops.subdomain + "." + .global.opsDomain')
@@ -30,27 +32,16 @@ describe('ops grafana user promotion', function () {
     })
   })
 
-  afterEach(function () {
-    cy.clearAllCookies()
-    cy.then(Cypress.session.clearAllSavedSessions)
+  after(function () {
+    Cypress.session.clearAllSavedSessions()
   })
 
-  it('admin demotes admin@example.com to Viewer', function () {
+  it('admin demotes + promotes admin@example.com to Admin', function () {
     cy.grafanaDexStaticLogin(`${this.ingress}/profile`, false)
-    cy.visit(`https://${this.ingress}/logout`)
-
-    cy.grafanaSetRole(this.ingress, '.grafana.password', 'admin@example.com', 'Viewer')
-
-    cy.visit(`https://${this.ingress}/logout`)
-
-    cy.grafanaCheckRole(this.ingress, 'admin@example.com', 'Viewer')
-  })
-
-  it('admin promotes admin@example.com to Admin', function () {
-    cy.grafanaSetRole(this.ingress, '.grafana.password', 'admin@example.com', 'Admin')
-
-    cy.visit(`https://${this.ingress}/logout`)
-
-    cy.grafanaCheckRole(this.ingress, 'admin@example.com', 'Admin')
+      .visit(`https://${this.ingress}/logout`)
+      .grafanaSetRole(this.ingress, '.grafana.password', ADMIN_USER, 'Viewer')
+      .grafanaSetRole(this.ingress, '.grafana.password', ADMIN_USER, 'Admin')
+      .visit(`https://${this.ingress}/logout`)
+      .grafanaCheckRole(this.ingress, ADMIN_USER, 'Admin')
   })
 })

--- a/tests/end-to-end/grafana/admin-promotion-ops.gen.bats
+++ b/tests/end-to-end/grafana/admin-promotion-ops.gen.bats
@@ -15,10 +15,6 @@ teardown_file() {
   cypress_teardown
 }
 
-@test "ops grafana user promotion admin demotes admin@example.com to Viewer" {
-  cypress_test "ops grafana user promotion admin demotes admin@example.com to Viewer"
-}
-
-@test "ops grafana user promotion admin promotes admin@example.com to Admin" {
-  cypress_test "ops grafana user promotion admin promotes admin@example.com to Admin"
+@test "ops grafana user promotion admin demotes + promotes admin@example.com to Admin" {
+  cypress_test "ops grafana user promotion admin demotes + promotes admin@example.com to Admin"
 }

--- a/tests/end-to-end/grafana/admin-promotion-user.cy.js
+++ b/tests/end-to-end/grafana/admin-promotion-user.cy.js
@@ -32,27 +32,16 @@ describe('user grafana user promotion', function () {
     })
   })
 
-  after(() => {
-    cy.clearAllCookies()
+  after(function () {
     Cypress.session.clearAllSavedSessions()
   })
 
-  it('admin demotes dev@example.com to Viewer', function () {
+  it('admin demotes + promotes dev@example.com to Admin', function () {
     cy.grafanaDexExtraStaticLogin(`${this.ingress}/profile`, DEV_USER)
-    cy.visit(`https://${this.ingress}/logout`)
-
-    cy.grafanaSetRole(this.ingress, '.user.grafanaPassword', DEV_USER, 'Viewer')
-
-    cy.visit(`https://${this.ingress}/logout`)
-
-    cy.grafanaCheckRole(this.ingress, DEV_USER, 'Viewer')
-  })
-
-  it('admin promotes dev@example.com to Admin', function () {
-    cy.grafanaSetRole(this.ingress, '.user.grafanaPassword', DEV_USER, 'Admin')
-
-    cy.visit(`https://${this.ingress}/logout`)
-
-    cy.grafanaCheckRole(this.ingress, DEV_USER, 'Admin')
+      .visit(`https://${this.ingress}/logout`)
+      .grafanaSetRole(this.ingress, '.user.grafanaPassword', DEV_USER, 'Viewer')
+      .grafanaSetRole(this.ingress, '.user.grafanaPassword', DEV_USER, 'Admin')
+      .visit(`https://${this.ingress}/logout`)
+      .grafanaCheckRole(this.ingress, DEV_USER, 'Admin')
   })
 })

--- a/tests/end-to-end/grafana/admin-promotion-user.cy.js
+++ b/tests/end-to-end/grafana/admin-promotion-user.cy.js
@@ -9,12 +9,12 @@ describe('user grafana user promotion', function () {
       .as('ingress')
 
     // Cypress does not like trailing dots
-    cy.yqDig('sc', '.grafana.user.trailingDots').should((value) =>
+    cy.yqDig('sc', '.grafana.user.trailingDots').then((value) =>
       assert(value !== 'true', ".grafana.user.trailingDots in sc config must not be 'true'")
     )
 
     // skipRoleSync must be true
-    cy.yqDig('sc', '.grafana.user.oidc.skipRoleSync').should((value) =>
+    cy.yqDig('sc', '.grafana.user.oidc.skipRoleSync').then((value) =>
       assert(value === 'true', ".grafana.user.oidc.skipRoleSync in sc config must be 'true'")
     )
 

--- a/tests/end-to-end/grafana/admin-promotion-user.gen.bats
+++ b/tests/end-to-end/grafana/admin-promotion-user.gen.bats
@@ -15,10 +15,6 @@ teardown_file() {
   cypress_teardown
 }
 
-@test "user grafana user promotion admin demotes dev@example.com to Viewer" {
-  cypress_test "user grafana user promotion admin demotes dev@example.com to Viewer"
-}
-
-@test "user grafana user promotion admin promotes dev@example.com to Admin" {
-  cypress_test "user grafana user promotion admin promotes dev@example.com to Admin"
+@test "user grafana user promotion admin demotes + promotes dev@example.com to Admin" {
+  cypress_test "user grafana user promotion admin demotes + promotes dev@example.com to Admin"
 }

--- a/tests/end-to-end/grafana/dashboards-admin.cy.js
+++ b/tests/end-to-end/grafana/dashboards-admin.cy.js
@@ -7,7 +7,9 @@ describe('grafana admin dashboards', function () {
       .as('ingress')
 
     // Cypress does not like trailing dots
-    cy.yqDig('sc', '.grafana.ops.trailingDots').should('not.equal', 'true')
+    cy.yqDig('sc', '.grafana.ops.trailingDots').then((value) =>
+      assert(value !== 'true', ".grafana.ops.trailingDots in sc config must not be 'true'")
+    )
   })
 
   beforeEach(function () {

--- a/tests/end-to-end/grafana/dashboards-dev.cy.js
+++ b/tests/end-to-end/grafana/dashboards-dev.cy.js
@@ -7,7 +7,9 @@ describe('grafana dev dashboards', function () {
       .as('ingress')
 
     // Cypress does not like trailing dots
-    cy.yqDig('sc', '.grafana.user.trailingDots').should('not.equal', 'true')
+    cy.yqDig('sc', '.grafana.user.trailingDots').then((value) =>
+      assert(value !== 'true', ".grafana.user.trailingDots in sc config must not be 'true'")
+    )
   })
 
   beforeEach(function () {

--- a/tests/end-to-end/grafana/dashboards-dev.cy.js
+++ b/tests/end-to-end/grafana/dashboards-dev.cy.js
@@ -20,7 +20,7 @@ describe('grafana dev dashboards', function () {
     cy.visit(`https://${this.ingress}/dashboards`)
   })
 
-  after(() => {
+  after(function () {
     Cypress.session.clearAllSavedSessions()
   })
 

--- a/tests/end-to-end/grafana/datasources.cy.js
+++ b/tests/end-to-end/grafana/datasources.cy.js
@@ -50,7 +50,7 @@ describe('grafana admin datasources', function () {
     loginNavigate(cy, this.ingress, '.grafana.password')
   })
 
-  after(() => {
+  after(function () {
     Cypress.session.clearAllSavedSessions()
   })
 
@@ -96,7 +96,7 @@ describe('grafana dev datasources', () => {
     loginNavigate(cy, this.ingress, '.user.grafanaPassword')
   })
 
-  after(() => {
+  after(function () {
     Cypress.session.clearAllSavedSessions()
   })
 

--- a/tests/end-to-end/grafana/datasources.cy.js
+++ b/tests/end-to-end/grafana/datasources.cy.js
@@ -41,7 +41,7 @@ describe('grafana admin datasources', function () {
       .as('ingress')
 
     // Cypress does not like trailing dots
-    cy.yqDig('sc', '.grafana.ops.trailingDots').should((value) =>
+    cy.yqDig('sc', '.grafana.ops.trailingDots').then((value) =>
       assert(value !== 'true', ".grafana.ops.trailingDots in sc config must not be 'true'")
     )
   })

--- a/tests/end-to-end/harbor/use-ui.cy.js
+++ b/tests/end-to-end/harbor/use-ui.cy.js
@@ -35,7 +35,7 @@ describe('harbor ui', () => {
     cy.viewport(1280, 720)
   })
 
-  after(() => {
+  after(function () {
     Cypress.session.clearAllSavedSessions()
   })
 

--- a/tests/end-to-end/log-manager/compaction-audit-sc.gen.bats
+++ b/tests/end-to-end/log-manager/compaction-audit-sc.gen.bats
@@ -91,7 +91,7 @@ setup() {
 @test "audit-sc - log-manager compaction job runs fine when no logs needs compaction" {
   object_storage.is_compacted "${BUCKET}" "${PREFIX}"
 
-  test_run_cronjob "${CRONJOB_NAME}" 60
+  test_run_cronjob "${CRONJOB_NAME}" 120
 }
 
 _create_uncompacted_objects() {

--- a/tests/end-to-end/log-manager/compaction-audit-wc.gen.bats
+++ b/tests/end-to-end/log-manager/compaction-audit-wc.gen.bats
@@ -91,7 +91,7 @@ setup() {
 @test "audit-wc - log-manager compaction job runs fine when no logs needs compaction" {
   object_storage.is_compacted "${BUCKET}" "${PREFIX}"
 
-  test_run_cronjob "${CRONJOB_NAME}" 60
+  test_run_cronjob "${CRONJOB_NAME}" 120
 }
 
 _create_uncompacted_objects() {

--- a/tests/end-to-end/log-manager/compaction-sc-logs.gen.bats
+++ b/tests/end-to-end/log-manager/compaction-sc-logs.gen.bats
@@ -91,7 +91,7 @@ setup() {
 @test "sc-logs - log-manager compaction job runs fine when no logs needs compaction" {
   object_storage.is_compacted "${BUCKET}" "${PREFIX}"
 
-  test_run_cronjob "${CRONJOB_NAME}" 60
+  test_run_cronjob "${CRONJOB_NAME}" 120
 }
 
 _create_uncompacted_objects() {

--- a/tests/end-to-end/log-manager/compaction.bats.gotmpl
+++ b/tests/end-to-end/log-manager/compaction.bats.gotmpl
@@ -94,7 +94,7 @@ setup() {
 @test "{{ .name }} - log-manager compaction job runs fine when no logs needs compaction" {
   object_storage.is_compacted "${BUCKET}" "${PREFIX}"
 
-  test_run_cronjob "${CRONJOB_NAME}" 60
+  test_run_cronjob "${CRONJOB_NAME}" 120
 }
 
 _create_uncompacted_objects() {

--- a/tests/end-to-end/log-manager/retention-audit-sc.gen.bats
+++ b/tests/end-to-end/log-manager/retention-audit-sc.gen.bats
@@ -91,7 +91,7 @@ setup() {
 }
 
 @test "audit-sc - log-manager retention job runs fine when no logs needs to be deleted" {
-  test_run_cronjob "${CRONJOB_NAME}" 60
+  test_run_cronjob "${CRONJOB_NAME}" 120
 }
 
 _get_cronjob_env() {

--- a/tests/end-to-end/log-manager/retention-audit-wc.gen.bats
+++ b/tests/end-to-end/log-manager/retention-audit-wc.gen.bats
@@ -91,7 +91,7 @@ setup() {
 }
 
 @test "audit-wc - log-manager retention job runs fine when no logs needs to be deleted" {
-  test_run_cronjob "${CRONJOB_NAME}" 60
+  test_run_cronjob "${CRONJOB_NAME}" 120
 }
 
 _get_cronjob_env() {

--- a/tests/end-to-end/log-manager/retention-sc-logs.gen.bats
+++ b/tests/end-to-end/log-manager/retention-sc-logs.gen.bats
@@ -91,7 +91,7 @@ setup() {
 }
 
 @test "sc-logs - log-manager retention job runs fine when no logs needs to be deleted" {
-  test_run_cronjob "${CRONJOB_NAME}" 60
+  test_run_cronjob "${CRONJOB_NAME}" 120
 }
 
 _get_cronjob_env() {

--- a/tests/end-to-end/log-manager/retention.bats.gotmpl
+++ b/tests/end-to-end/log-manager/retention.bats.gotmpl
@@ -94,7 +94,7 @@ setup() {
 }
 
 @test "{{ .name }} - log-manager retention job runs fine when no logs needs to be deleted" {
-  test_run_cronjob "${CRONJOB_NAME}" 60
+  test_run_cronjob "${CRONJOB_NAME}" 120
 }
 
 _get_cronjob_env() {

--- a/tests/end-to-end/opensearch/dashboards.cy.js
+++ b/tests/end-to-end/opensearch/dashboards.cy.js
@@ -34,7 +34,7 @@ describe('opensearch dashboards', function () {
     })
   })
 
-  after(() => {
+  after(function () {
     Cypress.session.clearAllSavedSessions()
   })
 

--- a/tests/integration/harbor/use-ui.cy.js
+++ b/tests/integration/harbor/use-ui.cy.js
@@ -39,7 +39,7 @@ describe('harbor ui', function () {
     cy.viewport(1280, 720)
   })
 
-  after(() => {
+  after(function () {
     Cypress.session.clearAllSavedSessions()
   })
 


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Various fixes encountered while automating the Apps installation for QA:

- Grafana promotion tests could be made much simpler by actually returning `Chainable<>` instances from the helper methods. Also concatenated the demote + promote action in the same test.
- Pre-conditions where using `.should()` instead of `.then()` in some places which implicitly activates Cypress' retry mechanism, meaning when a configuration value expectation is not met the test suite will be stuck retrying to fetch it until it times out
- Restored more `function() { ... }` instead of `() => {}` (yeah I know this is the 3rd time I had to do this, sorry)
- The `socat` existence check should abort the suite
- Increased timeouts for log-manager tests
- Allowed for missing data in one of the nginx dashboard panels, so we don't have to deploy a demo application and hit its ingress just to pass the Grafana dashboards suite

Part of https://github.com/elastisys/ck8s-issue-tracker/issues/73

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
