### PR TITLE
falco: switch over to the 'modern_ebpf' driver by default

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -182,7 +182,7 @@ falco:
   ## configure syscall source
   ## ref: https://falco.org/docs/concepts/event-sources/kernel/
   driver:
-    kind: kmod
+    kind: "modern-bpf"
 
     ebpf:
       # -- Path where the eBPF probe is located. It comes handy when the probe have been installed in the nodes using tools other than the init

--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -182,7 +182,7 @@ falco:
   ## configure syscall source
   ## ref: https://falco.org/docs/concepts/event-sources/kernel/
   driver:
-    kind: "modern_ebpf"
+    kind: modern_ebpf
 
     ebpf:
       # -- Path where the eBPF probe is located. It comes handy when the probe have been installed in the nodes using tools other than the init

--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -182,7 +182,7 @@ falco:
   ## configure syscall source
   ## ref: https://falco.org/docs/concepts/event-sources/kernel/
   driver:
-    kind: "modern-bpf"
+    kind: "modern_ebpf"
 
     ebpf:
       # -- Path where the eBPF probe is located. It comes handy when the probe have been installed in the nodes using tools other than the init

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -3221,11 +3221,11 @@ properties:
             default: kmod
             enum:
               - kmod
-              - modern-bpf
+              - modern_ebpf
               - ebpf
             meta:enum:
               kmod: Kernel module (default)
-              modern-bpf: Modern eBPF probe
+              modern_ebpf: Modern eBPF probe
               ebpf: Legacy eBPF probe
         if:
           properties:
@@ -3251,7 +3251,7 @@ properties:
             kind:
               type: string
               enum:
-                - modern-bpf
+                - modern_ebpf
                 - ebpf
             ebpf:
               additionalProperties: false

--- a/helmfile.d/values/falco/falco-common.yaml.gotmpl
+++ b/helmfile.d/values/falco/falco-common.yaml.gotmpl
@@ -75,8 +75,8 @@ driver:
     {{- end }}
     hostNetwork: {{ .Values.falco.driver.ebpf.hostNetwork }}
     leastPrivileged: true
-  {{- else if eq .Values.falco.driver.kind "modern-bpf" }}
-  modern_bpf:
+  {{- else if eq .Values.falco.driver.kind "modern_ebpf" }}
+  modernEbpf:
     leastPrivileged: true
   {{- end }}
   loader:

--- a/migration/v0.49/prepare/10-rename-falco-modern-bpf.sh
+++ b/migration/v0.49/prepare/10-rename-falco-modern-bpf.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+rename_falco_driver() {
+  local -r cluster="${1}"
+  local current_driver
+  current_driver="$(yq_dig "${cluster}" '.falco.driver.kind')"
+
+  if [[ "${current_driver}" == "modern-bpf" ]]; then
+    log_info "Renaming falco driver from modern-bpf to modern_ebpf in ${cluster}-config..."
+    yq_add "${cluster}" '.falco.driver.kind' '"modern_ebpf"'
+  fi
+}
+
+if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+  rename_falco_driver sc
+fi
+if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+  rename_falco_driver wc
+fi
+rename_falco_driver common

--- a/migration/v0.49/prepare/10-update-falco-driver.sh
+++ b/migration/v0.49/prepare/10-update-falco-driver.sh
@@ -6,21 +6,21 @@ ROOT="$(readlink -f "${HERE}/../../../")"
 # shellcheck source=scripts/migration/lib.sh
 source "${ROOT}/scripts/migration/lib.sh"
 
-rename_falco_driver() {
+update_falco_driver() {
   local -r cluster="${1}"
   local current_driver
   current_driver="$(yq_dig "${cluster}" '.falco.driver.kind')"
 
-  if [[ "${current_driver}" == "modern-bpf" ]]; then
-    log_info "Renaming falco driver from modern-bpf to modern_ebpf in ${cluster}-config..."
+  if [[ "${current_driver}" == "modern-bpf" ]] || [[ "${current_driver}" == "kmod" ]]; then
+    log_info "Updating falco driver from ${current_driver} to modern_ebpf in ${cluster}-config..."
     yq_add "${cluster}" '.falco.driver.kind' '"modern_ebpf"'
   fi
 }
 
 if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
-  rename_falco_driver sc
+  update_falco_driver sc
 fi
 if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
-  rename_falco_driver wc
+  update_falco_driver wc
 fi
-rename_falco_driver common
+update_falco_driver common

--- a/tests/unit/general/images.bats
+++ b/tests/unit/general/images.bats
@@ -17,6 +17,7 @@ setup_file() {
   env.init openstack capi dev
 
   yq.set sc .externalDns.enabled 'true'
+  yq.set sc .falco.driver.kind '"kmod"'
   yq.set sc .fluentd.enabled 'true'
   yq.set sc .gpu.enabled 'true'
   yq.set sc .harbor.backup.enabled 'true'
@@ -35,6 +36,7 @@ setup_file() {
 
   yq.set wc .hnc.enabled 'true'
   yq.set wc .velero.enabled 'true'
+  yq.set wc .falco.driver.kind '"kmod"'
   _setup_rclone wc sync
 }
 


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice

The migration introduced in this PR will have two effects:
- environments that already use the `modern-bpf` driver will be updated to the correct `modern_ebpf` value
- environments using the `kmod` driver will be be updated to `modern_ebpf`

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

As the title suggests, it's high-time we switched to the `modern-bpf` driver as the default for Falco. Security GoTo task.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
