### PR TITLE
Add templating and default restricted CSP for Dex

### DIFF
--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -521,10 +521,10 @@ dex:
   additionalKubeloginRedirects: []
   contentSecurityPolicy:
     default-src: "'none'"
-    style-src: "'self'"
-    img-src: "'self'"
     frame-ancestors: "'none'"
+    img-src: "'self'"
     require-trusted-types-for: "'script'"
+    style-src: "'self'"
   enableStaticLogin: true
   serviceMonitor:
     enabled: true

--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -519,6 +519,12 @@ dex:
   replicaCount: 2
   # subdomain moved to common-config
   additionalKubeloginRedirects: []
+  contentSecurityPolicy:
+    default-src: "'none'"
+    style-src: "'self'"
+    img-src: "'self'"
+    frame-ancestors: "'none'"
+    require-trusted-types-for: "'script'"
   enableStaticLogin: true
   serviceMonitor:
     enabled: true

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -3052,6 +3052,14 @@ properties:
           format: uri
           examples:
             - http://localhost:8080/redirect
+      contentSecurityPolicy:
+        $ref: '#/$defs/contentSecurityPolicy'
+        default:
+          default-src: 'none'
+          style-src: 'self'
+          img-src: 'self'
+          frame-ancestors: 'none'
+          require-trusted-types-for: 'script'
       enableStaticLogin:
         title: Dex Static Login
         description: Configure Dex with a static password login `admin@example.com`.

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -3055,11 +3055,11 @@ properties:
       contentSecurityPolicy:
         $ref: '#/$defs/contentSecurityPolicy'
         default:
-          default-src: 'none'
-          style-src: 'self'
-          img-src: 'self'
-          frame-ancestors: 'none'
-          require-trusted-types-for: 'script'
+          default-src: "'none'"
+          frame-ancestors: "'none'"
+          img-src: "'self'"
+          require-trusted-types-for: "'script'"
+          style-src: "'self'"
       enableStaticLogin:
         title: Dex Static Login
         description: Configure Dex with a static password login `admin@example.com`.

--- a/helmfile.d/values/dex.yaml.gotmpl
+++ b/helmfile.d/values/dex.yaml.gotmpl
@@ -43,6 +43,15 @@ config:
     config:
       inCluster: true
   issuer: https://{{ .Values.dex.subdomain }}.{{ .Values.global.baseDomain }}
+  {{- with .Values.dex.contentSecurityPolicy }}
+  web:
+    headers:
+        {{- $dexCSP := list }}
+        {{- range $cspKey, $cspValue := . }}
+        {{- $dexCSP = append $dexCSP (printf "%s %s" $cspKey $cspValue)  }}
+        {{- end }}
+      Content-Security-Policy: {{ $dexCSP | join ";" | quote }}
+  {{- end }}
   connectors:
   {{- toYaml .Values.dex.connectors | nindent 4 }}
   staticClients:


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Adds templating and a default restricted Content-Security-Policy for Dex.

The CSP can be evaluated with https://csp-evaluator.withgoogle.com/.

For additional context, see arch topic here: https://github.com/elastisys/ck8s-arch/issues/303

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
