### PR TITLE
Bump kured helm chart to v5.10.0

### DIFF
--- a/helmfile.d/lists/images.yaml
+++ b/helmfile.d/lists/images.yaml
@@ -50,7 +50,7 @@ images:
     admissionWebhooksPatch: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.2
     fileCopier: docker.io/library/busybox:1.36
   kured:
-    image: ghcr.io/kubereboot/kured:1.17.0
+    image: ghcr.io/kubereboot/kured:1.20.0
   kyverno:
     main: ghcr.io/kyverno/kyverno:v1.13.4
     init: ghcr.io/kyverno/kyverno:v1.13.4

--- a/helmfile.d/upstream/index.yaml
+++ b/helmfile.d/upstream/index.yaml
@@ -55,7 +55,7 @@ charts:
 
   kokuwa/fluentd-elasticsearch: 13.12.2
 
-  kubereboot/kured: 5.6.0
+  kubereboot/kured: 5.10.0
 
   kubernetes-external-dns/external-dns: 1.14.4
   kubernetes-ingress-nginx/ingress-nginx: 4.12.1

--- a/helmfile.d/upstream/kubereboot/kured/Chart.yaml
+++ b/helmfile.d/upstream/kubereboot/kured/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.17.0
+appVersion: 1.20.0
 description: A Helm chart for kured
 home: https://github.com/kubereboot/kured
 icon: https://raw.githubusercontent.com/kubereboot/website/main/static/img/kured.png
@@ -11,4 +11,4 @@ maintainers:
 name: kured
 sources:
 - https://github.com/kubereboot/kured
-version: 5.6.0
+version: 5.10.0

--- a/helmfile.d/upstream/kubereboot/kured/README.md
+++ b/helmfile.d/upstream/kubereboot/kured/README.md
@@ -78,7 +78,7 @@ The following changes have been made compared to the stable chart:
 | Config                                  | Description                                                                 | Default                   |
 | ------                                  | -----------                                                                 | -------                   |
 | `image.repository`                      | Image repository                                                            | `ghcr.io/kubereboot/kured`|
-| `image.tag`                             | Image tag                                                                   | `1.17.0`                  |
+| `image.tag`                             | Image tag                                                                   | `1.20.0`                  |
 | `image.pullPolicy`                      | Image pull policy                                                           | `IfNotPresent`            |
 | `image.pullSecrets`                     | Image pull secrets                                                          | `[]`                      |
 | `revisionHistoryLimit`                  | Number of old history to retain to allow rollback                           | `10`                      |

--- a/helmfile.d/upstream/kubereboot/kured/templates/service.yaml
+++ b/helmfile.d/upstream/kubereboot/kured/templates/service.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- else }}
   name: {{ template "kured.fullname" . }}
   {{- end }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kured.labels" . | nindent 4 }}
   {{- if .Values.service.annotations }}

--- a/helmfile.d/upstream/kubereboot/kured/templates/serviceaccount.yaml
+++ b/helmfile.d/upstream/kubereboot/kured/templates/serviceaccount.yaml
@@ -6,4 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kured.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.extraAnnotations }}
+    {{ toYaml . }}
+  {{- end }}
 {{- end -}}

--- a/helmfile.d/upstream/kubereboot/kured/values.yaml
+++ b/helmfile.d/upstream/kubereboot/kured/values.yaml
@@ -18,11 +18,15 @@ dsAnnotations: {}
 extraArgs: {}
 
 extraEnvVars:
-#  - name: slackHookUrl
+#  - name: KURED_SLACK_HOOK_URL
 #    valueFrom:
 #      secretKeyRef:
 #        name: secret_name
 #        key: secret_key
+#
+# Note: To override kured options with environment variables, use the KURED_ prefix and uppercase with underscores.
+# For example, to override slackHookUrl, use KURED_SLACK_HOOK_URL. For notifyUrl, use KURED_NOTIFY_URL.
+#
 #  - name: regularEnvVariable
 #    value: 123
 
@@ -76,6 +80,7 @@ rbac:
 serviceAccount:
   create: true
   name:
+  extraAnnotations: {}
 
 podSecurityPolicy:
   create: false


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Had a @elastisys/goto-security to bump the Kured version / helm chart so there we go:
- chart is bumped to `v5.10.0`
- the kured container image is bumped to `v1.20.0`

The helm values surface changed slightly - now it's possible to add extra annotations to the ServiceAccount object; everything else looks like just version bumps.

As for the [Kured diff itself](https://github.com/kubereboot/kured/compare/1.17.0...1.20.0), looks a bit more involved, but still mostly dependabot version bumps.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
