### PR TITLE
fix: free up as much disk as possible in the integration test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,6 +108,16 @@ jobs:
           - general
           - harbor
     steps:
+      - name: cleanup preinstalled software
+        shell: bash
+        run: |
+          echo -e "\n=== Disk usage before cleanup ==="
+          df -h
+
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+
+          echo -e "\n=== Disk usage after cleanup ==="
+          df -h
       - name: checkout compliantkubernetes-apps
         uses: actions/checkout@v4
       - name: setup docker with buildx
@@ -127,6 +137,18 @@ jobs:
           push: false
           provenance: false
           tags: compliantkubernetes-apps-tests:main
+      - name: prune docker artefacts
+        run: |
+          echo -e "\n=== Disk usage before docker prune ==="
+          df -h
+
+          docker stop $(docker ps -q)
+          docker container prune -f
+          docker volume prune -af
+          docker builder prune -af
+
+          echo -e "\n=== Disk usage after docker prune ==="
+          df -h
       - name: create local cache
         run: ./scripts/local-cluster.sh cache create
       - name: create local resolve


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [x] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

Attempts to maximize disk space available to workflow runners during integration tests. 

Inspiration taken from a [cursed GitHub action](https://github.com/marketplace/actions/maximize-build-disk-space)

This should fix an outstanding issue with the integration suite for harbor intermittently failing for the last couple of weeks.

Some stats for nerds:

```
=== Disk usage before maximize ===
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   54G   19G  75% /

=== Disk usage after maximize ===
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   36G   36G  50% /

=== Disk usage before docker prune ===
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   45G   28G  63% /

=== Disk usage after docker prune ===
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   40G   32G  56% /
```

So GitHub gave us 19G to begin with, but we've turned that into 32G. Kind can now splurge. Not bad.

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [x] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
