### PR TITLE
docs: Maintenance note for v0.49

### DIFF
--- a/changelog/0.49.md
+++ b/changelog/0.49.md
@@ -1,5 +1,11 @@
 # v0.49.0
 
+> [!caution]
+> v0.49.0 has a known issue with a migration missing for maintaining the old configuration for the Ingress Controller using UpCloud as provider.
+>
+> The default configuration changed from using HostPorts on the Pods to NodePorts on the Service.
+> This changes the used port numbers, so unless you reconfigure your load balancer to use the new NodePorts, ingress traffic will not be able to enter your environment.
+
 Released 2025-09-18
 <!-- -->
 > [!IMPORTANT]

--- a/migration/v0.49/README.md
+++ b/migration/v0.49/README.md
@@ -54,6 +54,56 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 
 ## Automatic method
 
+> [!caution]
+> v0.49.0 has a known issue with a migration missing for maintaining the old configuration for the Ingress Controller using UpCloud as provider.
+>
+> The default configuration changed from using HostPorts on the Pods to NodePorts on the Service.
+> This changes the used port numbers, so unless you reconfigure your load balancer to use the new NodePorts, ingress traffic will not be able to enter your environment.
+>
+> For the SC:
+>
+> ```bash
+> host_port="$(yq ea "explode(.) | .ingressNginx.controller.useHostPort | select(. != null) | {\"wrapper\": .} as \$item ireduce ({}; . * \$item) | .wrapper | ... comments=\"\"" \
+>   "${CK8S_CONFIG_PATH}/defaults/common-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/defaults/sc-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/common-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/sc-config.yaml")"
+> if [[ "${host_port}" == "true" ]]; then
+>   yq -i '.ingressNginx.controller.useHostPort = true' "${CK8S_CONFIG_PATH}/sc-config.yaml"
+> fi
+>
+> service_enabled="$(yq ea "explode(.) | .ingressNginx.controller.service.enabled | select(. != null) | {\"wrapper\": .} as \$item ireduce ({}; . * \$item) | .wrapper | ... comments=\"\"" \
+>   "${CK8S_CONFIG_PATH}/defaults/common-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/defaults/sc-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/common-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/sc-config.yaml")"
+> if [[ "${service_enabled}" == "false" ]]; then
+>   yq -i '.ingressNginx.controller.service.enabled = false' "${CK8S_CONFIG_PATH}/sc-config.yaml"
+> fi
+> ```
+>
+> For the WC:
+>
+> ```bash
+> host_port="$(yq ea "explode(.) | .ingressNginx.controller.useHostPort | select(. != null) | {\"wrapper\": .} as \$item ireduce ({}; . * \$item) | .wrapper | ... comments=\"\"" \
+>   "${CK8S_CONFIG_PATH}/defaults/common-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/defaults/wc-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/common-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/wc-config.yaml")"
+> if [[ "${host_port}" == "true" ]]; then
+>   yq -i '.ingressNginx.controller.useHostPort = true' "${CK8S_CONFIG_PATH}/wc-config.yaml"
+> fi
+>
+> service_enabled="$(yq ea "explode(.) | .ingressNginx.controller.service.enabled | select(. != null) | {\"wrapper\": .} as \$item ireduce ({}; . * \$item) | .wrapper | ... comments=\"\"" \
+>   "${CK8S_CONFIG_PATH}/defaults/common-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/defaults/wc-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/common-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/wc-config.yaml")"
+> if [[ "${service_enabled}" == "false" ]]; then
+>   yq -i '.ingressNginx.controller.service.enabled = false' "${CK8S_CONFIG_PATH}/wc-config.yaml"
+> fi
+> ```
+
 1. Pull the latest changes and switch to the correct branch:
 
     ```bash
@@ -95,6 +145,56 @@ As with all scripts in this repository `CK8S_CONFIG_PATH` is expected to be set.
 ### Prepare upgrade - _non-disruptive_
 
 > _Done before maintenance window._
+
+> [!caution]
+> v0.49.0 has a known issue with a migration missing for maintaining the old configuration for the Ingress Controller using UpCloud as provider.
+>
+> The default configuration changed from using HostPorts on the Pods to NodePorts on the Service.
+> This changes the used port numbers, so unless you reconfigure your load balancer to use the new NodePorts, ingress traffic will not be able to enter your environment.
+>
+> For the SC:
+>
+> ```bash
+> host_port="$(yq ea "explode(.) | .ingressNginx.controller.useHostPort | select(. != null) | {\"wrapper\": .} as \$item ireduce ({}; . * \$item) | .wrapper | ... comments=\"\"" \
+>   "${CK8S_CONFIG_PATH}/defaults/common-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/defaults/sc-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/common-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/sc-config.yaml")"
+> if [[ "${host_port}" == "true" ]]; then
+>   yq -i '.ingressNginx.controller.useHostPort = true' "${CK8S_CONFIG_PATH}/sc-config.yaml"
+> fi
+>
+> service_enabled="$(yq ea "explode(.) | .ingressNginx.controller.service.enabled | select(. != null) | {\"wrapper\": .} as \$item ireduce ({}; . * \$item) | .wrapper | ... comments=\"\"" \
+>   "${CK8S_CONFIG_PATH}/defaults/common-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/defaults/sc-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/common-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/sc-config.yaml")"
+> if [[ "${service_enabled}" == "false" ]]; then
+>   yq -i '.ingressNginx.controller.service.enabled = false' "${CK8S_CONFIG_PATH}/sc-config.yaml"
+> fi
+> ```
+>
+> For the WC:
+>
+> ```bash
+> host_port="$(yq ea "explode(.) | .ingressNginx.controller.useHostPort | select(. != null) | {\"wrapper\": .} as \$item ireduce ({}; . * \$item) | .wrapper | ... comments=\"\"" \
+>   "${CK8S_CONFIG_PATH}/defaults/common-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/defaults/wc-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/common-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/wc-config.yaml")"
+> if [[ "${host_port}" == "true" ]]; then
+>   yq -i '.ingressNginx.controller.useHostPort = true' "${CK8S_CONFIG_PATH}/wc-config.yaml"
+> fi
+>
+> service_enabled="$(yq ea "explode(.) | .ingressNginx.controller.service.enabled | select(. != null) | {\"wrapper\": .} as \$item ireduce ({}; . * \$item) | .wrapper | ... comments=\"\"" \
+>   "${CK8S_CONFIG_PATH}/defaults/common-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/defaults/wc-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/common-config.yaml" \
+>   "${CK8S_CONFIG_PATH}/wc-config.yaml")"
+> if [[ "${service_enabled}" == "false" ]]; then
+>   yq -i '.ingressNginx.controller.service.enabled = false' "${CK8S_CONFIG_PATH}/wc-config.yaml"
+> fi
+> ```
 
 1. Pull the latest changes and switch to the correct branch:
 

--- a/migration/v0.49/prepare/40-lift-upcloud-ingress.sh
+++ b/migration/v0.49/prepare/40-lift-upcloud-ingress.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+ROOT="$(readlink -f "${HERE}/../../../")"
+
+# shellcheck source=scripts/migration/lib.sh
+source "${ROOT}/scripts/migration/lib.sh"
+
+lift_ingress() {
+  host_port="$(yq_dig "${1}" '.ingressNginx.controller.useHostPort')"
+  if [[ "${host_port}" == "true" ]]; then
+    yq_dig "${1}" '.ingressNginx.controller.useHostPort' "true"
+  fi
+
+  service_enabled="$(yq_dig "${1}" '.ingressNginx.controller.service.enabled')"
+  if [[ "${service_enabled}" == "false" ]]; then
+    yq_dig "${1}" '.ingressNginx.controller.service.enabled' "false"
+  fi
+}
+
+provider="$(yq '.global.ck8sCloudProvider' "${CK8S_CONFIG_PATH}/defaults/common-config.yaml")"
+if [[ "${provider}" == "upcloud" ]]; then
+  if [[ "${CK8S_CLUSTER}" =~ ^(sc|both)$ ]]; then
+    lift_ingress sc
+  fi
+  if [[ "${CK8S_CLUSTER}" =~ ^(wc|both)$ ]]; then
+    lift_ingress wc
+  fi
+fi


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [x] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Add maintenance note on not making a breaking change.

#### Information to reviewers

I wish we had a command to interact with the config, rather than this...

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
