### PR TITLE
config: crossplane debug logs

### DIFF
--- a/config/common-config.yaml
+++ b/config/common-config.yaml
@@ -79,6 +79,7 @@ clusterApi:
 
 crossplane:
   enabled: false
+  debugEnabled: false
   resources:
     requests:
       cpu: 150m
@@ -96,6 +97,7 @@ crossplane:
         memory: 128Mi
   functions:
     auto-ready:
+      debugEnabled: false
       resources:
         requests:
           cpu: 10m
@@ -104,6 +106,7 @@ crossplane:
           cpu: 20m
           memory: 128Mi
     capability:
+      debugEnabled: false
       resources:
         requests:
           cpu: 10m
@@ -112,6 +115,7 @@ crossplane:
           cpu: 20m
           memory: 128Mi
     go-templating:
+      debugEnabled: false
       resources:
         requests:
           cpu: 25m
@@ -120,13 +124,14 @@ crossplane:
           cpu: 50m
           memory: 128Mi
     patch-and-transform:
-        resources:
-          requests:
-            cpu: 25m
-            memory: 64Mi
-          limits:
-            cpu: 50m
-            memory: 128Mi
+      debugEnabled: false
+      resources:
+        requests:
+          cpu: 25m
+          memory: 64Mi
+        limits:
+          cpu: 50m
+          memory: 128Mi
   providers:
     helm:
       debugEnabled: false

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -8779,6 +8779,10 @@ properties:
         title: Enable Crossplane
         default: false
         type: boolean
+      debugEnabled:
+        title: Enable debug logging for Crossplane
+        default: false
+        type: boolean
       resources:
         $ref: '#/$defs/kubernetesResourceRequirements'
       rbacManager:
@@ -8808,6 +8812,10 @@ properties:
           "^[a-z-]+$":
             resources:
               $ref: '#/$defs/kubernetesResourceRequirements'
+            debugEnabled:
+              title: Enable debug logging for the function
+              default: false
+              type: boolean
         additionalProperties: false
 additionalProperties:
   title: Additional Properties

--- a/helmfile.d/charts/crossplane/packages/templates/functions.yaml
+++ b/helmfile.d/charts/crossplane/packages/templates/functions.yaml
@@ -32,6 +32,10 @@ spec:
               type: RuntimeDefault
           containers:
             - name: package-runtime
+              {{- if $values.debugEnabled }}
+              args:
+                - --debug
+              {{- end }}
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:

--- a/helmfile.d/values/crossplane-packages.yaml.gotmpl
+++ b/helmfile.d/values/crossplane-packages.yaml.gotmpl
@@ -32,6 +32,7 @@ configurations:
 {{- end }}
 {{- end }}
 
+{{ $functionValues := .Values.crossplane.functions }}
 functions:
 {{- range $function, $image := .Values.images.crossplane.functions }}
   {{ $function }}:
@@ -45,10 +46,11 @@ functions:
       tag: "{{ .tag }}{{ if .digest }}@{{ .digest }}{{ end }}"
       {{- end }}
     {{- end }}
-    {{- $.Values | dig "crossplane" "functions" $function "resources" | toYaml | nindent 4 }}
+    resources: {{ dig $function "resources" dict $functionValues | toYaml | nindent 6 }}
+    debugEnabled: {{ dig $function "debugEnabled" false $functionValues | toYaml | nindent 6 }}
 {{- end }}
 
-{{ $providerConfig := .Values.crossplane.providers }}
+{{ $providerValues := .Values.crossplane.providers }}
 providers:
 {{- range $provider, $image := .Values.images.crossplane.providers }}
   {{ $provider }}:
@@ -62,6 +64,6 @@ providers:
       tag: "{{ .tag }}{{ if .digest }}@{{ .digest }}{{ end }}"
       {{- end }}
     {{- end }}
-    resources: {{ dig $provider "resources" dict $providerConfig | toYaml | nindent 6 }}
-    debugEnabled: {{ dig $provider "debugEnabled" false $providerConfig | toYaml | nindent 6 }}
+    resources: {{ dig $provider "resources" dict $providerValues | toYaml | nindent 6 }}
+    debugEnabled: {{ dig $provider "debugEnabled" false $providerValues | toYaml | nindent 6 }}
 {{- end }}

--- a/helmfile.d/values/crossplane.yaml.gotmpl
+++ b/helmfile.d/values/crossplane.yaml.gotmpl
@@ -31,6 +31,11 @@ image:
 {{- end }}
 {{- end }}
 
+{{ if eq (index .Values.crossplane "debugEnabled") true }}
+args:
+  - --debug
+{{ end }}
+
 resourcesCrossplane:
   {{- toYaml .Values.crossplane.resources | nindent 2 }}
 


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Adds the option to enable debug logs for Crossplane and Crossplane Functions. We already had it for [Providers](https://github.com/elastisys/compliantkubernetes-apps/commit/5ba1651873d92019fe5a11ef97e89237a09a03ad), did a small refactor of the Provider values template to not confuse it with providerConfigs.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
