### PR TITLE
apps sc: opensearch anti-affinity enablement

### DIFF
--- a/config/providers/elastx/sc-config.yaml
+++ b/config/providers/elastx/sc-config.yaml
@@ -85,54 +85,48 @@ opensearch:
   masterNode:
     affinity:
       podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              topologyKey: topology.kubernetes.io/zone
-              labelSelector:
-                matchExpressions:
-                  - key: app.kubernetes.io/instance
-                    operator: In
-                    values:
-                      - opensearch-master
-                  - key: app.kubernetes.io/name
-                    operator: In
-                    values:
-                      - opensearch
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+              - opensearch-master
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - opensearch
+          topologyKey: topology.kubernetes.io/zone
   dataNode:
     affinity:
       podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              topologyKey: topology.kubernetes.io/zone
-              labelSelector:
-                matchExpressions:
-                  - key: app.kubernetes.io/instance
-                    operator: In
-                    values:
-                      - opensearch-master
-                  - key: app.kubernetes.io/name
-                    operator: In
-                    values:
-                      - opensearch
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+              - opensearch-data
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - opensearch
+          topologyKey: topology.kubernetes.io/zone
   clientNode:
     affinity:
       podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              topologyKey: topology.kubernetes.io/zone
-              labelSelector:
-                matchExpressions:
-                  - key: app.kubernetes.io/instance
-                    operator: In
-                    values:
-                      - opensearch-master
-                  - key: app.kubernetes.io/name
-                    operator: In
-                    values:
-                      - opensearch
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+              - opensearch-client
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - opensearch
+          topologyKey: topology.kubernetes.io/zone
 dex:
   topologySpreadConstraints:
     - labelSelector:

--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -877,6 +877,12 @@ opensearch:
       ## - Only one rule and term can be set
       ## - The label selector is hardcoded and changing it here does not affect it
       podAntiAffinity:
+        ## Some providers (such as elastx) have default hard anti-affinity.
+        ## To override them with soft anti-affinity (as below), you need to also set
+        ## requiredDuringSchedulingIgnoredDuringExecution to an empty value.
+        ## If both keys are set to non-empty values at the same time, only the
+        ## hard anti-affinity rules will be used.
+        #requiredDuringSchedulingIgnoredDuringExecution: []
         preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
             podAffinityTerm:

--- a/helmfile.d/values/opensearch/master.yaml.gotmpl
+++ b/helmfile.d/values/opensearch/master.yaml.gotmpl
@@ -20,10 +20,10 @@ persistence:
   size: {{ .Values.opensearch.masterNode.storageSize }}
   storageClass: {{ toYaml .Values.opensearch.masterNode.storageClass }}
 
-{{ if (hasKey .Values.opensearch.masterNode.affinity.podAntiAffinity "requiredDuringSchedulingIgnoredDuringExecution") -}}
+{{ if .Values.opensearch | dig "masterNode" "affinity" "podAntiAffinity" "requiredDuringSchedulingIgnoredDuringExecution" list -}}
 antiAffinityTopologyKey: {{ (first .Values.opensearch.masterNode.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution).topologyKey | quote }}
 antiAffinity: hard
-{{ else if (hasKey .Values.opensearch.masterNode.affinity.podAntiAffinity "preferredDuringSchedulingIgnoredDuringExecution") -}}
+{{ else if .Values.opensearch | dig "masterNode" "affinity" "podAntiAffinity" "preferredDuringSchedulingIgnoredDuringExecution" list -}}
 antiAffinityTopologyKey: {{ (first .Values.opensearch.masterNode.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution).podAffinityTerm.topologyKey | quote }}
 antiAffinity: soft
 {{ end -}}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
The PR re-enables hard anti-affinity configuration by default for Elastx. Previously, this was reverted since it was impossible to override in the configuration. This PR makes it possible to override the anti-affinity settings in your local `sc-config.yaml` regardless of the default anti-affinity configuration of the provider.

This PR solves it by:
1) Tweaking the Helmfile templates to not only look for certain keys, but also if they are empty or not,
2) This allows to override e.g. an Elastx default hard anti-affinity by setting `requiredDuringSchedulingIgnoredDuringExecution: []`, i.e. an empty list, and then set the soft anti-affinity using `preferredDuringSchedulingIgnoredDuringExecution` as usual,
3) Document how do override in the config files.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2635 

#### Information to reviewers

I chose this solution since it required the least amount of changes, with no breaking changes to existing configurations.

I've tested it by running `helmfile template -e service_cluster` for the follow configuration combinations.

| Provider | Own `sc-config.yaml` `required...`-value | Own `sc-config.yaml` `preferred...`-value |**Outcome** |
|--------|--------|--------|--------|
| OpenStack | Not set | Not set | Soft anti-affinity |
| OpenStack | Empty list | Not set | Soft anti-affinity |
| OpenStack | Set | Not set | Hard anti-affinity |
| Elastx | Not set | Not set | Hard anti-affinity (because of default provider config) | 
| Elastx | Empty list | Set | Soft anti-affinity | 
| Elastx | Set | Not set | Hard anti-affinity (with key from own config) | 


An **alternative solution** would be to do a bigger revamp of the anti-affinity design, and for example better match it with the upstream OpenSearch helm chart configuration which uses the keys: `antiAffinity: <hard|soft>` and `antiAffinityTopologyKey: topology.kubernetes.io/zone`. Having these keys in `sc-config.yaml` would then directly map to the upstream chart, and make it trivial to override by just setting these keys. The downside of this solution is that it requires breaking changes in configs, and that anti-affinity configuration will look completely different for OpenSearch and other services such as Harbor. 

Let me know what you think :).


#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
