### PR TITLE
Add serviceMonitor for kube-vip in SafeSpring

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -412,6 +412,9 @@ openstackMonitoring:
   ## Enables openstack api metrics.
   enabled: false
 
+kubeVIPMonitoring:
+  enabled: false
+
 prometheus:
   replicas: 1
   devAlertmanager:

--- a/config/providers/safespring/common-config.yaml
+++ b/config/providers/safespring/common-config.yaml
@@ -1,5 +1,7 @@
 openstackMonitoring:
   enabled: true
+kubeVIPMonitoring:
+  enabled: true
 storageClasses:
   default: cinder-csi
 networkPolicies:

--- a/helmfile.d/charts/prometheus-servicemonitor/templates/_helpers.tpl
+++ b/helmfile.d/charts/prometheus-servicemonitor/templates/_helpers.tpl
@@ -43,3 +43,8 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{- define "prometheus-servicemonitor.kube-vip.labels" -}}
+{{ include "prometheus-servicemonitor.labels" . }}
+app: kube-vip
+{{- end -}}

--- a/helmfile.d/charts/prometheus-servicemonitor/templates/kube-vip-monitor.yaml
+++ b/helmfile.d/charts/prometheus-servicemonitor/templates/kube-vip-monitor.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.kubeVIP.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prometheus-servicemonitor.fullname" . | printf "%s-kube-vip" | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Values.kubeVIP.namespace }}
+  labels:
+{{ include "prometheus-servicemonitor.kube-vip.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.kubeVIP.service.type }}
+  ports:
+    - port: {{ .Values.kubeVIP.service.port }}
+      targetPort: {{ .Values.kubeVIP.service.targetPort }}
+      protocol: TCP
+      name: monitoring
+  selector: {{- toYaml .Values.kubeVIP.service.selectorLabels | nindent 4 }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ printf "%s-%s" (include "prometheus-servicemonitor.fullname" .) "kube-vip" | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Values.kubeVIP.namespace }}
+  labels:
+{{ include "prometheus-servicemonitor.kube-vip.labels" . | indent 4 }}
+spec:
+  endpoints:
+  - interval: 30s
+    port: monitoring
+  jobLabel: component
+  namespaceSelector:
+    matchNames:
+    - {{ .Values.kubeVIP.namespace }}
+  selector:
+    matchLabels:
+{{ include "prometheus-servicemonitor.kube-vip.labels" . | indent 6 }}
+{{- end }}

--- a/helmfile.d/charts/prometheus-servicemonitor/values.yaml
+++ b/helmfile.d/charts/prometheus-servicemonitor/values.yaml
@@ -7,3 +7,13 @@ rookMonitor:
   relabelings: []
   # - targetLabel: cluster
   #   replacement: service_cluster
+
+kubeVIP:
+  enabled: true
+  namespace: kube-system
+
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: http
+    selectorLabels: {}

--- a/helmfile.d/stacks/monitoring.yaml.gotmpl
+++ b/helmfile.d/stacks/monitoring.yaml.gotmpl
@@ -49,6 +49,7 @@ templates:
       app: metrics-server
     values:
       - values/metrics-server.yaml.gotmpl
+
   autoscaling-monitoring:
     disableValidationOnInstall: true
     condition: ck8sManagementCluster.enabled

--- a/helmfile.d/values/sc-servicemonitor.yaml.gotmpl
+++ b/helmfile.d/values/sc-servicemonitor.yaml.gotmpl
@@ -4,3 +4,14 @@ defaultRules:
 
 rookMonitor:
   enabled: {{ .Values.rookCeph.monitoring.enabled }}
+
+kubeVIP:
+  enabled: {{ .Values.kubeVIPMonitoring.enabled }}
+  namespace: kube-system
+  service:
+    type: ClusterIP
+    port: 2112
+    targetPort: 2112
+    selectorLabels:
+      app.kubernetes.io/instance: kube-vip-service-loadbalancer
+      app.kubernetes.io/name: kube-vip

--- a/helmfile.d/values/wc-servicemonitor.yaml.gotmpl
+++ b/helmfile.d/values/wc-servicemonitor.yaml.gotmpl
@@ -4,3 +4,14 @@ defaultRules:
 
 rookMonitor:
   enabled: {{ .Values.rookCeph.monitoring.enabled }}
+
+kubeVIP:
+  enabled: {{ .Values.kubeVIPMonitoring.enabled }}
+  namespace: kube-system
+  service:
+    type: ClusterIP
+    port: 2112
+    targetPort: 2112
+    selectorLabels:
+      app.kubernetes.io/instance: kube-vip-service-loadbalancer
+      app.kubernetes.io/name: kube-vip


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Add serviceMonitor for kube-vip when using it as serviceLoadbalancer on Safespring. 
Part of https://github.com/elastisys/ck8s-cluster-api/issues/396

#### Information to reviewers

This PR is prerequisite of the following capi PR. 
https://github.com/elastisys/ck8s-cluster-api/pull/464

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
