### PR TITLE
Add Auto-configure curator retention rule for indexPerNamespace

### DIFF
--- a/config/sc-config.yaml
+++ b/config/sc-config.yaml
@@ -1009,6 +1009,11 @@ opensearch:
   # Config for https://www.elastic.co/guide/en/elasticsearch/client/curator/5.8/about.html
   curator:
     enabled: true
+    # Defaults used for automatic index-per-namespace patterns in the curator values:
+    #   - "^[^.].*"    (non-system indices)
+    #   - ".orphaned*" (orphaned indices from removed namespaces)
+    indexPerNamespaceDefaultSizeGB: 5000
+    indexPerNamespaceDefaultAgeDays: 30
     retention:
       - pattern: other-*
         sizeGB: 5000

--- a/config/schemas/config.yaml
+++ b/config/schemas/config.yaml
@@ -6485,6 +6485,16 @@ properties:
             title: OpenSearch Curator Enabled
             type: boolean
             default: true
+          indexPerNamespaceDefaultSizeGB:
+            title: OpenSearch Curator Index-Per-Namespace Default Size GB
+            description: Default size threshold in GB for automatically generated index-per-namespace patterns.
+            type: number
+            default: 5000
+          indexPerNamespaceDefaultAgeDays:
+            title: OpenSearch Curator Index-Per-Namespace Default Age Days
+            description: Default age threshold in days for automatically generated index-per-namespace patterns.
+            type: number
+            default: 30
           retention:
             title: OpenSearch Curator Retention
             description: Configures the retention of indices in OpenSearch.

--- a/helmfile.d/charts/opensearch/curator/values.yaml
+++ b/helmfile.d/charts/opensearch/curator/values.yaml
@@ -15,7 +15,6 @@ opensearch:
 
 startingDeadlineSeconds: 300
 activeDeadlineSeconds: 1800
-
 failedJobsHistoryLimit: 3
 successfulJobsHistoryLimit: 1
 

--- a/helmfile.d/values/opensearch/curator.yaml.gotmpl
+++ b/helmfile.d/values/opensearch/curator.yaml.gotmpl
@@ -10,7 +10,20 @@ tolerations:  {{- toYaml .Values.opensearch.curator.tolerations | nindent 2 }}
 nodeSelector: {{- toYaml .Values.opensearch.curator.nodeSelector | nindent 2 }}
 resources:    {{- toYaml .Values.opensearch.curator.resources | nindent 2 }}
 
-retention: {{ toYaml .Values.opensearch.curator.retention | nindent 2 }}
+retention:
+  {{- if .Values.opensearch.indexPerNamespace }}
+  - pattern: "^[^.].*"
+    sizeGB: {{ .Values.opensearch.curator.indexPerNamespaceDefaultSizeGB }}
+    ageDays: {{ .Values.opensearch.curator.indexPerNamespaceDefaultAgeDays }}
+  - pattern: ".orphaned*"
+    sizeGB: {{ .Values.opensearch.curator.indexPerNamespaceDefaultSizeGB }}
+    ageDays: {{ .Values.opensearch.curator.indexPerNamespaceDefaultAgeDays }}
+  {{- end }}
+  {{- range .Values.opensearch.curator.retention }}
+  - pattern: {{ .pattern | quote }}
+    sizeGB: {{ .sizeGB }}
+    ageDays: {{ .ageDays }}
+  {{- end }}
 
 {{- $global := dict
   "registry" (ternary (dig "uri" "" .Values.images.global.registry) "" .Values.images.global.registry.enabled)


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?
**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->

Automatically configures an OpenSearch Curator retention rule for all non-system indices when `indexPerNamespace` is enabled, removing a manual configuration step that is easy to miss.

When `indexPerNamespace` is enabled, logs are indexed by Kubernetes namespace instead of fixed patterns. This requires a retention rule to clean up non-system indices (`^[^.].*` pattern). Previously, users had to manually add this rule to their configuration in `sc-config.yaml` / `common-config.yaml`.

The Solution:

- Automatically adds the `^[^.].*` pattern when `opensearch.indexPerNamespace` is true.

 - Uses configurable defaults exposed in `sc-config.yaml`:

    - `opensearch.curator.indexPerNamespaceDefaultSizeGB` → default 5000

    - `opensearch.curator.indexPerNamespaceDefaultAgeDays` → default 30

- Preserves all existing user-configured retention rules (they are appended after the auto-generated non-system rule).

- Keeps behaviour unchanged when `indexPerNamespace` is `false.

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2724

#### Information to reviewers
- The change is transparent for environments where `indexPerNamespace` is disabled.

- When `indexPerNamespace` is enabled, a previously required manual step is now automated but still configurable via `sc-config.yaml`.

#### How to test 

*Pre-condition:* Ensure your environment is on a matching Welkin Apps version (no version mismatch between cluster/config/repository) before running these commands.

### Test with `indexPerNamespace` disabled


##### Verify current setting (indexPerNamespace is false/not set):  

```
yq '.opensearch.indexPerNamespace' ${CK8S_CONFIG_PATH}/common-config.yaml  
```


##### Apply changes  

```
./bin/ck8s apply sc  
``` 


##### Inspect Curator ConfigMap

```` 
./bin/ck8s ops kubectl sc get configmap -n opensearch-system opensearch-curator -o yaml
````

*Expected:*

 - Only the retention rules explicitly configured under `opensearch.curator.retention` are present.

 - No `^[^.].*` pattern is injected.

### Test with `indexPerNamespace` enabled:

##### Enable indexPerNamespace

```
yq '.opensearch.indexPerNamespace = true' -i ${CK8S_CONFIG_PATH}/sc-config.yaml
```

#### *Optionally override defaults (to verify configurability):*
````
yq '.opensearch.curator.indexPerNamespaceDefaultSizeGB = 5000' -i ${CK8S_CONFIG_PATH}/sc-config.yaml
yq '.opensearch.curator.indexPerNamespaceDefaultAgeDays = 30'  -i ${CK8S_CONFIG_PATH}/sc-config.yaml
````

##### Apply changes  

```
./bin/ck8s apply sc  
````
  
##### Inspect Curator ConfigMap

````
./bin/ck8s ops kubectl sc get configmap -n opensearch-system opensearch-curator -o yaml
````
#### Expected:

- A retention rule with pattern `^[^.].*` appears first, using:

   - `disk_space` = `indexPerNamespaceDefaultSizeGB` (default 5000)

   - age filter = `indexPerNamespaceDefaultAgeDays` (default 30)

- All existing user-defined patterns (e.g. `kubernetes-*`, `kubeaudit-*`, `other-*`, `authlog-*`, `security-auditlog-*`) are still present and evaluated after the non-system rule.


Verify curator CronJob exists and is valid::

```
./bin/ck8s ops kubectl sc get cronjob -n opensearch-system opensearch-curator
```

##### Expected behavior:
- When `indexPerNamespace` is false: Only user-configured retention rules are applied
- When `indexPerNamespace` is true: The ^[^.].* rule is added first with defaults, then user-configured rules
- The curator role already has permissions to delete indices matching the non-system pattern configurer.yaml.gotmpl:134-142 .

#### Technical Details 

Changes include:

- `helmfile.d/values/opensearch/curator.yaml.gotmpl`

   - Switch from static retention configuration to logic that derives retention rules from:

       - `opensearch.curator.retention`

       - `opensearch.indexPerNamespace`

       - `opensearch.curator.indexPerNamespaceDefaultSizeGB`

       - `opensearch.curator.indexPerNamespaceDefaultAgeDays`

- `helmfile.d/charts/opensearch/curator/values.yaml`

   - Extend Curator chart values to support the automatically generated non-system retention rule while preserving user-defined rules.

- `config/schemas/config.yaml`

   - Add schema entries under `opensearch.curator`:

       - `indexPerNamespaceDefaultSizeGB` (number, default `5000`)

       - `indexPerNamespaceDefaultAgeDays` (number, default `30`)

   - This ensures the new values are validated, documented, and configurable via `sc-config.yaml`.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests