### PR TITLE
Remove ThanosReceiveTrafficBelowThreshold runbook templating

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -185,6 +185,7 @@
 /helmfile.d/values/minio.yaml.gotmpl @elastisys/goto-qa
 /helmfile.d/values/node-local-dns.yaml.gotmpl @elastisys/goto-networking
 /helmfile.d/values/openstack-monitoring.yaml.gotmpl @elastisys/goto-kubespray
+/helmfile.d/values/prometheus-alerts-runbook-urls.yaml.gotmpl @elastisys/goto-monitoring-stack
 /helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl @elastisys/goto-monitoring-stack
 /helmfile.d/values/prometheus-blackbox-exporter-* @elastisys/goto-monitoring-stack
 /helmfile.d/values/prometheus-opensearch-exporter.yaml.gotmpl @elastisys/goto-logging-stack

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # By default, this whole repo should be reviewed by the product architect
-/* @elastisys/product-architect
+* @elastisys/product-architect
 
 
 /.github/ @elastisys/goto-qa

--- a/helmfile.d/values/prometheus-alerts-runbook-urls.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-alerts-runbook-urls.yaml.gotmpl
@@ -273,7 +273,6 @@ runbookUrls:
     {{- dict "name" "ThanosReceiveHighHashringFileRefreshFailures" "header" "thanos-receive" "config" .thanos | include "tpl.thanos" }}
     {{- dict "name" "ThanosReceiveConfigReloadFailure" "header" "thanos-receive" "config" .thanos | include "tpl.thanos" }}
     {{- dict "name" "ThanosReceiveNoUpload" "header" "thanos-receive" "config" .thanos | include "tpl.thanos" }}
-    {{- dict "name" "ThanosReceiveTrafficBelowThreshold" "header" "thanos-receive" "config" .thanos | include "tpl.thanos" }}
     {{- dict "name" "ThanosStoreGrpcErrorRate" "header" "thanos-store" "config" .thanos | include "tpl.thanos" }}
     {{- dict "name" "ThanosStoreSeriesGateLatencyHigh" "header" "thanos-store" "config" .thanos | include "tpl.thanos" }}
     {{- dict "name" "ThanosStoreBucketHighOperationFailures" "header" "thanos-store" "config" .thanos | include "tpl.thanos" }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [x] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
I was a bit too quick with merging https://github.com/elastisys/compliantkubernetes-apps/pull/2745 as I missed this templating that is used to configure the runbook for the removed alert. :face_exhaling: 

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
