### PR TITLE
Adding OpenSearch alert for total shards limit

### DIFF
--- a/helmfile.d/charts/prometheus-alerts/CHANGELOG.md
+++ b/helmfile.d/charts/prometheus-alerts/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2025.08.29
+
+1. helmfile/charts/prometheus-alerts/templates/alerts/opensearch.yaml
+    - ADDED - OpenSearchTotalSHardsTooHigh alert
+
 ## 2025.01.03
 
 1. helmfile.d/charts/prometheus-alerts/templates/alerts/alertmanager.rules.yaml

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/opensearch.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/opensearch.yaml
@@ -17,6 +17,24 @@ spec:
   groups:
   - name: opensearch-alerts
     rules:
+    - alert: OpenSearchTotalShardsWarning
+      expr: sum(elasticsearch_node_shards_total{namespace="opensearch-system"}) > {{ mulf (mul .Values.osMaxShardsPerNode .Values.osDataNodeCount) 0.85 }}
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        description: Cluster total shards near hard limit
+        summary: The total number of shards across the nodes is {{`{{ $value }}`}} which is above 85% of the combined hard limit {{ mul .Values.osDataNodeCount .Values.osMaxShardsPerNode }}
+        runbook_url: {{ .Values.runbookUrls.opensearch.OpenSearchTotalShardsTooHigh }}
+    - alert: OpenSearchTotalShardsCritical
+      expr: sum(elasticsearch_node_shards_total{namespace="opensearch-system"}) > {{ mulf (mul .Values.osMaxShardsPerNode .Values.osDataNodeCount) 0.95 }}
+      for: 15m
+      labels:
+        severity: critical
+      annotations:
+        description: Cluster total shards near hard limit
+        summary: The total number of shards across the nodes is {{`{{ $value }}`}} which is above 95% of the combined hard limit {{ mul .Values.osDataNodeCount .Values.osMaxShardsPerNode }}
+        runbook_url: {{ .Values.runbookUrls.opensearch.OpenSearchTotalShardsTooHigh }}
     - alert: OpenSearchTooFewNodesRunning
       expr: elasticsearch_cluster_health_number_of_nodes{namespace="opensearch-system"} < {{ .Values.osNodeCount }}
       for: 15m

--- a/helmfile.d/charts/prometheus-alerts/values.yaml
+++ b/helmfile.d/charts/prometheus-alerts/values.yaml
@@ -2,6 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 osNodeCount: 3
+osDataNodeCount: 3
+osMaxShardsPerNode: 1000
 alertmanagerJob: kube-prometheus-stack-alertmanager
 alertmanagerNamespace: monitoring
 prometheusJob: kube-prometheus-stack-prometheus

--- a/helmfile.d/values/prometheus-alerts-runbook-urls.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-alerts-runbook-urls.yaml.gotmpl
@@ -193,6 +193,7 @@ runbookUrls:
   nodeNetwork:
     {{- dict "name" "NodeNetworkInterfaceFlapping" "subpath" "general" "config" .nodeNetwork | include "tpl.prometheus-operator" }}
   opensearch:
+    {{- dict "name" "OpenSearchTotalShardsTooHigh" "config" .opensearch | include "tpl.missing-runbook" }}
     {{- dict "name" "OpenSearchTooFewNodesRunning" "config" .opensearch | include "tpl.missing-runbook" }}
     {{- dict "name" "OpenSearchHeapTooHigh" "config" .opensearch | include "tpl.missing-runbook" }}
     {{- dict "name" "OpenSearchFieldLimit" "config" .opensearch | include "tpl.missing-runbook" }}

--- a/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
@@ -10,10 +10,16 @@
 {{- $groupLabel := printf "label_%s" $transformedGroupLabel -}}
 
 {{- $groupLabelValueArray := .Values.prometheus.autoscaledNodeGroupAlerts.groupLabelValues -}}
-{{- $groupLabelValueArrayRegex := join "|" $groupLabelValueArray -}}
+{{- $groupLabelValueArrayRegex := join "|" $groupLabelValueArray }}
 
 osNodeCount: {{ add .Values.opensearch.dataNode.count .Values.opensearch.clientNode.count .Values.opensearch.masterNode.count }}
+{{- if .Values.opensearch.dataNode.dedicatedPods }}
+osDataNodeCount: {{ .Values.opensearch.dataNode.count }}
+{{- else }}
+osDataNodeCount: {{ .Values.opensearch.masterNode.count }}
+{{- end }}
 osIndexAlerts: {{ toYaml .Values.opensearch.promIndexAlerts | nindent 2 }}
+osMaxShardsPerNode: {{ .Values.opensearch.maxShardsPerNode }}
 
 defaultRules:
   create: true

--- a/helmfile.d/values/prometheus-user-alerts-wc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-user-alerts-wc.yaml.gotmpl
@@ -8,6 +8,8 @@
 {{- $groupLabelValueArray := .Values.prometheus.autoscaledNodeGroupAlerts.groupLabelValues -}}
 {{- $groupLabelValueArrayRegex := join "|" $groupLabelValueArray -}}
 
+osMaxShardsPerNode: 0
+osDataNodeCount: 0
 osNodeCount: 0
 alertmanagerJob: alertmanager-operated
 alertmanagerNamespace: alertmanager


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Adds an alert for when the combined total shards is greater than 90% of the `maxShardsPerNode` value.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes https://github.com/elastisys/compliantkubernetes-apps/issues/2684

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
