### PR TITLE
added welkin quickstart script

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,45 @@ If this is all new to you, here's a [link](https://riseup.net/en/security/messag
 ### Quickstart
 
 > [!NOTE]
+> This Quickstart sets up a local learning environment.
+> It is **NOT production-ready** and **NOT security-hardened**.
+
+#### Limitations
+
+- **Security**: Uses temporary GPG keys and permissive security settings.
+- **Persistence**: Uses local storage; data may be lost if containers are removed.
+- **Infrastructure**: Runs on local Docker containers (Kind cluster).
+
+> [!NOTE]
+> Use this environment only to learn, test, and develop against the Welkin platform.
+
+This script orchestrates the creation of local Kind clusters, initializes configuration, and installs the Welkin application stack automatically.
+
+#### Prerequisites
+
+- **Container runtime**: Docker or Podman installed and running
+- **Resources**: Minimum 4 vCPUs and 16 GB RAM
+- **Dependencies**: Install the repository requirements
+
+#### Running setup
+
+The following command will create local clusters, generate a temporary GPG key, configure the environment, and install welkin:
+
+```bash
+./bin/quick-start setup
+```
+
+#### Teardown Setup
+
+The following command will delete the local Kind clusters:
+
+```bash
+./bin/quick-start delete
+```
+
+### Standard Installation
+
+> [!NOTE]
 > **You probably want to check the [compliantkubernetes-kubespray][compliantkubernetes-kubespray] repository first, since compliantkubernetes-apps depends on having two clusters already set up.**
 
 > [!NOTE]

--- a/bin/quick-start
+++ b/bin/quick-start
@@ -46,14 +46,18 @@ if [[ ! -f "${LOCAL_CLUSTERS_SCRIPT}" ]]; then
 fi
 
 check_prerequisites() {
-  log_header "Checking System Prerequisites..."
+  log_header "📋 Checking System Prerequisites..."
   check_ports
   local req_output
-  if ! req_output=$("${ROOT}/bin/ck8s" check-requirements 2>&1) || [[ "$req_output" =~ "Run the following command to install" ]]; then
+  # We check requirements but mask the exit code so we can handle the output string manually
+  if ! req_output=$("${ROOT}/bin/ck8s" check-requirements 2>&1) ||
+    [[ "$req_output" =~ "Run the following command to install" ]] ||
+    [[ "$req_output" =~ "Run the following command to update" ]]; then
+
     log.warn "Missing or outdated requirements detected:"
-    log.info.no_newline "❓  Would you like to run the installer now? [y/N] "
+    log.info.no_newline "❓  Would you like to run the installer now? [Y/n] "
     read -r reply
-    if [[ "${reply}" =~ ^[Yy]$ ]]; then
+    if [[ -z "${reply}" || "${reply}" =~ ^[Yy]$ ]]; then
       "${ROOT}/bin/ck8s" install-requirements
       log.info "✅ Dependencies installed."
     else
@@ -88,11 +92,10 @@ check_prerequisites() {
     fi
 
     if [[ "$needs_fix" == "true" ]]; then
-      log.info ""
       log.warn "Your system limits are too low. Pods may fail to start."
-      log.info.no_newline "❓ Would you like to fix these settings via sudo now? [y/N] "
+      log.info.no_newline "❓ Would you like to fix these settings via sudo now? [Y/n] "
       read -r reply
-      if [[ "${reply}" =~ ^[Yy]$ ]]; then
+      if [[ -z "${reply}" || "${reply}" =~ ^[Yy]$ ]]; then
         log.info "Applying fixes..."
         sudo sysctl -w fs.inotify.max_user_watches=102400
         sudo sysctl -w fs.inotify.max_user_instances=1024
@@ -111,7 +114,7 @@ check_prerequisites() {
 }
 
 teardown() {
-  log_header "Tearing down Welkin Quickstart Environment..."
+  log_header "🗑️ Tearing down Welkin Quickstart Environment..."
 
   log.info "Deleting Workload Cluster..."
   "${LOCAL_CLUSTERS_SCRIPT}" delete "${CK8S_ENVIRONMENT_NAME}-wc" || true
@@ -128,7 +131,7 @@ teardown() {
 }
 
 setup() {
-  log_header "Setting up Welkin Quick Start Local cluster"
+  log_header "🚀 Setting up Welkin Quick Start Local cluster"
 
   if [[ ! -d "${CK8S_CONFIG_PATH}" ]]; then
     mkdir -p "${CK8S_CONFIG_PATH}"
@@ -148,11 +151,11 @@ setup() {
     log_header "Starting Welkin Local Quickstart"
     log.info "Flavor: ${CK8S_FLAVOR}"
     log.info "Welkin Config Path: ${CK8S_CONFIG_PATH}"
-    log_header "Setting up local domain resolve & cache..."
+    log_header "🌐 Setting up local domain resolve & cache..."
     "${LOCAL_CLUSTERS_SCRIPT}" cache create
     "${LOCAL_CLUSTERS_SCRIPT}" resolve create "${DOMAIN}"
 
-    log_header "Init Configuration..."
+    log_header "⚙️ Init Configuration..."
 
     "${LOCAL_CLUSTERS_SCRIPT}" config "${CK8S_ENVIRONMENT_NAME}" "${CK8S_FLAVOR}" "${DOMAIN}"
 
@@ -171,7 +174,7 @@ setup() {
     log_header "Configuring node local dns setup..."
     "${LOCAL_CLUSTERS_SCRIPT}" setup node-local-dns
 
-    log_header "Verifying Environment Status..."
+    log_header "🔍 Running final welkin environment checks..."
 
     set +e
     "${LOCAL_CLUSTERS_SCRIPT}" status
@@ -180,11 +183,12 @@ setup() {
 
     log.info ""
     if [[ ${STATUS_CODE} -eq 0 ]]; then
-      log.info "✅ Welkin Quickstart Complete!"
+      log.info "✅ Welkin Quickstart Completed!"
       log.info "---------------------------------------------------"
       log.info "  Welkin Configuration Path: ${CK8S_CONFIG_PATH}"
       log.info "  Grafana:     https://grafana.${DOMAIN}"
       log.info "  Harbor:      https://harbor.${DOMAIN}"
+      log.info "  Objectstroage: https://console.minio.ops.${DOMAIN}"
       log.info "---------------------------------------------------"
       log.info "To view/edit secrets manually, run:"
       log.info "  source ${CK8S_CONFIG_PATH}/..temp_gpg_env"
@@ -196,7 +200,7 @@ setup() {
       log.warn "---------------------------------------------------"
       log.warn "Please check the logs above."
       log.warn "You can retry the status check with:"
-      log.warn "  ./bin/ck8s quickstart status"
+      log.warn "  ./scripts/local-cluster.sh status"
     fi
   fi
 }
@@ -227,9 +231,9 @@ wait_for_ready() {
 check_and_install_kind() {
   if ! command -v kind &>/dev/null; then
     log.warn "'kind' is not installed. It is required to create a local cluster."
-    log.info.no_newline "❓ Would you like to install the latest 'kind' to /usr/local/bin now? [y/N] "
+    log.info.no_newline "❓ Would you like to install the latest 'kind' to /usr/local/bin now? [Y/n] "
     read -r reply
-    if [[ "${reply}" =~ ^[Yy]$ ]]; then
+    if [[ -z "${reply}" || "${reply}" =~ ^[Yy]$ ]]; then
       log.info "Fetching latest Kind version..."
       local KIND_VERSION
       KIND_VERSION=$(curl -s https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r '.tag_name')
@@ -276,6 +280,17 @@ check_ports() {
         proc_name=$(sudo lsof -i ":${port}" -sTCP:LISTEN -t | head -n 1 | xargs -r ps -p | tail -n 1 | awk '{print $NF}')
       fi
       log.warn "Process blocking it: ${proc_name}"
+
+      if [[ "${proc_name}" == "docker-proxy" ]]; then
+        local container_name
+        container_name=$(docker ps --format '{{.Names}}' --filter "publish=${port}" | head -n 1)
+
+        if [[ "$container_name" == *"${CK8S_ENVIRONMENT_NAME}"* ]]; then
+          log.error "❌ Port ${port} is occupied by an existing Welkin Quickstart cluster ($container_name)."
+          log.warn "We cannot overwrite the existing cluster safely."
+          log.fatal "💡 Please run '$0 delete' to clean up the old cluster, then try again."
+        fi
+      fi
     fi
   done
 

--- a/bin/quick-start
+++ b/bin/quick-start
@@ -92,7 +92,7 @@ check_prerequisites() {
       log.warn "Your system limits are too low. Pods may fail to start."
       log.info.no_newline "❓ Would you like to fix these settings via sudo now? [y/N] "
       read -r reply
-      if [[ "$reply" =~ ^[Yy]$ ]]; then
+      if [[ "${reply}" =~ ^[Yy]$ ]]; then
         log.info "Applying fixes..."
         sudo sysctl -w fs.inotify.max_user_watches=102400
         sudo sysctl -w fs.inotify.max_user_instances=1024

--- a/bin/quick-start
+++ b/bin/quick-start
@@ -67,14 +67,15 @@ check_prerequisites() {
 
     local unpriv_port
     unpriv_port=$(sysctl -n net.ipv4.ip_unprivileged_port_start 2>/dev/null || echo 1024)
-    if ((unpriv_port == 53)); then
+    if ((unpriv_port != 53)); then
       log.warn "net.ipv4.ip_unprivileged_port_start is $unpriv_port (Recommended: 53 for rootless setups)."
+      needs_fix=true
     fi
 
     if [[ "$needs_fix" == "true" ]]; then
       log.info ""
       log.warn "Your system limits are too low. Pods may fail to start."
-      log.info -n "❓  Would you like to fix these settings via sudo now? [y/N] "
+      log.info.no_newline "❓ Would you like to fix these settings via sudo now? [y/N] "
       read -r reply
       if [[ "$reply" =~ ^[Yy]$ ]]; then
         log.info "Applying fixes..."

--- a/bin/quick-start
+++ b/bin/quick-start
@@ -10,7 +10,7 @@ LOCAL_CLUSTERS_SCRIPT="${ROOT}/scripts/local-cluster.sh"
 
 export CK8S_ENVIRONMENT_NAME="welkin-quick-start"
 export CK8S_FLAVOR="dev"
-export CK8S_CONFIG_PATH="${HOME}/.ck8s/${CK8S_ENVIRONMENT_NAME}"
+export CK8S_CONFIG_PATH="${XDG_CONFIG_HOME:-${HOME}/.config}/welkin/${CK8S_ENVIRONMENT_NAME}"
 DOMAIN="welkin.test"
 
 log_header() {
@@ -67,7 +67,7 @@ check_prerequisites() {
 
     local unpriv_port
     unpriv_port=$(sysctl -n net.ipv4.ip_unprivileged_port_start 2>/dev/null || echo 1024)
-    if ((unpriv_port = 53)); then
+    if ((unpriv_port == 53)); then
       log.warn "net.ipv4.ip_unprivileged_port_start is $unpriv_port (Recommended: 53 for rootless setups)."
     fi
 
@@ -115,7 +115,7 @@ setup() {
     mkdir -p "${CK8S_CONFIG_PATH}"
   fi
 
-  local env_file="${CK8S_CONFIG_PATH}/.temp_gpg_env"
+  local env_file="${CK8S_CONFIG_PATH}/.temp-gpg-env"
 
   check_prerequisites
 

--- a/bin/quick-start
+++ b/bin/quick-start
@@ -168,6 +168,12 @@ setup() {
     "${LOCAL_CLUSTERS_SCRIPT}" create "${CK8S_ENVIRONMENT_NAME}-sc" single-node-cache
     "${LOCAL_CLUSTERS_SCRIPT}" create "${CK8S_ENVIRONMENT_NAME}-wc" single-node-cache --skip-minio
 
+    log_header "Deploying Welkin Apps in ${CK8S_ENVIRONMENT_NAME}-sc..."
+    "${ROOT}/bin/ck8s" apply sc
+
+    log_header "Deploying Welkin Apps in ${CK8S_ENVIRONMENT_NAME}-wc..."
+    "${ROOT}/bin/ck8s" apply wc
+
     wait_for_ready "sc"
     wait_for_ready "wc"
 

--- a/bin/quick-start
+++ b/bin/quick-start
@@ -47,7 +47,7 @@ fi
 
 check_prerequisites() {
   log_header "Checking System Prerequisites..."
-
+  check_ports
   local req_output
   if ! req_output=$("${ROOT}/bin/ck8s" check-requirements 2>&1) || [[ "$req_output" =~ "Run the following command to install" ]]; then
     log.warn "Missing or outdated requirements detected:"
@@ -132,6 +132,7 @@ setup() {
 
   if [[ ! -d "${CK8S_CONFIG_PATH}" ]]; then
     mkdir -p "${CK8S_CONFIG_PATH}"
+    log.info "✅ Created Welkin config path at: ${CK8S_CONFIG_PATH}"
   fi
 
   local env_file="${CK8S_CONFIG_PATH}/.temp-gpg-env"
@@ -142,11 +143,11 @@ setup() {
     log.info "✅ Configuration found at: ${CK8S_CONFIG_PATH}"
     log.info "Skipping setup steps."
     log.info "💡 To rerun the quick start setup from scratch, remove the configuration by running:"
-    log.info "  rm -rf ${CK8S_CONFIG_PATH}"
+    log.info " rm -rf ${CK8S_CONFIG_PATH}"
   else
     log_header "Starting Welkin Local Quickstart"
     log.info "Flavor: ${CK8S_FLAVOR}"
-
+    log.info "Welkin Config Path: ${CK8S_CONFIG_PATH}"
     log_header "Setting up local domain resolve & cache..."
     "${LOCAL_CLUSTERS_SCRIPT}" cache create
     "${LOCAL_CLUSTERS_SCRIPT}" resolve create "${DOMAIN}"
@@ -158,8 +159,6 @@ setup() {
     if [[ -f "${env_file}" ]]; then
       # shellcheck disable=SC1090
       source "${env_file}"
-    else
-      log.error "Temp GPG env file not found."
     fi
 
     log_header "Creating Clusters..."
@@ -257,6 +256,34 @@ check_and_install_kind() {
     fi
   else
     log.info "✅ 'kind' is already installed."
+  fi
+}
+
+check_ports() {
+  log.info "Checking for port conflicts..."
+  local ports=("80" "443")
+  local conflict=false
+
+  for port in "${ports[@]}"; do
+    if (command -v ss >/dev/null && sudo ss -tulpn | grep -q ":${port} ") ||
+      (command -v lsof >/dev/null && sudo lsof -i ":${port}" -sTCP:LISTEN -t >/dev/null 2>&1); then
+
+      log.error "❌ Port ${port} is already in use!"
+      conflict=true
+
+      local proc_name="unknown"
+      if command -v lsof >/dev/null; then
+        proc_name=$(sudo lsof -i ":${port}" -sTCP:LISTEN -t | head -n 1 | xargs -r ps -p | tail -n 1 | awk '{print $NF}')
+      fi
+      log.warn "Process blocking it: ${proc_name}"
+    fi
+  done
+
+  if [[ "${conflict}" == "true" ]]; then
+    log.error "The local cluster requires ports 80 and 443 to be free."
+    log.fatal "Please stop the process and try again."
+  else
+    log.info "✅ Ports 80 and 443 are free."
   fi
 }
 

--- a/bin/quick-start
+++ b/bin/quick-start
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+
+# local quickstart using dev flavour
+
+set -euo pipefail
+
+HERE="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+ROOT="$(dirname "${HERE}")"
+LOCAL_CLUSTERS_SCRIPT="${ROOT}/scripts/local-cluster.sh"
+
+export CK8S_ENVIRONMENT_NAME="welkin-quick-start"
+export CK8S_FLAVOR="dev"
+export CK8S_CONFIG_PATH="${HOME}/.ck8s/${CK8S_ENVIRONMENT_NAME}"
+DOMAIN="welkin.test"
+
+log_header() {
+  echo -e "\n\033[1;34m[welkin-quickstart] $1\033[0m"
+}
+
+log.info.no_newline() {
+  echo -en "[\e[34mck8s\e[0m] ${*}" 1>&2
+}
+log.info() {
+  log.info.no_newline "${*}\n"
+}
+log.warn.no_newline() {
+  echo -e -n "[\e[33mck8s\e[0m] ${*}" 1>&2
+}
+log.warn() {
+  log.warn.no_newline "${*}\n"
+}
+log.error.no_newline() {
+  echo -e -n "[\e[31mck8s\e[0m] ${*}" 1>&2
+}
+log.error() {
+  log.error.no_newline "${*}\n"
+}
+log.fatal() {
+  log.error "${*}"
+  exit 1
+}
+
+if [[ ! -f "${LOCAL_CLUSTERS_SCRIPT}" ]]; then
+  log.error "Error: Could not find helper script at ${LOCAL_CLUSTERS_SCRIPT}"
+  exit 1
+fi
+
+check_prerequisites() {
+  log_header "Checking System Prerequisites..."
+
+  if [[ "$(uname)" == "Linux" ]]; then
+    local needs_fix=false
+    local current_watches
+
+    current_watches=$(sysctl -n fs.inotify.max_user_watches 2>/dev/null || echo 0)
+    if ((current_watches < 102400)); then
+      log.warn "fs.inotify.max_user_watches is too low ($current_watches < 102400)."
+      needs_fix=true
+    fi
+
+    local current_instances
+    current_instances=$(sysctl -n fs.inotify.max_user_instances 2>/dev/null || echo 0)
+    if ((current_instances < 1024)); then
+      log.warn "fs.inotify.max_user_instances is too low ($current_instances < 1024)."
+      needs_fix=true
+    fi
+
+    local unpriv_port
+    unpriv_port=$(sysctl -n net.ipv4.ip_unprivileged_port_start 2>/dev/null || echo 1024)
+    if ((unpriv_port = 53)); then
+      log.warn "net.ipv4.ip_unprivileged_port_start is $unpriv_port (Recommended: 53 for rootless setups)."
+    fi
+
+    if [[ "$needs_fix" == "true" ]]; then
+      log.info ""
+      log.warn "Your system limits are too low. Pods may fail to start."
+      log.info -n "❓  Would you like to fix these settings via sudo now? [y/N] "
+      read -r reply
+      if [[ "$reply" =~ ^[Yy]$ ]]; then
+        log.info "Applying fixes..."
+        sudo sysctl -w fs.inotify.max_user_watches=102400
+        sudo sysctl -w fs.inotify.max_user_instances=1024
+        sudo sysctl -w net.ipv4.ip_unprivileged_port_start=53
+        log.info "✅ Limits updated."
+      else
+        log.warn "Proceeding without fixing limits. Instability is likely."
+      fi
+    else
+      log.info "✅ System limits are healthy."
+    fi
+  fi
+}
+
+teardown() {
+  log_header "Tearing down Welkin Quickstart Environment..."
+
+  log.info "Deleting Workload Cluster..."
+  "${LOCAL_CLUSTERS_SCRIPT}" delete "${CK8S_ENVIRONMENT_NAME}-wc" || true
+
+  log.info "Deleting Service Cluster..."
+  "${LOCAL_CLUSTERS_SCRIPT}" delete "${CK8S_ENVIRONMENT_NAME}-sc" || true
+
+  log.info "Cleaning up DNS..."
+  "${LOCAL_CLUSTERS_SCRIPT}" resolve delete "${DOMAIN}" || true
+
+  log.warn "⚠️Environment deleted."
+  log.info "Note: The config directory at ${CK8S_CONFIG_PATH} was preserved."
+  log.info "To remove it, run: rm -rf ${CK8S_CONFIG_PATH}"
+}
+
+setup() {
+  log_header "Setting up Welkin Quick Start Local cluster"
+
+  if [[ ! -d "${CK8S_CONFIG_PATH}" ]]; then
+    mkdir -p "${CK8S_CONFIG_PATH}"
+  fi
+
+  local env_file="${CK8S_CONFIG_PATH}/.temp_gpg_env"
+
+  check_prerequisites
+
+  if [[ -f "${CK8S_CONFIG_PATH}/secrets.yaml" ]]; then
+    log.info "✅ Configuration exists. Skipping setup."
+  else
+    log_header "Starting Welkin Local Quickstart"
+    log.info "Flavor: ${CK8S_FLAVOR}"
+
+    log_header "Setting up local domain resolve..."
+    "${LOCAL_CLUSTERS_SCRIPT}" cache create
+    "${LOCAL_CLUSTERS_SCRIPT}" resolve create "${DOMAIN}"
+
+    log_header "Init Configuration..."
+
+    "${LOCAL_CLUSTERS_SCRIPT}" config "${CK8S_ENVIRONMENT_NAME}" "${CK8S_FLAVOR}" "${DOMAIN}"
+
+    if [[ -f "${env_file}" ]]; then
+      # shellcheck disable=SC1090
+      source "${env_file}"
+    else
+      log.error "Temp GPG env file not found."
+    fi
+
+    log_header "Creating Clusters..."
+    "${LOCAL_CLUSTERS_SCRIPT}" create "${CK8S_ENVIRONMENT_NAME}-sc" single-node-cache
+    "${LOCAL_CLUSTERS_SCRIPT}" create "${CK8S_ENVIRONMENT_NAME}-wc" single-node-cache --skip-minio
+
+    wait_for_ready "sc"
+    wait_for_ready "wc"
+
+    log_header "Configuring node local dns setup..."
+    "${LOCAL_CLUSTERS_SCRIPT}" setup node-local-dns
+
+    log_header "Verifying Environment Status..."
+
+    set +e
+    "${LOCAL_CLUSTERS_SCRIPT}" status
+    STATUS_CODE=$?
+    set -e
+
+    log.info ""
+    if [[ ${STATUS_CODE} -eq 0 ]]; then
+      log.info "✅ Welkin Quickstart Complete!"
+      log.info "---------------------------------------------------"
+      log.info "  Grafana:     https://grafana.${DOMAIN}"
+      log.info "  Harbor:      https://harbor.${DOMAIN}"
+      log.info "---------------------------------------------------"
+      log.info "To view/edit secrets manually, run:"
+      log.info "  source ${CK8S_CONFIG_PATH}/..temp_gpg_env"
+      log.info "---------------------------------------------------"
+      log.info "To tear down environment:"
+      log.info "  $0 delete"
+    else
+      log.warn "⚠️  Setup finished, but some status checks failed."
+      log.warn "---------------------------------------------------"
+      log.warn "Please check the logs above."
+      log.warn "You can retry the status check with:"
+      log.warn "  ./bin/ck8s local-quickstart status"
+    fi
+  fi
+}
+
+wait_for_ready() {
+  local affix="$1"
+  local kubeconfig="${CK8S_CONFIG_PATH}/.state/kube_config_${affix}.yaml"
+
+  log.info "Waiting for ${affix^^} cluster to be ready..."
+
+  export KUBECONFIG="${kubeconfig}"
+  if ! kubectl wait --for=condition=Ready nodes --all --timeout=120s >/dev/null 2>&1; then
+    log.warn "Nodes are not ready yet. Waiting a bit longer..."
+    sleep 10
+  fi
+
+  log.info "Waiting for system pods in ${affix^^}..."
+
+  kubectl wait --for=condition=Available deployment -n calico-system --all --timeout=300s >/dev/null 2>&1 || true
+
+  kubectl wait --for=condition=Available deployment/coredns -n kube-system --timeout=300s >/dev/null 2>&1 || true
+
+  kubectl wait --for=condition=Available deployment -n gatekeeper-system --all --timeout=300s >/dev/null 2>&1 || true
+
+  log.info "✅ ${affix^^} is stable."
+}
+
+if [[ "${1:-}" == "delete" ]]; then
+  teardown
+else
+  setup
+fi

--- a/bin/quick-start
+++ b/bin/quick-start
@@ -48,6 +48,21 @@ fi
 check_prerequisites() {
   log_header "Checking System Prerequisites..."
 
+  local req_output
+  if ! req_output=$("${ROOT}/bin/ck8s" check-requirements 2>&1) || [[ "$req_output" =~ "Run the following command to install" ]]; then
+    log.warn "Missing or outdated requirements detected:"
+    log.info.no_newline "❓  Would you like to run the installer now? [y/N] "
+    read -r reply
+    if [[ "${reply}" =~ ^[Yy]$ ]]; then
+      "${ROOT}/bin/ck8s" install-requirements
+      log.info "✅ Dependencies installed."
+    else
+      log.warn "Proceeding with current tools. Unexpected behavior may occur."
+    fi
+  else
+    log.info "✅ Dependencies are up to date."
+  fi
+
   if [[ "$(uname)" == "Linux" ]]; then
     local needs_fix=false
     local current_watches
@@ -90,6 +105,9 @@ check_prerequisites() {
       log.info "✅ System limits are healthy."
     fi
   fi
+
+  #check for kind cluster
+  check_and_install_kind
 }
 
 teardown() {
@@ -121,12 +139,15 @@ setup() {
   check_prerequisites
 
   if [[ -f "${CK8S_CONFIG_PATH}/secrets.yaml" ]]; then
-    log.info "✅ Configuration exists. Skipping setup."
+    log.info "✅ Configuration found at: ${CK8S_CONFIG_PATH}"
+    log.info "Skipping setup steps."
+    log.info "💡 To rerun the quick start setup from scratch, remove the configuration by running:"
+    log.info "  rm -rf ${CK8S_CONFIG_PATH}"
   else
     log_header "Starting Welkin Local Quickstart"
     log.info "Flavor: ${CK8S_FLAVOR}"
 
-    log_header "Setting up local domain resolve..."
+    log_header "Setting up local domain resolve & cache..."
     "${LOCAL_CLUSTERS_SCRIPT}" cache create
     "${LOCAL_CLUSTERS_SCRIPT}" resolve create "${DOMAIN}"
 
@@ -162,6 +183,7 @@ setup() {
     if [[ ${STATUS_CODE} -eq 0 ]]; then
       log.info "✅ Welkin Quickstart Complete!"
       log.info "---------------------------------------------------"
+      log.info "  Welkin Configuration Path: ${CK8S_CONFIG_PATH}"
       log.info "  Grafana:     https://grafana.${DOMAIN}"
       log.info "  Harbor:      https://harbor.${DOMAIN}"
       log.info "---------------------------------------------------"
@@ -175,7 +197,7 @@ setup() {
       log.warn "---------------------------------------------------"
       log.warn "Please check the logs above."
       log.warn "You can retry the status check with:"
-      log.warn "  ./bin/ck8s local-quickstart status"
+      log.warn "  ./bin/ck8s quickstart status"
     fi
   fi
 }
@@ -201,6 +223,41 @@ wait_for_ready() {
   kubectl wait --for=condition=Available deployment -n gatekeeper-system --all --timeout=300s >/dev/null 2>&1 || true
 
   log.info "✅ ${affix^^} is stable."
+}
+
+check_and_install_kind() {
+  if ! command -v kind &>/dev/null; then
+    log.warn "'kind' is not installed. It is required to create a local cluster."
+    log.info.no_newline "❓ Would you like to install the latest 'kind' to /usr/local/bin now? [y/N] "
+    read -r reply
+    if [[ "${reply}" =~ ^[Yy]$ ]]; then
+      log.info "Fetching latest Kind version..."
+      local KIND_VERSION
+      KIND_VERSION=$(curl -s https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r '.tag_name')
+
+      if [[ -z "$KIND_VERSION" || "$KIND_VERSION" == "null" ]]; then
+        log.fatal "Failed to fetch latest Kind version."
+      fi
+
+      local OS ARCH
+      OS="$(uname | tr '[:upper:]' '[:lower:]')"
+      ARCH="$(uname -m)"
+      [ "$ARCH" = "x86_64" ] && ARCH="amd64"
+      [ "$ARCH" = "aarch64" ] && ARCH="arm64"
+      log.info "Downloading..."
+      curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-${OS}-${ARCH}"
+      chmod +x ./kind
+      log.info "Installing to /usr/local/bin (requires sudo)..."
+      sudo mv ./kind /usr/local/bin/kind
+
+      log.info "✅ Kind ($KIND_VERSION) installed successfully."
+    else
+      log.error "Cannot proceed without 'kind'. Aborting."
+      exit 1
+    fi
+  else
+    log.info "✅ 'kind' is already installed."
+  fi
 }
 
 if [[ "${1:-}" == "delete" ]]; then

--- a/roles/get-requirements.yaml
+++ b/roles/get-requirements.yaml
@@ -67,6 +67,12 @@
       set_fact:
         requirements: "{{ parse_requirements_result.stdout | from_json }}"
 
+    - name: Ensure install path exists
+      file:
+        path: "{{ install_path }}"
+        state: directory
+        mode: '0755'
+
     - name: Install apt-packages
       become: yes
       become_user: root

--- a/scripts/local-cluster.sh
+++ b/scripts/local-cluster.sh
@@ -252,7 +252,7 @@ resolve() {
 
         for link in "${links[@]}"; do
           if log.continue "set local-resolve as current dns server on ${link}?"; then
-            resolvectl dns "${link}" 127.0.64.43
+            sudo resolvectl dns "${link}" 127.0.64.43
           fi
         done
       elif command -v unbound-control || [[ -x /usr/sbin/unbound-control ]]; then


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [x] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [ ] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [ ] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
...
-->

### What does this PR do / why do we need this PR?

This PR introduces bin/quick-start, a script that fully automates the setup of a local Welkin environment which handles kind cluster creation, configuration, and app installation. It also updates the README.md with a simplified "Quickstart" section.
...

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #2767 

#### Information to reviewers

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [ ] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [ ] The change is transparent
    - [ ] The change is disruptive
    - [ ] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [ ] The metrics are still exposed and present in Grafana after the change
    - [ ] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [ ] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [ ] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [ ] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
