### PR TITLE
apps: upgrade ingress-nginx controller to 4.13.7 and chart to 1.13.7

### DIFF
--- a/helmfile.d/lists/images.yaml
+++ b/helmfile.d/lists/images.yaml
@@ -44,10 +44,10 @@ images:
   hnc:
     image: ghcr.io/elastisys/hnc-manager:v1.1.0
   ingressNginx:
-    controller: registry.k8s.io/ingress-nginx/controller:v1.13.3
-    controllerChroot: registry.k8s.io/ingress-nginx/controller-chroot:v1.13.3
+    controller: registry.k8s.io/ingress-nginx/controller:v1.13.7
+    controllerChroot: registry.k8s.io/ingress-nginx/controller-chroot:v1.13.7
     defaultBackend: registry.k8s.io/defaultbackend-amd64:1.5
-    admissionWebhooksPatch: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.3
+    admissionWebhooksPatch: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.7
     fileCopier: docker.io/library/busybox:1.36
   kured:
     image: ghcr.io/kubereboot/kured:1.20.0

--- a/helmfile.d/upstream/index.yaml
+++ b/helmfile.d/upstream/index.yaml
@@ -53,7 +53,7 @@ charts:
   kubereboot/kured: 5.10.0
 
   kubernetes-external-dns/external-dns: 1.14.4
-  kubernetes-ingress-nginx/ingress-nginx: 4.13.3
+  kubernetes-ingress-nginx/ingress-nginx: 4.13.7
   kubernetes-metrics-server/metrics-server: 3.12.1
 
   kyverno/kyverno: 3.3.6

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/Chart.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/Chart.yaml
@@ -1,9 +1,9 @@
 annotations:
   artifacthub.io/changes: |
-    - Update Ingress-Nginx version controller-v1.13.3
+    - Update Ingress-Nginx version controller-v1.13.7
   artifacthub.io/prerelease: "false"
 apiVersion: v2
-appVersion: 1.13.3
+appVersion: 1.13.7
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and
   load balancer
 home: https://github.com/kubernetes/ingress-nginx
@@ -20,4 +20,4 @@ maintainers:
 name: ingress-nginx
 sources:
 - https://github.com/kubernetes/ingress-nginx
-version: 4.13.3
+version: 4.13.7

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/README.md
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/README.md
@@ -2,7 +2,7 @@
 
 [ingress-nginx](https://github.com/kubernetes/ingress-nginx) Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
 
-![Version: 4.13.3](https://img.shields.io/badge/Version-4.13.3-informational?style=flat-square) ![AppVersion: 1.13.3](https://img.shields.io/badge/AppVersion-1.13.3-informational?style=flat-square)
+![Version: 4.13.7](https://img.shields.io/badge/Version-4.13.7-informational?style=flat-square) ![AppVersion: 1.13.7](https://img.shields.io/badge/AppVersion-1.13.7-informational?style=flat-square)
 
 To use, add `ingressClassName: nginx` spec field or the `kubernetes.io/ingress.class: nginx` annotation to your Ingress resources.
 
@@ -273,10 +273,10 @@ metadata:
 | controller.admissionWebhooks.namespaceSelector | object | `{}` |  |
 | controller.admissionWebhooks.objectSelector | object | `{}` |  |
 | controller.admissionWebhooks.patch.enabled | bool | `true` |  |
-| controller.admissionWebhooks.patch.image.digest | string | `"sha256:3d671cf20a35cd94efc5dcd484970779eb21e7938c98fbc3673693b8a117cf39"` |  |
+| controller.admissionWebhooks.patch.image.digest | string | `"sha256:7c74a715af2c94cb734785b4d3ea1357b4f02b88e1e123c622a9cb68b62f669c"` |  |
 | controller.admissionWebhooks.patch.image.image | string | `"ingress-nginx/kube-webhook-certgen"` |  |
 | controller.admissionWebhooks.patch.image.pullPolicy | string | `"IfNotPresent"` |  |
-| controller.admissionWebhooks.patch.image.tag | string | `"v1.6.3"` |  |
+| controller.admissionWebhooks.patch.image.tag | string | `"v1.6.7"` |  |
 | controller.admissionWebhooks.patch.labels | object | `{}` | Labels to be added to patch job resources |
 | controller.admissionWebhooks.patch.networkPolicy.enabled | bool | `false` | Enable 'networkPolicy' or not |
 | controller.admissionWebhooks.patch.nodeSelector."kubernetes.io/os" | string | `"linux"` |  |
@@ -345,8 +345,8 @@ metadata:
 | controller.hostname | object | `{}` | Optionally customize the pod hostname. |
 | controller.image.allowPrivilegeEscalation | bool | `false` |  |
 | controller.image.chroot | bool | `false` |  |
-| controller.image.digest | string | `"sha256:1b044f6dcac3afbb59e05d98463f1dec6f3d3fb99940bc12ca5d80270358e3bd"` |  |
-| controller.image.digestChroot | string | `"sha256:27de15aea4ec7639f7cec6ae96bff11ce57bb1171040351a0b0eedf66655d0dd"` |  |
+| controller.image.digest | string | `"sha256:13db2f8aca4bb71ae7f727288620c4569b01bab4911b01fa3917995ff7755de8"` |  |
+| controller.image.digestChroot | string | `"sha256:ecc934a4653d3b8c17100882b58cc16c59a697930c3598acda02227edfc41c34"` |  |
 | controller.image.image | string | `"ingress-nginx/controller"` |  |
 | controller.image.pullPolicy | string | `"IfNotPresent"` |  |
 | controller.image.readOnlyRootFilesystem | bool | `false` |  |
@@ -354,7 +354,7 @@ metadata:
 | controller.image.runAsNonRoot | bool | `true` |  |
 | controller.image.runAsUser | int | `101` | This value must not be changed using the official image. uid=101(www-data) gid=82(www-data) groups=82(www-data) |
 | controller.image.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| controller.image.tag | string | `"v1.13.3"` |  |
+| controller.image.tag | string | `"v1.13.7"` |  |
 | controller.ingressClass | string | `"nginx"` | For backwards compatibility with ingress.class annotation, use ingressClass. Algorithm is as follows, first ingressClassName is considered, if not present, controller looks for ingress.class annotation |
 | controller.ingressClassByName | bool | `false` | Process IngressClass per name (additionally as per spec.controller). |
 | controller.ingressClassResource | object | `{"aliases":[],"annotations":{},"controllerValue":"k8s.io/ingress-nginx","default":false,"enabled":true,"name":"nginx","parameters":{}}` | This section refers to the creation of the IngressClass resource. IngressClasses are immutable and cannot be changed after creation. We do not support namespaced IngressClasses, yet, so a ClusterRole and a ClusterRoleBinding is required. |

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/cloudbuild.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/cloudbuild.yaml
@@ -2,7 +2,7 @@ options:
   # Ignore Prow provided substitutions.
   substitution_option: ALLOW_LOOSE
 steps:
-- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260127-c1affcc8de
   dir: charts
   env:
   - NAME=ingress-nginx

--- a/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/values.yaml
+++ b/helmfile.d/upstream/kubernetes-ingress-nginx/ingress-nginx/values.yaml
@@ -30,9 +30,9 @@ controller:
     ## for backwards compatibility consider setting the full image url via the repository value below
     ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
     ## repository:
-    tag: "v1.13.3"
-    digest: sha256:1b044f6dcac3afbb59e05d98463f1dec6f3d3fb99940bc12ca5d80270358e3bd
-    digestChroot: sha256:27de15aea4ec7639f7cec6ae96bff11ce57bb1171040351a0b0eedf66655d0dd
+    tag: "v1.13.7"
+    digest: sha256:13db2f8aca4bb71ae7f727288620c4569b01bab4911b01fa3917995ff7755de8
+    digestChroot: sha256:ecc934a4653d3b8c17100882b58cc16c59a697930c3598acda02227edfc41c34
     pullPolicy: IfNotPresent
     runAsNonRoot: true
     # -- This value must not be changed using the official image.
@@ -820,8 +820,8 @@ controller:
         ## for backwards compatibility consider setting the full image url via the repository value below
         ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
         ## repository:
-        tag: v1.6.3
-        digest: sha256:3d671cf20a35cd94efc5dcd484970779eb21e7938c98fbc3673693b8a117cf39
+        tag: v1.6.7
+        digest: sha256:7c74a715af2c94cb734785b4d3ea1357b4f02b88e1e123c622a9cb68b62f669c
         pullPolicy: IfNotPresent
       # -- Provide a priority class name to the webhook patching job
       ##

--- a/sbom/sbom.cdx.json
+++ b/sbom/sbom.cdx.json
@@ -1,10 +1,10 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:b57a8c32-510d-4a08-849f-5c786f5c0372",
+  "serialNumber": "urn:uuid:b74f3749-3749-4833-aa4c-673ad303efce",
   "version": 1,
   "metadata": {
-    "timestamp": "2025-11-28T14:39:31Z",
+    "timestamp": "2026-02-03T13:47:42Z",
     "lifecycles": [
       {
         "phase": "build"
@@ -33,10 +33,10 @@
       }
     ],
     "component": {
-      "bom-ref": "pkg:generic/compliantkubernetes-apps@v0.50.0",
+      "bom-ref": "pkg:generic/compliantkubernetes-apps@latest",
       "type": "application",
       "name": "compliantkubernetes-apps",
-      "version": "v0.50.0",
+      "version": "latest",
       "licenses": [
         {
           "license": {
@@ -44,11 +44,11 @@
           }
         }
       ],
-      "purl": "pkg:generic/compliantkubernetes-apps@v0.50.0",
+      "purl": "pkg:generic/compliantkubernetes-apps@latest",
       "properties": [
         {
           "name": "vcs:tag",
-          "value": "v0.50.0"
+          "value": "latest"
         }
       ]
     },
@@ -1271,13 +1271,13 @@
       }
     },
     {
-      "bom-ref": "pkg:helm/ingress-nginx@4.13.3",
+      "bom-ref": "pkg:helm/ingress-nginx@4.13.7",
       "type": "library",
       "supplier": {
         "name": "kubernetes"
       },
       "name": "ingress-nginx",
-      "version": "4.13.3",
+      "version": "4.13.7",
       "description": "Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer",
       "licenses": [
         {
@@ -1286,7 +1286,7 @@
           }
         }
       ],
-      "purl": "pkg:helm/ingress-nginx@4.13.3",
+      "purl": "pkg:helm/ingress-nginx@4.13.7",
       "properties": [
         {
           "name": "Elastisys evaluation",
@@ -3463,26 +3463,26 @@
       "purl": "pkg:oci/ingress-controller/controller@1.0.0-dev"
     },
     {
-      "bom-ref": "pkg:oci/ingress-nginx/controller-chroot@v1.13.3?repository_url=registry.k8s.io",
+      "bom-ref": "pkg:oci/ingress-nginx/controller-chroot@v1.13.7?repository_url=registry.k8s.io",
       "type": "container",
       "supplier": {
         "name": "ingress-nginx"
       },
       "name": "registry.k8s.io/ingress-nginx/controller-chroot",
-      "version": "v1.13.3",
-      "cpe": "cpe:2.3:a:kubernetes:controller-chroot:1.13.3:*:*:*:*:*:*:*",
-      "purl": "pkg:oci/ingress-nginx/controller-chroot@v1.13.3?repository_url=registry.k8s.io"
+      "version": "v1.13.7",
+      "cpe": "cpe:2.3:a:kubernetes:controller-chroot:1.13.7:*:*:*:*:*:*:*",
+      "purl": "pkg:oci/ingress-nginx/controller-chroot@v1.13.7?repository_url=registry.k8s.io"
     },
     {
-      "bom-ref": "pkg:oci/ingress-nginx/controller@v1.13.3?repository_url=registry.k8s.io",
+      "bom-ref": "pkg:oci/ingress-nginx/controller@v1.13.7?repository_url=registry.k8s.io",
       "type": "container",
       "supplier": {
         "name": "ingress-nginx"
       },
       "name": "registry.k8s.io/ingress-nginx/controller",
-      "version": "v1.13.3",
-      "cpe": "cpe:2.3:a:kubernetes:controller:1.13.3:*:*:*:*:*:*:*",
-      "purl": "pkg:oci/ingress-nginx/controller@v1.13.3?repository_url=registry.k8s.io"
+      "version": "v1.13.7",
+      "cpe": "cpe:2.3:a:kubernetes:controller:1.13.7:*:*:*:*:*:*:*",
+      "purl": "pkg:oci/ingress-nginx/controller@v1.13.7?repository_url=registry.k8s.io"
     },
     {
       "bom-ref": "pkg:oci/ingress-nginx/kube-webhook-certgen@v1.5.2?repository_url=registry.k8s.io",
@@ -3507,15 +3507,15 @@
       "purl": "pkg:oci/ingress-nginx/kube-webhook-certgen@v1.6.2"
     },
     {
-      "bom-ref": "pkg:oci/ingress-nginx/kube-webhook-certgen@v1.6.3?repository_url=registry.k8s.io",
+      "bom-ref": "pkg:oci/ingress-nginx/kube-webhook-certgen@v1.6.7?repository_url=registry.k8s.io",
       "type": "container",
       "supplier": {
         "name": "ingress-nginx"
       },
       "name": "registry.k8s.io/ingress-nginx/kube-webhook-certgen",
-      "version": "v1.6.3",
-      "cpe": "cpe:2.3:a:kubernetes:kube-webhook-certgen:1.6.3:*:*:*:*:*:*:*",
-      "purl": "pkg:oci/ingress-nginx/kube-webhook-certgen@v1.6.3?repository_url=registry.k8s.io"
+      "version": "v1.6.7",
+      "cpe": "cpe:2.3:a:kubernetes:kube-webhook-certgen:1.6.7:*:*:*:*:*:*:*",
+      "purl": "pkg:oci/ingress-nginx/kube-webhook-certgen@v1.6.7?repository_url=registry.k8s.io"
     },
     {
       "bom-ref": "pkg:oci/jetstack/cert-manager-acmesolver@v1.17.1?repository_url=quay.io",
@@ -4169,7 +4169,7 @@
   ],
   "dependencies": [
     {
-      "ref": "pkg:generic/compliantkubernetes-apps@v0.50.0",
+      "ref": "pkg:generic/compliantkubernetes-apps@latest",
       "dependsOn": [
         "pkg:helm/autoscaling-monitoring@0.1.0",
         "pkg:helm/calico-accountant@0.1.1",
@@ -4209,7 +4209,7 @@
         "pkg:helm/hnc-config@0.1.0",
         "pkg:helm/hnc@0.1.0",
         "pkg:helm/ingress-nginx-probe-ingress@0.1.0",
-        "pkg:helm/ingress-nginx@4.13.3",
+        "pkg:helm/ingress-nginx@4.13.7",
         "pkg:helm/init-harbor@0.2.0",
         "pkg:helm/k8s-metacollector@0.1.10",
         "pkg:helm/kube-prometheus-stack@77.11.1",
@@ -4589,7 +4589,7 @@
       "ref": "pkg:helm/hnc@0.1.0",
       "dependsOn": [
         "pkg:oci/elastisys/hnc-manager@v1.1.0?repository_url=ghcr.io",
-        "pkg:oci/ingress-nginx/controller@v1.13.3?repository_url=registry.k8s.io",
+        "pkg:oci/ingress-nginx/controller@v1.13.7?repository_url=registry.k8s.io",
         "pkg:oci/jetstack/cert-manager-controller@v1.17.1?repository_url=quay.io",
         "pkg:oci/tektoncd/github.com/tektoncd/pipeline/cmd/controller@v0.45.0?repository_url=ghcr.io"
       ]
@@ -4598,18 +4598,18 @@
       "ref": "pkg:helm/ingress-nginx-probe-ingress@0.1.0",
       "dependsOn": [
         "pkg:oci/defaultbackend-amd64@1.5?repository_url=registry.k8s.io",
-        "pkg:oci/ingress-nginx/controller-chroot@v1.13.3?repository_url=registry.k8s.io",
-        "pkg:oci/ingress-nginx/kube-webhook-certgen@v1.6.3?repository_url=registry.k8s.io"
+        "pkg:oci/ingress-nginx/controller-chroot@v1.13.7?repository_url=registry.k8s.io",
+        "pkg:oci/ingress-nginx/kube-webhook-certgen@v1.6.7?repository_url=registry.k8s.io"
       ]
     },
     {
-      "ref": "pkg:helm/ingress-nginx@4.13.3",
+      "ref": "pkg:helm/ingress-nginx@4.13.7",
       "dependsOn": [
         "pkg:oci/defaultbackend-amd64@1.5?repository_url=registry.k8s.io",
         "pkg:oci/ingress-controller/controller@1.0.0-dev",
-        "pkg:oci/ingress-nginx/controller-chroot@v1.13.3?repository_url=registry.k8s.io",
-        "pkg:oci/ingress-nginx/controller@v1.13.3?repository_url=registry.k8s.io",
-        "pkg:oci/ingress-nginx/kube-webhook-certgen@v1.6.3?repository_url=registry.k8s.io"
+        "pkg:oci/ingress-nginx/controller-chroot@v1.13.7?repository_url=registry.k8s.io",
+        "pkg:oci/ingress-nginx/controller@v1.13.7?repository_url=registry.k8s.io",
+        "pkg:oci/ingress-nginx/kube-webhook-certgen@v1.6.7?repository_url=registry.k8s.io"
       ]
     },
     {
@@ -5251,11 +5251,11 @@
       "dependsOn": []
     },
     {
-      "ref": "pkg:oci/ingress-nginx/controller-chroot@v1.13.3?repository_url=registry.k8s.io",
+      "ref": "pkg:oci/ingress-nginx/controller-chroot@v1.13.7?repository_url=registry.k8s.io",
       "dependsOn": []
     },
     {
-      "ref": "pkg:oci/ingress-nginx/controller@v1.13.3?repository_url=registry.k8s.io",
+      "ref": "pkg:oci/ingress-nginx/controller@v1.13.7?repository_url=registry.k8s.io",
       "dependsOn": []
     },
     {
@@ -5267,7 +5267,7 @@
       "dependsOn": []
     },
     {
-      "ref": "pkg:oci/ingress-nginx/kube-webhook-certgen@v1.6.3?repository_url=registry.k8s.io",
+      "ref": "pkg:oci/ingress-nginx/kube-webhook-certgen@v1.6.7?repository_url=registry.k8s.io",
       "dependsOn": []
     },
     {


### PR DESCRIPTION
<!-- Choose your PR title carefully as it will be used as the entry in the changelog! -->

<!-- markdownlint-disable MD041 -->
> [!warning]
> **This is a public repository, ensure not to disclose:**
>
> - [ ] personal data beyond what is necessary for interacting with this pull request, nor
> - [ ] business confidential information, such as customer names.

### What kind of PR is this?

**Required**: Mark one of the following that is applicable:

- [ ] kind/feature       <!-- This PR adds a new feature -->
- [ ] kind/improvement   <!-- This PR changes an existing feature -->
- [ ] kind/deprecation   <!-- This PR removes an existing feature -->
- [ ] kind/documentation <!-- This PR contains documentation -->
- [ ] kind/clean-up      <!-- This PR cleans up technical debt -->
- [ ] kind/bug           <!-- This PR fixes a bug -->
- [x] kind/other         <!-- This PR does something else -->

_Optional_: Mark one or more of the following that are applicable:

> [!important]
> Breaking changes should be marked `kind/admin-change` or `kind/dev-change` depending on type
> Critical security fixes should be marked with `kind/security`

- [ ] kind/admin-change   <!-- This PR introduces an admin facing change, add "Platform Administrator notice" section -->
- [ ] kind/dev-change     <!-- This PR introduces a dev facing change, add "Application Developer notice" section -->
- [x] kind/security       <!-- This PR introduces a critical security fix, add "Security notice" section -->
- [ ] [kind/adr](set-me\) <!-- This PR implements an ADR, add the link -->

<!-- Uncomment the additional sections that applies. -->

<!-- Additional information to be added in the release notes
### Release notes
...
-->

<!-- Additional information with kind/admin-change
### Platform Administrator notice
...
-->

<!-- Add additional information with kind/dev-change
### Application Developer notice
...
-->

<!-- Add additional information with kind/security
### Security notice
  - https://github.com/kubernetes/kubernetes/issues/136677
-->

### What does this PR do / why do we need this PR?

<!-- Add description of the change -->
Fixes a high-severity CVE, and ingress-nginx has clusterwide secret access

<!-- Add all issues that are fixed by this PR, use "Part of" instead of "Fixes" if you want to keep issues open. -->
- Fixes #

#### Information to reviewers

This upgrade mitigates several CVE's have been announced before ingress-nginx's official retirement, including secret disclosure https://discuss.kubernetes.io/t/security-advisory-multiple-issues-in-ingress-nginx/34115

### Security notice

- This upgrade mitigates the following high security vulnerability:
  - [CVE-2026-1580](https://github.com/kubernetes/kubernetes/issues/136677)
- This upgrade mitigates the following medium severity vulnerabilities:
  - [CVE-2026-24512](https://github.com/kubernetes/kubernetes/issues/136678)
  - [CVE-2026-24513](https://github.com/kubernetes/kubernetes/issues/136679)
  - [CVE-2026-24513](github.com/kubernetes/kubernetes/issues/136680)

<!--
Any additional information reviews should know.

How to run / how to test.

Include screenshots if applicable to help explain these changes.
--->

#### Checklist

<!-- This section is not added to the changelog or release notes, it is to help you as a contributor and reviewers. -->

- [x] Proper commit message prefix on all commits
    <!-- Example of commit message prefixes:
    - all: changes to multiple areas
    - apps: changes to applications running in all clusters
    - apps sc: changes to applications running in service clusters
    - apps wc: changes to applications running in workload clusters
    - bin: changes to management binaries
    - config: changes to configuration
    - docs: changes to documentation
    - release: release related
    - scripts: changes to scripts
    - tests: changes to tests
    --->
- Change checks:
    - [x] The change is transparent
    - [ ] The change is disruptive
    - [x] The change requires no migration steps
    - [ ] The change requires migration steps
    - [ ] The change updates CRDs
    - [ ] The change updates the config _and_ the schema
- Documentation checks:
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required no updates
    - [ ] The [public documentation](https://github.com/elastisys/welkin) required an update - [link to change](set-me\)
- Metrics checks:
    - [x] The metrics are still exposed and present in Grafana after the change
    - [x] The metrics names didn't change (Grafana dashboards and Prometheus alerts required no updates)
    - [ ] The metrics names did change (Grafana dashboards and Prometheus alerts required an update)
- Logs checks:
    - [x] The logs do not show any errors after the change
- PodSecurityPolicy checks:
    - [ ] Any changed Pod is covered by Kubernetes Pod Security Standards
    - [ ] Any changed Pod is covered by Gatekeeper Pod Security Policies
    - [ ] The change does not cause any Pods to be blocked by Pod Security Standards or Policies
- NetworkPolicy checks:
    - [ ] Any changed Pod is covered by Network Policies
    - [ ] The change does not cause any dropped packets in the NetworkPolicy Dashboard
- Audit checks:
    - [x] The change does not cause any unnecessary Kubernetes audit events
    - [ ] The change requires changes to Kubernetes audit policy
- Falco checks:
    - [x] The change does not cause any alerts to be generated by Falco
- Bug checks:
    - [ ] The bug fix is covered by regression tests
