### PR TITLE
Improve Network Policies E2E suite

### DIFF
--- a/tests/common/cypress/index.d.ts
+++ b/tests/common/cypress/index.d.ts
@@ -61,7 +61,7 @@ declare namespace Cypress {
     retryRequest(arguments_: {
       request: Partial<RequestOptions>
       condition: (Response) => bool
-      body: (Response) => void
+      body?: (Response) => void
       attempts?: number
       waitTime?: number
     }): Chainable<any>

--- a/tests/common/cypress/support.js
+++ b/tests/common/cypress/support.js
@@ -79,7 +79,9 @@ Cypress.Commands.add('retryRequest', (options) => {
 
   cy.request(request).then((response) => {
     if (condition(response)) {
-      body(response)
+      if (body) {
+        body(response)
+      }
     } else {
       if (attempts > 0) {
         cy.wait(waitTime)

--- a/tests/common/exec.bash
+++ b/tests/common/exec.bash
@@ -146,6 +146,7 @@ end_to_end.socat_up() {
   if ! command -v socat >/dev/null; then
     echo "error: the end-to-end suites require the socat binary be present on your system" >&2
     echo "tip: run './bin/ck8s install-requirements' to update your requirements" >&2
+    return 1
   fi
 
   mkdir -p "${tests}/end-to-end/.run"

--- a/tests/common/git.bash
+++ b/tests/common/git.bash
@@ -7,7 +7,7 @@ git.is_tracked() {
   local work_tree
   work_tree="$(git.parent_dir "${path}")"
 
-  if git -C "${work_tree}" ls-files --error-unmatch "${path}" >/dev/null; then
+  if git -C "${work_tree}" ls-files --error-unmatch "${path}" >/dev/null 2>&1; then
     return 0
   else
     return 1

--- a/tests/end-to-end/netpol/netpol.cy.js
+++ b/tests/end-to-end/netpol/netpol.cy.js
@@ -11,20 +11,14 @@ function makePrometheusURL(/** @type {Cluster} */ cluster) {
 }
 
 describe('workload cluster network policies', function () {
-  before(function () {
-    cy.request('GET', `${makePrometheusURL('wc')}/api/v1/status/runtimeinfo`)
-      .then(assertServerTime)
-      .as('serverTime')
-  })
-
   it('are not dropping any packets from workloads', function () {
-    cy.request('GET', makeQueryURL('wc', DROP_QUERY, this.serverTime)).then((response) => {
+    cy.request('GET', makeQueryURL('wc', DROP_QUERY)).then((response) => {
       assertNoDrops(response, 'fw', 'from')
     })
   })
 
   it('are not dropping any packets to workloads', function () {
-    cy.request('GET', makeQueryURL('wc', DROP_QUERY, this.serverTime)).then((response) => {
+    cy.request('GET', makeQueryURL('wc', DROP_QUERY)).then((response) => {
       assertNoDrops(response, 'tw', 'to')
     })
   })
@@ -35,20 +29,14 @@ describe('workload cluster network policies', function () {
 })
 
 describe('service cluster network policies', function () {
-  before(function () {
-    cy.request('GET', `${makePrometheusURL('sc')}/api/v1/status/runtimeinfo`)
-      .then(assertServerTime)
-      .as('serverTime')
-  })
-
   it('are not dropping any packets from workloads', function () {
-    cy.request('GET', makeQueryURL('sc', DROP_QUERY, this.serverTime)).then((response) => {
+    cy.request('GET', makeQueryURL('sc', DROP_QUERY)).then((response) => {
       assertNoDrops(response, 'fw', 'from')
     })
   })
 
   it('are not dropping any packets to workloads', function () {
-    cy.request('GET', makeQueryURL('sc', DROP_QUERY, this.serverTime)).then((response) => {
+    cy.request('GET', makeQueryURL('sc', DROP_QUERY)).then((response) => {
       assertNoDrops(response, 'tw', 'to')
     })
   })
@@ -58,19 +46,13 @@ describe('service cluster network policies', function () {
   })
 })
 
-const assertServerTime = (response) => {
-  expect(response.status).to.eq(200)
-
-  const runtimeInfo = response.body
-  expect(runtimeInfo.status).to.eq('success')
-  expect(runtimeInfo.data.serverTime).to.be.a('string')
-
-  return runtimeInfo.data.serverTime
-}
-
-const makeQueryURL = (/** @type {Cluster} */ cluster, query, serverTime) => {
+const makeQueryURL = (/** @type {Cluster} */ cluster, query, serverTime = '') => {
   const metric = encodeURI(query)
-  return `${makePrometheusURL(cluster)}/api/v1/query?query=${metric}&${new URLSearchParams({ time: serverTime })}`
+  let returnValue = `${makePrometheusURL(cluster)}/api/v1/query?query=${metric}`
+  if (serverTime !== '') {
+    returnValue = `${returnValue}&${new URLSearchParams({ time: serverTime })}`
+  }
+  return returnValue
 }
 
 const assertNoDrops = (response, metricType, direction) => {

--- a/tests/end-to-end/netpol/netpol.cy.js
+++ b/tests/end-to-end/netpol/netpol.cy.js
@@ -1,5 +1,5 @@
-const DROP_QUERY = 'round(increase(no_policy_drop_counter[15m]))'
-const ACCEPT_QUERY = 'sum by (type) (round(increase(policy_accept_counter[15m])))'
+const DROP_QUERY = 'round(increase(no_policy_drop_counter[5m]))'
+const ACCEPT_QUERY = 'sum by (type) (round(increase(policy_accept_counter[5m])))'
 
 function makePrometheusURL(/** @type {Cluster} */ cluster) {
   const port = cluster === 'wc' ? Cypress.env('WC_PROXY_PORT') : Cypress.env('SC_PROXY_PORT')

--- a/tests/end-to-end/opensearch/dashboards.cy.js
+++ b/tests/end-to-end/opensearch/dashboards.cy.js
@@ -227,9 +227,6 @@ describe('Create a manual snapshot', function () {
           )
         )
       },
-      body: () => {
-        cy.log(`Found snapshot with ID ${snapshotName} in API response!`)
-      },
       attempts: 10,
     })
   })


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Because Prometheus is now being [scaled down](https://github.com/elastisys/compliantkubernetes-apps/pull/2692) during the `log-manager` suite, the network policy metrics can be a bit delayed during the `netpol` suite run. This PR adds retries around the fetching of accept metrics. It also fixes some smaller issues within the bats setup.

Part of: https://github.com/elastisys/ck8s-issue-tracker/issues/73

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
