### PR TITLE
scripts: Enable mock direct routed load balancer for local clusters

### DIFF
--- a/helmfile.d/values/ingress-nginx.yaml.gotmpl
+++ b/helmfile.d/values/ingress-nginx.yaml.gotmpl
@@ -87,11 +87,17 @@ controller:
     {{- if .Values | get "ingressNginx.controller.service.type" "" | eq "LoadBalancer" }}
 
     allocateLoadBalancerNodePorts: {{ .Values.ingressNginx.controller.service.allocateLoadBalancerNodePorts }}
+    {{- with .Values | get "ingressNginx.controller.service.externalIPs" list }}
+    externalIPs: {{- toYaml . | nindent 6 }}
+    {{- end }}
     {{- with .Values | get "ingressNginx.controller.service.loadBalancerSourceRanges" list }}
     loadBalancerSourceRanges: {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values | get "ingressNginx.controller.service.loadBalancerIP" "" }}
     loadBalancerIP: {{ . }}
+    {{- end }}
+    {{- if .Values.ingressNginx.controller.service.allocateLoadBalancerNodePorts }}
+    nodePorts: {{- toYaml .Values.ingressNginx.controller.service.nodePorts | nindent 6 }}
     {{- end }}
 
     {{- else if .Values | get "ingressNginx.controller.service.type" "" | eq "NodePort" }}

--- a/scripts/local-cluster.sh
+++ b/scripts/local-cluster.sh
@@ -432,6 +432,11 @@ create() {
     kubectl get configmap -n kube-system coredns -oyaml | sed '/forward/a \           prefer_udp' | kubectl apply -f -
   fi
 
+  declare workers
+  workers="$(kubectl get no -oyaml | yq -I0 -oj '[.items[] | select(.metadata.labels."node-role.kubernetes.io/control-plane" != "") | .status.addresses[] | select(.type == "InternalIP") | .address] | sort')"
+
+  yq -i ".ingressNginx.controller.service.externalIPs = ${workers}" "${CK8S_CONFIG_PATH}/${affix}-config.yaml"
+
   kubectl label namespace local-path-storage owner=operator
 
   # install calico

--- a/scripts/local-clusters/configs/common-config.yaml
+++ b/scripts/local-clusters/configs/common-config.yaml
@@ -35,10 +35,7 @@ ingressNginx:
       annotations:
         elastisys.io/local-cluster: tests
       clusterIP: 10.96.0.20
-      type: NodePort
-      nodePorts:
-        http: 30080
-        https: 30443
+      type: LoadBalancer
       allocateLoadBalancerNodePorts: false
     config:
       useProxyProtocol: false
@@ -90,4 +87,6 @@ networkPolicies:
         - 0.0.0.0/0
   ingressNginx:
     ingressOverride:
-      enabled: false
+      enabled: true
+      ips:
+        - 0.0.0.0/0

--- a/scripts/local-clusters/profiles/multi-node-cache.yaml
+++ b/scripts/local-clusters/profiles/multi-node-cache.yaml
@@ -49,11 +49,11 @@ nodes:
         hostPath: ${ROOT}/scripts/local-clusters/registries
         readOnly: true
     extraPortMappings:
-      - containerPort: 30080
+      - containerPort: 80
         hostPort: 80
         listenAddress: ${CK8S_LOCAL_LISTEN_ADDRESS}
         protocol: TCP
-      - containerPort: 30443
+      - containerPort: 443
         hostPort: 443
         listenAddress: ${CK8S_LOCAL_LISTEN_ADDRESS}
         protocol: TCP

--- a/scripts/local-clusters/profiles/multi-node.yaml
+++ b/scripts/local-clusters/profiles/multi-node.yaml
@@ -38,11 +38,11 @@ nodes:
   - role: worker
     image: "${KIND_NODE_IMAGE}"
     extraPortMappings:
-      - containerPort: 30080
+      - containerPort: 80
         hostPort: 80
         listenAddress: ${CK8S_LOCAL_LISTEN_ADDRESS}
         protocol: TCP
-      - containerPort: 30443
+      - containerPort: 443
         hostPort: 443
         listenAddress: ${CK8S_LOCAL_LISTEN_ADDRESS}
         protocol: TCP

--- a/scripts/local-clusters/profiles/single-node-cache.yaml
+++ b/scripts/local-clusters/profiles/single-node-cache.yaml
@@ -49,11 +49,11 @@ nodes:
         hostPath: ${ROOT}/scripts/local-clusters/registries
         readOnly: true
     extraPortMappings:
-      - containerPort: 30080
+      - containerPort: 80
         hostPort: 80
         listenAddress: ${CK8S_LOCAL_LISTEN_ADDRESS}
         protocol: TCP
-      - containerPort: 30443
+      - containerPort: 443
         hostPort: 443
         listenAddress: ${CK8S_LOCAL_LISTEN_ADDRESS}
         protocol: TCP

--- a/scripts/local-clusters/profiles/single-node.yaml
+++ b/scripts/local-clusters/profiles/single-node.yaml
@@ -38,11 +38,11 @@ nodes:
   - role: worker
     image: "${KIND_NODE_IMAGE}"
     extraPortMappings:
-      - containerPort: 30080
+      - containerPort: 80
         hostPort: 80
         listenAddress: ${CK8S_LOCAL_LISTEN_ADDRESS}
         protocol: TCP
-      - containerPort: 30443
+      - containerPort: 443
         hostPort: 443
         listenAddress: ${CK8S_LOCAL_LISTEN_ADDRESS}
         protocol: TCP


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [x] personal data beyond what is necessary for interacting with this pull request, nor
> - [x] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This solves the SC <-> WC connectivity for local clusters, by mocking a load balancer service.

With external IPs you can basically assign anything you want to a service, and if it receives traffic on that IP through the configured ports, then it is taken care of.

Better than a host port solution for testing, as then we can test network policies in more detail in the future.

#### Information to reviewers

Setup as normal and it should just work.

I've personally tested with wc prometheus -> sc thanos, and I could see all metrics in grafana.

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
