### PR TITLE
bin: Expand curl -k to --insecure for visibility

### DIFF
--- a/bin/diagnostics.bash
+++ b/bin/diagnostics.bash
@@ -343,7 +343,7 @@ run_diagnostics_default_metrics() {
   query_and_parse() {
     query="${1}"
     print_func="${2}"
-    res="$(curl "${endpoint}/query_range" -k -s --header "${header}" --data-urlencode query="${query}" "${range_arg[@]}")"
+    res="$(curl "${endpoint}/query_range" --insecure -s --header "${header}" --data-urlencode query="${query}" "${range_arg[@]}")"
     if [[ $(jq '.data.result | length' <<<"${res}") -gt 0 ]]; then
       readarray metric_results_arr < <(jq -c '.data.result[]' <<<"${res}")
       for row in "${metric_results_arr[@]}"; do
@@ -390,7 +390,7 @@ run_diagnostics_default_metrics() {
   # Opensearch status <instant Query>
   printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
   echo "Querying Opensearch cluster status"
-  res="$(curl "${endpoint}/query" -k -s --header "${header}" --data-urlencode query='elasticsearch_cluster_health_status{color=~"yellow|red"} > 0')"
+  res="$(curl "${endpoint}/query" --insecure -s --header "${header}" --data-urlencode query='elasticsearch_cluster_health_status{color=~"yellow|red"} > 0')"
   if [[ $(jq '.data.result | length' <<<"${res}") -gt 0 ]]; then
     echo "Opensearch is in $(jq '.data.result[0].metric.color' <<<"${res}") state!"
   fi
@@ -403,7 +403,7 @@ run_diagnostics_query_metric() {
   endpoint="${domain}/api/v1/namespaces/thanos/services/thanos-query-query-frontend:9090/proxy/api/v1"
   header="Authorization: Bearer ${token}"
 
-  curl "${endpoint}/query" -k --header "${header}" --data-urlencode query="${1}" | jq
+  curl "${endpoint}/query" --insecure --header "${header}" --data-urlencode query="${1}" | jq
 }
 
 if [[ -z "${CK8S_PGP_FP:-}" ]]; then

--- a/helmfile.d/charts/harbor/init-harbor/files/init.sh
+++ b/helmfile.d/charts/harbor/init-harbor/files/init.sh
@@ -3,7 +3,7 @@ set -e
 
 validate_harbor() {
   echo "testing curl address ${ENDPOINT}"
-  exists=$(curl -k "${ENDPOINT}"/projects/1 | jq '.code') || {
+  exists=$(curl --insecure "${ENDPOINT}"/projects/1 | jq '.code') || {
     echo "ERROR L.${LINENO} - Harbor url ${ENDPOINT}/projects/1 cannot be reached."
     exit 1
   }
@@ -17,12 +17,12 @@ validate_harbor() {
 delete_library_project() {
   echo Removing project library from harbor
   # Curl will return status 500 even though it successfully removed the project.
-  curl -k -X DELETE -u admin:"${HARBOR_PASSWORD}" "${ENDPOINT}"/projects/1 >/dev/null
+  curl --insecure -X DELETE -u admin:"${HARBOR_PASSWORD}" "${ENDPOINT}"/projects/1 >/dev/null
 }
 
 create_new_private_default_project() {
   echo "Creating new private project default"
-  curl -k -X POST -u admin:"${HARBOR_PASSWORD}" "${ENDPOINT}"/projects --header 'Content-Type: application/json' --header 'Accept: application/json' --data '{
+  curl --insecure -X POST -u admin:"${HARBOR_PASSWORD}" "${ENDPOINT}"/projects --header 'Content-Type: application/json' --header 'Accept: application/json' --data '{
                 "project_name": "default",
                 "metadata": {
                     "public": "0",
@@ -41,7 +41,7 @@ init_harbor_state() {
 
   echo "Setting up initial harbor state"
   if [ "$exists" != "404" ]; then
-    name=$(curl -k -X GET "${ENDPOINT}"/projects/1 | jq '.name')
+    name=$(curl --insecure -X GET "${ENDPOINT}"/projects/1 | jq '.name')
 
     if [ "$name" = "\"library\"" ]; then
       delete_library_project
@@ -54,7 +54,7 @@ init_harbor_state() {
 
 configure_OIDC() {
   echo "Configuring oidc support"
-  err=$(curl -k -X PUT "${ENDPOINT}/configurations" \
+  err=$(curl --insecure -X PUT "${ENDPOINT}/configurations" \
     -u admin:"${HARBOR_PASSWORD}" \
     -H "accept: application/json" \
     -H "Content-Type: application/json" \
@@ -79,7 +79,7 @@ configure_GC() {
   echo "Configuring GC"
 
   if [ "${GC_FORCE_CONFIGURE}" = "false" ]; then
-    res=$(curl -k -X GET -w "%{http_code}" "${ENDPOINT}/system/gc/schedule" \
+    res=$(curl --insecure -X GET -w "%{http_code}" "${ENDPOINT}/system/gc/schedule" \
       -u admin:"${HARBOR_PASSWORD}")
 
     # shellcheck disable=SC3057
@@ -96,7 +96,7 @@ configure_GC() {
     fi
   fi
 
-  err=$(curl -k -X PUT "${ENDPOINT}/system/gc/schedule" \
+  err=$(curl --insecure -X PUT "${ENDPOINT}/system/gc/schedule" \
     -u admin:"${HARBOR_PASSWORD}" \
     -H "accept: application/json" \
     -H "Content-Type: application/json" \

--- a/pipeline/opensearch.bash
+++ b/pipeline/opensearch.bash
@@ -5,7 +5,7 @@ set -eu
 opensearch_url=https://opensearch.ops.pipeline-exoscale.elastisys.se/api/status
 retries=60
 while [ ${retries} -gt 0 ]; do
-  result="$(curl --connect-timeout 20 --max-time 60 -ksIL -o /dev/null -w "%{http_code}" $opensearch_url || true)"
+  result="$(curl --connect-timeout 20 --max-time 60 --insecure -sIL -o /dev/null -w "%{http_code}" $opensearch_url || true)"
   [[ "${result}" == "401" ]] && echo "Opensearch is ready. Got status ${result}"
   break
   echo "Waiting for OpenSearch to be ready. Got status ${result}"

--- a/pipeline/test/services/funcs.sh
+++ b/pipeline/test/services/funcs.sh
@@ -259,7 +259,8 @@ function testEndpoint {
     args=(
       --connect-timeout 20
       --max-time 60
-      -ksIL
+      --insecure
+      -sIL
       -o /dev/null
       -X GET
       -w "%{http_code}"
@@ -294,7 +295,8 @@ function testEndpointProtected {
     args=(
       --connect-timeout 20
       --max-time 60
-      -ksI
+      --insecure
+      -sI
       -o /dev/null
       -X GET
       -w "%{http_code}"

--- a/tests/common/bats/harbor.bash
+++ b/tests/common/bats/harbor.bash
@@ -38,7 +38,7 @@ _harbor.curl() {
   fi
 
   if [[ "${harbor_secure}" != "true" ]]; then
-    curl_args=(-k "${curl_args[@]}")
+    curl_args=(--insecure "${curl_args[@]}")
   fi
 
   curl "${curl_args[@]}" "$@"


### PR DESCRIPTION
- Should be okay from inside the cluster (harbor and opensearch scripts)
- Should be okay from tests (tests/ and pipeline/)
- No migrations changed

<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

The `curl` flag `-k` or `--insecure` disables certificate validation and such security checks.
The short form especially might be easy to miss during review, so preferrincg the long version is better.

This replaces the short form `curl -k` with `--insecure` in order to make it more visible where this is used and obvious what it does.

#### Information to reviewers

Double check whether the use of `--insecure` is really warranted in these places.

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
