### PR TITLE
Add support for Modules

### DIFF
--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -1,10 +1,12 @@
 pkg:deb/ubuntu/apache2-utils@2.4.*?arch=amd64&distro=noble
 pkg:deb/ubuntu/curl@8.5.*?arch=amd64&distro=noble
 pkg:deb/ubuntu/dnsutils@1:9.18.*?arch=amd64&distro=noble
+pkg:deb/ubuntu/gzip@1.12-*?arch=amd64&distro=noble
 pkg:deb/ubuntu/pwgen@2.08-*?arch=amd64&distro=noble
 pkg:deb/ubuntu/s3cmd@2.4.*?arch=amd64&distro=noble
 pkg:deb/ubuntu/socat@1.*?arch=amd64&distro=noble
 pkg:generic/kubectl@v1.32.8
+pkg:generic/crossplane@v2.0.2
 pkg:github/jkroepke/helm-secrets@v4.6.5
 pkg:github/jqlang/jq@jq-1.6
 pkg:golang/github.com/databus23/helm-diff%2Fv3@v3.10.0

--- a/bin/common.bash
+++ b/bin/common.bash
@@ -156,6 +156,7 @@ check_tools() {
   check_minor "$(echo "${req}" | jq --raw-output '.["helm-secrets"].version')" "$(helm plugin list | grep secrets)" "helm secrets plugin"
   check_minor "$(echo "${req}" | jq --raw-output '.["getsops/sops/v3"].version')" "$(sops --version)" "sops"
   check_minor "$(echo "${req}" | jq --raw-output '.["s3cmd"].version')" "$(s3cmd --version)" "s3cmd"
+  check_minor "$(echo "${req}" | jq --raw-output '.["crossplane"].version')" "$(crossplane version --client)" "crossplane"
 
   if [[ "${warn}" != 0 ]]; then
     if [[ -t 1 ]]; then

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -8468,6 +8468,14 @@ properties:
             patternProperties:
               "^[a-z-]+$":
                 $ref: '#/$defs/containerImage'
+          configurations:
+            title: Crossplane Configuration packages configuration
+            description: Crossplane Configuration packages configuration
+            type: object
+            additionalProperties: false
+            patternProperties:
+              "^[a-z-]+$":
+                $ref: '#/$defs/containerImage'
       dex:
         title: Dex stack image configuration
         description: Dex stack image configuration

--- a/helmfile.d/charts/crossplane/packages/templates/configurations.yaml
+++ b/helmfile.d/charts/crossplane/packages/templates/configurations.yaml
@@ -1,0 +1,11 @@
+{{- range $name, $values := .Values.configurations }}
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: {{ $name }}
+spec:
+  package: {{ $values.image.repository }}:{{ $values.image.tag }}
+  # Setting this to true to make us handle all dependency management instead of Crossplane.
+  skipDependencyResolution: true
+{{- end }}

--- a/helmfile.d/charts/crossplane/packages/values.yaml
+++ b/helmfile.d/charts/crossplane/packages/values.yaml
@@ -1,3 +1,4 @@
+configurations: {}
 functions: {}
 providers: {}
 kubectlImage: {}

--- a/helmfile.d/values/crossplane-packages.yaml.gotmpl
+++ b/helmfile.d/values/crossplane-packages.yaml.gotmpl
@@ -15,6 +15,23 @@ kubectlImage:
 {{- end }}
 {{- end }}
 
+{{- with .Values.images | dig "crossplane" "configurations" dict }}
+configurations:
+{{- range $configuration, $image := . }}
+  {{ $configuration }}:
+    {{- $image = merge (include "container_uri.parse" $image | fromJson) $imagesGlobal }}
+    {{- with $image }}
+    image:
+      {{- with include "gen.reg-rep-img" . }}
+      repository: {{ . }}
+      {{- end }}
+      {{- if or .tag .digest }}
+      tag: "{{ .tag }}{{ if .digest }}@{{ .digest }}{{ end }}"
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}
+
 functions:
 {{- range $function, $image := .Values.images.crossplane.functions }}
   {{ $function }}:

--- a/roles/get-requirements.yaml
+++ b/roles/get-requirements.yaml
@@ -5,8 +5,10 @@
     install_path: "{{ lookup('env', 'CK8S_INSTALL_PATH', default='/usr/local/bin') }}"
     install_user: "{{ lookup('env','USER') }}"
     apache2_utils_version: "{{ requirements['apache2-utils'].version }}"
+    crossplane_version: "{{ requirements['crossplane'].version }}"
     curl_version: "{{ requirements['curl'].version }}"
     dnsutils_version: "{{ requirements['dnsutils'].version }}"
+    gzip_version: "{{ requirements['gzip'].version }}"
     helm_version: "{{ requirements['helm.sh/helm/v3'].version | regex_replace('^v', '') }}"
     helmdiff_version: "{{ requirements['github.com/databus23/helm-diff/v3'].version | regex_replace('^v', '') }}"
     helmfile_version: "{{ requirements['github.com/helmfile/helmfile'].version | regex_replace('^v', '') }}"
@@ -27,7 +29,13 @@
       - dnsutils={{ dnsutils_version }}
       - apache2-utils={{ apache2_utils_version }}
       - pwgen={{ pwgen_version }}
+      - gzip={{ gzip_version }}
     get_url_list:
+      - command: crossplane
+        version: "{{ crossplane_version }}"
+        url: https://releases.crossplane.io/stable/{{ crossplane_version }}/bin/linux_amd64/crank
+        dest: "{{ install_path }}/crossplane"
+        version_flag: "version --client"
       - command: jq
         version: "{{ jq_version }}"
         url: https://github.com/stedolan/jq/releases/download/jq-{{ jq_version }}/jq-linux64

--- a/scripts/helm-kustomize-post-renderer.sh
+++ b/scripts/helm-kustomize-post-renderer.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# This script is used to run kustomize as a Helm post-renderer.
+#
+# Example: helm diff --post-renderer ./helm-kustomize-post-renderer.sh --post-renderer-args /path/to/kustomize/directory
+#
+# Note that the kustomization.yaml should have an initial resource named
+# "rendered-templates.yaml" which will include the initial output from Helm's
+# template rendering which then can be patched further.
+#
+# Example:
+#
+# resources:
+#   - rendered-templates.yaml
+# patches:
+#   - path: patch.yaml
+#     target:
+#       kind: Deployment
+#       name: foo
+
+set -euo pipefail
+
+if [ "${#}" -ne "1" ]; then
+  echo "Usage: ${0} KUSTOMIZE_DIR" >&2
+  exit 1
+fi
+
+cat >"${1}/rendered-templates.yaml"
+
+kubectl kustomize "${1}" && rm "${1}/rendered-templates.yaml"

--- a/scripts/migration/crossplane.sh
+++ b/scripts/migration/crossplane.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+module_maintenance_test() {
+  if [[ "${#}" -lt 2 ]] || [[ ! "${1}" =~ ^(sc|wc)$ ]]; then
+    log_fatal "usage: module_maintenance_test <sc|wc> <module_selector> [<helm-post-renderer-kustomization-dir>]"
+  fi
+
+  local helmfile_list_result
+  local helmfile_list_count
+  local new_release_name
+  local old_release_name
+  local namespace
+  local crossplane_release
+  local crossplane_release_external_name
+  local chart_repository
+  local chart_name
+  local chart_version
+  local values
+  local helm_diff_args
+
+  helmfile_list_result="$(helmfile_list "${1}" "${2}")"
+
+  helmfile_list_count="$(jq -r 'length' <<<"${helmfile_list_result}")"
+
+  if [ "${helmfile_list_count}" -ne "1" ]; then
+    log_fatal "Expected helmfile list -l ${2} to return 1 result, actual number: ${helmfile_list_count}"
+  fi
+
+  new_release_name="$(jq -r '.[0].name' <<<"${helmfile_list_result}")"
+  old_release_name="${new_release_name#"module-"}"
+  namespace="$(jq -r '.[0].namespace' <<<"${helmfile_list_result}")"
+
+  log_info "Running ${new_release_name} maintenance test by comparing it with existing Helm Release ${old_release_name} in cluster ${1}"
+
+  crossplane_release="$(_crossplane_render "${1}" "${new_release_name}" | yq 'select(.kind == "Release")')"
+
+  crossplane_release_external_name=$(yq '.metadata.annotations["crossplane.io/external-name"]' <<<"${crossplane_release}")
+  if [ "${crossplane_release_external_name}" != "${old_release_name}" ]; then
+    log_error "Annotation 'crossplane.io/external-name' in Release in Module does not match existing Helm Release name"
+    log_error "Expected: ${old_release_name}"
+    log_error "Actual: ${crossplane_release_external_name}"
+    log_fatal "DO NOT UPGRADE"
+  fi
+
+  if [ "$(_crossplane_xr "${1}" "${new_release_name}" | yq 'select(.apiVersion == "module.elastisys.com/v1alpha1").metadata.namespace')" != "null" ]; then
+    log_fatal "The XR namespace is set, it should not be set. The namespace should be decided by Helmfile instead."
+  fi
+  if [ "$(yq '.metadata.namespace' <<<"${crossplane_release}")" != "null" ]; then
+    log_fatal "Release .metadata.namespace is set, it should not be set. The namespace should be decided by where the Module is installed."
+  fi
+  if [ "$(yq '.spec.forProvider.namespace' <<<"${crossplane_release}")" != "null" ]; then
+    log_fatal "Release .spec.forProvider.namespace is set, it should not be set. The namespace should be decided by where the Module is installed."
+  fi
+
+  chart_repository=$(yq '.spec.forProvider.chart.repository' <<<"${crossplane_release}")
+  chart_name=$(yq '.spec.forProvider.chart.name' <<<"${crossplane_release}")
+  chart_version=$(yq '.spec.forProvider.chart.version' <<<"${crossplane_release}")
+  values="$(yq -o json '.spec.forProvider.values' <<<"${crossplane_release}")"
+
+  helm_diff_args=(
+    -n "${namespace}"
+    upgrade "${old_release_name}" "${chart_repository}/${chart_name}"
+    --version "${chart_version}"
+    --allow-unreleased
+    --reset-values
+    --values -
+    --detailed-exitcode
+    --normalize-manifests
+  )
+
+  [[ "${#}" -gt 2 ]] &&
+    helm_diff_args+=(
+      --post-renderer "${ROOT}/scripts/helm-kustomize-post-renderer.sh"
+      --post-renderer-args "${3}"
+    )
+
+  if ! echo "${values}" | helm_do "${1}" diff "${helm_diff_args[@]}"; then
+    log_error "Detected unexpected differences between the existing Helm Release and the Helm Release installed by the Module."
+    log_fatal "DO NOT UPGRADE"
+  fi
+
+  log_info "${new_release_name} maintenance test for cluster ${1} succeeded!"
+}
+
+_crossplane_render() {
+  if [[ "${#}" -lt 2 ]] || [[ ! "${1}" =~ ^(sc|wc)$ ]]; then
+    log_fatal "usage: _crossplane_render <sc|wc> <module_name>"
+  fi
+
+  log_info "Rendering ${2}"
+
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+
+  append_trap 'rm -r '"${tmpdir}" EXIT
+
+  _crossplane_composition "${1}" "${2}" >"${tmpdir}/composition.yaml"
+
+  _crossplane_functions "${1}" >"${tmpdir}/functions.yaml"
+
+  _crossplane_xr "${1}" "${2}" >"${tmpdir}/xr.yaml"
+
+  crossplane render "${tmpdir}/xr.yaml" "${tmpdir}/composition.yaml" "${tmpdir}/functions.yaml"
+}
+
+_crossplane_composition() {
+  if [[ "${#}" -lt 2 ]] || [[ ! "${1}" =~ ^(sc|wc)$ ]]; then
+    log_fatal "usage: _crossplane_composition <sc|wc> <configuration_name>"
+  fi
+
+  log_info "Extracting Composition from Configuration ${2}"
+
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+
+  append_trap 'rm -r '"${tmpdir}" EXIT
+
+  local configuration_package
+  configuration_package=$(helmfile_do "${1}" template -l name=crossplane-packages | yq 'select(.kind == "Configuration" and .metadata.name == "'"${2}"'").spec.package')
+
+  if [ -z "${configuration_package}" ]; then
+    log_fatal "Failed to determine package from Configuration ${2}"
+  fi
+
+  log_info "Found Configuration package: ${configuration_package}"
+
+  crossplane xpkg extract "${configuration_package}" -o "${tmpdir}/out.gz"
+
+  zcat "${tmpdir}/out.gz" | yq 'select(.kind == "Composition")'
+}
+
+_crossplane_functions() {
+  if [[ ! "${1}" =~ ^(sc|wc)$ ]]; then
+    log_fatal "usage: _crossplane_functions <sc|wc>"
+  fi
+
+  log_info "Getting Functions that should be installed by Apps"
+
+  helmfile_do "${1}" template -l name=crossplane-packages | yq 'select(.kind == "Function")'
+}
+
+_crossplane_xr() {
+  if [[ "${#}" -lt 2 ]] || [[ ! "${1}" =~ ^(sc|wc)$ ]]; then
+    log_fatal "usage: _crossplane_xr <sc|wc> <module_release_name>"
+  fi
+
+  log_info "Getting XR from ${2}"
+
+  helmfile_do "${1}" template -l "name=${2}"
+}

--- a/scripts/migration/lib.sh
+++ b/scripts/migration/lib.sh
@@ -520,6 +520,8 @@ record_upgrade_done() {
   kubectl_do "${1}" delete configmap --namespace kube-system welkin-apps-upgrade >/dev/null
 }
 
+# shellcheck source=scripts/migration/crossplane.sh
+source "${ROOT}/scripts/migration/crossplane.sh"
 # shellcheck source=scripts/migration/helm.sh
 source "${ROOT}/scripts/migration/helm.sh"
 # shellcheck source=scripts/migration/helmfile.sh


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

- Fixes https://github.com/elastisys/ck8s-issue-tracker/issues/594

#### Information to reviewers

Some stuff that I know is still missing:
* ~Support for creating a kubeconfig secret in Kubespray that the ClusterProviderConfigs refer to for managing resources in wc~ Starting with only local provider configs, see follow-up: https://github.com/elastisys/ck8s-issue-tracker/issues/651
* Migration - How do we make sure that the module adopts the existing node-local-dns Helm release?
  * We now safeguard against diffs with the acceptance test but I think we still need to verify that it's actually **adopted** somehow. Feel free to propose solutions here!
* What to do with missing capabilities?
  * For the MetricCollection capability we can manually add ServiceMonitors, see example in: https://github.com/elastisys/compliantkubernetes-apps/pull/2839

See https://github.com/elastisys/compliantkubernetes-apps/pull/2779 for the integration of Crossplane itself.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
