### PR TITLE
Gabbe16/add probe wc ingress

### DIFF
--- a/config/wc-config.yaml
+++ b/config/wc-config.yaml
@@ -309,6 +309,7 @@ prometheusBlackboxExporter:
     gatekeeper: true
     falco: true
     sc: true
+    wc: true
 
 ingressNginx:
   subDomain: ingress-nginx

--- a/helmfile.d/values/prometheus-blackbox-exporter-wc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-blackbox-exporter-wc.yaml.gotmpl
@@ -50,6 +50,17 @@ config:
         preferred_ip_protocol: "ip4"
         tls_config:
           insecure_skip_verify: true
+    http_404:
+      prober: http
+      timeout: 5s
+      http:
+        # we are not logged in, just cheking that it can be reached
+        valid_status_codes: [404]
+        valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+        follow_redirects: true 
+        preferred_ip_protocol: "ip4"
+        tls_config:
+          insecure_skip_verify: true
     tcp_connect:
       prober: tcp
 service:
@@ -94,6 +105,14 @@ serviceMonitor:
       interval: 60s
       scrapeTimeout: 30s
       module: http_2xx
+    {{- end }}
+
+    {{- if .Values.prometheusBlackboxExporter.targets.wc}}
+    - name: wc-ingress-probe
+      url: https://{{ .Values.ingressNginx.subDomain }}.{{ .Values.global.baseDomain  }}
+      interval: 60s
+      scrapeTimeout: 30s
+      module: http_404
     {{- end }}
 
     {{- if .Values.prometheusBlackboxExporter.targets.sc}}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

### What does this PR do / why do we need this PR?

There was an ingress created for ingress-nginx health from an [older PR](https://github.com/elastisys/compliantkubernetes-apps/pull/1896) although there was never a probe added for it in either wc or sc that could provide metrics. With this PR i have added a probe for that same ingress in wc which is configured via the blackbox exporter so it can provide metrics on the Grafana blackbox exporter dashboard.

#### Information to reviewers

<!--
Any additional information reviews should know.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
