### PR TITLE
fix: use standard unixy dir for the socat socket

### DIFF
--- a/scripts/run-from-container.sh
+++ b/scripts/run-from-container.sh
@@ -172,9 +172,10 @@ if [[ "${FORWARD_ENVIRONMENT:-false}" == "true" ]]; then
 
   # Auto-open localhost:8000 for auth
   socat_run="${root}/tests/end-to-end/.run"
+  socat_socket_dir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
   socat_bin="${root}/tests/end-to-end/.bin"
   if [[ -f "${socat_run}/socat.pid" ]] && kill -0 "$(cat "${socat_run}/socat.pid")" 2>/dev/null; then
-    args+=("-v" "${socat_run}/open-browser.sock:/run/user/$(id -u)/open-browser.sock")
+    args+=("-v" "${socat_socket_dir}/ck8s-apps-browser.sock:/run/user/$(id -u)/open-browser.sock")
     args+=("-v" "${socat_bin}/x-www-browser:/usr/bin/x-www-browser:ro")
   fi
 fi

--- a/tests/common/exec.bash
+++ b/tests/common/exec.bash
@@ -150,8 +150,12 @@ end_to_end.socat_up() {
 
   mkdir -p "${tests}/end-to-end/.run"
   if [[ ! -f "${pid_file}" ]] || ! kill -0 "$(<"${pid_file}")" 2>/dev/null; then
-    local -r sock_file="${tests}/end-to-end/.run/open-browser.sock"
+    local -r sock_dir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+    mkdir -p "${sock_dir}"
+
+    local -r sock_file="${sock_dir}/ck8s-apps-browser.sock"
     rm -f "${sock_file}"
+
     socat -lf "${tests}/end-to-end/.run/socat.log" unix-listen:"${sock_file}",fork system:'xargs xdg-open' &
     echo "$!" >"${pid_file}"
   fi


### PR DESCRIPTION
Fixes an issue found by Anders: https://github.com/elastisys/compliantkubernetes-apps/pull/2682#issuecomment-3210638587

<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Fixes [an issue](https://github.com/elastisys/compliantkubernetes-apps/pull/2682#issuecomment-3210638587) found by @anders-elastisys where hosting the socat socket inside the `apps` repository directory could lead to paths being too long. 

This also means we can't support parallel runs from two (or more) clones of the apps repo anymore, but I don't think that's a use case we were aiming for. Alternatively, a short hash of the Git repo path could be added to the socket name/path, but I think that's overkill.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
