### PR TITLE
apps wc: move user alertmanager secret to created with install hook

### DIFF
--- a/helmfile.d/hooks/alertmanager/dev-secret.yaml
+++ b/helmfile.d/hooks/alertmanager/dev-secret.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-kube-prometheus-stack-alertmanager
+  namespace: alertmanager
+  labels:
+    app: kube-prometheus-stack-alertmanager
+stringData:
+  alertmanager.yaml: |-
+    global:
+      resolve_timeout: 5m
+    inhibit_rules: []
+    receivers:
+    - name: "null"
+    route:
+      group_by:
+      - alertname
+      group_interval: 5m
+      group_wait: 30s
+      receiver: "null"
+      repeat_interval: 12h
+      routes:
+      - matchers:
+        - alertname = "Watchdog"
+        receiver: "null"
+    templates:
+    - /etc/alertmanager/config/*.tmpl

--- a/helmfile.d/stacks/monitoring-prometheus.yaml.gotmpl
+++ b/helmfile.d/stacks/monitoring-prometheus.yaml.gotmpl
@@ -27,6 +27,13 @@ templates:
       - values/kube-prometheus-stack-sc.yaml.gotmpl
       {{- else if .Values | get "ck8sWorkloadCluster.enabled" false }}
       - values/kube-prometheus-stack-wc.yaml.gotmpl
+    hooks:
+      - events: [ presync ]
+        showlogs: true
+        command: hooks/create-from-manifest.sh
+        args:
+          - "{{ .Environment.Name }}"
+          - alertmanager/dev-secret.yaml
       {{- end }}
     wait: true
     timeout: 600

--- a/helmfile.d/values/kube-prometheus-stack-wc.yaml.gotmpl
+++ b/helmfile.d/values/kube-prometheus-stack-wc.yaml.gotmpl
@@ -42,6 +42,9 @@ alertmanager:
       group_by: {{ toYaml .Values.prometheus.alertmanagerSpec.groupBy | nindent 8 }}
   alertmanagerSpec:
     automountServiceAccountToken: false
+    useExistingSecret: true
+    secrets:
+     - alertmanager-kube-prometheus-stack-alertmanager
     replicas: {{ .Values.prometheus.alertmanagerSpec.replicas }}
     retention: {{ .Values.prometheus.retention.alertmanager }}
     resources: {{- toYaml .Values.prometheus.alertmanagerSpec.resources | nindent 6 }}

--- a/migration/v0.50/apply/10-kube-prometheus-stack.sh
+++ b/migration/v0.50/apply/10-kube-prometheus-stack.sh
@@ -16,6 +16,11 @@ run() {
     fi
 
     for cluster in "${clusters[@]}"; do
+
+      if [[ "${cluster}" == "wc" ]]; then
+        kubectl_do "${cluster}" annotate secret -n alertmanager alertmanager-kube-prometheus-stack-alertmanager helm.sh/resource-policy=keep
+      fi
+
       current_version=$(helm_do "${cluster}" get metadata -n monitoring kube-prometheus-stack -ojson | jq -r '.version')
 
       log_info "Upgrading kube-prometheus-stack on ${cluster}: ${current_version} -> ${chart_version}"


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->

Before the rework of how we install alertmanager in wc we only installed the alertmanager config secret at first install of the chart and then orphaned it from helm, to ensure that app devs could update the secret without fear of platform admins overriding it when they applied the alertmanager chart. But with the rework this was lost, which means that upgrades of the kube-prometheus-stack chart risks overriding any changes that the app devs have done.

This PR fixes this issue by instead installing the secret via a helm hook that first checks if the secret exists and only creates it if it does not exist.
To ensure that we do not lose any customer config as part of this migration there is a migration step that first sets `helm.sh/resource-policy: keep` on the secret, this will ensure that the helm release does not delete the secret even though it is no longer part of the release.


<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

Note that fresh installs of the secret will only have the labels that are listed in the new secrets file. But any existing cluster will keep whatever labels are there from the helm release, such as which version of the chart was used. Do you think that we need to clean up the secret as part of this migration? I think that it is fine to leave these old labels.

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [x] The change is disruptive
    - [ ] The change requires no migration steps
    - [x] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
