### PR TITLE
Add network policy write-values test for automated documentation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,15 @@ jobs:
       - name: run static unit tests
         working-directory: ./tests
         run: make run-unit/${{ matrix.tag }}
+      - name: Upload network policy artifact
+        if: matrix.tag == 'general' && github.event_name == 'push' && github.ref_name == 'main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: network-policy-values
+          retention-days: 90
+          path: |
+            ./tests/unit/general/.tmp
+            ./tests/unit/general/resources/known-cidrs.yaml
 
   regression:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 __pycache__
 /tests/end-to-end/.run
+/tests/unit/general/.tmp
 .cache

--- a/tests/unit/general/netpol-write-values.bats
+++ b/tests/unit/general/netpol-write-values.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+# bats file_tags=static,general
+
+setup_file() {
+  load "../../bats.lib.bash"
+  load_common "env.bash"
+  load_common "gpg.bash"
+  load_common "yq.bash"
+
+  gpg.setup
+  env.setup
+
+  env.init baremetal kubespray prod --skip-object-storage
+
+  _object_storage_cidr="$(yq '.known_cidrs | to_entries | .[] | select(.value == "*Object storage*") | .key' "${BATS_TEST_DIRNAME}/resources/known-cidrs.yaml")"
+  _dns_cidr="$(yq '.known_cidrs | to_entries | .[] | select(.value == "*DNS*") | .key' "${BATS_TEST_DIRNAME}/resources/known-cidrs.yaml")"
+
+  _sc_api_cidr="$(yq '.known_cidrs | to_entries | .[] | select(.value == "*Management Cluster API*") | .key' "${BATS_TEST_DIRNAME}/resources/known-cidrs.yaml")"
+  _sc_ingress_cidr="$(yq '.known_cidrs | to_entries | .[] | select(.value == "*Management Cluster Ingress*") | .key' "${BATS_TEST_DIRNAME}/resources/known-cidrs.yaml")"
+  _sc_subnet_cidr="$(yq '.known_cidrs | to_entries | .[] | select(.value == "*Management Cluster subnet*") | .key' "${BATS_TEST_DIRNAME}/resources/known-cidrs.yaml")"
+
+  _wc_api_cidr="$(yq '.known_cidrs | to_entries | .[] | select(.value == "*Workload Cluster API*") | .key' "${BATS_TEST_DIRNAME}/resources/known-cidrs.yaml")"
+  _wc_ingress_cidr="$(yq '.known_cidrs | to_entries | .[] | select(.value == "*Workload Cluster Ingress*") | .key' "${BATS_TEST_DIRNAME}/resources/known-cidrs.yaml")"
+  _wc_subnet_cidr="$(yq '.known_cidrs | to_entries | .[] | select(.value == "*Workload Cluster subnet*") | .key' "${BATS_TEST_DIRNAME}/resources/known-cidrs.yaml")"
+
+  yq.set 'common' '.global.clusterDns' "\"${_dns_cidr%/32}\""
+  yq.set 'common' '.networkPolicies.global.objectStorage.ips[0]' "\"${_object_storage_cidr}\""
+  yq.set 'common' '.networkPolicies.global.scIngress.ips[0]' "\"${_sc_ingress_cidr}\""
+  yq.set 'common' '.networkPolicies.global.wcIngress.ips[0]' "\"${_wc_ingress_cidr}\""
+
+  yq.set 'sc' '.networkPolicies.global.scApiserver.ips[0]' "\"${_sc_api_cidr}\""
+  yq.set 'sc' '.networkPolicies.global.scNodes.ips[0]' "\"${_sc_subnet_cidr}\""
+
+  yq.set 'wc' '.networkPolicies.global.wcApiserver.ips[0]' "\"${_wc_api_cidr}\""
+  yq.set 'wc' '.networkPolicies.global.wcNodes.ips[0]' "\"${_wc_subnet_cidr}\""
+
+}
+
+setup() {
+  load "../../bats.lib.bash"
+
+  load_common "yq.bash"
+
+  load_assert
+}
+
+teardown_file() {
+  env.teardown
+  gpg.teardown
+}
+
+@test "helmfile sc netpol write-values" {
+  run ck8s ops helmfile sc -l policy=netpol,netpol!=additional write-values --output-file-template "${BATS_TEST_DIRNAME}/.tmp/sc/{{ .Release.Namespace }}-{{ .Release.Name}}.yaml"
+  assert_success
+}
+
+@test "helmfile wc netpol write-values" {
+  run ck8s ops helmfile wc -l policy=netpol,netpol!=additional write-values --output-file-template "${BATS_TEST_DIRNAME}/.tmp/wc/{{ .Release.Namespace }}-{{ .Release.Name}}.yaml"
+  assert_success
+}

--- a/tests/unit/general/resources/known-cidrs.yaml
+++ b/tests/unit/general/resources/known-cidrs.yaml
@@ -1,0 +1,9 @@
+known_cidrs:
+  "1.0.0.0/32": "Object storage CIDR"
+  "2.0.0.0/32": "Cluster DNS Service IP"
+  "0.1.0.0/32": "Management Cluster API Server CIDR"
+  "0.0.1.0/32": "Management Cluster Ingress CIDR"
+  "0.0.0.1/32": "Management Cluster subnet CIDR"
+  "0.2.0.0/32": "Workload Cluster API Server CIDR"
+  "0.0.2.0/32": "Workload Cluster Ingress CIDR"
+  "0.0.0.2/32": "Workload Cluster subnet CIDR"


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [x] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Adds a bats test that uses `helmfile write-values` to template the network policy generator values into the final values that will be used by the chart. This will be used in the public docs repo to automatically generate documentation showcasing all network policies and their rules.

Combines with this public docs PR: https://github.com/elastisys/welkin/pull/1220

Relies on all the netpol refactor PRs being merged first.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
