### PR TITLE
Fix Grafana netpol dashboard tests for Cilium

### DIFF
--- a/helmfile.d/charts/grafana-dashboards/dashboards/cilium-networkpolicy-dashboard.json
+++ b/helmfile.d/charts/grafana-dashboards/dashboards/cilium-networkpolicy-dashboard.json
@@ -110,7 +110,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(hubble_flows_processed_total{type=\"PolicyVerdict\",verdict=\"FORWARDED\",traffic_direction=\"egress\",source_namespace=~\"$namespace\"}[1m])",
+          "expr": "rate(hubble_flows_processed_total{cluster=~\"$cluster\",type=\"PolicyVerdict\",verdict=\"FORWARDED\",traffic_direction=\"egress\",source_namespace=~\"$namespace\"}[1m])",
           "legendFormat": "{{source_pod}} - (to {{destination_pod}})",
           "range": true,
           "refId": "A"
@@ -208,7 +208,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(hubble_flows_processed_total{type=\"PolicyVerdict\",verdict=\"FORWARDED\",traffic_direction=\"ingress\",source_namespace=~\"$namespace\"}[1m])",
+          "expr": "rate(hubble_flows_processed_total{cluster=~\"$cluster\",type=\"PolicyVerdict\",verdict=\"FORWARDED\",traffic_direction=\"ingress\",source_namespace=~\"$namespace\"}[1m])",
           "legendFormat": "{{source_pod}} - (to {{destination_pod}})",
           "range": true,
           "refId": "A"
@@ -306,7 +306,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(hubble_drop_total{reason=\"POLICY_DENIED\",traffic_direction=\"egress\",source_namespace=~\"$namespace\"}[1m])",
+          "expr": "rate(hubble_drop_total{cluster=~\"$cluster\",reason=\"POLICY_DENIED\",traffic_direction=\"egress\",source_namespace=~\"$namespace\"}[1m])",
           "legendFormat": "{{source_pod}} - (to {{destination_pod}})",
           "range": true,
           "refId": "A"
@@ -406,7 +406,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(hubble_drop_total{reason=\"POLICY_DENIED\",traffic_direction=\"ingress\",source_namespace=~\"$namespace\"}[1m])",
+          "expr": "rate(hubble_drop_total{cluster=~\"$cluster\",reason=\"POLICY_DENIED\",traffic_direction=\"ingress\",source_namespace=~\"$namespace\"}[1m])",
           "format": "time_series",
           "legendFormat": "{{source_pod}} - (from {{destination_pod}})",
           "range": true,
@@ -436,6 +436,36 @@
         "refresh": 1,
         "regex": "",
         "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(hubble_flows_processed_total,cluster)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(hubble_flows_processed_total,cluster)",
+          "refId": "Thanos All-cluster-Variable-Query"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       },
       {
         "current": {

--- a/tests/end-to-end/grafana/dashboards-admin.cy.js
+++ b/tests/end-to-end/grafana/dashboards-admin.cy.js
@@ -35,11 +35,19 @@ describe('grafana admin dashboards', function () {
   })
 
   it('open the NetworkPolicy Dashboard', function () {
-    cy.testGrafanaDashboard('NetworkPolicy Dashboard', false)
-
-    cy.get(
-      '[data-testid="data-testid Panel menu Packets allowed by NetworkPolicy going from pod"]'
-    ).should('exist')
+    cy.yqDig('sc', '.networkPlugin.type').then((value) => {
+      if (value == 'calico') {
+        cy.testGrafanaDashboard('NetworkPolicy Dashboard', false)
+        cy.get(
+          '[data-testid="data-testid Panel menu Packets allowed by NetworkPolicy going from pod"]'
+        ).should('exist')
+      } else {
+        cy.testGrafanaDashboard('NetworkPolicy Dashboard Cilium', false)
+        cy.get(
+          '[data-testid="data-testid Panel menu Allowed packages going from pod"]'
+        ).should('exist')
+      }
+    })
   })
 
   it('open the Kubernetes cluster status dashboard', function () {

--- a/tests/end-to-end/grafana/dashboards-dev.cy.js
+++ b/tests/end-to-end/grafana/dashboards-dev.cy.js
@@ -39,11 +39,19 @@ describe('grafana dev dashboards', function () {
   })
 
   it('open the NetworkPolicy Dashboard', function () {
-    cy.testGrafanaDashboard('NetworkPolicy Dashboard', false)
-
-    cy.get(
-      '[data-testid="data-testid Panel menu Packets allowed by NetworkPolicy going from pod"]'
-    ).should('exist')
+    cy.yqDig('sc', '.networkPlugin.type').then((value) => {
+      if (value == 'calico') {
+        cy.testGrafanaDashboard('NetworkPolicy Dashboard', false)
+        cy.get(
+          '[data-testid="data-testid Panel menu Packets allowed by NetworkPolicy going from pod"]'
+        ).should('exist')
+      } else {
+        cy.testGrafanaDashboard('NetworkPolicy Dashboard Cilium', false)
+        cy.get(
+          '[data-testid="data-testid Panel menu Allowed packages going from pod"]'
+        ).should('exist')
+      }
+    })
   })
 
   it('open the Kubernetes cluster status dashboard', function () {


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Our Grafana end-to-end tests for checking the NetPol dashboard did not support the new Cilium specific dashboard.
This PR fixes these issues by checking which networkType is set in the end-to-end tests and based on that check the correct dashboard.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Partially fixes https://github.com/elastisys/compliantkubernetes-apps/issues/2726

#### Information to reviewers

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
