### PR TITLE
Disable CpuThrottlingHigh alert by default

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -218,8 +218,8 @@ alerts:
     thanos: {}
     webhook: {}
 
-  disabled:
-    CPUThrottlingHigh: true
+  enabled:
+    CPUThrottlingHigh: false
 
 ## Falco configuration.
 falco:

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -4427,16 +4427,16 @@ properties:
                 type: string
           webhook:
             $ref: '#/properties/alerts/properties/runbookUrls/$defs/noUpstreamRunbook'
-      disabled:
+      enabled:
         type: object
-        title: Disabled alerts
-        description: Alerts that can be disabled
+        title: Enabled alerts
+        description: Enabled alerts
         properties:
           CPUThrottlingHigh:
-            title: CPUThrottlingHigh disabled
-            description: Configure whether or not CPUThrottlingHigh alert should be disabled
+            title: CPUThrottlingHigh enabled
+            description: Configure whether or not CPUThrottlingHigh alert should be enabled
             type: boolean
-            default: true
+            default: false
   grafana:
     title: Grafana Config
     description: |-

--- a/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-resources.yaml
+++ b/helmfile.d/charts/prometheus-alerts/templates/alerts/kubernetes-resources.yaml
@@ -49,7 +49,7 @@ spec:
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
-{{- if not (.Values.defaultRules.disabled.CPUThrottlingHigh | default false) }}
+{{- if .Values.defaultRules.enabled.CPUThrottlingHigh }}
     - alert: CPUThrottlingHigh
       annotations:
         description: '{{`{{`}} $value | humanizePercentage {{`}}`}} throttling of CPU in namespace {{`{{`}} $labels.namespace {{`}}`}} for container {{`{{`}} $labels.container {{`}}`}} in pod {{`{{`}} $labels.pod {{`}}`}}.'

--- a/helmfile.d/charts/prometheus-alerts/values.yaml
+++ b/helmfile.d/charts/prometheus-alerts/values.yaml
@@ -151,7 +151,7 @@ defaultRules:
     # alertLabels:
     #   key: value
 
-  disabled:
+  enabled:
     CPUThrottlingHigh: false
 
 capacityManagementAlertsPredictUsage: false

--- a/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
+++ b/helmfile.d/values/prometheus-alerts-sc.yaml.gotmpl
@@ -58,8 +58,8 @@ defaultRules:
       evaluate_prometheus: "1"
   {{- end }}
 
-  disabled:
-    CPUThrottlingHigh: {{ .Values.alerts.disabled.CPUThrottlingHigh }}
+  enabled:
+    CPUThrottlingHigh: {{ .Values.alerts.enabled.CPUThrottlingHigh }}
 
 capacityManagementAlertsPersistentVolumeEnabled: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.enabled }}
 capacityManagementAlertsPersistentVolumeLimit: {{ .Values.prometheus.capacityManagementAlerts.persistentVolume.limit }}


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [x] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [x] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

### Platform Administrator notice

The CpuThrottlingHigh alert has been disabled by default and is instead left as an opt-in alert.

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
This PR disables the CPUThrottlingHigh alert by default, as it is already ignored with OpsGenie integration, but not when integrating with other receivers like Slack or Teams.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Part of https://github.com/elastisys/ck8s-issue-tracker/issues/548

#### Information to reviewers

Planning to discuss the disabled option further with GoTos as we might want to have the option to disable other alerts as well. The config is pretty much copy pasted from the upstream prometheus chart in case we ever decide to move to using the upstream chart for some alerts instead of our own.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
