### PR TITLE
apps: Removal of previous work-around to increase vm.max_map_count for OpenSearch

### DIFF
--- a/helmfile.d/lists/images.yaml
+++ b/helmfile.d/lists/images.yaml
@@ -75,7 +75,6 @@ images:
     image: registry.k8s.io/dns/k8s-dns-node-cache:1.25.0
   opensearch:
     image: docker.io/opensearchproject/opensearch:2.19.3
-    initSysctl: ghcr.io/elastisys/curl-jq:1.0.0
     dashboards: docker.io/opensearchproject/opensearch-dashboards:2.19.3
     configurerJob: ghcr.io/elastisys/curl-jq:1.0.0
     curatorCronjob: ghcr.io/elastisys/bitnami/elasticsearch-curator:5.8.4-debian-10-r235

--- a/helmfile.d/stacks/opensearch.yaml.gotmpl
+++ b/helmfile.d/stacks/opensearch.yaml.gotmpl
@@ -6,16 +6,6 @@ templates:
     labels:
       app: opensearch
 
-  opensearch-podsecuritypolicy:
-    inherit:
-      - template: opensearch
-      - template: podsecuritypolicies
-    installed: {{ and (.Values | get "ck8sManagementCluster.enabled" false) (.Values | get "opensearch.enabled" false) }}
-    labels:
-      psp: opensearch
-    values:
-      - values/podsecuritypolicies/service/opensearch.yaml.gotmpl
-
   opensearch-secrets:
     disableValidationOnInstall: true # creates cert-manager/certificates
     inherit: [ template: opensearch ]
@@ -41,7 +31,6 @@ templates:
       {{- end }}
       - kube-system/service-cluster-np
       - opensearch-system/opensearch-secrets
-      - opensearch-system/podsecuritypolicy
     values:
       - values/opensearch/common.yaml.gotmpl
       - values/opensearch/master.yaml.gotmpl
@@ -56,7 +45,6 @@ templates:
     needs:
       - kube-system/service-cluster-np
       - opensearch-system/opensearch-master
-      - opensearch-system/podsecuritypolicy
     values:
       - values/opensearch/common.yaml.gotmpl
       - values/opensearch/client.yaml.gotmpl
@@ -71,7 +59,6 @@ templates:
     needs:
       - kube-system/service-cluster-np
       - opensearch-system/opensearch-master
-      - opensearch-system/podsecuritypolicy
     values:
       - values/opensearch/common.yaml.gotmpl
       - values/opensearch/data.yaml.gotmpl
@@ -89,7 +76,6 @@ templates:
       {{- end }}
       - kube-system/service-cluster-np
       - opensearch-system/opensearch-master
-      - opensearch-system/podsecuritypolicy
     values:
       - values/opensearch/dashboards.yaml.gotmpl
     wait: true

--- a/helmfile.d/state.yaml.gotmpl
+++ b/helmfile.d/state.yaml.gotmpl
@@ -163,7 +163,6 @@ releases:
   - inherit: [ template: harbor-backup ]
   - inherit: [ template: harbor-mpu-cleaner ]
 
-  - inherit: [ template: opensearch-podsecuritypolicy ]
   - inherit: [ template: opensearch-secrets ]
   - inherit: [ template: opensearch-master ]
   - inherit: [ template: opensearch-client ]

--- a/helmfile.d/values/admin-namespaces-sc.yaml.gotmpl
+++ b/helmfile.d/values/admin-namespaces-sc.yaml.gotmpl
@@ -67,9 +67,9 @@ namespaces:
       pod-security.kubernetes.io/warn: privileged
   - name: opensearch-system
     labels:
-      pod-security.kubernetes.io/audit: privileged
-      pod-security.kubernetes.io/enforce: privileged
-      pod-security.kubernetes.io/warn: privileged
+      pod-security.kubernetes.io/audit: restricted
+      pod-security.kubernetes.io/enforce: restricted
+      pod-security.kubernetes.io/warn: restricted
   {{ if or (.Values.objectStorage.sync.enabled) (.Values.objectStorage.restore.enabled) }}
   - name: rclone
     labels:

--- a/helmfile.d/values/opensearch/common.yaml.gotmpl
+++ b/helmfile.d/values/opensearch/common.yaml.gotmpl
@@ -125,28 +125,6 @@ extraEnvs:
   - name: DISABLE_INSTALL_DEMO_CONFIG
     value: "true"
 
-# This is a workaround to set vm.max_map_count before OpenSearch starts.
-# The chart provides this using non privileged container, and instead allows the unsafe sysctl through PSP.
-# However this relies on the unsafe sysctl to be allowed in kubelet, which it is not by default.
-extraInitContainers:
-  - name: init-sysctl
-    {{- with .Values.images | dig "opensearch" "initSysctl" "" }}
-    {{- with merge (include "container_uri.parse" . | fromJson) $global }}
-    image: "{{- include "gen.container_uri" . }}"
-    {{- end }}
-    {{- else }}
-    image: ghcr.io/elastisys/curl-jq:1.0.0
-    {{- end }}
-    command:
-      - sysctl
-      - -w
-      - vm.max_map_count=262144
-    securityContext:
-      allowPrivilegeEscalation: true
-      privileged: true
-      runAsNonRoot: false
-      runAsUser: 0
-
 secretMounts:
   - secretName: opensearch-transport-cert
     name: opensearch-transport-cert

--- a/helmfile.d/values/podsecuritypolicies/service/opensearch.yaml.gotmpl
+++ b/helmfile.d/values/podsecuritypolicies/service/opensearch.yaml.gotmpl
@@ -4,12 +4,6 @@ constraints:
       podSelectorLabels:
         app.kubernetes.io/name: opensearch
       allow:
-        allowPrivilegeEscalation: true
-        # allowedUnsafeSysctls:
-        #   - vm.max_map_count
-        privileged: true
-        runAsUser:
-          rule: RunAsAny
         volumes:
           - configMap
           - emptyDir

--- a/migration/v0.49/README.md
+++ b/migration/v0.49/README.md
@@ -109,6 +109,12 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     export CK8S_CLUSTER=<wc|sc|both>
     ```
 
+1. Reinstall OpenSearch, as its PSA has been lowered to `restricted`.
+
+    ```bash
+    ./migration/v0.49/apply/30-opensearch-initContainer.sh
+    ```
+
 1. Update apps configuration:
 
     This will take a backup into `backups/` before modifying any files.

--- a/migration/v0.49/README.md
+++ b/migration/v0.49/README.md
@@ -109,7 +109,7 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
     export CK8S_CLUSTER=<wc|sc|both>
     ```
 
-1. Reinstall OpenSearch, as its PSA has been lowered to `restricted`.
+1. Apply OpenSearch and remove PSPs, as its PSA has been lowered to `restricted`.
 
     ```bash
     ./migration/v0.49/apply/30-opensearch-initContainer.sh

--- a/migration/v0.49/apply/30-opensearch-initContainer.sh
+++ b/migration/v0.49/apply/30-opensearch-initContainer.sh
@@ -23,5 +23,4 @@ run() {
   esac
 }
 
-#run "${@}"
-helmfile_upgrade sc app=opensearch
+run "${@}"

--- a/migration/v0.49/apply/30-opensearch-initContainer.sh
+++ b/migration/v0.49/apply/30-opensearch-initContainer.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+ROOT="$(readlink -f "$(dirname "${0}")/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+run() {
+  case "${1:-}" in
+  execute)
+    if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+      log_info "operation on service cluster"
+      helmfile_upgrade sc app=opensearch
+      helm_uninstall sc opensearch-system podsecuritypolicy
+    fi
+    ;;
+  rollback)
+    log_warn "rollback not implemented"
+    ;;
+  *)
+    log_fatal "usage: \"${0}\" <execute|rollback>"
+    ;;
+  esac
+}
+
+#run "${@}"
+helmfile_upgrade sc app=opensearch

--- a/tests/unit/general/resources/images-parametric-tests.json
+++ b/tests/unit/general/resources/images-parametric-tests.json
@@ -271,12 +271,6 @@
       "template_file": "sc/opensearch/templates/statefulset.yaml"
     },
     {
-      "image_property": "opensearch.initSysctl",
-      "helmfile_selector": "app=opensearch",
-      "container_name": "init-sysctl",
-      "template_file": "sc/opensearch/templates/statefulset.yaml"
-    },
-    {
       "image_property": "opensearch.dashboards",
       "helmfile_selector": "app=opensearch",
       "container_name": "dashboards",


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [x] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice 
An initContainer running for OpenSearch which used to set the vm.max_map_count has been removed as new versions of Ubuntu sets it to a sufficiently high value by default. Environments running versions of Ubuntu older than 24 has to set this variable manually in some way.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?
These changes allow us to lower the privileges of the OpenSearch namespace. Improves platform security.

<!-- Add description of the change -->
Previously a specialized temporary container ran to increase the vm.max_map_count from `65530` to `262144`, a setting needed for OpenSearch. With Ubuntu 24.04 this was increased to 1048576` by default, meaning this container is now redundant. With the removal of this work-around the OpenSearch namespace shouldn't need its privileged status either.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2427

#### Information to reviewers
I tested to see if OpenSearch would still deploy after lowering the namespace privileges. Everything seemed to deploy as per usual, and when describing the namespace the new PSA-levels had been successfully applied.
<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [x] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [x] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [x] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [x] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
