### PR TITLE
apps: cilium network fixes

### DIFF
--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -6550,24 +6550,14 @@ properties:
       - calico
     if:
       properties:
-        calico:
-          anyOf:
-          - properties:
-              calicoAccountant:
-                properties:
-                  enabled:
-                    type: boolean
-                    const: true
-          - properties:
-              calicoFelixMetrics:
-                properties:
-                  enabled:
-                    type: boolean
-                    const: true
-    then:
-      properties:
         type:
           const: "calico"
+    then:
+      properties:
+        calico:
+          required:
+            - calicoAccountant
+            - calicoFelixMetrics
   certmanager:
     title: cert-manager Config
     description: Configure cert-manager, used to provision certificates either self-signed or via Let's Encrypt.

--- a/helmfile.d/charts/networkpolicy/service-cluster/templates/ingress-nginx/controller.yaml
+++ b/helmfile.d/charts/networkpolicy/service-cluster/templates/ingress-nginx/controller.yaml
@@ -34,6 +34,17 @@ spec:
       {{- end }}
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: opensearch-system
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: harbor
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: core
+              app.kubernetes.io/instance: harbor
+              app.kubernetes.io/name: harbor
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: monitoring
           podSelector:
             matchLabels:


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Due to differences in how network policies work between Cilium/Calico, these changes to network policies seem to be needed. If you have a Cilium cluster with apps installed feel free to test this to confirm.

You could not get redirected to dex from harbor without this change (Internal server error)

Harbor core error
```
2025-09-04T19:24:00Z [ERROR] [/pkg/oidc/helper.go:166]: Failed to get OAuth configuration, error: failed to create OIDC provider, error: Get "https://dex.marcus-elastx.dev-ck8s.com/.well-known/openid-configuration": context canceled
2025-09-04T19:24:00Z [ERROR] [/lib/http/error.go:58]: {"errors":[{"code":"INTERNAL_SERVER_ERROR","message":"failed to create OIDC provider, error: Get \"https://dex.marcus-elastx.dev-ck8s.com/.well-known/openid-configuration\": context canceled"}]} 
```

Similarly Opensearch dashboards did not redirect back to opensearch dashboards after dex login without the change to network policy.


Also I fixed this schema error that appeared after setting Cilium as network plugin (to prevent install of calico related stuff)
```
[ck8s] Failed schema validation:
sc-config.yaml: networkPlugin: Must validate "then" as "if" was valid
sc-config.yaml: networkPlugin.type: networkPlugin.type does not match: "calico"
1 of 1 failed validation
```


<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
