### PR TITLE
Apps install script for QA

### DIFF
--- a/scripts/qa/README.md
+++ b/scripts/qa/README.md
@@ -1,0 +1,308 @@
+# QA installer script for Welkin Apps
+
+This is an implementation of an installer script for Weklin Apps that:
+
+- is as independent as possible from the "installer" layer (Kubespray or CAPI)
+- has been tested and should work well on multiple cloud providers (ElastX, Upcloud, Brewer)
+- aims to automate the deployment of Apps, in a as vanilla as possible form
+- for a release version, the deployed Apps should pass all end-to-end test suites
+- allows skipping to a certain step in the process, manually confirming each step, or dry-running to list the steps
+
+## Configuration
+
+The script is configured via a simple `.json` file. The configuration data types are handled by the `config.py` module,
+which also doubles as a runnable script.
+
+When run without arguments, it will produce a "maximal" configuration file, a file where all properties are set, which
+should serve as a good guideline of what's possible (but necessarily _required_) to configure:
+
+  <details><summary>Maximal configuration example</summary>
+
+```json
+{
+  "kubeloginClientSecret": "set-me",
+  "adminGroup": "set-me",
+  "dex": {
+    "gcp": {
+      "clientID": "set-me",
+      "clientSecret": "set-me"
+    }
+  },
+  "dnsProvider": {
+    "domain": "set-me",
+    "aws": {
+      "hostedZone": "set-me",
+      "secrets": {
+        "accessKey": "set-me",
+        "secretKey": "set-me"
+      }
+    }
+  },
+  "externalLoadbalancers": {
+    "scAddress": "set-me",
+    "scDomainName": "set-me",
+    "scProxyProtocol": false,
+    "wcAddress": "set-me",
+    "wcDomainName": "set-me",
+    "wcProxyProtocol": false
+  },
+  "objectStorage": {
+    "config": {
+      "s3": {
+        "region": "set-me",
+        "regionEndpoint": "set-me"
+      }
+    },
+    "secrets": {
+      "s3": {
+        "accessKey": "set-me",
+        "secretKey": "set-me"
+      },
+      "swift": {
+        "applicationCredentialID": "set-me",
+        "applicationCredentialSecret": "set-me"
+      }
+    }
+  },
+  "wcSubnets": {
+    "apiServer": [
+      "set-me"
+    ],
+    "nodes": [
+      "set-me"
+    ],
+    "ingress": [
+      "set-me"
+    ]
+  },
+  "scSubnets": {
+    "apiServer": [
+      "set-me"
+    ],
+    "nodes": [
+      "set-me"
+    ],
+    "ingress": [
+      "set-me"
+    ]
+  }
+}
+```
+
+  </details>
+
+When run with the `--minimal` argument, it will produce a "minimally" viable config, that is, a config file which
+won't trigger any errors if no other fields are configured, but that also might not be _sufficient_ for a correct
+setup (depending on cloud provider, installer, etc.)
+
+  <details><summary>Minimal configuration example</summary>
+
+```json
+{
+  "kubeloginClientSecret": "set-me",
+  "adminGroup": "set-me",
+  "dex": {
+    "gcp": {
+      "clientID": "set-me",
+      "clientSecret": "set-me"
+    }
+  },
+  "dnsProvider": {
+    "domain": "set-me",
+    "aws": {
+      "hostedZone": "set-me",
+      "secrets": {
+        "accessKey": "set-me",
+        "secretKey": "set-me"
+      }
+    }
+  },
+  "objectStorage": {
+    "secrets": {
+      "s3": {
+        "accessKey": "set-me",
+        "secretKey": "set-me"
+      }
+    }
+  }
+}
+```
+
+  </details>
+
+This script has been tested on ElastX, Upcloud and Brewer, but it could potentially be viable on other cloud providers.
+
+To check, start from the minimal config and keep adding configuration keys as needed until you get a good setup.
+
+### Credential scope
+
+- The AWS credentials are used by the external DNS controller to automatically set up subdomains for both the SC and the WC.
+- The GCP credentials are used to set up the Dex connector in the service cluster. Refer to the [IDP preparation page](https://elastisys.io/welkin/user-guide/prepare-idp/#google) in the Welkin documentation for details.
+- Object storage credentials are used for 🥁 accessing object storage and should be set according to cloud provider.
+- The `kubeloginClientSecret` should match the value under `.clusters.wc.oidc.client_secret` when installing with CAPI. This allows us to avoid an additional Control Plane rollout during the Apps install, thus avoiding any interaction with the installer layer.
+- For Kubespray, check the generated kubectl config file for the Workload Cluster (usually `$CK8S_CONFIG_PATH/.state/kube_config_wc.yaml`) and look for the value of the `--oidc-client-secret` argument.
+
+> [!NOTE]
+>
+> The script assumes that the `$CK8S_CONFIG_PATH/dex-google-group-claim/secret/google-sa-secret.yml` exists and is populated with the proper key (corresponding to the IDP credentials used in the secrets config file)
+
+### Sample configuration files
+
+  <details><summary>Elastx</summary>
+
+The only tricky bit on Elastx is that we have to use `/24` subnets for API servers and nodes,
+to prevent the `update-ips` script from filling in specific node IPs because the IP associated with the
+load balancer won't be included.
+
+```json
+{
+  "kubeloginClientSecret": "redacted",
+  "adminGroup": "admins@example.com",
+  "dex": {
+    "gcp": {
+      "clientID": "hocus-bogus.apps.googleusercontent.com",
+      "clientSecret": "GOCSPX-redacted"
+    }
+  },
+  "dnsProvider": {
+    "domain": "dev-ck8s.com",
+    "aws": {
+      "hostedZone": "redacted",
+      "secrets": {
+        "accessKey": "redacted",
+        "secretKey": "redacted"
+      }
+    }
+  },
+  "objectStorage": {
+    "secrets": {
+      "s3": {
+        "accessKey": "redacted",
+        "secretKey": "redacted"
+      },
+      "swift": {
+        "applicationCredentialID": "redacted",
+        "applicationCredentialSecret": "redacted"
+      }
+    }
+  },
+  "scSubnets": {
+    "apiServer": ["172.16.35.0/24"],
+    "nodes": ["172.16.35.0/24"]
+  },
+  "wcSubnets": {
+    "apiServer": ["172.16.36.0/24"],
+    "nodes": ["172.16.36.0/24"]
+  }
+}
+```
+
+  </details>
+  <details><summary>Upcloud</summary>
+
+Find the public hostnames for your SC/WC on the [Load Balancers page](https://hub.upcloud.com/load-balancer/services) of the Upcload web interface.
+
+```json
+{
+  "kubeloginClientSecret": "redacted",
+  "adminGroup": "admins@example.com",
+  "dex": {
+    "gcp": {
+      "clientID": "hocus-bogus.apps.googleusercontent.com",
+      "clientSecret": "GOCSPX-redacted"
+    }
+  },
+  "dnsProvider": {
+    "domain": "dev-ck8s.com",
+    "aws": {
+      "hostedZone": "redacted",
+      "secrets": {
+        "accessKey": "redacted",
+        "secretKey": "redacted"
+      }
+    }
+  },
+   "externalLoadbalancers": {
+    "scDomainName": "lb-redacted.upcloudlb.com",
+    "scProxyProtocol": true,
+    "wcDomainName": "lb-redacted.upcloudlb.com",
+    "wcProxyProtocol": true
+  },
+  "objectStorage": {
+    "config": {
+      "s3": {
+        "region": "fi-hel2",
+        "regionEndpoint": "https://redacted.upcloudobjects.com"
+      }
+    },
+    "secrets": {
+      "s3": {
+        "accessKey": "redacted",
+        "secretKey": "redacted"
+      }
+    }
+  }
+}
+```
+
+  </details>
+  <details><summary>Brewer</summary>
+
+We're going with very permissive subnets for Brewer, but you can totally close these down to specific IPs if you want.
+
+```json
+{
+  "kubeloginClientSecret": "redacted",
+  "adminGroup": "admins@example.com",
+  "dex": {
+    "gcp": {
+      "clientID": "hocus-bogus.apps.googleusercontent.com",
+      "clientSecret": "GOCSPX-redacted"
+    }
+  },
+  "dnsProvider": {
+    "domain": "dev-ck8s.com",
+    "aws": {
+      "hostedZone": "redacted",
+      "secrets": {
+        "accessKey": "redacted",
+        "secretKey": "redacted"
+      }
+    }
+  },
+  "objectStorage": {
+    "config": {
+      "s3": {
+        "region": "us-east-1",
+        "regionEndpoint": "https://s3.internal.elastisys.se:8443"
+      }
+    },
+    "secrets": {
+      "s3": {
+        "accessKey": "redacted",
+        "secretKey": "redacted"
+      }
+    }
+  },
+  "scSubnets": {
+    "nodes": [ "0.0.0.0/0" ],
+    "apiServer": [ "0.0.0.0/0" ]
+  },
+  "wcSubnets": {
+    "nodes": [ "0.0.0.0/0" ],
+    "apiServer": [ "0.0.0.0/0" ]
+  }
+}
+```
+
+  </details>
+
+## Honorable mentions
+
+> [!NOTE]
+>
+> The script doesn't handle the creation of object storage buckets.
+>
+> On a fresh environment, the following incantation usually does the job:
+>
+> `sops exec-file --no-fifo "${CK8S_CONFIG_PATH}/.state/s3cfg.ini" "scripts/S3/entry.sh --s3cfg {} create"`

--- a/scripts/qa/boilerplate.py
+++ b/scripts/qa/boilerplate.py
@@ -1,0 +1,212 @@
+"""
+Reusable components for the QA scripts.
+"""
+
+import argparse
+import json
+import os
+import pty
+import select
+import subprocess
+import sys
+from argparse import ArgumentParser
+from contextlib import suppress
+from contextvars import ContextVar
+from dataclasses import dataclass
+from functools import partial, wraps
+from itertools import count
+from pathlib import Path
+from threading import Thread
+from typing import Any, Callable, Iterator, TextIO
+
+# JSON is a complex type, but for our purposes this will suffice
+Jsonable = dict | list | str
+
+
+@dataclass(frozen=True)
+class AppsConfig:
+    """Handles config operations"""
+
+    path: Path
+
+    def set(self, key: str, value: Jsonable) -> None:
+        """Set a config key (with merge)"""
+        _run(
+            "yq",
+            "-i",
+            f".{key} = .{key} * {json.dumps(value)}",
+            self.path.resolve().as_posix(),
+        )
+
+    def get(self, key: str) -> list | dict:
+        """Get a config key"""
+        return _get_json("yq", "-oj", f".{key}", self.path.resolve().as_posix()) or {}
+
+
+@dataclass(frozen=True)
+class StepArgs:
+    """Holds the step execution arguments"""
+
+    dry_run: bool
+    start_at: int
+    interactive: bool
+
+    @staticmethod
+    def add_parser_args(parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "-n",
+            "--dry-run",
+            action=argparse.BooleanOptionalAction,
+            help="doesn't perform any effects; just lists steps.",
+        )
+        parser.add_argument("-s", "--step", type=int, required=False, help="start at step.")
+        parser.add_argument(
+            "-m",
+            "--interactive",
+            action=argparse.BooleanOptionalAction,
+            help="manually confirm each step.",
+        )
+
+    @classmethod
+    def from_parsed_args(cls, args: argparse.Namespace) -> "StepArgs":
+        return cls(
+            dry_run=args.dry_run,
+            start_at=(args.step or 1),
+            interactive=args.interactive,
+        )
+
+
+STEP_ARGS: ContextVar[StepArgs] = ContextVar("args")
+STEP_COUNTER: Iterator[int] = count(1)
+
+
+def _step[**P, R](func: Callable[P, R], doc_suffix: str = "") -> Callable[P, R | None]:
+    step_no = next(STEP_COUNTER)
+    setattr(func, "__step_no__", step_no)
+
+    step_doc = f"Step {step_no}: {func.__doc__} {doc_suffix}".rstrip()
+    setattr(func, "__step_doc__", step_doc)
+
+    return _effect(func)
+
+
+def _effect[**P, R](func: Callable[P, R]) -> Callable[P, R | None]:
+    @wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R | None:
+        step_args = STEP_ARGS.get()
+        if (step_doc := getattr(func, "__step_doc__", None)) is not None:
+            if getattr(func, "__step_no__") < step_args.start_at:
+                print(f"\033[90m{step_doc} [skipped]\033[0m", file=sys.stderr)
+                return None
+
+            print(f"\033[95m{step_doc}\033[0m", file=sys.stderr)
+
+            if not step_args.dry_run and step_args.interactive and not _confirm("Perform step?"):
+                return None
+
+        if step_args.dry_run:
+            return None
+
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@_effect
+def _run(*command: str, **kwargs: Any) -> None:
+    """
+    Poor man's bash: just a subprocess.Popen at its core, but with
+    its standard descriptors wired to a pseudoterminal.
+
+    This allows the child process to output colors and accept user input.
+    """
+    try:
+        parent, child = pty.openpty()
+
+        process = subprocess.Popen(
+            command,
+            stdin=child,
+            stdout=child,
+            stderr=child,
+            **kwargs,
+        )
+
+        # Close the child end in the parent process to avoid deadlock
+        os.close(child)
+
+        # If we get a file descriptor (int), mirror it right out
+        # but if we're passed TextIO instances (like sys.stdin), call the `.fileno()` method
+        # to obtain the file descriptor.
+        def get_fd(stream: TextIO | int) -> int:
+            return stream if isinstance(stream, int) else stream.fileno()
+
+        def wire_streams(in_s: TextIO | int, out_s: TextIO | int) -> None:
+            with suppress(OSError, IOError):
+
+                # Popen.poll returns None as long as the child process is alive
+                while process.poll() is None:
+
+                    # We only pass the stream that we're interested in reading from in
+                    # to the 'read list' argument of select, then go ahead and pipe the read
+                    # data to the output stream (when selected).
+                    if in_s in select.select([in_s], [], [], 0.1)[0]:
+                        data = os.read(get_fd(in_s), 1024)
+                        if data:
+                            os.write(get_fd(out_s), data)
+
+        # The `partial` usage here just gives us back a function that has all the arguments
+        # set, but hasn't been called yet.
+        #
+        # We're starting separate threads for:
+        # - passing reads from our stdin to the PTY's parent
+        # - passing reads from the PTY's parent to our stdout
+        Thread(target=partial(wire_streams, sys.stdin, parent), daemon=True).start()
+        Thread(target=partial(wire_streams, parent, sys.stdout), daemon=True).start()
+
+        return_code = process.wait()
+
+        # Process remaining output
+        with suppress(OSError):
+            remaining = os.read(parent, 1024)
+            if remaining:
+                os.write(sys.stdout.fileno(), remaining)
+                sys.stdout.flush()
+
+        os.close(parent)
+        if return_code != 0:
+            sys.exit(return_code)
+
+    except Exception as e:
+        print(f"Error running command: {e}", file=sys.stderr)
+
+        # Equivalent of `set -e`. Any error means execution is halted.
+        sys.exit(1)
+
+
+@_effect
+def _get_json(*command: str, **kwargs: Any) -> list | dict:
+    return json.loads(subprocess.check_output(command, **kwargs).decode().strip())
+
+
+def _set_secret_key(secret_path: Path, key: str, value: Jsonable) -> None:
+    _run(
+        "sops",
+        "--set",
+        f"{key} {json.dumps(value)}",
+        secret_path.resolve().as_posix(),
+    )
+
+
+def _confirm(question: str) -> bool:
+    prompt = f":: {question} [Y/n] "
+
+    while True:
+        answer = input(prompt).lower().strip()
+        if not answer:
+            print(f"\033[A\033[K{prompt}y")
+            return True
+        if answer in ["y", "yes"]:
+            return True
+        if answer in ["n", "no"]:
+            return False
+        print("Please enter 'y' or 'n'")

--- a/scripts/qa/boilerplate.py
+++ b/scripts/qa/boilerplate.py
@@ -40,7 +40,19 @@ class AppsConfig:
 
     def get(self, key: str) -> list | dict:
         """Get a config key"""
-        return _get_json("yq", "-oj", f".{key}", self.path.resolve().as_posix()) or {}
+        # fmt: off
+        return (
+            _get_json(
+                "yq",
+                "--output-format", "json",
+                "--nul-output",
+                "--indent", "0",
+                f".{key}",
+                self.path.resolve().as_posix(),
+            )
+            or {}
+        )
+        # fmt: on
 
 
 @dataclass(frozen=True)
@@ -185,7 +197,8 @@ def _run(*command: str, **kwargs: Any) -> None:
 
 @_effect
 def _get_json(*command: str, **kwargs: Any) -> list | dict:
-    return json.loads(str(subprocess.check_output(command, text=True, **kwargs)).strip())
+    stripped = str(subprocess.check_output(command, text=True, **kwargs)).strip(" \x00")
+    return json.loads(stripped)
 
 
 def _set_secret_key(secret_path: Path, key: str, value: Jsonable) -> None:

--- a/scripts/qa/boilerplate.py
+++ b/scripts/qa/boilerplate.py
@@ -185,7 +185,7 @@ def _run(*command: str, **kwargs: Any) -> None:
 
 @_effect
 def _get_json(*command: str, **kwargs: Any) -> list | dict:
-    return json.loads(subprocess.check_output(command, **kwargs).decode().strip())
+    return json.loads(str(subprocess.check_output(command, text=True, **kwargs)).strip())
 
 
 def _set_secret_key(secret_path: Path, key: str, value: Jsonable) -> None:

--- a/scripts/qa/config.json.sample
+++ b/scripts/qa/config.json.sample
@@ -7,10 +7,10 @@
       "clientSecret": "set-me"
     }
   },
-  "externalDns": {
+  "dnsProvider": {
     "domain": "set-me",
-    "hostedZone": "set-me",
     "aws": {
+      "hostedZone": "set-me",
       "accessKey": "set-me",
       "secretKey": "set-me"
     }

--- a/scripts/qa/config.json.sample
+++ b/scripts/qa/config.json.sample
@@ -11,26 +11,46 @@
     "domain": "set-me",
     "aws": {
       "hostedZone": "set-me",
-      "accessKey": "set-me",
-      "secretKey": "set-me"
+      "secrets": {
+        "accessKey": "set-me",
+        "secretKey": "set-me"
+      }
     }
+  },
+  "externalLoadbalancers": {
+    "scAddress": "set-me",
+    "scDomainName": "set-me",
+    "scProxyProtocol": false,
+    "wcAddress": "set-me",
+    "wcDomainName": "set-me",
+    "wcProxyProtocol": false
   },
   "objectStorage": {
-    "s3": {
-      "accessKey": "set-me",
-      "secretKey": "set-me"
+    "config": {
+      "s3": {
+        "region": "set-me",
+        "regionEndpoint": "set-me"
+      }
     },
-    "swift": {
-      "applicationCredentialID": "set-me",
-      "applicationCredentialSecret": "set-me"
+    "secrets": {
+      "s3": {
+        "accessKey": "set-me",
+        "secretKey": "set-me"
+      },
+      "swift": {
+        "applicationCredentialID": "set-me",
+        "applicationCredentialSecret": "set-me"
+      }
     }
   },
-  "scSubnets": {
-    "apiServer": ["set-me"],
-    "nodes": ["set-me"]
-  },
   "wcSubnets": {
-    "apiServer": ["set-me"],
-    "nodes": ["set-me"]
+    "apiServer": [],
+    "nodes": [],
+    "ingress": []
+  },
+  "scSubnets": {
+    "apiServer": [],
+    "nodes": [],
+    "ingress": []
   }
 }

--- a/scripts/qa/config.json.sample
+++ b/scripts/qa/config.json.sample
@@ -1,5 +1,6 @@
 {
   "kubeloginClientSecret": "set-me",
+  "adminGroup": "set-me",
   "dex": {
     "gcp": {
       "clientID": "set-me",
@@ -7,6 +8,8 @@
     }
   },
   "externalDns": {
+    "domain": "set-me",
+    "hostedZone": "set-me",
     "aws": {
       "accessKey": "set-me",
       "secretKey": "set-me"

--- a/scripts/qa/config.json.sample
+++ b/scripts/qa/config.json.sample
@@ -25,14 +25,12 @@
       "applicationCredentialSecret": "set-me"
     }
   },
-  "wcSubnets": {
-    "apiServer": ["0.0.0.0/0"],
-    "nodes": ["0.0.0.0/0"],
-    "ingress": ["0.0.0.0/0"]
-  },
   "scSubnets": {
-    "apiServer": ["0.0.0.0/0"],
-    "nodes": ["0.0.0.0/0"],
-    "ingress": ["0.0.0.0/0"]
+    "apiServer": ["set-me"],
+    "nodes": ["set-me"]
+  },
+  "wcSubnets": {
+    "apiServer": ["set-me"],
+    "nodes": ["set-me"]
   }
 }

--- a/scripts/qa/config.json.sample
+++ b/scripts/qa/config.json.sample
@@ -21,5 +21,15 @@
       "applicationCredentialID": "set-me",
       "applicationCredentialSecret": "set-me"
     }
+  },
+  "wcSubnets": {
+    "apiServer": ["0.0.0.0/0"],
+    "nodes": ["0.0.0.0/0"],
+    "ingress": ["0.0.0.0/0"]
+  },
+  "scSubnets": {
+    "apiServer": ["0.0.0.0/0"],
+    "nodes": ["0.0.0.0/0"],
+    "ingress": ["0.0.0.0/0"]
   }
 }

--- a/scripts/qa/config.py
+++ b/scripts/qa/config.py
@@ -94,15 +94,18 @@ def _instantiate_typeddict(
     Instantiate a TypedDict class, filling all str leaf values with default_str.
     """
 
+    def get_non_none_types(f_type: Type) -> list[Type]:
+        args = get_args(f_type)
+        return [arg for arg in args if arg is not type(None)]
+
     def get_default_value(f_type: Type) -> Any:
         """Recursively determine the default value for a given type."""
 
         # Handle Union types (including Optional which is Union[T, None])
         origin = get_origin(f_type)
         if origin is Union:
-            args = get_args(f_type)
             # For Optional types, use the non-None type
-            non_none_types = [arg for arg in args if arg is not type(None)]
+            non_none_types = get_non_none_types(f_type)
             return get_default_value(non_none_types[0]) if non_none_types else None
 
         # Handle basic types
@@ -115,7 +118,8 @@ def _instantiate_typeddict(
         if f_type is bool:
             return False
         if f_type is list or origin is list:
-            return []
+            non_none_types = get_non_none_types(f_type)
+            return [get_default_value(non_none_types[0])] if non_none_types else []
         if f_type is dict or origin is dict:
             return {}
 

--- a/scripts/qa/config.py
+++ b/scripts/qa/config.py
@@ -42,7 +42,7 @@ SwiftSecrets = TypedDict(
 )
 
 ObjectStorageSecrets = TypedDict(
-    "ObjectStorageSecrets", {"s3": AwsSecrets, "swift": SwiftSecrets}, total=False
+    "ObjectStorageSecrets", {"s3": AwsSecrets, "swift": Optional[SwiftSecrets]}
 )
 
 S3Config = TypedDict("S3Config", {"region": str, "regionEndpoint": str})
@@ -51,8 +51,7 @@ ObjectStorageConfig = TypedDict("ObjectStorageConfig", {"s3": S3Config})
 
 ObjectStorage = TypedDict(
     "ObjectStorage",
-    {"config": ObjectStorageConfig, "secrets": ObjectStorageSecrets},
-    total=False,
+    {"config": Optional[ObjectStorageConfig], "secrets": ObjectStorageSecrets},
 )
 
 Subnets = TypedDict(
@@ -71,7 +70,7 @@ class Config(TypedDict):
     dnsProvider: DnsProvider
 
     externalLoadbalancers: Optional[ExternalLoadbalancers]
-    objectStorage: Optional[ObjectStorage]
+    objectStorage: ObjectStorage
 
     wcSubnets: Optional[Subnets]
     scSubnets: Optional[Subnets]

--- a/scripts/qa/config.py
+++ b/scripts/qa/config.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Configuration for the installer script.
+
+- When executed prints the config sample.
+- When executed with '--minimal' as the only argument prints the minimally viable config.
+"""
+import json
+import sys
+from contextlib import suppress
+from typing import Any, Optional, Type, TypedDict, Union, cast, get_args, get_origin, get_type_hints
+
+AwsSecrets = TypedDict(
+    "AwsSecrets",
+    {"accessKey": str, "secretKey": str},
+)
+
+GcpSecrets = TypedDict("GcpSecrets", {"clientID": str, "clientSecret": str})
+
+DexSecrets = TypedDict("DexSecrets", {"gcp": GcpSecrets})
+
+AwsDnsProvider = TypedDict("AwsDnsProvider", {"hostedZone": str, "secrets": AwsSecrets})
+
+DnsProvider = TypedDict("DnsProvider", {"domain": str, "aws": AwsDnsProvider})
+
+ExternalLoadbalancers = TypedDict(
+    "ExternalLoadbalancers",
+    {
+        "scAddress": str,
+        "scDomainName": str,
+        "scProxyProtocol": bool,
+        "wcAddress": str,
+        "wcDomainName": str,
+        "wcProxyProtocol": bool,
+    },
+    total=False,
+)
+
+SwiftSecrets = TypedDict(
+    "SwiftSecrets",
+    {"applicationCredentialID": str, "applicationCredentialSecret": str},
+)
+
+ObjectStorageSecrets = TypedDict(
+    "ObjectStorageSecrets", {"s3": AwsSecrets, "swift": SwiftSecrets}, total=False
+)
+
+S3Config = TypedDict("S3Config", {"region": str, "regionEndpoint": str})
+
+ObjectStorageConfig = TypedDict("ObjectStorageConfig", {"s3": S3Config})
+
+ObjectStorage = TypedDict(
+    "ObjectStorage",
+    {"config": ObjectStorageConfig, "secrets": ObjectStorageSecrets},
+    total=False,
+)
+
+Subnets = TypedDict(
+    "Subnets",
+    {"apiServer": list[str], "nodes": list[str], "ingress": list[str]},
+    total=False,
+)
+
+
+class Config(TypedDict):
+    """Holds the parsed configuration"""
+
+    kubeloginClientSecret: str
+    adminGroup: str
+    dex: DexSecrets
+    dnsProvider: DnsProvider
+
+    externalLoadbalancers: Optional[ExternalLoadbalancers]
+    objectStorage: Optional[ObjectStorage]
+
+    wcSubnets: Optional[Subnets]
+    scSubnets: Optional[Subnets]
+
+
+def dig(config: Config, path: str) -> str | int | float | bool | list | dict | None:
+    """Dig a dotted expression out of the config"""
+    cur = cast(dict, config)
+    with suppress(KeyError):
+        for sub_key in path.split("."):
+            cur = cur[sub_key]
+        return cur
+    return None
+
+
+def _instantiate_typeddict(
+    typed_dict_class: Type, default_str: str = "set-me", maximal: bool = False
+) -> dict:
+    """
+    Instantiate a TypedDict class, filling all str leaf values with default_str.
+    """
+
+    def get_default_value(f_type: Type) -> Any:
+        """Recursively determine the default value for a given type."""
+
+        # Handle Union types (including Optional which is Union[T, None])
+        origin = get_origin(f_type)
+        if origin is Union:
+            args = get_args(f_type)
+            # For Optional types, use the non-None type
+            non_none_types = [arg for arg in args if arg is not type(None)]
+            return get_default_value(non_none_types[0]) if non_none_types else None
+
+        # Handle basic types
+        if f_type is str:
+            return default_str
+        if f_type is int:
+            return 0
+        if f_type is float:
+            return 0.0
+        if f_type is bool:
+            return False
+        if f_type is list or origin is list:
+            return []
+        if f_type is dict or origin is dict:
+            return {}
+
+        # Handle TypedDict types
+        if hasattr(f_type, "__annotations__") and hasattr(f_type, "__total__"):
+            return (
+                _instantiate_typeddict(f_type, default_str, maximal)
+                if getattr(f_type, "__total__", True) or maximal
+                else {}
+            )
+
+        # Handle generic types like List[str], Dict[str, int], etc.
+        if origin is not None:
+            if origin is list:
+                return []
+            if origin is dict:
+                return {}
+            if origin is set:
+                return set()
+            if origin is tuple:
+                return ()
+
+        # Default fallback
+        return None
+
+    # Get type hints for the TypedDict
+    type_hints = get_type_hints(typed_dict_class)
+
+    # Create instance with default values
+    instance = {}
+    for field_name, field_type in type_hints.items():
+        if type(None) not in get_args(field_type) or maximal:
+            instance[field_name] = get_default_value(field_type)
+
+    return instance
+
+
+if __name__ == "__main__":
+    # Print maximal config unless "--minimal" is passed
+    print(
+        json.dumps(
+            _instantiate_typeddict(Config, maximal="--minimal" not in " ".join(sys.argv[1:])),
+            indent=2,
+        )
+    )

--- a/scripts/qa/install_apps.py
+++ b/scripts/qa/install_apps.py
@@ -38,30 +38,60 @@ class Args:
 
     @property
     def domain(self) -> str:
-        return f"{self.environment_name}.{self.config['externalDns']['domain']}"
-
-
-AwsSecrets = TypedDict(
-    "AwsSecrets",
-    {"accessKey": str, "secretKey": str},
-)
-
-SwiftSecrets = TypedDict(
-    "SwiftSecrets",
-    {"applicationCredentialID": str, "applicationCredentialSecret": str},
-)
-
-StorageSecrets = TypedDict(
-    "StorageSecrets",
-    {"s3": AwsSecrets, "swift": SwiftSecrets},
-)
+        return f"{self.environment_name}.{self.config['dnsProvider']['domain']}"
 
 GcpSecrets = TypedDict("GcpSecrets", {"clientID": str, "clientSecret": str})
 
 DexSecrets = TypedDict("DexSecrets", {"gcp": GcpSecrets})
 
-ExternalDnsConfig = TypedDict(
-    "ExternalDnsConfig", {"domain": str, "hostedZone": str, "aws": AwsSecrets}
+DnsProviderConfig = TypedDict(
+    "DnsProviderConfig",
+    {
+        "domain": str,
+        "aws": {
+            "hostedZone": str,
+            "accessKey": str,
+            "secretKey": str
+        }
+    }
+)
+
+ExternalLoadbalancers = TypedDict(
+    "ExternalLoadbalancers",
+    {
+        "scAddress": Optional[str],
+        "scDomainName": Optional[str],
+        "scProxyProtocol": Optional[bool],
+        "wcAddress": Optional[str],
+        "wcDomainName": Optional[str],
+        "wcProxyProtocol": Optional[bool]
+    }
+)
+
+S3Secrets = TypedDict(
+    "S3Secrets",
+    {
+        "region": Optional[str],
+        "regionEndpoint": Optional[str],
+        "accessKey": str,
+        "secretKey": str
+    }
+)
+
+SwiftSecrets = TypedDict(
+    "SwiftSecrets",
+    {
+        "applicationCredentialID": str,
+        "applicationCredentialSecret": str
+    }
+)
+
+StorageSecrets = TypedDict(
+    "StorageSecrets",
+    {
+        "s3": Optional[S3Secrets],
+        "swift": Optional[SwiftSecrets]
+    }
 )
 
 Subnets = TypedDict(
@@ -73,33 +103,18 @@ Subnets = TypedDict(
     },
 )
 
-
 class Config(TypedDict):
     """Holds secrets"""
 
     kubeloginClientSecret: str
     adminGroup: str
     dex: DexSecrets
-    externalDns: ExternalDnsConfig
+    dnsProvider: DnsProviderConfig
+    externalLoadbalancers: Optional[ExternalLoadbalancers]
     objectStorage: StorageSecrets
 
     wcSubnets: Subnets
     scSubnets: Subnets
-
-
-def initialize_apps() -> None:
-    """Initialize apps"""
-    _run_ck8s("init", "both")
-
-
-def set_objectstorage_secrets(secrets_path: Path, secrets: StorageSecrets) -> None:
-    """Set objectstorage secrets"""
-    _set_secret_key(secrets_path, '["objectStorage"]', dict(secrets))
-
-
-def update_ips(cluster: str) -> None:
-    """Update IPs"""
-    _run_ck8s("update-ips", cluster, "apply")
 
 
 def configure_apps(
@@ -107,22 +122,59 @@ def configure_apps(
 ) -> None:
     """Configure apps"""
 
-    opensearch_cfg = cast(dict, sc_config.get("opensearch"))
+    # Configure platform administrators
+    common_config.set("clusterAdmin", {"users": [], "groups": [args.config["adminGroup"]]})
 
-    # Set domains
+    # Configure application developers
+    wc_config.set(
+        "user",
+        {
+            "namespaces": ["production", "staging"],
+            "adminUsers": ALL_USERS,
+            "adminGroups": [],
+        },
+    )
+
+    # Configure domains
     common_config.set(
         "global",
         {"baseDomain": args.domain, "opsDomain": f"ops.{args.domain}"},
     )
 
+    # Configure external loadbalancer
+    try:
+        cond = args.config["externalLoadbalancers"]["scProxyProtocol"]
+        sc_config.set("ingressNginx.controller.config", {"useProxyProtocol": cond})
+    except KeyError:
+        pass # Use default
+    try:
+        cond = args.config["externalLoadbalancers"]["wcProxyProtocol"]
+        wc_config.set("ingressNginx.controller.config", {"useProxyProtocol": cond})
+    except KeyError:
+        pass # Use default
+
+    # Configure object storage
+    try:
+        region = args.config["objectStorage"]["s3"]["region"]
+        if region != "":
+            common_config.set("objectStorage.s3", {"region": region})
+    except KeyError:
+        pass # Use default
+    try:
+        regionEndpoint = args.config["objectStorage"]["s3"]["regionEndpoint"]
+        if region != "":
+            common_config.set("objectStorage.s3", {"regionEndpoint": regionEndpoint})
+    except KeyError:
+        pass # Use default
+
     # Configure cluster issuers
     dns_solver = {
-        "selector": {"dnsZones": [args.config["externalDns"]["domain"]]},
+        "selector": {"dnsZones": [args.config["dnsProvider"]["domain"]]},
         "dns01": {
             "route53": {
                 "region": "eu-north-1",
-                "hostedZoneID": args.config["externalDns"]["hostedZone"],
-                "accessKeyID": args.config["externalDns"]["aws"]["accessKey"],
+                "hostedZoneID": args.config["dnsProvider"]["aws"]["hostedZone"],
+                "accessKeyID": args.config["dnsProvider"]["aws"]["accessKey"],
                 "secretAccessKeySecretRef": {
                     "name": "route53-credentials-secret",
                     "key": "secretKey",
@@ -144,10 +196,7 @@ def configure_apps(
         },
     )
 
-    # Configure cluster admin
-    common_config.set("clusterAdmin", {"users": [], "groups": [args.config["adminGroup"]]})
-
-    # Configure allowed OPA registries
+    # Configure OPA allowed registries
     common_config.set(
         "opa.imageRegistry.URL",
         [
@@ -157,40 +206,7 @@ def configure_apps(
         ],
     )
 
-    # Use BPF Driver for Falco
-    common_config.set("falco.driver", {"kind": "modern-bpf"})
-
-    # Disable Felix metrics
-    common_config.set("networkPlugin.calico.calicoFelixMetrics", {"enabled": False})
-
-    # Open up Network Policies
-    common_config.set(
-        "networkPolicies",
-        {
-            "harbor": {"jobservice": ALL_IPS, "trivy": ALL_IPS, "registries": ALL_IPS},
-            "opensearch": {"plugins": ALL_IPS},
-            "dex": {"connectors": ALL_IPS},
-            "coredns": {"externalDns": ALL_IPS},
-            "kured": {"notificationSlack": ALL_IPS},
-            "falco": {"plugins": ALL_IPS},
-            "alertmanager": {"alertReceivers": ALL_IPS},
-            "global": {"trivy": ALL_IPS, "wcIngress": ALL_IPS, "scIngress": ALL_IPS},
-        },
-    )
-
-    sc_config.set("networkPolicies.global", {"scApiserver": ALL_IPS, "scNodes": ALL_IPS})
-    wc_config.set("networkPolicies.global", {"wcApiserver": ALL_IPS, "wcNodes": ALL_IPS})
-
-    sc_config.set(
-        "networkPolicies",
-        {"monitoring": {"grafana": {"externalDashboardProvider": ALL_IPS}}},
-    )
-
-    # Configure Harbor in SC
-    sc_config.set("harbor.oidc", {"adminGroupName": args.config["adminGroup"]})
-    # sc_config.set("harbor.trivy.persistentVolumeClaim", {"size": "10Gi"})
-
-    # Configure Dex in SC
+    # Configure Dex Google group support and static login
     sc_config.set(
         "dex",
         {
@@ -199,7 +215,10 @@ def configure_apps(
         },
     )
 
-    # Configure Grafanas
+    # Configure Falco BPF driver
+    common_config.set("falco.driver", {"kind": "modern-bpf"})
+
+    # Configure Grafana with test requirements
     grafana_cfg = {
         "trailingDots": False,
         "oidc": {
@@ -210,7 +229,12 @@ def configure_apps(
     sc_config.set("grafana.ops", grafana_cfg)
     sc_config.set("grafana.user", grafana_cfg)
 
-    # Configure opensearch user mappings
+    # Configure Harbor administrator group
+    sc_config.set("harbor.oidc", {"adminGroupName": args.config["adminGroup"]})
+    # sc_config.set("harbor.trivy.persistentVolumeClaim", {"size": "10Gi"})
+
+    # Configure OpenSearch role mappings
+    opensearch_cfg = cast(dict, sc_config.get("opensearch"))
     all_access_found = False
     for mapping in opensearch_cfg["extraRoleMappings"]:
         if mapping["mapping_name"] == "all_access":
@@ -229,46 +253,42 @@ def configure_apps(
     # Disable OpsGenie heartbeat
     sc_config.set("alerts", {"opsGenieHeartbeat": {"enabled": False}})
 
-    # Configure WC admin users
-    wc_config.set(
-        "user",
+    # Disable Calico Felix metrics
+    common_config.set("networkPlugin.calico.calicoFelixMetrics", {"enabled": False})
+
+    # Open up Network Policies
+    common_config.set(
+        "networkPolicies",
         {
-            "namespaces": ["production", "staging"],
-            "adminUsers": ALL_USERS,
-            "adminGroups": [],
+            "global": {"scIngress": ALL_IPS, "wcIngress": ALL_IPS, "trivy": ALL_IPS},
+            "alertmanager": {"alertReceivers": ALL_IPS},
+            "coredns": {"externalDns": ALL_IPS},
+            "dex": {"connectors": ALL_IPS},
+            "falco": {"plugins": ALL_IPS},
+            "harbor": {"jobservice": ALL_IPS, "registries": ALL_IPS, "trivy": ALL_IPS},
+            "kured": {"notificationSlack": ALL_IPS},
+            "opensearch": {"plugins": ALL_IPS},
         },
+    )
+
+    sc_config.set("networkPolicies.global", {"scApiserver": ALL_IPS, "scNodes": ALL_IPS})
+    wc_config.set("networkPolicies.global", {"wcApiserver": ALL_IPS, "wcNodes": ALL_IPS})
+
+    sc_config.set(
+        "networkPolicies",
+        {"monitoring": {"grafana": {"externalDashboardProvider": ALL_IPS}}},
     )
 
 
 def configure_secrets(secrets_path: Path, args: Args) -> None:
     """Configure secrets"""
+    # Configure Dex client secret for Kubernetes API
     _set_secret_key(
         secrets_path,
         '["dex"]["kubeloginClientSecret"]',
         args.config["kubeloginClientSecret"],
     )
-
-    _set_secret_key(
-        secrets_path,
-        '["issuers"]',
-        {
-            "secrets": {
-                "route53-credentials-secret": {
-                    "secretKey": args.config["externalDns"]["aws"]["secretKey"]
-                }
-            }
-        },
-    )
-    _set_secret_key(
-        secrets_path,
-        '["externalDns"]',
-        {
-            "awsRoute53": {
-                "accessKey": args.config["externalDns"]["aws"]["accessKey"],
-                "secretKey": args.config["externalDns"]["aws"]["secretKey"],
-            }
-        },
-    )
+    # Configure Dex connector to Google
     _set_secret_key(
         secrets_path,
         '["dex"]["connectors"][0]',
@@ -287,7 +307,6 @@ def configure_secrets(secrets_path: Path, args: Args) -> None:
             },
         },
     )
-
     # Configure the 'dev@example.com' static user
     _set_secret_key(
         secrets_path,
@@ -301,15 +320,66 @@ def configure_secrets(secrets_path: Path, args: Args) -> None:
         },
     )
 
+    # Configure cert-manager AWS secrets
+    _set_secret_key(
+        secrets_path,
+        '["issuers"]',
+        {
+            "secrets": {
+                "route53-credentials-secret": {
+                    "secretKey": args.config["dnsProvider"]["aws"]["secretKey"]
+                }
+            }
+        },
+    )
+    # Configure ExternalDNS AWS secrets
+    _set_secret_key(
+        secrets_path,
+        '["externalDns"]',
+        {
+            "awsRoute53": {
+                "accessKey": args.config["dnsProvider"]["aws"]["accessKey"],
+                "secretKey": args.config["dnsProvider"]["aws"]["secretKey"],
+            }
+        },
+    )
 
-def install_ingress(cluster: str) -> str:
+    # Configure object storage secrets
+    if "s3" in args.config["objectStorage"]:
+        _set_secret_key(
+            secrets_path,
+            '["objectStorage"]["s3"]',
+            {
+                "accessKey": args.config["objectStorage"]["s3"]["accessKey"],
+                "secretKey": args.config["objectStorage"]["s3"]["secretKey"]
+            }
+        )
+    if "swift" in args.config["objectStorage"]:
+        _set_secret_key(
+            secrets_path,
+            '["objectStorage"]["swift"]',
+            {
+                "applicationCredentialID": args.config["objectStorage"]["swift"]["applicationCredentialID"],
+                "applicationCredentialSecret": args.config["objectStorage"]["swift"]["applicationCredentialSecret"]
+            }
+        )
+
+
+def install_ingress(cluster: str, args: Args) -> str:
     """Install Ingress"""
     # fmt: off
     _run_ck8s(
         "ops", "helmfile", cluster,
         "-l", "app=ingress-nginx",
-        "sync", "--include-transitive-needs"
+        "sync" if args.use_sync else "apply", "--include-transitive-needs"
     )
+
+    if "externalLoadbalancers" in args.config:
+        if f"{cluster}DomainName" in args.config["externalLoadbalancers"]:
+            return ""
+        if f"{cluster}IP" in args.config["externalLoadbalancers"]:
+            return args.config["externalLoadbalancers"][f"{cluster}IP"]
+
     # fmt: on
     _run_ck8s(
         *f"ops kubectl {cluster} wait -n ingress-nginx "
@@ -319,29 +389,45 @@ def install_ingress(cluster: str) -> str:
     return _get_ingress_ip(cluster)
 
 
-def configure_external_dns(
+def install_external_dns(
     cluster_config: AppsConfig,
+    cluster: str,
     dns_names: list[str],
     ingress_ip: str,
     args: Args,
 ) -> None:
     """Configure External DNS"""
+
     record_common = {"recordTTL": 180, "recordType": "A", "targets": [ingress_ip]}
+
+    try:
+        domain_name = args.config["externalLoadbalancers"][f"{cluster}DomainName"]
+        if domain_name != "":
+            record_common = {"recordTTL": 180, "recordType": "CNAME", "targets": [domain_name]}
+    except KeyError:
+        pass # Use A records
 
     dns_config = {
         "enabled": True,
         "txtOwnerId": args.environment_name,
         "txtPrefix": args.environment_name,
-        "domains": [args.config["externalDns"]["domain"]],
+        "domains": [args.config["dnsProvider"]["domain"]],
         "sources": {"crd": True, "ingress": False, "service": False},
         "endpoints": [{**record_common, "dnsName": dns_name} for dns_name in dns_names],
     }
     cluster_config.set("externalDns", dns_config)
 
+    # fmt: off
+    _run_ck8s(
+        "ops", "helmfile", cluster,
+        "-l", "app=external-dns",
+        "sync" if args.use_sync else "apply", "--include-transitive-needs"
+    )
 
-def install_dex() -> None:
+
+def install_dex(args: Args) -> None:
     """Install Dex"""
-    _run_ck8s("ops", "helmfile", "sc", "-l", "app=admin-namespaces", "sync")
+    _run_ck8s("ops", "helmfile", "sc", "-l", "app=admin-namespaces", "sync" if args.use_sync else "apply")
     _run(
         "bash",
         "-c",
@@ -351,10 +437,9 @@ def install_dex() -> None:
     # fmt: off
     _run_ck8s(
         "ops", "helmfile", "sc",
-        "-l", "app=external-dns",
         "-l", "app=cert-manager",
         "-l", "app=dex",
-        "sync",
+        "sync" if args.use_sync else "apply", "--include-transitive-needs"
     )
     _run(
         "timeout", "300",
@@ -372,16 +457,17 @@ def reconfigure_ips(
     common_config: AppsConfig, sc_config: AppsConfig, wc_config: AppsConfig, args: Args
 ) -> None:
     """Reconfigure IPs"""
-    if (wc_ingress_subnet := args.config["wcSubnets"].get("ingress")) is not None:
-        common_config.set(
-            "networkPolicies",
-            {"global": {"wcIngress": {"ips": wc_ingress_subnet}}},
-        )
 
     if (sc_ingress_subnet := args.config["scSubnets"].get("ingress")) is not None:
         common_config.set(
             "networkPolicies",
-            {"global": {"wcIngress": {"ips": sc_ingress_subnet}}},
+            {"global": {"scIngress": {"ips": sc_ingress_subnet}}},
+        )
+
+    if (wc_ingress_subnet := args.config["wcSubnets"].get("ingress")) is not None:
+        common_config.set(
+            "networkPolicies",
+            {"global": {"wcIngress": {"ips": wc_ingress_subnet}}},
         )
 
     sc_config.set(
@@ -401,14 +487,23 @@ def reconfigure_ips(
     )
 
 
-def sync_apps(cluster: str) -> None:
-    """Sync apps"""
-    _run_ck8s("apply", cluster, "--sync", f"--concurrency={os.cpu_count() or 8}")
+# Apps commands
 
+def initialize_apps() -> None:
+    """Initialize apps"""
+    _run_ck8s("init", "both")
+
+def update_ips(cluster: str) -> None:
+    """Update IPs"""
+    _run_ck8s("update-ips", cluster, "apply")
 
 def apply_apps(cluster: str) -> None:
     """Apply apps"""
     _run_ck8s("apply", cluster, f"--concurrency={os.cpu_count() or 8}")
+
+def sync_apps(cluster: str) -> None:
+    """Sync apps"""
+    _run_ck8s("apply", cluster, "--sync", f"--concurrency={os.cpu_count() or 8}")
 
 
 def main() -> None:
@@ -428,20 +523,20 @@ def main() -> None:
     secrets_path = config_path / "secrets.yaml"
 
     _step(initialize_apps)()
-    _step(set_objectstorage_secrets)(secrets_path, args.config["objectStorage"])
     _step(configure_apps)(common_config, sc_config, wc_config, args)
     _step(configure_secrets)(secrets_path, args)
     _step(update_ips, doc_suffix="for both clusters")("both")
-    sc_ingress_ip = _step(install_ingress, doc_suffix="in SC")("sc") or ""
-    _step(configure_external_dns, doc_suffix="for SC")(
+    sc_ingress_ip = _step(install_ingress, doc_suffix="in SC")("sc", args) or ""
+    _step(install_external_dns, doc_suffix="for SC")(
         sc_config,
+        "sc",
         ["*.ops", "dex", "grafana", "harbor", "opensearch"],
         sc_ingress_ip,
         args,
     )
-    _step(install_dex)()
-    wc_ingress_ip = _step(install_ingress, doc_suffix="in WC")("wc") or ""
-    _step(configure_external_dns, doc_suffix="for WC")(wc_config, ["*"], wc_ingress_ip, args)
+    _step(install_dex)(args)
+    wc_ingress_ip = _step(install_ingress, doc_suffix="in WC")("wc", args) or ""
+    _step(install_external_dns, doc_suffix="for WC")(wc_config, "wc", ["*"], wc_ingress_ip, args)
     _step(reconfigure_ips)(common_config, sc_config, wc_config, args)
     _step(update_ips, doc_suffix="for both clusters")("both")
     if args.use_sync:
@@ -450,16 +545,6 @@ def main() -> None:
     else:
         _step(apply_apps, doc_suffix="in SC")("sc")
         _step(apply_apps, doc_suffix="in WC")("wc")
-
-
-def _check_ck8s_env(*var_names: str) -> None:
-    missing_vars = [
-        f"CK8S_{var_name}" for var_name in var_names if f"CK8S_{var_name}" not in os.environ
-    ]
-
-    if missing_vars:
-        print(f"Fatal: {', '.join(missing_vars)} not set.", file=sys.stderr)
-        sys.exit(1)
 
 
 def _parse_arguments(**environment: str) -> tuple[StepArgs, Args]:
@@ -515,13 +600,23 @@ def _validate_subnet(subnet: str) -> str:
         raise argparse.ArgumentTypeError(f"Invalid IP address: {subnet} ({e})")
 
 
-def _run_ck8s(*args: str, **kwargs: Any) -> None:
-    env_arg = os.environ | ({} if STEP_ARGS.get().interactive else {"CK8S_AUTO_APPROVE": "true"})
-    _run(str(BIN_DIR / "ck8s"), *args, **kwargs, env=env_arg)
+def _check_ck8s_env(*var_names: str) -> None:
+    missing_vars = [
+        f"CK8S_{var_name}" for var_name in var_names if f"CK8S_{var_name}" not in os.environ
+    ]
+
+    if missing_vars:
+        print(f"Fatal: {', '.join(missing_vars)} not set.", file=sys.stderr)
+        sys.exit(1)
 
 
 def _get_ck8s_json(*args: str, **kwargs: Any) -> list | dict:
     return _get_json(str(BIN_DIR / "ck8s"), *args, **kwargs) or {}
+
+
+def _run_ck8s(*args: str, **kwargs: Any) -> None:
+    env_arg = os.environ | ({} if STEP_ARGS.get().interactive else {"CK8S_AUTO_APPROVE": "true"})
+    _run(str(BIN_DIR / "ck8s"), *args, **kwargs, env=env_arg)
 
 
 if __name__ == "__main__":

--- a/scripts/qa/install_apps.py
+++ b/scripts/qa/install_apps.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""
+Configure and install Apps for QA.
+"""
+import argparse
+import ipaddress
+import json
+import os
+import sys
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, TypedDict, cast, Optional
+
+SCRIPT_DIR: Path = Path(__file__).parent.absolute()
+sys.path.insert(0, SCRIPT_DIR.as_posix())
+
+from boilerplate import STEP_ARGS, AppsConfig, StepArgs, _get_json, _run, _set_secret_key, _step
+
+BIN_DIR: Path = SCRIPT_DIR / ".." / ".." / "bin"
+
+ADMIN_USERS: list[str] = ["admin@example.com", "dev@example.com"]
+ADMIN_GROUP: str = "ck8sdevops@elastisys.com"
+ALL_IPS: dict[str, list[str]] = {"ips": ["0.0.0.0/0"]}
+
+DEV_DOMAIN: str = "dev-ck8s.com"
+DEV_HOSTED_ZONE: str = "Z1001117397DAU71G3RN2"
+
+
+@dataclass(frozen=True)
+class Args:
+    """Holds the parsed arguments"""
+
+    secrets: "Secrets"
+
+    cloud_provider: str
+    environment_name: str
+    sc_subnet: Optional[str] = None
+    wc_subnet: Optional[str] = None
+
+    @property
+    def domain(self) -> str:
+        return f"{self.environment_name}.{DEV_DOMAIN}"
+
+
+S3Secrets = TypedDict(
+    "S3Secrets",
+    {"accessKey": str, "secretKey": str},
+)
+
+SwiftSecrets = TypedDict(
+    "SwiftSecrets",
+    {"applicationCredentialID": str, "applicationCredentialSecret": str},
+)
+
+StorageSecrets = TypedDict(
+    "StorageSecrets",
+    {"s3": S3Secrets, "swift": SwiftSecrets},
+)
+
+
+class Secrets(TypedDict):
+    """Holds secrets"""
+
+    kubeloginClientSecret: str
+    awsAccessKey: str
+    awsSecretKey: str
+    gcpClientID: str
+    gcpClientSecret: str
+    objectStorage: StorageSecrets
+
+
+def initialize_apps() -> None:
+    """Initialize apps"""
+    _run_ck8s("init", "both")
+
+
+def set_objectstorage_secrets(secrets_path: Path, secrets: StorageSecrets) -> None:
+    """Set objectstorage secrets"""
+    _set_secret_key(secrets_path, '["objectStorage"]', dict(secrets))
+
+
+def update_ips(cluster: str) -> None:
+    """Update IPs"""
+    _run_ck8s("update-ips", cluster, "apply")
+
+
+def configure_apps(
+    common_config: AppsConfig, sc_config: AppsConfig, wc_config: AppsConfig, args: Args
+) -> None:
+    """Configure apps"""
+
+    opensearch_cfg = cast(dict, sc_config.get("opensearch"))
+
+    # Set domains
+    common_config.set(
+        "global",
+        {"baseDomain": args.domain, "opsDomain": f"ops.{args.domain}"},
+    )
+
+    # Configure cluster issuers
+    dns_solver = {
+        "selector": {"dnsZones": [DEV_DOMAIN]},
+        "dns01": {
+            "route53": {
+                "region": "eu-north-1",
+                "hostedZoneID": DEV_HOSTED_ZONE,
+                "accessKeyID": args.secrets["awsAccessKey"],
+                "secretAccessKeySecretRef": {
+                    "name": "route53-credentials-secret",
+                    "key": "secretKey",
+                },
+            }
+        },
+    }
+    common_config.set(
+        "issuers",
+        {
+            "letsencrypt": {
+                "enabled": True,
+                "prod": {
+                    "email": "letsencrypt@elastisys.com",
+                    "solvers": [dns_solver],
+                },
+                "staging": {"email": "letsencrypt@elastisys.com"},
+            }
+        },
+    )
+
+    # Configure cluster admin
+    common_config.set("clusterAdmin", {"users": [], "groups": [ADMIN_GROUP]})
+
+    # Configure allowed OPA registries
+    common_config.set(
+        "opa.imageRegistry.URL",
+        [
+            f"harbor.{args.domain}",
+            "quay.io/jetstack/cert-manager-acmesolver",
+            "ghcr.io/elastisys/user-demo",
+        ],
+    )
+
+    # Disable Felix metrics
+    common_config.set("networkPlugin.calico.calicoFelixMetrics", {"enabled": False})
+
+    # Open up Network Policies
+    common_config.set(
+        "networkPolicies",
+        {
+            "harbor": {"jobservice": ALL_IPS, "trivy": ALL_IPS, "registries": ALL_IPS},
+            "opensearch": {"plugins": ALL_IPS},
+            "dex": {"connectors": ALL_IPS},
+            "coredns": {"externalDns": ALL_IPS},
+            "kured": {"notificationSlack": ALL_IPS},
+            "falco": {"plugins": ALL_IPS},
+            "alertmanager": {"alertReceivers": ALL_IPS},
+            "global": {"trivy": ALL_IPS, "wcIngress": ALL_IPS, "scIngress": ALL_IPS},
+        },
+    )
+
+    if args.sc_subnet is not None:
+        sc_config.set(
+            "networkPolicies.global",
+            {
+                "scApiserver": {"ips": [args.sc_subnet]},
+                "scNodes": {"ips": [args.sc_subnet]},
+            },
+        )
+
+    if args.wc_subnet is not None:
+        wc_config.set(
+            "networkPolicies.global",
+            {
+                "wcApiserver": {"ips": [args.wc_subnet]},
+                "wcNodes": {"ips": [args.wc_subnet]},
+            },
+        )
+
+    sc_config.set(
+        "networkPolicies",
+        {"monitoring": {"grafana": {"externalDashboardProvider": ALL_IPS}}},
+    )
+
+    # Configure Harbor in SC
+    sc_config.set("harbor.oidc", {"adminGroupName": ADMIN_GROUP})
+    # sc_config.set("harbor.trivy.persistentVolumeClaim", {"size": "10Gi"})
+
+    # Configure Dex in SC
+    sc_config.set(
+        "dex",
+        {
+            "enableStaticLogin": True,
+            "google": {"groupSupport": True, "SASecretName": "google-sa"},
+        },
+    )
+
+    # Configure Grafanas
+    grafana_cfg = {
+        "trailingDots": False,
+        "oidc": {
+            "skipRoleSync": True,
+            "allowedDomains": ["elastisys.com", "example.com"],
+        },
+    }
+    sc_config.set("grafana.ops", grafana_cfg)
+    sc_config.set("grafana.user", grafana_cfg)
+
+    # Configure opensearch user mappings
+    all_access_found = False
+    for mapping in opensearch_cfg["extraRoleMappings"]:
+        if mapping["mapping_name"] == "all_access":
+            all_access_found = True
+        mapping["definition"]["users"] = ADMIN_USERS
+
+    if not all_access_found:
+        opensearch_cfg["extraRoleMappings"].append(
+            {
+                "mapping_name": "all_access",
+                "definition": {"users": ADMIN_USERS},
+            }
+        )
+    sc_config.set("opensearch", opensearch_cfg)
+
+    # Disable OpsGenie heartbeat
+    sc_config.set("alerts", {"opsGenieHeartbeat": {"enabled": False}})
+
+    # Configure WC admin users
+    wc_config.set(
+        "user",
+        {
+            "namespaces": ["production", "staging"],
+            "adminUsers": ADMIN_USERS,
+            "adminGroups": [],
+        },
+    )
+
+
+def configure_secrets(secrets_path: Path, args: Args) -> None:
+    """Configure secrets"""
+    _set_secret_key(
+        secrets_path,
+        '["dex"]["kubeloginClientSecret"]',
+        args.secrets["kubeloginClientSecret"],
+    )
+
+    _set_secret_key(
+        secrets_path,
+        '["issuers"]',
+        {"secrets": {"route53-credentials-secret": {"secretKey": args.secrets["awsSecretKey"]}}},
+    )
+    _set_secret_key(
+        secrets_path,
+        '["externalDns"]',
+        {
+            "awsRoute53": {
+                "accessKey": args.secrets["awsAccessKey"],
+                "secretKey": args.secrets["awsSecretKey"],
+            }
+        },
+    )
+    _set_secret_key(
+        secrets_path,
+        '["dex"]["connectors"][0]',
+        {
+            "name": "Elastisys",
+            "id": "elastisys-google",
+            "type": "google",
+            "config": {
+                "clientID": args.secrets["gcpClientID"],
+                "clientSecret": args.secrets["gcpClientSecret"],
+                "redirectURI": f"https://dex.{args.domain}/callback",
+                "serviceAccountFilePath": "/etc/dex/google/sa.json",
+                "adminEmail": "dex-admin-account@elastisys.com",
+                "groups": [ADMIN_GROUP],
+                "hostedDomains": ["elastisys.com"],
+            },
+        },
+    )
+
+    # Configure the 'dev@example.com' static user
+    _set_secret_key(
+        secrets_path,
+        '["dex"]["extraStaticLogins"][0]',
+        {
+            "email": "dev@example.com",
+            "userID": "08a8684b-db88-4b73-90a9-3cd1661f5467",
+            "username": "dev",
+            "password": "password",
+            "hash": "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W",
+        },
+    )
+
+
+def install_ingress(cluster: str) -> str:
+    """Install Ingress"""
+    # fmt: off
+    _run_ck8s(
+        "ops", "helmfile", cluster,
+        "-l", "app=admin-namespaces",
+        "-l", "app=dev-namespaces",
+        "-l", "bootstrap=prometheus",
+        "-l", "bootstrap=ingress-nginx",
+        "sync",
+    )
+    # fmt: on
+    _run_ck8s(
+        *f"ops kubectl {cluster} wait -n ingress-nginx "
+        r"--for=jsonpath={.metadata.annotations.loadbalancer\.openstack\.org/load-balancer-address}"
+        " service/ingress-nginx-controller --timeout=300s".split()
+    )
+    return _get_ingress_ip(cluster)
+
+
+def configure_external_dns(
+    cluster_config: AppsConfig,
+    dns_names: list[str],
+    ingress_ip: str,
+    args: Args,
+) -> None:
+    """Configure External DNS"""
+    record_common = {"recordTTL": 180, "recordType": "A", "targets": [ingress_ip]}
+
+    dns_config = {
+        "enabled": True,
+        "txtOwnerId": args.environment_name,
+        "txtPrefix": args.environment_name,
+        "domains": [DEV_DOMAIN],
+        "sources": {"crd": True, "ingress": False, "service": False},
+        "endpoints": [{**record_common, "dnsName": dns_name} for dns_name in dns_names],
+    }
+    cluster_config.set("externalDns", dns_config)
+
+
+def install_dex() -> None:
+    """Install Dex"""
+    _run_ck8s("ops", "helmfile", "sc", "-l", "app=admin-namespaces", "sync")
+    _run(
+        "bash",
+        "-c",
+        "sops -d ${CK8S_CONFIG_PATH}/dex-google-group-claim/secret/google-sa-secret.yml "
+        "| kubectl --kubeconfig ${CK8S_CONFIG_PATH}/.state/kube_config_sc.yaml apply -f -",
+    )
+    # fmt: off
+    _run_ck8s(
+        "ops", "helmfile", "sc",
+        "-l", "app=external-dns",
+        "-l", "app=cert-manager",
+        "-l", "app=dex",
+        "sync",
+    )
+    _run(
+        "timeout", "300",
+        "bash", "-c",
+        f"while ! {BIN_DIR}/ck8s ops kubectl sc get cert -n dex dex-tls -o name 2>/dev/null;"
+        f"do sleep 5; done",
+    )
+    # fmt: on
+    _run_ck8s(
+        *"ops kubectl sc wait cert -n dex dex-tls --for condition=Ready=True --timeout 15m".split()
+    )
+
+
+def sync_apps(cluster: str) -> None:
+    """Sync apps"""
+    _run_ck8s("apply", cluster, "--sync", f"--concurrency={os.cpu_count() or 8}")
+
+
+def main() -> None:
+    """Entrypoint"""
+    _check_ck8s_env("CONFIG_PATH", "CLOUD_PROVIDER", "ENVIRONMENT_NAME", "FLAVOR", "K8S_INSTALLER")
+
+    step_args, args = _parse_arguments(
+        cloud_provider=os.environ["CK8S_CLOUD_PROVIDER"],
+        environment_name=os.environ["CK8S_ENVIRONMENT_NAME"],
+    )
+    STEP_ARGS.set(step_args)
+
+    config_path = Path(os.environ["CK8S_CONFIG_PATH"])
+    common_config = AppsConfig(path=config_path / "common-config.yaml")
+    sc_config = AppsConfig(path=config_path / "sc-config.yaml")
+    wc_config = AppsConfig(path=config_path / "wc-config.yaml")
+    secrets_path = config_path / "secrets.yaml"
+
+    _step(initialize_apps)()
+    _step(set_objectstorage_secrets)(secrets_path, args.secrets["objectStorage"])
+    _step(configure_apps)(common_config, sc_config, wc_config, args)
+    _step(configure_secrets)(secrets_path, args)
+    _step(update_ips, doc_suffix="for SC")("sc")
+    sc_ingress_ip = _step(install_ingress, doc_suffix="in SC")("sc") or ""
+    _step(configure_external_dns, doc_suffix="for SC")(
+        sc_config,
+        ["*.ops", "dex", "grafana", "harbor", "opensearch"],
+        sc_ingress_ip,
+        args,
+    )
+    _step(install_dex)()
+    _step(update_ips, doc_suffix="for WC")("wc")
+    wc_ingress_ip = _step(install_ingress, doc_suffix="in WC")("wc") or ""
+    _step(configure_external_dns, doc_suffix="for WC")(wc_config, ["*"], wc_ingress_ip, args)
+    _step(sync_apps, doc_suffix="in SC")("sc")
+    _step(sync_apps, doc_suffix="in WC")("wc")
+
+
+def _check_ck8s_env(*var_names: str) -> None:
+    missing_vars = [
+        f"CK8S_{var_name}" for var_name in var_names if f"CK8S_{var_name}" not in os.environ
+    ]
+
+    if missing_vars:
+        print(f"Fatal: {', '.join(missing_vars)} not set.", file=sys.stderr)
+        sys.exit(1)
+
+
+def _parse_arguments(**environment: str) -> tuple[StepArgs, Args]:
+    parser = argparse.ArgumentParser(description="Configure and install Apps for QA.")
+
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=argparse.FileType("r"),
+        required=True,
+        help="secrets configuration file.",
+    )
+    if environment["cloud_provider"] == "elastx":
+        parser.add_argument(
+            "--sc-subnet",
+            type=_validate_subnet,
+            required=False,
+            help="subnet for SC nodes.",
+        )
+        parser.add_argument(
+            "--wc-subnet",
+            type=_validate_subnet,
+            required=False,
+            help="subnet for WC nodes.",
+        )
+
+    StepArgs.add_parser_args(parser)
+
+    parsed_args = parser.parse_args()
+
+    # we're using pathlib for reading
+    parsed_args.config.close()
+
+    args = Args(
+        secrets=json.loads(Path(parsed_args.config.name).read_text(encoding="utf-8")),
+        **environment,
+    )
+    if environment["cloud_provider"] == "elastx":
+        args = replace(args, sc_subnet=parsed_args.sc_subnet, wc_subnet=parsed_args.wc_subnet)
+
+    return StepArgs.from_parsed_args(parsed_args), args
+
+
+def _get_ingress_ip(cluster: str) -> str:
+    ingress = cast(
+        dict,
+        _get_ck8s_json(
+            *f"ops kubectl {cluster} get -n ingress-nginx"
+            " service/ingress-nginx-controller -ojson".split()
+        ),
+    )
+    return ingress["metadata"]["annotations"]["loadbalancer.openstack.org/load-balancer-address"]
+
+
+def _validate_subnet(subnet: str) -> str:
+    try:
+        ipaddress.ip_network(subnet)
+        return subnet
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(f"Invalid IP address: {subnet} ({e})")
+
+
+def _run_ck8s(*args: str, **kwargs: Any) -> None:
+    env_arg = os.environ | ({} if STEP_ARGS.get().interactive else {"CK8S_AUTO_APPROVE": "true"})
+    _run(str(BIN_DIR / "ck8s"), *args, **kwargs, env=env_arg)
+
+
+def _get_ck8s_json(*args: str, **kwargs: Any) -> list | dict:
+    return _get_json(str(BIN_DIR / "ck8s"), *args, **kwargs) or {}
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qa/install_apps.py
+++ b/scripts/qa/install_apps.py
@@ -313,11 +313,8 @@ def install_ingress(cluster: str) -> str:
     # fmt: off
     _run_ck8s(
         "ops", "helmfile", cluster,
-        "-l", "app=admin-namespaces",
-        "-l", "app=dev-namespaces",
-        "-l", "bootstrap=prometheus",
-        "-l", "bootstrap=ingress-nginx",
-        "sync",
+        "-l", "app=ingress-nginx",
+        "sync", "--include-transitive-needs"
     )
     # fmt: on
     _run_ck8s(

--- a/scripts/qa/install_apps.py
+++ b/scripts/qa/install_apps.py
@@ -157,6 +157,9 @@ def configure_apps(
         ],
     )
 
+    # Use BPF Driver for Falco
+    common_config.set("falco.driver", {"kind": "modern-bpf"})
+
     # Disable Felix metrics
     common_config.set("networkPlugin.calico.calicoFelixMetrics", {"enabled": False})
 

--- a/scripts/qa/install_apps.py
+++ b/scripts/qa/install_apps.py
@@ -168,26 +168,26 @@ def configure_apps(
     common_config.set("networkPlugin.calico.calicoFelixMetrics", {"enabled": False})
 
     # Open up Network Policies
-    common_config.set(
-        "networkPolicies",
-        {
-            "global": {
-                "scIngress": ALL_IPS,
-                "wcIngress": ALL_IPS,
-                "trivy": ALL_IPS,
-                "objectStorage": {**ALL_IPS, "ports": [443]},
-                "objectStorageSwift": ALL_IPS,
-            },
-            "kubeSystem": {"openstack": ALL_IPS},
-            "alertmanager": {"alertReceivers": ALL_IPS},
-            "coredns": {"externalDns": ALL_IPS},
-            "dex": {"connectors": ALL_IPS},
-            "falco": {"plugins": ALL_IPS},
-            "harbor": {"jobservice": ALL_IPS, "registries": ALL_IPS, "trivy": ALL_IPS},
-            "kured": {"notificationSlack": ALL_IPS},
-            "opensearch": {"plugins": ALL_IPS},
+    common_network_policies = {
+        "global": {
+            "scIngress": ALL_IPS,
+            "wcIngress": ALL_IPS,
+            "trivy": ALL_IPS,
+            "objectStorage": {**ALL_IPS, "ports": [443]},
+            "objectStorageSwift": ALL_IPS,
         },
-    )
+        "alertmanager": {"alertReceivers": ALL_IPS},
+        "coredns": {"externalDns": ALL_IPS},
+        "dex": {"connectors": ALL_IPS},
+        "falco": {"plugins": ALL_IPS},
+        "harbor": {"jobservice": ALL_IPS, "registries": ALL_IPS, "trivy": ALL_IPS},
+        "kured": {"notificationSlack": ALL_IPS},
+        "opensearch": {"plugins": ALL_IPS},
+    }
+    if args.cloud_provider in ["openstack", "upcloud"]:
+        common_network_policies["kubeSystem"] = {args.cloud_provider: ALL_IPS}
+
+    common_config.set("networkPolicies", common_network_policies)
 
     sc_config.set("networkPolicies.global", {"scApiserver": ALL_IPS, "scNodes": ALL_IPS})
     wc_config.set("networkPolicies.global", {"wcApiserver": ALL_IPS, "wcNodes": ALL_IPS})

--- a/scripts/qa/install_apps.py
+++ b/scripts/qa/install_apps.py
@@ -3,7 +3,6 @@
 Configure and install Apps for QA.
 """
 import argparse
-import ipaddress
 import json
 import os
 import sys
@@ -509,14 +508,6 @@ def _get_ingress_ip(args: Args, cluster: str) -> str:
             "loadbalancer.openstack.org/load-balancer-address"
         ]
     return ""
-
-
-def _validate_subnet(subnet: str) -> str:
-    try:
-        ipaddress.ip_network(subnet)
-        return subnet
-    except ValueError as e:
-        raise argparse.ArgumentTypeError(f"Invalid IPv4 subnet: {subnet} ({e})")
 
 
 def _check_ck8s_env(*var_names: str) -> None:

--- a/scripts/qa/install_apps.py
+++ b/scripts/qa/install_apps.py
@@ -18,7 +18,10 @@ from boilerplate import STEP_ARGS, AppsConfig, StepArgs, _get_json, _run, _set_s
 
 BIN_DIR: Path = SCRIPT_DIR / ".." / ".." / "bin"
 
-ADMIN_USERS: list[str] = ["admin@example.com", "dev@example.com"]
+ADMIN_USER: str = "admin@example.com"
+APP_DEV_USER: str = "dev@example.com"
+
+ALL_USERS: list[str] = [ADMIN_USER, APP_DEV_USER]
 ADMIN_GROUP: str = "ck8sdevops@elastisys.com"
 ALL_IPS: dict[str, list[str]] = {"ips": ["0.0.0.0/0"]}
 
@@ -131,7 +134,7 @@ def configure_apps(
     )
 
     # Configure cluster admin
-    common_config.set("clusterAdmin", {"users": [], "groups": [ADMIN_GROUP]})
+    common_config.set("clusterAdmin", {"users": [ADMIN_USER], "groups": [ADMIN_GROUP]})
 
     # Configure allowed OPA registries
     common_config.set(
@@ -213,13 +216,13 @@ def configure_apps(
     for mapping in opensearch_cfg["extraRoleMappings"]:
         if mapping["mapping_name"] == "all_access":
             all_access_found = True
-        mapping["definition"]["users"] = ADMIN_USERS
+        mapping["definition"]["users"] = ALL_USERS
 
     if not all_access_found:
         opensearch_cfg["extraRoleMappings"].append(
             {
                 "mapping_name": "all_access",
-                "definition": {"users": ADMIN_USERS},
+                "definition": {"users": ALL_USERS},
             }
         )
     sc_config.set("opensearch", opensearch_cfg)
@@ -232,7 +235,7 @@ def configure_apps(
         "user",
         {
             "namespaces": ["production", "staging"],
-            "adminUsers": ADMIN_USERS,
+            "adminUsers": ALL_USERS,
             "adminGroups": [],
         },
     )

--- a/scripts/qa/secrets.json.sample
+++ b/scripts/qa/secrets.json.sample
@@ -1,9 +1,17 @@
 {
   "kubeloginClientSecret": "set-me",
-  "awsAccessKey": "set-me",
-  "awsSecretKey": "set-me",
-  "gcpClientID": "set-me",
-  "gcpClientSecret": "set-me",
+  "dex": {
+    "gcp": {
+      "clientID": "set-me",
+      "clientSecret": "set-me"
+    }
+  },
+  "externalDns": {
+    "aws": {
+      "accessKey": "set-me",
+      "secretKey": "set-me"
+    }
+  },
   "objectStorage": {
     "s3": {
       "accessKey": "set-me",

--- a/scripts/qa/secrets.json.sample
+++ b/scripts/qa/secrets.json.sample
@@ -1,0 +1,17 @@
+{
+  "kubeloginClientSecret": "set-me",
+  "awsAccessKey": "set-me",
+  "awsSecretKey": "set-me",
+  "gcpClientID": "set-me",
+  "gcpClientSecret": "set-me",
+  "objectStorage": {
+    "s3": {
+      "accessKey": "set-me",
+      "secretKey": "set-me"
+    },
+    "swift": {
+      "applicationCredentialID": "set-me",
+      "applicationCredentialSecret": "set-me"
+    }
+  }
+}

--- a/tests/common/exec.bash
+++ b/tests/common/exec.bash
@@ -151,14 +151,19 @@ end_to_end.socat_up() {
 
   mkdir -p "${tests}/end-to-end/.run"
   if [[ ! -f "${pid_file}" ]] || ! kill -0 "$(<"${pid_file}")" 2>/dev/null; then
-    local -r sock_dir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
-    mkdir -p "${sock_dir}"
+    {
+      flock -x 200
 
-    local -r sock_file="${sock_dir}/ck8s-apps-browser.sock"
-    rm -f "${sock_file}"
+      local -r sock_dir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+      mkdir -p "${sock_dir}"
 
-    socat -lf "${tests}/end-to-end/.run/socat.log" unix-listen:"${sock_file}",fork system:'xargs xdg-open' &
-    echo "$!" >"${pid_file}"
+      local -r sock_file="${sock_dir}/ck8s-apps-browser.sock"
+      rm -f "${sock_file}"
+
+      socat -lf "${tests}/end-to-end/.run/socat.log" unix-listen:"${sock_file}",fork system:'xargs xdg-open' &
+      echo "$!" >"${pid_file}"
+
+    } 200>"${tests}/end-to-end/.run/socat.lock"
   fi
 }
 


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Implements an installer script for Apps that's as independent as possible from the "install" layer. 

NOTE: This script has been tested *only* on clusters installed with CAPI on the Elastx cloud provider. Should we want to extend support to other installers or cloud provider, we'll do that in separate tickets / PRs.

```
# ./scripts/qa/install_apps.py --help
usage: install_apps.py [-h] -c CONFIG [--sc-subnet SC_SUBNET] [--wc-subnet WC_SUBNET] [-n | --dry-run | --no-dry-run] [-s STEP] [-m | --interactive | --no-interactive]

Configure and install Apps for QA.

options:
  -h, --help            show this help message and exit
  -c, --config CONFIG   secrets configuration file.
  --sc-subnet SC_SUBNET
                        subnet for SC nodes.
  --wc-subnet WC_SUBNET
                        subnet for WC nodes.
  -n, --dry-run, --no-dry-run
                        doesn't perform any effects; just lists steps.
  -s, --step STEP       start at step.
  -m, --interactive, --no-interactive
                        manually confirm each step.
```

Similar to the `ckctl` command series in the Devbox, this script allows skipping to a certain step in the process, manually confirming each step, or dry-running to list the steps. A normal flow looks like this:

```
# ./scripts/qa/install_apps.py -c $CK8S_CONFIG_PATH/qa.json --dry-run
Step 1: Initialize apps
Step 2: Set objectstorage secrets
Step 3: Configure apps
Step 4: Configure secrets
Step 5: Update IPs for SC
Step 6: Install Ingress in SC
Step 7: Configure External DNS for SC
Step 8: Install Dex
Step 9: Update IPs for WC
Step 10: Install Ingress in WC
Step 11: Configure External DNS for WC
Step 12: Sync apps in SC
Step 13: Sync apps in WC
```

The script relies on a minimal `JSON` configuration file that contains the minimum amount of secret material to bootstrap apps in a cluster:

```json
{
  "kubeloginClientSecret": "set-me",
  "awsAccessKey": "set-me",
  "awsSecretKey": "set-me",
  "gcpClientID": "set-me",
  "gcpClientSecret": "set-me",
  "objectStorage": {
    "s3": {
      "accessKey": "set-me",
      "secretKey": "set-me"
    },
    "swift": {
      "applicationCredentialID": "set-me",
      "applicationCredentialSecret": "set-me"
    }
  }
}
```

Credential scope is as follows:

- the AWS credentials are used by the external DNS controller to automatically set up subdomains for both the SC and the WC. These are inferred from the IP address of LoadBalancers associated with the ingress-nginx services, after they stabilized. We do not set any records for the Kubernetes API servers themselves, but this doesn't seem to affect E2E runs.
- the GCP credentials are used to set up the Dex connector in the service cluster. Refer to the [IDP preparation page](https://elastisys.io/welkin/user-guide/prepare-idp/#google) in the Welkin documentation for details. 
- object storage credentials according to your cloud provider
- the `kubeloginClientSecret` should match the value under `.clusters.wc.oidc.client_secret`. This allows us to avoid an additional Control Plane rollout during the Apps install, thus avoiding any interaction with the installer layer.

NOTE: the script assumes that the `$CK8S_CONFIG_PATH/dex-google-group-claim/secret/google-sa-secret.yml` exists and is populated with the proper key (corresponding to the IDP credentials used in the secrets config file)

Fixes https://github.com/elastisys/ck8s-issue-tracker/issues/73

#### Information to reviewers

Prerequisites:
- an empty CAPI cluster on Elastx (with no Apps on it, or on which `./scripts/clean-sc.sh` and `./scripts/clean-wc.sh` have run)
- `$CK8S_CONFIG_PATH/dex-google-group-claim/secret/google-sa-secret.yml` present and client secret configured with the desired callback URL for the domain
- the JSON configuration file populated with the required secrets. A template is available under `scripts/qa/secrets.json.sample`
- `$CK8S_CONFIG_PATH/.state/kube_config_wc.yaml` is initially set to the `kubernetes:admin` configuration. Once the Dex connection is established (after the entire script has run, it can be reverted back to the OIDC config):
  - to get the admin config from CAPI: `./bin/ck8s-capi ops clusterctl mc get kubeconfig <cluster_name> -n capi-cluster > $CK8S_CONFIG_PATH/.state/kube_config_wc.yaml`
  - after the script runs, to get an OIDC-based config: `./bin/ck8s-capi kubeconfig wc`
  
```
./scripts/qa/install_apps.py -c <path_to_secrets_json> --sc-subnet <sc_subnet> --wc-subnet <wc_subnet>
```

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
