### PR TITLE
Improve Log Manager E2E suite

### DIFF
--- a/tests/end-to-end/log-manager/compaction-audit-sc.gen.bats
+++ b/tests/end-to-end/log-manager/compaction-audit-sc.gen.bats
@@ -91,7 +91,7 @@ setup() {
 @test "audit-sc - log-manager compaction job runs fine when no logs needs compaction" {
   object_storage.is_compacted "${BUCKET}" "${PREFIX}"
 
-  test_run_cronjob "${CRONJOB_NAME}" 60
+  test_run_cronjob "${CRONJOB_NAME}" 120
 }
 
 _create_uncompacted_objects() {

--- a/tests/end-to-end/log-manager/compaction-audit-sc.gen.bats
+++ b/tests/end-to-end/log-manager/compaction-audit-sc.gen.bats
@@ -23,8 +23,8 @@ setup_file() {
   CRONJOB_NAME="audit-$(yq.get sc '.global.ck8sEnvironmentName')-sc-compaction"
   export CRONJOB_NAME
 
-  # TODO: Should probably make sure that the cronjob isn't currently running.
   kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+  terminate_cronjob_jobs "${CRONJOB_NAME}" 300
 
   local cronjob_env_bucket
   local cronjob_env_prefix

--- a/tests/end-to-end/log-manager/compaction-audit-wc.gen.bats
+++ b/tests/end-to-end/log-manager/compaction-audit-wc.gen.bats
@@ -23,8 +23,8 @@ setup_file() {
   CRONJOB_NAME="audit-$(yq.get sc '.global.ck8sEnvironmentName')-wc-compaction"
   export CRONJOB_NAME
 
-  # TODO: Should probably make sure that the cronjob isn't currently running.
   kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+  terminate_cronjob_jobs "${CRONJOB_NAME}" 300
 
   local cronjob_env_bucket
   local cronjob_env_prefix

--- a/tests/end-to-end/log-manager/compaction-audit-wc.gen.bats
+++ b/tests/end-to-end/log-manager/compaction-audit-wc.gen.bats
@@ -91,7 +91,7 @@ setup() {
 @test "audit-wc - log-manager compaction job runs fine when no logs needs compaction" {
   object_storage.is_compacted "${BUCKET}" "${PREFIX}"
 
-  test_run_cronjob "${CRONJOB_NAME}" 60
+  test_run_cronjob "${CRONJOB_NAME}" 120
 }
 
 _create_uncompacted_objects() {

--- a/tests/end-to-end/log-manager/compaction-sc-logs.gen.bats
+++ b/tests/end-to-end/log-manager/compaction-sc-logs.gen.bats
@@ -91,7 +91,7 @@ setup() {
 @test "sc-logs - log-manager compaction job runs fine when no logs needs compaction" {
   object_storage.is_compacted "${BUCKET}" "${PREFIX}"
 
-  test_run_cronjob "${CRONJOB_NAME}" 60
+  test_run_cronjob "${CRONJOB_NAME}" 120
 }
 
 _create_uncompacted_objects() {

--- a/tests/end-to-end/log-manager/compaction-sc-logs.gen.bats
+++ b/tests/end-to-end/log-manager/compaction-sc-logs.gen.bats
@@ -23,8 +23,8 @@ setup_file() {
   CRONJOB_NAME="sc-logs-logs-compaction"
   export CRONJOB_NAME
 
-  # TODO: Should probably make sure that the cronjob isn't currently running.
   kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+  terminate_cronjob_jobs "${CRONJOB_NAME}" 300
 
   local cronjob_env_bucket
   local cronjob_env_prefix

--- a/tests/end-to-end/log-manager/compaction.bats.gotmpl
+++ b/tests/end-to-end/log-manager/compaction.bats.gotmpl
@@ -26,8 +26,8 @@ setup_file() {
   CRONJOB_NAME="{{ .cronjob }}"
   export CRONJOB_NAME
 
-  # TODO: Should probably make sure that the cronjob isn't currently running.
   kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+  terminate_cronjob_jobs "${CRONJOB_NAME}" 300
 
   local cronjob_env_bucket
   local cronjob_env_prefix

--- a/tests/end-to-end/log-manager/compaction.bats.gotmpl
+++ b/tests/end-to-end/log-manager/compaction.bats.gotmpl
@@ -94,7 +94,7 @@ setup() {
 @test "{{ .name }} - log-manager compaction job runs fine when no logs needs compaction" {
   object_storage.is_compacted "${BUCKET}" "${PREFIX}"
 
-  test_run_cronjob "${CRONJOB_NAME}" 60
+  test_run_cronjob "${CRONJOB_NAME}" 120
 }
 
 _create_uncompacted_objects() {

--- a/tests/end-to-end/log-manager/resources/calico-allow-all.yaml
+++ b/tests/end-to-end/log-manager/resources/calico-allow-all.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
+  name: global-allow-all-traffic
+  namespace: calico-system
+spec:
+  selector: all()
+  ingress:
+  - action: Allow
+  egress:
+  - action: Allow
+  types:
+  - Ingress
+  - Egress
+  # High priority to override other policies
+  order: 100

--- a/tests/end-to-end/log-manager/retention-audit-sc.gen.bats
+++ b/tests/end-to-end/log-manager/retention-audit-sc.gen.bats
@@ -23,8 +23,8 @@ setup_file() {
   CRONJOB_NAME="audit-$(yq.get sc '.global.ck8sEnvironmentName')-sc-retention"
   export CRONJOB_NAME
 
-  # TODO: Should probably make sure that the cronjob isn't currently running.
   kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+  terminate_cronjob_jobs "${CRONJOB_NAME}" 300
 
   local cronjob_env_bucket
   local cronjob_env_prefix

--- a/tests/end-to-end/log-manager/retention-audit-sc.gen.bats
+++ b/tests/end-to-end/log-manager/retention-audit-sc.gen.bats
@@ -91,7 +91,7 @@ setup() {
 }
 
 @test "audit-sc - log-manager retention job runs fine when no logs needs to be deleted" {
-  test_run_cronjob "${CRONJOB_NAME}" 60
+  test_run_cronjob "${CRONJOB_NAME}" 120
 }
 
 _get_cronjob_env() {

--- a/tests/end-to-end/log-manager/retention-audit-wc.gen.bats
+++ b/tests/end-to-end/log-manager/retention-audit-wc.gen.bats
@@ -91,7 +91,7 @@ setup() {
 }
 
 @test "audit-wc - log-manager retention job runs fine when no logs needs to be deleted" {
-  test_run_cronjob "${CRONJOB_NAME}" 60
+  test_run_cronjob "${CRONJOB_NAME}" 120
 }
 
 _get_cronjob_env() {

--- a/tests/end-to-end/log-manager/retention-audit-wc.gen.bats
+++ b/tests/end-to-end/log-manager/retention-audit-wc.gen.bats
@@ -23,8 +23,8 @@ setup_file() {
   CRONJOB_NAME="audit-$(yq.get sc '.global.ck8sEnvironmentName')-wc-retention"
   export CRONJOB_NAME
 
-  # TODO: Should probably make sure that the cronjob isn't currently running.
   kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+  terminate_cronjob_jobs "${CRONJOB_NAME}" 300
 
   local cronjob_env_bucket
   local cronjob_env_prefix

--- a/tests/end-to-end/log-manager/retention-sc-logs.gen.bats
+++ b/tests/end-to-end/log-manager/retention-sc-logs.gen.bats
@@ -91,7 +91,7 @@ setup() {
 }
 
 @test "sc-logs - log-manager retention job runs fine when no logs needs to be deleted" {
-  test_run_cronjob "${CRONJOB_NAME}" 60
+  test_run_cronjob "${CRONJOB_NAME}" 120
 }
 
 _get_cronjob_env() {

--- a/tests/end-to-end/log-manager/retention-sc-logs.gen.bats
+++ b/tests/end-to-end/log-manager/retention-sc-logs.gen.bats
@@ -23,8 +23,8 @@ setup_file() {
   CRONJOB_NAME="sc-logs-logs-retention"
   export CRONJOB_NAME
 
-  # TODO: Should probably make sure that the cronjob isn't currently running.
   kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+  terminate_cronjob_jobs "${CRONJOB_NAME}" 300
 
   local cronjob_env_bucket
   local cronjob_env_prefix

--- a/tests/end-to-end/log-manager/retention.bats.gotmpl
+++ b/tests/end-to-end/log-manager/retention.bats.gotmpl
@@ -26,8 +26,8 @@ setup_file() {
   CRONJOB_NAME="{{ .cronjob }}"
   export CRONJOB_NAME
 
-  # TODO: Should probably make sure that the cronjob isn't currently running.
   kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+  terminate_cronjob_jobs "${CRONJOB_NAME}" 300
 
   local cronjob_env_bucket
   local cronjob_env_prefix

--- a/tests/end-to-end/log-manager/retention.bats.gotmpl
+++ b/tests/end-to-end/log-manager/retention.bats.gotmpl
@@ -94,7 +94,7 @@ setup() {
 }
 
 @test "{{ .name }} - log-manager retention job runs fine when no logs needs to be deleted" {
-  test_run_cronjob "${CRONJOB_NAME}" 60
+  test_run_cronjob "${CRONJOB_NAME}" 120
 }
 
 _get_cronjob_env() {

--- a/tests/end-to-end/log-manager/setup_suite.bash
+++ b/tests/end-to-end/log-manager/setup_suite.bash
@@ -8,14 +8,73 @@ setup_suite() {
   with_kubeconfig sc
   with_namespace fluentd-system
 
-  # Pause logs being flushed to object storage
-  fluentd_aggregator_replicas="$(kubectl -n "${NAMESPACE}" get statefulset fluentd-aggregator -o jsonpath='{.spec.replicas}')"
-  kubectl -n "${NAMESPACE}" scale statefulset fluentd-aggregator --replicas 0 --timeout 5m
+  # Temporarily allow all traffic
+  if kubectl get crd globalnetworkpolicies.crd.projectcalico.org; then
+    kubectl apply -f "${BATS_CWD}/end-to-end/log-manager/resources/calico-allow-all.yaml" >&3 2>&1
+    # Give the CNI a bit of time to settle (arbitrary, I know..)
+    sleep 15
+  fi
+
+  kctl="kubectl -n ${NAMESPACE}"
+
+  # -> downscale monitoring the blackbox exporter to 0
+  blackbox_exporter_replicas="$(scale_down monitoring deployment/prometheus-blackbox-exporter)"
+  prom="kube-prometheus-stack-prometheus"
+  kubectl patch prometheus "${prom}" -n monitoring --type='merge' --patch='{"spec": {"paused": true}}'
+  scale_down monitoring "sts/prometheus-${prom}"
+
+  # Pause logs being flushed to object storage:
+  # -> remove output config from forwarders, otherwise they'll try to reach inexisting pods
+  mkdir -p "${BATS_SUITE_TMPDIR}"
+  $kctl get configmap fluentd-forwarder -o yaml >"${BATS_SUITE_TMPDIR}/fluentd-forwarder-cm.yaml"
+  $kctl patch configmap fluentd-forwarder --type json \
+    --patch="[{\"op\": \"remove\", \"path\": \"/data/30-output.conf\"}]" >&3 2>&1 || true
+  rollout_forwarder
+
+  # -> downscale the aggregator to 0
+  fluentd_aggregator_replicas="$(scale_down "${NAMESPACE}" statefulset/fluentd-aggregator)"
 }
 
 teardown_suite() {
   load "../../bats.lib.bash"
 
-  # Unpause logs being flushed to object storage
-  kubectl -n "${NAMESPACE}" scale statefulset fluentd-aggregator --replicas "${fluentd_aggregator_replicas}" --timeout 5m
+  # Unpause logs being flushed to object storage:
+  # -> scale the aggregator back up
+  $kctl scale statefulset fluentd-aggregator --replicas "${fluentd_aggregator_replicas}" --timeout 5m
+  $kctl wait --for=condition=ready pod -l app=aggregator --timeout 5m
+  echo 'pod/app=aggregator ready' >&3
+
+  # -> restore the forwarder output config
+  $kctl replace --force -f "${BATS_SUITE_TMPDIR}/fluentd-forwarder-cm.yaml" >&3 2>&1
+  rollout_forwarder
+
+  # -> scale monitoring back up
+  scale_up monitoring deployment/prometheus-blackbox-exporter "${blackbox_exporter_replicas}"
+  kubectl -n monitoring patch prometheus "${prom}" --type='merge' --patch='{"spec": {"paused":false}}'
+  kubectl -n monitoring wait --for=jsonpath='{.subsets[*].addresses[*].ip}' endpoints "${prom}"
+
+  # Delete allow-all policy
+  if kubectl get crd globalnetworkpolicies.crd.projectcalico.org; then
+    kubectl delete -f "${BATS_CWD}/end-to-end/log-manager/resources/calico-allow-all.yaml" --ignore-not-found >&3 2>&1
+  fi
+}
+
+scale_down() {
+  local -r ns="${1}"
+  local -r object="${2}"
+  kubectl -n "${ns}" get "${object}" -o jsonpath='{.spec.replicas}'
+  kubectl -n "${ns}" scale "${object}" --replicas 0 --timeout 5m >&3 2>&1
+}
+
+scale_up() {
+  local -r ns="${1}"
+  local -r object="${2}"
+  local -r replicas="${3}"
+  kubectl -n "${ns}" scale "${object}" --replicas "${replicas}" --timeout 5m >&3 2>&1
+}
+
+rollout_forwarder() {
+  $kctl rollout restart daemonset/fluentd-forwarder
+  $kctl rollout status daemonset/fluentd-forwarder --timeout 5m
+  echo 'statefulset/fluentd-forwarder rolled out' >&3
 }


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

The main focus is avoiding a bad interaction between the `log-manager` test suite and the (in execution order following) `netpol` suite. 

Scaling down the `fluentd-aggregator` causes forwarder pods, as well as pods from the `monitoring` stack to try and contact it, but since the CNI endpoint is removed, Calico will simply drop the packages and increase its drop metrics, causing the subsequent `netpol` suite to fail.

We try to close all possible angles in the `setup_suite` to prevent this from happening:
- deploy a global policy to temporarily allow all traffic
- downscale the blackbox-exporter deployment
- downscales the prometheus STS
- remove the config output from forwarders and re-rolls the deployment

Part of: https://github.com/elastisys/ck8s-issue-tracker/issues/73

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
