### PR TITLE
tests: changed unit test dockerfile and schema bats

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -18,7 +18,7 @@ ARG TZ="Etc/UTC"
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y apache2-utils curl dnsutils gettext-base git gpg iputils-ping jq locales make net-tools nodejs parallel pwgen python3-pip s3cmd ssh unzip && \
+    apt-get install -y apache2-utils curl dnsutils gettext-base git gpg iputils-ping jq locales make net-tools nodejs parallel pwgen python3-venv s3cmd ssh unzip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
@@ -97,11 +97,14 @@ RUN git clone --depth 1 https://github.com/grayhemp/bats-mock.git /usr/local/lib
 RUN git clone --depth 1 https://github.com/bats-core/bats-support.git /usr/local/lib/bats/support
 
 ENV DOCS_PATH="/usr/local/share/docs"
-RUN git clone --depth 1 https://github.com/elastisys/welkin.git "${DOCS_PATH}" && \
-    chmod --recursive a+w "${DOCS_PATH}" && \
-    python3 -m pip install --no-cache-dir --break-system-packages jsonref requests pyyaml
+RUN git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/elastisys/welkin.git "${DOCS_PATH}" && \
+    chmod -R a+w "${DOCS_PATH}" && \
+    python3 -m venv /opt/docs-venv && \
+    /opt/docs-venv/bin/python -m pip install --upgrade pip && \
+    cd "${DOCS_PATH}" && \
+    /opt/docs-venv/bin/pip install --no-cache-dir -r requirements.txt
 
-ENV PATH="$PATH:/usr/local/lib/node_modules/.bin"
+ENV PATH="/opt/docs-venv/bin:${PATH}:/usr/local/lib/node_modules/.bin"
 COPY --from=node-deps /usr/local/lib/node_modules/welkin-test/node_modules /usr/local/lib/node_modules
 
 # Container to run integration and end-to-end tests

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -18,6 +18,7 @@ ARG TZ="Etc/UTC"
 
 RUN apt-get update && \
     apt-get upgrade -y && \
+    apt-get install -y python3-pip && \
     apt-get install -y apache2-utils curl dnsutils gettext-base parallel git gpg iputils-ping jq locales make net-tools nodejs pwgen s3cmd ssh unzip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
@@ -98,7 +99,8 @@ RUN git clone --depth 1 https://github.com/bats-core/bats-support.git /usr/local
 
 ENV DOCS_PATH="/usr/local/share/docs"
 RUN git clone --depth 1 https://github.com/elastisys/welkin.git "${DOCS_PATH}" && \
-    chmod --recursive a+w "${DOCS_PATH}"
+    chmod --recursive a+w "${DOCS_PATH}" && \
+    python3 -m pip install --no-cache-dir --break-system-packages jsonref requests pyyaml
 
 ENV PATH="$PATH:/usr/local/lib/node_modules/.bin"
 COPY --from=node-deps /usr/local/lib/node_modules/welkin-test/node_modules /usr/local/lib/node_modules

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -18,8 +18,7 @@ ARG TZ="Etc/UTC"
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y python3-pip && \
-    apt-get install -y apache2-utils curl dnsutils gettext-base parallel git gpg iputils-ping jq locales make net-tools nodejs pwgen s3cmd ssh unzip && \
+    apt-get install -y apache2-utils curl dnsutils gettext-base git gpg iputils-ping jq locales make net-tools nodejs parallel pwgen python3-pip s3cmd ssh unzip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8

--- a/tests/unit/general/schema.bats
+++ b/tests/unit/general/schema.bats
@@ -120,7 +120,7 @@ find_schemas() {
 @test "documentation should be generated" {
   pushd "${DOCS_PATH}" || exit 1
 
-  run "./scripts/jsonschema2md.sh" --path "${APPS_PATH}"
+  run "./scripts/jsonschema2md.py" "${APPS_PATH}/config/schemas"
 
   popd || exit 1
 


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

With respect to the recent change in the Welkin repository(https://github.com/elastisys/welkin/blob/main/scripts/jsonschema2md.py), I updated the unit-test Dockerfile and the schema Bats test to use the new Python jsonschema2md.py script.
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
