### PR TITLE
Add templating and default restricted CSP for OpenSearch

### DIFF
--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -754,13 +754,12 @@ opensearch:
 
   dashboards:
     contentSecurityPolicy:
-      rules:
-        default-src: "'self'"
-        frame-ancestors: "'none'"
-        img-src: "'self' data:"
-        script-src: "'unsafe-eval' 'self'"
-        style-src: "'unsafe-inline' 'self'"
-        worker-src: "blob: 'self'"
+      default-src: "'self'"
+      frame-ancestors: "'none'"
+      img-src: "'self' data:"
+      script-src: "'unsafe-eval' 'self'"
+      style-src: "'unsafe-inline' 'self'"
+      worker-src: "blob: 'self'"
 
     # subdomain moved to common-config
     # Note SSO is enabled via `opensearch.sso.enabled`

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -29,21 +29,14 @@ $defs:
     title: Common Resource
     type: object
   contentSecurityPolicy:
-    title: Content-Security-Policy
+    title: Content-Security-Policy rules
     description: |-
       Configure Content-Security-Policy header rules
+      Reference: https://content-security-policy.com/
     type: object
-    additionalProperties: false
-    properties:
-      rules:
-        title: Content-Security-Policy rules
-        description: |-
-          Configure Content-Security-Policy header rules
-          Reference: https://content-security-policy.com/
-        type: object
-        additionalProperties:
-          type: string
-          additionalProperties: false
+    additionalProperties:
+      type: string
+      additionalProperties: false
   cpumem:
     deprecated: true
     description: |-
@@ -6046,15 +6039,13 @@ properties:
         properties:
           contentSecurityPolicy:
             $ref: '#/$defs/contentSecurityPolicy'
-            properties:
-              rules:
-                default:
-                  default-src: "'self'"
-                  frame-ancestors: "'none'"
-                  img-src: "'self' data:"
-                  script-src: "'unsafe-eval' 'self'"
-                  style-src: "'unsafe-inline' 'self'"
-                  worker-src: "blob: 'self'"
+            default:
+              default-src: "'self'"
+              frame-ancestors: "'none'"
+              img-src: "'self' data:"
+              script-src: "'unsafe-eval' 'self'"
+              style-src: "'unsafe-inline' 'self'"
+              worker-src: "blob: 'self'"
           subdomain:
             title: OpenSearch Dashboards Subdomain
             description: |-

--- a/helmfile.d/values/opensearch/dashboards.yaml.gotmpl
+++ b/helmfile.d/values/opensearch/dashboards.yaml.gotmpl
@@ -10,7 +10,7 @@ config:
     server:
       host: "0"
 
-    {{- with .Values.opensearch.dashboards.contentSecurityPolicy.rules }}
+    {{- with .Values.opensearch.dashboards.contentSecurityPolicy }}
     csp:
       rules:
       {{- range $cspKey, $cspValue := . }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Adds templating and a default restricted Content-Security-Policy for OpenSearch Dashboards.

The templating is slightly different then for Dex and Grafana due to how the templating is in upstream chart, we could look at trying to harmonize the CSP templating in our helmfile values.

The CSP can be evaluated with https://csp-evaluator.withgoogle.com/.

Note that OpenSearch has a CSP by default, and complains about missing `script-src 'unsafe-inline'` when checking the console even without these new stricter CSP rules:
```console
Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'unsafe-eval' 'self'". Either the 'unsafe-inline' keyword, a hash , or a nonce ('nonce-...') is required to enable inline execution.
```

OpenSearch Dashboards seems to work even without including this in the rules, so I kept it out.

For additional context, see arch topic here: https://github.com/elastisys/ck8s-arch/issues/303

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
