### PR TITLE
test(log-manager): delete ongoing jobs during setup

### DIFF
--- a/tests/end-to-end/log-manager/compaction-audit-sc.gen.bats
+++ b/tests/end-to-end/log-manager/compaction-audit-sc.gen.bats
@@ -23,8 +23,8 @@ setup_file() {
   CRONJOB_NAME="audit-$(yq.get sc '.global.ck8sEnvironmentName')-sc-compaction"
   export CRONJOB_NAME
 
-  # TODO: Should probably make sure that the cronjob isn't currently running.
   kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+  terminate_cronjob_jobs "${CRONJOB_NAME}" 300
 
   local cronjob_env_bucket
   local cronjob_env_prefix

--- a/tests/end-to-end/log-manager/compaction-audit-wc.gen.bats
+++ b/tests/end-to-end/log-manager/compaction-audit-wc.gen.bats
@@ -23,8 +23,8 @@ setup_file() {
   CRONJOB_NAME="audit-$(yq.get sc '.global.ck8sEnvironmentName')-wc-compaction"
   export CRONJOB_NAME
 
-  # TODO: Should probably make sure that the cronjob isn't currently running.
   kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+  terminate_cronjob_jobs "${CRONJOB_NAME}" 300
 
   local cronjob_env_bucket
   local cronjob_env_prefix

--- a/tests/end-to-end/log-manager/compaction-sc-logs.gen.bats
+++ b/tests/end-to-end/log-manager/compaction-sc-logs.gen.bats
@@ -23,8 +23,8 @@ setup_file() {
   CRONJOB_NAME="sc-logs-logs-compaction"
   export CRONJOB_NAME
 
-  # TODO: Should probably make sure that the cronjob isn't currently running.
   kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+  terminate_cronjob_jobs "${CRONJOB_NAME}" 300
 
   local cronjob_env_bucket
   local cronjob_env_prefix

--- a/tests/end-to-end/log-manager/compaction.bats.gotmpl
+++ b/tests/end-to-end/log-manager/compaction.bats.gotmpl
@@ -26,8 +26,8 @@ setup_file() {
   CRONJOB_NAME="{{ .cronjob }}"
   export CRONJOB_NAME
 
-  # TODO: Should probably make sure that the cronjob isn't currently running.
   kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+  terminate_cronjob_jobs "${CRONJOB_NAME}" 300
 
   local cronjob_env_bucket
   local cronjob_env_prefix

--- a/tests/end-to-end/log-manager/retention-audit-sc.gen.bats
+++ b/tests/end-to-end/log-manager/retention-audit-sc.gen.bats
@@ -23,8 +23,8 @@ setup_file() {
   CRONJOB_NAME="audit-$(yq.get sc '.global.ck8sEnvironmentName')-sc-retention"
   export CRONJOB_NAME
 
-  # TODO: Should probably make sure that the cronjob isn't currently running.
   kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+  terminate_cronjob_jobs "${CRONJOB_NAME}" 300
 
   local cronjob_env_bucket
   local cronjob_env_prefix

--- a/tests/end-to-end/log-manager/retention-audit-wc.gen.bats
+++ b/tests/end-to-end/log-manager/retention-audit-wc.gen.bats
@@ -23,8 +23,8 @@ setup_file() {
   CRONJOB_NAME="audit-$(yq.get sc '.global.ck8sEnvironmentName')-wc-retention"
   export CRONJOB_NAME
 
-  # TODO: Should probably make sure that the cronjob isn't currently running.
   kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+  terminate_cronjob_jobs "${CRONJOB_NAME}" 300
 
   local cronjob_env_bucket
   local cronjob_env_prefix

--- a/tests/end-to-end/log-manager/retention-sc-logs.gen.bats
+++ b/tests/end-to-end/log-manager/retention-sc-logs.gen.bats
@@ -23,8 +23,8 @@ setup_file() {
   CRONJOB_NAME="sc-logs-logs-retention"
   export CRONJOB_NAME
 
-  # TODO: Should probably make sure that the cronjob isn't currently running.
   kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+  terminate_cronjob_jobs "${CRONJOB_NAME}" 300
 
   local cronjob_env_bucket
   local cronjob_env_prefix

--- a/tests/end-to-end/log-manager/retention.bats.gotmpl
+++ b/tests/end-to-end/log-manager/retention.bats.gotmpl
@@ -26,8 +26,8 @@ setup_file() {
   CRONJOB_NAME="{{ .cronjob }}"
   export CRONJOB_NAME
 
-  # TODO: Should probably make sure that the cronjob isn't currently running.
   kubectl -n "${NAMESPACE}" patch cronjob "${CRONJOB_NAME}" -p '{"spec" : {"suspend" : true}}'
+  terminate_cronjob_jobs "${CRONJOB_NAME}" 300
 
   local cronjob_env_bucket
   local cronjob_env_prefix


### PR DESCRIPTION
### What does this PR do / why do we need this PR?

Took a stab at cleaning up ongoing Jobs created by the compaction/retention Cronjobs, so we avoid the surprise of extra files popping up in the object storage during assertions.
