### PR TITLE
Split network policies tests between Calico & Cilium

### DIFF
--- a/tests/common/cypress/index.d.ts
+++ b/tests/common/cypress/index.d.ts
@@ -2,7 +2,6 @@ type Cluster = 'sc' | 'wc'
 type GrafanaRole = 'Admin' | 'Editor' | 'Viewer'
 
 declare const yqArgumentsToConfigFiles: (cluster: Cluster, expression: string) => string
-declare const userToSession: (user: string) => string
 
 /// <reference types="cypress" />
 

--- a/tests/end-to-end/grafana/dashboards-admin.cy.js
+++ b/tests/end-to-end/grafana/dashboards-admin.cy.js
@@ -36,7 +36,7 @@ describe('grafana admin dashboards', function () {
 
   it('open the NetworkPolicy Dashboard', function () {
     cy.yqDig('sc', '.networkPlugin.type').then((value) => {
-      if (value == 'calico') {
+      if (value === 'calico') {
         cy.testGrafanaDashboard('NetworkPolicy Dashboard', false)
         cy.get(
           '[data-testid="data-testid Panel menu Packets allowed by NetworkPolicy going from pod"]'

--- a/tests/end-to-end/netpol/netpol-calico.cy.js
+++ b/tests/end-to-end/netpol/netpol-calico.cy.js
@@ -11,6 +11,14 @@ function makePrometheusURL(/** @type {Cluster} */ cluster) {
 }
 
 describe('workload cluster network policies', function () {
+  before(function () {
+    cy.yqDig('wc', '.networkPlugin.type').then(function (value) {
+      if (value !== 'calico') {
+        this.skip('not a calico cluster')
+      }
+    })
+  })
+
   it('are not dropping any packets from workloads', function () {
     cy.request('GET', makeQueryURL('wc', DROP_QUERY)).then((response) => {
       assertNoDrops(response, 'fw', 'from')
@@ -34,6 +42,14 @@ describe('workload cluster network policies', function () {
 })
 
 describe('service cluster network policies', function () {
+  before(function () {
+    cy.yqDig('sc', '.networkPlugin.type').then(function (value) {
+      if (value !== 'calico') {
+        this.skip('not a calico cluster')
+      }
+    })
+  })
+
   it('are not dropping any packets from workloads', function () {
     cy.request('GET', makeQueryURL('sc', DROP_QUERY)).then((response) => {
       assertNoDrops(response, 'fw', 'from')

--- a/tests/end-to-end/netpol/netpol-calico.cy.js
+++ b/tests/end-to-end/netpol/netpol-calico.cy.js
@@ -10,7 +10,7 @@ function makePrometheusURL(/** @type {Cluster} */ cluster) {
   )
 }
 
-describe('workload cluster network policies', function () {
+describe('workload cluster network policies (calico)', function () {
   before(function () {
     cy.yqDig('wc', '.networkPlugin.type').then(function (value) {
       if (value !== 'calico') {
@@ -41,7 +41,7 @@ describe('workload cluster network policies', function () {
   })
 })
 
-describe('service cluster network policies', function () {
+describe('service cluster network policies (calico)', function () {
   before(function () {
     cy.yqDig('sc', '.networkPlugin.type').then(function (value) {
       if (value !== 'calico') {

--- a/tests/end-to-end/netpol/netpol-calico.gen.bats
+++ b/tests/end-to-end/netpol/netpol-calico.gen.bats
@@ -3,7 +3,7 @@
 setup_file() {
   load "../../bats.lib.bash"
 
-  cypress_setup "${ROOT}/tests/end-to-end/netpol/netpol.cy.js"
+  cypress_setup "${ROOT}/tests/end-to-end/netpol/netpol-calico.cy.js"
 }
 
 setup() {

--- a/tests/end-to-end/netpol/netpol-calico.gen.bats
+++ b/tests/end-to-end/netpol/netpol-calico.gen.bats
@@ -15,26 +15,26 @@ teardown_file() {
   cypress_teardown
 }
 
-@test "workload cluster network policies are not dropping any packets from workloads" {
-  cypress_test "workload cluster network policies are not dropping any packets from workloads"
+@test "workload cluster network policies (calico) are not dropping any packets from workloads" {
+  cypress_test "workload cluster network policies (calico) are not dropping any packets from workloads"
 }
 
-@test "workload cluster network policies are not dropping any packets to workloads" {
-  cypress_test "workload cluster network policies are not dropping any packets to workloads"
+@test "workload cluster network policies (calico) are not dropping any packets to workloads" {
+  cypress_test "workload cluster network policies (calico) are not dropping any packets to workloads"
 }
 
-@test "workload cluster network policies are accepting allowed traffic" {
-  cypress_test "workload cluster network policies are accepting allowed traffic"
+@test "workload cluster network policies (calico) are accepting allowed traffic" {
+  cypress_test "workload cluster network policies (calico) are accepting allowed traffic"
 }
 
-@test "service cluster network policies are not dropping any packets from workloads" {
-  cypress_test "service cluster network policies are not dropping any packets from workloads"
+@test "service cluster network policies (calico) are not dropping any packets from workloads" {
+  cypress_test "service cluster network policies (calico) are not dropping any packets from workloads"
 }
 
-@test "service cluster network policies are not dropping any packets to workloads" {
-  cypress_test "service cluster network policies are not dropping any packets to workloads"
+@test "service cluster network policies (calico) are not dropping any packets to workloads" {
+  cypress_test "service cluster network policies (calico) are not dropping any packets to workloads"
 }
 
-@test "service cluster network policies are accepting allowed traffic" {
-  cypress_test "service cluster network policies are accepting allowed traffic"
+@test "service cluster network policies (calico) are accepting allowed traffic" {
+  cypress_test "service cluster network policies (calico) are accepting allowed traffic"
 }

--- a/tests/end-to-end/netpol/netpol-cilium.cy.js
+++ b/tests/end-to-end/netpol/netpol-cilium.cy.js
@@ -1,0 +1,140 @@
+const DROP_QUERY = 'round(increase(hubble_drop_total{reason="POLICY_DENIED"}[5m]))'
+const ACCEPT_QUERY =
+  'sum by (traffic_direction) (round(increase(hubble_flows_processed_total{verdict="FORWARDED"}[5m])))'
+
+function makePrometheusURL(/** @type {Cluster} */ cluster) {
+  const port = cluster === 'wc' ? Cypress.env('WC_PROXY_PORT') : Cypress.env('SC_PROXY_PORT')
+
+  return (
+    `http://127.0.0.1:${port}/api/v1/namespaces/monitoring/services` +
+    '/kube-prometheus-stack-prometheus:9090/proxy'
+  )
+}
+
+describe('workload cluster network policies', function () {
+  before(function () {
+    cy.yqDig('wc', '.networkPlugin.type').then(function (value) {
+      if (value !== 'cilium') {
+        this.skip('not a cilium cluster')
+      }
+    })
+  })
+
+  it('are not dropping any packets from workloads', function () {
+    cy.request('GET', makeQueryURL('wc', DROP_QUERY)).then((response) => {
+      assertNoDrops(response, 'egress', 'from')
+    })
+  })
+
+  it('are not dropping any packets to workloads', function () {
+    cy.request('GET', makeQueryURL('wc', DROP_QUERY)).then((response) => {
+      assertNoDrops(response, 'ingress', 'to')
+    })
+  })
+
+  it('are accepting allowed traffic', function () {
+    cy.retryRequest({
+      request: { method: 'GET', url: makeQueryURL('sc', ACCEPT_QUERY) },
+      condition: acceptCondition,
+      waitTime: 10000,
+      attempts: 30,
+    })
+  })
+})
+
+describe('service cluster network policies', function () {
+  before(function () {
+    cy.yqDig('sc', '.networkPlugin.type').then(function (value) {
+      if (value !== 'cilium') {
+        this.skip('not a cilium cluster')
+      }
+    })
+  })
+
+  it('are not dropping any packets from workloads', function () {
+    cy.request('GET', makeQueryURL('sc', DROP_QUERY)).then((response) => {
+      assertNoDrops(response, 'egress', 'from')
+    })
+  })
+
+  it('are not dropping any packets to workloads', function () {
+    cy.request('GET', makeQueryURL('sc', DROP_QUERY)).then((response) => {
+      assertNoDrops(response, 'ingress', 'to')
+    })
+  })
+
+  it('are accepting allowed traffic', function () {
+    cy.retryRequest({
+      request: { method: 'GET', url: makeQueryURL('sc', ACCEPT_QUERY) },
+      condition: acceptCondition,
+      waitTime: 10000,
+      attempts: 30,
+    })
+  })
+})
+
+const makeQueryURL = (/** @type {Cluster} */ cluster, query, serverTime = '') => {
+  const metric = encodeURI(query)
+  let returnValue = `${makePrometheusURL(cluster)}/api/v1/query?query=${metric}`
+  if (serverTime !== '') {
+    returnValue = `${returnValue}&${new URLSearchParams({ time: serverTime })}`
+  }
+  return returnValue
+}
+
+const assertNoDrops = (response, trafficDirection, direction) => {
+  expect(response.status).to.eq(200)
+  expect(response.body.data.result).to.be.a('array')
+
+  const result = response.body.data.result
+
+  const drops = result.filter(filterNonZero(trafficDirection)).map((element) => mapDrops(element))
+
+  if (drops.length > 0) {
+    cy.fail(formatError(drops, direction))
+  }
+}
+
+const acceptCondition = (response) => {
+  try {
+    expect(response.status).to.eq(200)
+    expect(response.body.data.result).to.be.a('array')
+
+    const result = response.body.data.result
+
+    const innerAssert = (values) => {
+      expect(values).to.be.an('array')
+      expect(values).to.have.property('0').that.is.a('number').and.is.greaterThan(0)
+    }
+
+    innerAssert(
+      result.filter(filterNonZero('ingress')).map((item) => Number.parseInt(item.value[1]))
+    )
+    innerAssert(
+      result.filter(filterNonZero('egress')).map((item) => Number.parseInt(item.value[1]))
+    )
+    return true
+  } catch {
+    return false
+  }
+}
+
+const filterNonZero = (trafficDirection) => {
+  return (item) =>
+    item.metric.traffic_direction === trafficDirection && item.value && item.value[1] !== '0'
+}
+
+const mapDrops = (item) => {
+  return {
+    podName: item.metric.pod,
+    podNamespace: item.metric.namespace,
+    drops: Number.parseInt(item.value[1]),
+  }
+}
+
+const formatError = (drops, direction) => {
+  const fmtDrops = drops
+    .map((item) => `- ${item.podNamespace}/${item.podName} had ${item.drops} dropped packets`)
+    .join('\n')
+  return `\nFound packets dropped ${direction} workloads:\n${fmtDrops}\n`
+}

--- a/tests/end-to-end/netpol/netpol-cilium.cy.js
+++ b/tests/end-to-end/netpol/netpol-cilium.cy.js
@@ -11,7 +11,7 @@ function makePrometheusURL(/** @type {Cluster} */ cluster) {
   )
 }
 
-describe('workload cluster network policies', function () {
+describe('workload cluster network policies (cilium)', function () {
   before(function () {
     cy.yqDig('wc', '.networkPlugin.type').then(function (value) {
       if (value !== 'cilium') {
@@ -42,7 +42,7 @@ describe('workload cluster network policies', function () {
   })
 })
 
-describe('service cluster network policies', function () {
+describe('service cluster network policies (cilium)', function () {
   before(function () {
     cy.yqDig('sc', '.networkPlugin.type').then(function (value) {
       if (value !== 'cilium') {

--- a/tests/end-to-end/netpol/netpol-cilium.gen.bats
+++ b/tests/end-to-end/netpol/netpol-cilium.gen.bats
@@ -15,26 +15,26 @@ teardown_file() {
   cypress_teardown
 }
 
-@test "workload cluster network policies are not dropping any packets from workloads" {
-  cypress_test "workload cluster network policies are not dropping any packets from workloads"
+@test "workload cluster network policies (cilium) are not dropping any packets from workloads" {
+  cypress_test "workload cluster network policies (cilium) are not dropping any packets from workloads"
 }
 
-@test "workload cluster network policies are not dropping any packets to workloads" {
-  cypress_test "workload cluster network policies are not dropping any packets to workloads"
+@test "workload cluster network policies (cilium) are not dropping any packets to workloads" {
+  cypress_test "workload cluster network policies (cilium) are not dropping any packets to workloads"
 }
 
-@test "workload cluster network policies are accepting allowed traffic" {
-  cypress_test "workload cluster network policies are accepting allowed traffic"
+@test "workload cluster network policies (cilium) are accepting allowed traffic" {
+  cypress_test "workload cluster network policies (cilium) are accepting allowed traffic"
 }
 
-@test "service cluster network policies are not dropping any packets from workloads" {
-  cypress_test "service cluster network policies are not dropping any packets from workloads"
+@test "service cluster network policies (cilium) are not dropping any packets from workloads" {
+  cypress_test "service cluster network policies (cilium) are not dropping any packets from workloads"
 }
 
-@test "service cluster network policies are not dropping any packets to workloads" {
-  cypress_test "service cluster network policies are not dropping any packets to workloads"
+@test "service cluster network policies (cilium) are not dropping any packets to workloads" {
+  cypress_test "service cluster network policies (cilium) are not dropping any packets to workloads"
 }
 
-@test "service cluster network policies are accepting allowed traffic" {
-  cypress_test "service cluster network policies are accepting allowed traffic"
+@test "service cluster network policies (cilium) are accepting allowed traffic" {
+  cypress_test "service cluster network policies (cilium) are accepting allowed traffic"
 }

--- a/tests/end-to-end/netpol/netpol-cilium.gen.bats
+++ b/tests/end-to-end/netpol/netpol-cilium.gen.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+setup_file() {
+  load "../../bats.lib.bash"
+
+  cypress_setup "${ROOT}/tests/end-to-end/netpol/netpol-cilium.cy.js"
+}
+
+setup() {
+  load "../../bats.lib.bash"
+  load_assert
+}
+
+teardown_file() {
+  cypress_teardown
+}
+
+@test "workload cluster network policies are not dropping any packets from workloads" {
+  cypress_test "workload cluster network policies are not dropping any packets from workloads"
+}
+
+@test "workload cluster network policies are not dropping any packets to workloads" {
+  cypress_test "workload cluster network policies are not dropping any packets to workloads"
+}
+
+@test "workload cluster network policies are accepting allowed traffic" {
+  cypress_test "workload cluster network policies are accepting allowed traffic"
+}
+
+@test "service cluster network policies are not dropping any packets from workloads" {
+  cypress_test "service cluster network policies are not dropping any packets from workloads"
+}
+
+@test "service cluster network policies are not dropping any packets to workloads" {
+  cypress_test "service cluster network policies are not dropping any packets to workloads"
+}
+
+@test "service cluster network policies are accepting allowed traffic" {
+  cypress_test "service cluster network policies are accepting allowed traffic"
+}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Similar to the [Grafana split](https://github.com/elastisys/compliantkubernetes-apps/pull/2744/files), this PR specializes the existing network policy suite to run on `calico` clusters only and adds a new suite that will run on `cilium` clusters.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
