### PR TITLE
apps: added read/write grafana dashboard for pods with pvcs

### DIFF
--- a/helmfile.d/charts/grafana-dashboards/dashboards/rw-podspvc-dashboard.json
+++ b/helmfile.d/charts/grafana-dashboards/dashboards/rw-podspvc-dashboard.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 4494,
+  "id": 4908,
   "links": [],
   "panels": [
     {
@@ -420,8 +420,8 @@
       {
         "allowCustomValue": false,
         "current": {
-          "text": "Thanos All",
-          "value": "PE090269EBE049DA8"
+          "text": "Service Cluster",
+          "value": "PD3B28F1364F2B8D6"
         },
         "description": "",
         "label": "Datasource",
@@ -433,25 +433,28 @@
         "type": "datasource"
       },
       {
+        "allowCustomValue": false,
         "current": {
           "text": [
-            "opensearch-system",
-            "alertmanager",
             "fluentd-system",
-            "harbor",
+            "thanos",
+            "opensearch-system",
             "monitoring",
-            "thanos"
+            "harbor"
           ],
           "value": [
-            "opensearch-system",
-            "alertmanager",
             "fluentd-system",
-            "harbor",
+            "thanos",
+            "opensearch-system",
             "monitoring",
-            "thanos"
+            "harbor"
           ]
         },
-        "definition": "label_values(kube_pod_info,namespace)",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\"},namespace)",
         "description": "",
         "includeAll": false,
         "label": "Namespace",
@@ -460,11 +463,12 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(kube_pod_info,namespace)",
+          "query": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\"},namespace)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
         "regex": "",
+        "sort": 1,
         "type": "query"
       }
     ]
@@ -477,5 +481,5 @@
   "timezone": "",
   "title": "Read and Write - Namespace (Pods with PVCs)",
   "uid": "277ee1ad-fad0-453f-a0a0-e10eda8c8131",
-  "version": 12
+  "version": 3
 }


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->


### Release notes

Added a new dashboard to Grafana that allows you to filter by namespace and see write and read throughput and IOPS for pods with persistent volumes. Named `Read and Write - Namespace (Pods with PVCs)`.

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Added a new grafana dashboard to view read/write throughput and IOPS for pods using PVCs only, filtered by namespace.

Since it's filtered by namespace, application developers will be able to select multiple of their own namespace to view more in-depth read/write data of pods using PVCs in those namespaces.

I wanted this because our current solution (Kubernetes Compute Resource dashboard) has a combined read/write (not separate read and write) panel that doesn't allow to compare a bunch of different namespaces at the same time without opening multiple dashboards. I want to be able to see multiple namespaces and only select pods that use PVCs to see their usage metrics. This will help to more easily compare disk usage between different apps to see if you can optimize your storage. Since it selects pods with PVCs only, it is also much cleaner (less clutter) and robust than our current throughput/iops panels in compute resource dashboard that uses a device field to filter.

Screenshot example:
<img width="1549" height="939" alt="readwritedashboard" src="https://github.com/user-attachments/assets/efbbf4e4-4560-49d1-ad5c-d22bc33fe9f4" />


<!-- Add description of the change -->
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->


#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [x] The metrics are still exposed and present in Grafana after the change
    - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [x] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [x] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [x] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
