### PR TITLE
scripts: QA install additions

### DIFF
--- a/scripts/qa/config.json.sample
+++ b/scripts/qa/config.json.sample
@@ -7,10 +7,10 @@
       "clientSecret": "set-me"
     }
   },
-  "externalDns": {
+  "dnsProvider": {
     "domain": "set-me",
-    "hostedZone": "set-me",
     "aws": {
+      "hostedZone": "set-me",
       "accessKey": "set-me",
       "secretKey": "set-me"
     }

--- a/scripts/qa/install_apps.py
+++ b/scripts/qa/install_apps.py
@@ -38,30 +38,60 @@ class Args:
 
     @property
     def domain(self) -> str:
-        return f"{self.environment_name}.{self.config['externalDns']['domain']}"
-
-
-AwsSecrets = TypedDict(
-    "AwsSecrets",
-    {"accessKey": str, "secretKey": str},
-)
-
-SwiftSecrets = TypedDict(
-    "SwiftSecrets",
-    {"applicationCredentialID": str, "applicationCredentialSecret": str},
-)
-
-StorageSecrets = TypedDict(
-    "StorageSecrets",
-    {"s3": AwsSecrets, "swift": SwiftSecrets},
-)
+        return f"{self.environment_name}.{self.config['dnsProvider']['domain']}"
 
 GcpSecrets = TypedDict("GcpSecrets", {"clientID": str, "clientSecret": str})
 
 DexSecrets = TypedDict("DexSecrets", {"gcp": GcpSecrets})
 
-ExternalDnsConfig = TypedDict(
-    "ExternalDnsConfig", {"domain": str, "hostedZone": str, "aws": AwsSecrets}
+DnsProviderConfig = TypedDict(
+    "DnsProviderConfig",
+    {
+        "domain": str,
+        "aws": {
+            "hostedZone": str,
+            "accessKey": str,
+            "secretKey": str
+        }
+    }
+)
+
+ExternalLoadbalancers = TypedDict(
+    "ExternalLoadbalancers",
+    {
+        "scAddress": Optional[str],
+        "scDomainName": Optional[str],
+        "scProxyProtocol": Optional[bool],
+        "wcAddress": Optional[str],
+        "wcDomainName": Optional[str],
+        "wcProxyProtocol": Optional[bool]
+    }
+)
+
+S3Secrets = TypedDict(
+    "S3Secrets",
+    {
+        "region": Optional[str],
+        "regionEndpoint": Optional[str],
+        "accessKey": str,
+        "secretKey": str
+    }
+)
+
+SwiftSecrets = TypedDict(
+    "SwiftSecrets",
+    {
+        "applicationCredentialID": str,
+        "applicationCredentialSecret": str
+    }
+)
+
+StorageSecrets = TypedDict(
+    "StorageSecrets",
+    {
+        "s3": Optional[S3Secrets],
+        "swift": Optional[SwiftSecrets]
+    }
 )
 
 Subnets = TypedDict(
@@ -73,33 +103,18 @@ Subnets = TypedDict(
     },
 )
 
-
 class Config(TypedDict):
     """Holds secrets"""
 
     kubeloginClientSecret: str
     adminGroup: str
     dex: DexSecrets
-    externalDns: ExternalDnsConfig
+    dnsProvider: DnsProviderConfig
+    externalLoadbalancers: Optional[ExternalLoadbalancers]
     objectStorage: StorageSecrets
 
     wcSubnets: Subnets
     scSubnets: Subnets
-
-
-def initialize_apps() -> None:
-    """Initialize apps"""
-    _run_ck8s("init", "both")
-
-
-def set_objectstorage_secrets(secrets_path: Path, secrets: StorageSecrets) -> None:
-    """Set objectstorage secrets"""
-    _set_secret_key(secrets_path, '["objectStorage"]', dict(secrets))
-
-
-def update_ips(cluster: str) -> None:
-    """Update IPs"""
-    _run_ck8s("update-ips", cluster, "apply")
 
 
 def configure_apps(
@@ -107,22 +122,59 @@ def configure_apps(
 ) -> None:
     """Configure apps"""
 
-    opensearch_cfg = cast(dict, sc_config.get("opensearch"))
+    # Configure platform administrators
+    common_config.set("clusterAdmin", {"users": [], "groups": [args.config["adminGroup"]]})
 
-    # Set domains
+    # Configure application developers
+    wc_config.set(
+        "user",
+        {
+            "namespaces": ["production", "staging"],
+            "adminUsers": ALL_USERS,
+            "adminGroups": [],
+        },
+    )
+
+    # Configure domains
     common_config.set(
         "global",
         {"baseDomain": args.domain, "opsDomain": f"ops.{args.domain}"},
     )
 
+    # Configure external loadbalancer
+    try:
+        cond = args.config["externalLoadbalancers"]["scProxyProtocol"]
+        sc_config.set("ingressNginx.controller.config", {"useProxyProtocol": cond})
+    except KeyError:
+        pass # Use default
+    try:
+        cond = args.config["externalLoadbalancers"]["wcProxyProtocol"]
+        wc_config.set("ingressNginx.controller.config", {"useProxyProtocol": cond})
+    except KeyError:
+        pass # Use default
+
+    # Configure object storage
+    try:
+        region = args.config["objectStorage"]["s3"]["region"]
+        if region != "":
+            common_config.set("objectStorage.s3", {"region": region})
+    except KeyError:
+        pass # Use default
+    try:
+        regionEndpoint = args.config["objectStorage"]["s3"]["regionEndpoint"]
+        if region != "":
+            common_config.set("objectStorage.s3", {"regionEndpoint": regionEndpoint})
+    except KeyError:
+        pass # Use default
+
     # Configure cluster issuers
     dns_solver = {
-        "selector": {"dnsZones": [args.config["externalDns"]["domain"]]},
+        "selector": {"dnsZones": [args.config["dnsProvider"]["domain"]]},
         "dns01": {
             "route53": {
                 "region": "eu-north-1",
-                "hostedZoneID": args.config["externalDns"]["hostedZone"],
-                "accessKeyID": args.config["externalDns"]["aws"]["accessKey"],
+                "hostedZoneID": args.config["dnsProvider"]["aws"]["hostedZone"],
+                "accessKeyID": args.config["dnsProvider"]["aws"]["accessKey"],
                 "secretAccessKeySecretRef": {
                     "name": "route53-credentials-secret",
                     "key": "secretKey",
@@ -144,10 +196,7 @@ def configure_apps(
         },
     )
 
-    # Configure cluster admin
-    common_config.set("clusterAdmin", {"users": [], "groups": [args.config["adminGroup"]]})
-
-    # Configure allowed OPA registries
+    # Configure OPA allowed registries
     common_config.set(
         "opa.imageRegistry.URL",
         [
@@ -157,40 +206,7 @@ def configure_apps(
         ],
     )
 
-    # Use BPF Driver for Falco
-    common_config.set("falco.driver", {"kind": "modern-bpf"})
-
-    # Disable Felix metrics
-    common_config.set("networkPlugin.calico.calicoFelixMetrics", {"enabled": False})
-
-    # Open up Network Policies
-    common_config.set(
-        "networkPolicies",
-        {
-            "harbor": {"jobservice": ALL_IPS, "trivy": ALL_IPS, "registries": ALL_IPS},
-            "opensearch": {"plugins": ALL_IPS},
-            "dex": {"connectors": ALL_IPS},
-            "coredns": {"externalDns": ALL_IPS},
-            "kured": {"notificationSlack": ALL_IPS},
-            "falco": {"plugins": ALL_IPS},
-            "alertmanager": {"alertReceivers": ALL_IPS},
-            "global": {"trivy": ALL_IPS, "wcIngress": ALL_IPS, "scIngress": ALL_IPS},
-        },
-    )
-
-    sc_config.set("networkPolicies.global", {"scApiserver": ALL_IPS, "scNodes": ALL_IPS})
-    wc_config.set("networkPolicies.global", {"wcApiserver": ALL_IPS, "wcNodes": ALL_IPS})
-
-    sc_config.set(
-        "networkPolicies",
-        {"monitoring": {"grafana": {"externalDashboardProvider": ALL_IPS}}},
-    )
-
-    # Configure Harbor in SC
-    sc_config.set("harbor.oidc", {"adminGroupName": args.config["adminGroup"]})
-    # sc_config.set("harbor.trivy.persistentVolumeClaim", {"size": "10Gi"})
-
-    # Configure Dex in SC
+    # Configure Dex Google group support and static login
     sc_config.set(
         "dex",
         {
@@ -199,7 +215,10 @@ def configure_apps(
         },
     )
 
-    # Configure Grafanas
+    # Configure Falco BPF driver
+    common_config.set("falco.driver", {"kind": "modern-bpf"})
+
+    # Configure Grafana with test requirements
     grafana_cfg = {
         "trailingDots": False,
         "oidc": {
@@ -210,7 +229,12 @@ def configure_apps(
     sc_config.set("grafana.ops", grafana_cfg)
     sc_config.set("grafana.user", grafana_cfg)
 
-    # Configure opensearch user mappings
+    # Configure Harbor administrator group
+    sc_config.set("harbor.oidc", {"adminGroupName": args.config["adminGroup"]})
+    # sc_config.set("harbor.trivy.persistentVolumeClaim", {"size": "10Gi"})
+
+    # Configure OpenSearch role mappings
+    opensearch_cfg = cast(dict, sc_config.get("opensearch"))
     all_access_found = False
     for mapping in opensearch_cfg["extraRoleMappings"]:
         if mapping["mapping_name"] == "all_access":
@@ -229,46 +253,42 @@ def configure_apps(
     # Disable OpsGenie heartbeat
     sc_config.set("alerts", {"opsGenieHeartbeat": {"enabled": False}})
 
-    # Configure WC admin users
-    wc_config.set(
-        "user",
+    # Disable Calico Felix metrics
+    common_config.set("networkPlugin.calico.calicoFelixMetrics", {"enabled": False})
+
+    # Open up Network Policies
+    common_config.set(
+        "networkPolicies",
         {
-            "namespaces": ["production", "staging"],
-            "adminUsers": ALL_USERS,
-            "adminGroups": [],
+            "global": {"scIngress": ALL_IPS, "wcIngress": ALL_IPS, "trivy": ALL_IPS},
+            "alertmanager": {"alertReceivers": ALL_IPS},
+            "coredns": {"externalDns": ALL_IPS},
+            "dex": {"connectors": ALL_IPS},
+            "falco": {"plugins": ALL_IPS},
+            "harbor": {"jobservice": ALL_IPS, "registries": ALL_IPS, "trivy": ALL_IPS},
+            "kured": {"notificationSlack": ALL_IPS},
+            "opensearch": {"plugins": ALL_IPS},
         },
+    )
+
+    sc_config.set("networkPolicies.global", {"scApiserver": ALL_IPS, "scNodes": ALL_IPS})
+    wc_config.set("networkPolicies.global", {"wcApiserver": ALL_IPS, "wcNodes": ALL_IPS})
+
+    sc_config.set(
+        "networkPolicies",
+        {"monitoring": {"grafana": {"externalDashboardProvider": ALL_IPS}}},
     )
 
 
 def configure_secrets(secrets_path: Path, args: Args) -> None:
     """Configure secrets"""
+    # Configure Dex client secret for Kubernetes API
     _set_secret_key(
         secrets_path,
         '["dex"]["kubeloginClientSecret"]',
         args.config["kubeloginClientSecret"],
     )
-
-    _set_secret_key(
-        secrets_path,
-        '["issuers"]',
-        {
-            "secrets": {
-                "route53-credentials-secret": {
-                    "secretKey": args.config["externalDns"]["aws"]["secretKey"]
-                }
-            }
-        },
-    )
-    _set_secret_key(
-        secrets_path,
-        '["externalDns"]',
-        {
-            "awsRoute53": {
-                "accessKey": args.config["externalDns"]["aws"]["accessKey"],
-                "secretKey": args.config["externalDns"]["aws"]["secretKey"],
-            }
-        },
-    )
+    # Configure Dex connector to Google
     _set_secret_key(
         secrets_path,
         '["dex"]["connectors"][0]',
@@ -287,7 +307,6 @@ def configure_secrets(secrets_path: Path, args: Args) -> None:
             },
         },
     )
-
     # Configure the 'dev@example.com' static user
     _set_secret_key(
         secrets_path,
@@ -301,15 +320,66 @@ def configure_secrets(secrets_path: Path, args: Args) -> None:
         },
     )
 
+    # Configure cert-manager AWS secrets
+    _set_secret_key(
+        secrets_path,
+        '["issuers"]',
+        {
+            "secrets": {
+                "route53-credentials-secret": {
+                    "secretKey": args.config["dnsProvider"]["aws"]["secretKey"]
+                }
+            }
+        },
+    )
+    # Configure ExternalDNS AWS secrets
+    _set_secret_key(
+        secrets_path,
+        '["externalDns"]',
+        {
+            "awsRoute53": {
+                "accessKey": args.config["dnsProvider"]["aws"]["accessKey"],
+                "secretKey": args.config["dnsProvider"]["aws"]["secretKey"],
+            }
+        },
+    )
 
-def install_ingress(cluster: str) -> str:
+    # Configure object storage secrets
+    if "s3" in args.config["objectStorage"]:
+        _set_secret_key(
+            secrets_path,
+            '["objectStorage"]["s3"]',
+            {
+                "accessKey": args.config["objectStorage"]["s3"]["accessKey"],
+                "secretKey": args.config["objectStorage"]["s3"]["secretKey"]
+            }
+        )
+    if "swift" in args.config["objectStorage"]:
+        _set_secret_key(
+            secrets_path,
+            '["objectStorage"]["swift"]',
+            {
+                "applicationCredentialID": args.config["objectStorage"]["swift"]["applicationCredentialID"],
+                "applicationCredentialSecret": args.config["objectStorage"]["swift"]["applicationCredentialSecret"]
+            }
+        )
+
+
+def install_ingress(cluster: str, args: Args) -> str:
     """Install Ingress"""
     # fmt: off
     _run_ck8s(
         "ops", "helmfile", cluster,
         "-l", "app=ingress-nginx",
-        "sync", "--include-transitive-needs"
+        "sync" if args.use_sync else "apply", "--include-transitive-needs"
     )
+
+    if "externalLoadbalancers" in args.config:
+        if f"{cluster}DomainName" in args.config["externalLoadbalancers"]:
+            return ""
+        if f"{cluster}IP" in args.config["externalLoadbalancers"]:
+            return args.config["externalLoadbalancers"][f"{cluster}IP"]
+
     # fmt: on
     _run_ck8s(
         *f"ops kubectl {cluster} wait -n ingress-nginx "
@@ -319,29 +389,45 @@ def install_ingress(cluster: str) -> str:
     return _get_ingress_ip(cluster)
 
 
-def configure_external_dns(
+def install_external_dns(
     cluster_config: AppsConfig,
+    cluster: str,
     dns_names: list[str],
     ingress_ip: str,
     args: Args,
 ) -> None:
     """Configure External DNS"""
+
     record_common = {"recordTTL": 180, "recordType": "A", "targets": [ingress_ip]}
+
+    try:
+        domain_name = args.config["externalLoadbalancers"][f"{cluster}DomainName"]
+        if domain_name != "":
+            record_common = {"recordTTL": 180, "recordType": "CNAME", "targets": [domain_name]}
+    except KeyError:
+        pass # Use A records
 
     dns_config = {
         "enabled": True,
         "txtOwnerId": args.environment_name,
         "txtPrefix": args.environment_name,
-        "domains": [args.config["externalDns"]["domain"]],
+        "domains": [args.config["dnsProvider"]["domain"]],
         "sources": {"crd": True, "ingress": False, "service": False},
         "endpoints": [{**record_common, "dnsName": dns_name} for dns_name in dns_names],
     }
     cluster_config.set("externalDns", dns_config)
 
+    # fmt: off
+    _run_ck8s(
+        "ops", "helmfile", cluster,
+        "-l", "app=external-dns",
+        "sync" if args.use_sync else "apply", "--include-transitive-needs"
+    )
 
-def install_dex() -> None:
+
+def install_dex(args: Args) -> None:
     """Install Dex"""
-    _run_ck8s("ops", "helmfile", "sc", "-l", "app=admin-namespaces", "sync")
+    _run_ck8s("ops", "helmfile", "sc", "-l", "app=admin-namespaces", "sync" if args.use_sync else "apply")
     _run(
         "bash",
         "-c",
@@ -351,10 +437,9 @@ def install_dex() -> None:
     # fmt: off
     _run_ck8s(
         "ops", "helmfile", "sc",
-        "-l", "app=external-dns",
         "-l", "app=cert-manager",
         "-l", "app=dex",
-        "sync",
+        "sync" if args.use_sync else "apply", "--include-transitive-needs"
     )
     _run(
         "timeout", "300",
@@ -372,16 +457,17 @@ def reconfigure_ips(
     common_config: AppsConfig, sc_config: AppsConfig, wc_config: AppsConfig, args: Args
 ) -> None:
     """Reconfigure IPs"""
-    if (wc_ingress_subnet := args.config["wcSubnets"].get("ingress")) is not None:
-        common_config.set(
-            "networkPolicies",
-            {"global": {"wcIngress": {"ips": wc_ingress_subnet}}},
-        )
 
     if (sc_ingress_subnet := args.config["scSubnets"].get("ingress")) is not None:
         common_config.set(
             "networkPolicies",
-            {"global": {"wcIngress": {"ips": sc_ingress_subnet}}},
+            {"global": {"scIngress": {"ips": sc_ingress_subnet}}},
+        )
+
+    if (wc_ingress_subnet := args.config["wcSubnets"].get("ingress")) is not None:
+        common_config.set(
+            "networkPolicies",
+            {"global": {"wcIngress": {"ips": wc_ingress_subnet}}},
         )
 
     sc_config.set(
@@ -401,14 +487,23 @@ def reconfigure_ips(
     )
 
 
-def sync_apps(cluster: str) -> None:
-    """Sync apps"""
-    _run_ck8s("apply", cluster, "--sync", f"--concurrency={os.cpu_count() or 8}")
+# Apps commands
 
+def initialize_apps() -> None:
+    """Initialize apps"""
+    _run_ck8s("init", "both")
+
+def update_ips(cluster: str) -> None:
+    """Update IPs"""
+    _run_ck8s("update-ips", cluster, "apply")
 
 def apply_apps(cluster: str) -> None:
     """Apply apps"""
     _run_ck8s("apply", cluster, f"--concurrency={os.cpu_count() or 8}")
+
+def sync_apps(cluster: str) -> None:
+    """Sync apps"""
+    _run_ck8s("apply", cluster, "--sync", f"--concurrency={os.cpu_count() or 8}")
 
 
 def main() -> None:
@@ -428,20 +523,20 @@ def main() -> None:
     secrets_path = config_path / "secrets.yaml"
 
     _step(initialize_apps)()
-    _step(set_objectstorage_secrets)(secrets_path, args.config["objectStorage"])
     _step(configure_apps)(common_config, sc_config, wc_config, args)
     _step(configure_secrets)(secrets_path, args)
     _step(update_ips, doc_suffix="for both clusters")("both")
-    sc_ingress_ip = _step(install_ingress, doc_suffix="in SC")("sc") or ""
-    _step(configure_external_dns, doc_suffix="for SC")(
+    sc_ingress_ip = _step(install_ingress, doc_suffix="in SC")("sc", args) or ""
+    _step(install_external_dns, doc_suffix="for SC")(
         sc_config,
+        "sc",
         ["*.ops", "dex", "grafana", "harbor", "opensearch"],
         sc_ingress_ip,
         args,
     )
-    _step(install_dex)()
-    wc_ingress_ip = _step(install_ingress, doc_suffix="in WC")("wc") or ""
-    _step(configure_external_dns, doc_suffix="for WC")(wc_config, ["*"], wc_ingress_ip, args)
+    _step(install_dex)(args)
+    wc_ingress_ip = _step(install_ingress, doc_suffix="in WC")("wc", args) or ""
+    _step(install_external_dns, doc_suffix="for WC")(wc_config, "wc", ["*"], wc_ingress_ip, args)
     _step(reconfigure_ips)(common_config, sc_config, wc_config, args)
     _step(update_ips, doc_suffix="for both clusters")("both")
     if args.use_sync:
@@ -450,16 +545,6 @@ def main() -> None:
     else:
         _step(apply_apps, doc_suffix="in SC")("sc")
         _step(apply_apps, doc_suffix="in WC")("wc")
-
-
-def _check_ck8s_env(*var_names: str) -> None:
-    missing_vars = [
-        f"CK8S_{var_name}" for var_name in var_names if f"CK8S_{var_name}" not in os.environ
-    ]
-
-    if missing_vars:
-        print(f"Fatal: {', '.join(missing_vars)} not set.", file=sys.stderr)
-        sys.exit(1)
 
 
 def _parse_arguments(**environment: str) -> tuple[StepArgs, Args]:
@@ -515,13 +600,23 @@ def _validate_subnet(subnet: str) -> str:
         raise argparse.ArgumentTypeError(f"Invalid IP address: {subnet} ({e})")
 
 
-def _run_ck8s(*args: str, **kwargs: Any) -> None:
-    env_arg = os.environ | ({} if STEP_ARGS.get().interactive else {"CK8S_AUTO_APPROVE": "true"})
-    _run(str(BIN_DIR / "ck8s"), *args, **kwargs, env=env_arg)
+def _check_ck8s_env(*var_names: str) -> None:
+    missing_vars = [
+        f"CK8S_{var_name}" for var_name in var_names if f"CK8S_{var_name}" not in os.environ
+    ]
+
+    if missing_vars:
+        print(f"Fatal: {', '.join(missing_vars)} not set.", file=sys.stderr)
+        sys.exit(1)
 
 
 def _get_ck8s_json(*args: str, **kwargs: Any) -> list | dict:
     return _get_json(str(BIN_DIR / "ck8s"), *args, **kwargs) or {}
+
+
+def _run_ck8s(*args: str, **kwargs: Any) -> None:
+    env_arg = os.environ | ({} if STEP_ARGS.get().interactive else {"CK8S_AUTO_APPROVE": "true"})
+    _run(str(BIN_DIR / "ck8s"), *args, **kwargs, env=env_arg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Tested to work with UpCloud, added:
- region and region endpoint for S3
- external loadbalancer support (and a bugfix for reconfigure IPs)
- made swift optional

Did some reshuffling to make it easier to go through for me at least but let me know if you disagree on some stuff.

Consolidated configuring object storage secrets and configuring secrets, as it didn't feel like it needed to be separate.

Move install of ExternalDNS to be on the same as its configuring, as it feels more logical to me than it being pulled in by Dex.

#### Information to reviewers

Also I don't usually write Python so let me know what improvements I can make.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
