### PR TITLE
scripts(qa): networkPlugin should be optional

### DIFF
--- a/scripts/qa/README.md
+++ b/scripts/qa/README.md
@@ -85,7 +85,8 @@ should serve as a good guideline of what's possible (but necessarily _required_)
     "ingress": [
       "set-me"
     ]
-  }
+  },
+  "networkPlugin": "set-me"
 }
 ```
 
@@ -193,7 +194,8 @@ load balancer won't be included.
   "wcSubnets": {
     "apiServer": ["172.16.36.0/24"],
     "nodes": ["172.16.36.0/24"]
-  }
+  },
+  "networkPlugin": "calico"
 }
 ```
 
@@ -241,7 +243,8 @@ Find the public hostnames for your SC/WC on the [Load Balancers page](https://hu
         "secretKey": "redacted"
       }
     }
-  }
+  },
+  "networkPlugin": "calico"
 }
 ```
 
@@ -291,7 +294,8 @@ We're going with very permissive subnets for Brewer, but you can totally close t
   "wcSubnets": {
     "nodes": [ "0.0.0.0/0" ],
     "apiServer": [ "0.0.0.0/0" ]
-  }
+  },
+  "networkPlugin": "calico"
 }
 ```
 

--- a/scripts/qa/install_apps.py
+++ b/scripts/qa/install_apps.py
@@ -50,7 +50,7 @@ def configure_apps(
     """Configure apps"""
 
     # Configure network plugin
-    if (network_plugin := args.config["networkPlugin"]) is not None:
+    if (network_plugin := args.config.get("networkPlugin")) is not None:
         common_config.set("networkPlugin.type", network_plugin, merge=False)
 
     # Configure platform administrators
@@ -351,6 +351,9 @@ def install_dex(args: Args) -> None:
 
 def open_network_policies(config: Config) -> None:
     """Open network policies"""
+    if config.get("networkPlugin") is None:
+        return
+
     for cluster in ["sc", "wc"]:
         allow_all_policy = (
             f"{TESTS_DIR}/common/network-policies/{config['networkPlugin']}-allow-all.yaml"
@@ -360,6 +363,9 @@ def open_network_policies(config: Config) -> None:
 
 def close_network_policies(config: Config) -> None:
     """Close network policies"""
+    if config.get("networkPlugin") is None:
+        return
+
     for cluster in ["sc", "wc"]:
         allow_all_policy = (
             f"{TESTS_DIR}/common/network-policies/{config['networkPlugin']}-allow-all.yaml"


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

While using the QA installer to get Welkin deployed on Joy's brewer, noticed that a missing `networkPlugin` key from the config caused a hard crash. Since we declare `networkPlugin` to be optional, we need more guards in place.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
